### PR TITLE
feat: add draft workout state UI

### DIFF
--- a/app/(app)/programs/[id]/workouts/[workoutId]/page.tsx
+++ b/app/(app)/programs/[id]/workouts/[workoutId]/page.tsx
@@ -73,9 +73,6 @@ export default async function WorkoutDetailPage({
     notFound()
   }
 
-  // Only mark as completed if there's a completion with status 'completed' (not 'draft')
-  const isCompleted = workout.completions.length > 0 && workout.completions[0].status === 'completed'
-
   // NEW: Fetch exercise history for each exercise
   const exerciseHistory = await Promise.all(
     workout.exercises.map(async (exercise) => ({
@@ -97,7 +94,6 @@ export default async function WorkoutDetailPage({
     <WorkoutDetail
       workout={workout}
       programId={programId}
-      isCompleted={isCompleted}
       exerciseHistory={historyMap} // NEW: Pass history to component
     />
   )

--- a/components/WeekView.tsx
+++ b/components/WeekView.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { Clock } from 'lucide-react'
 
 type WorkoutCompletion = {
   id: string
@@ -229,6 +230,7 @@ export default function WeekView({
             {workouts.map((workout) => {
               const completion = workout.completions[0]
               const isCompleted = completion?.status === 'completed'
+              const isDraft = completion?.status === 'draft'
               const isSkipped = completion?.status === 'skipped'
               const hasStatus = !!completion
 
@@ -245,6 +247,8 @@ export default function WeekView({
                       ${
                         isCompleted
                           ? 'border-green-500 bg-green-50'
+                          : isDraft
+                          ? 'border-amber-500 bg-amber-50'
                           : isSkipped
                           ? 'border-gray-400 bg-gray-50'
                           : 'border-gray-200 hover:border-blue-300'
@@ -272,6 +276,16 @@ export default function WeekView({
                                 </svg>
                               </div>
                             )}
+                            {isDraft && (
+                              <>
+                                <div className="flex items-center justify-center w-6 h-6 rounded-full bg-amber-500">
+                                  <Clock className="w-4 h-4 text-white" />
+                                </div>
+                                <span className="px-2 py-0.5 bg-amber-500 text-white text-xs font-semibold rounded">
+                                  IN PROGRESS
+                                </span>
+                              </>
+                            )}
                             {isSkipped && (
                               <span className="px-2 py-0.5 bg-gray-400 text-white text-xs font-semibold rounded">
                                 SKIPPED
@@ -284,11 +298,19 @@ export default function WeekView({
                           {completion && (
                             <p
                               className={`text-sm mt-1 ${
-                                isCompleted ? 'text-green-700' : 'text-gray-600'
+                                isCompleted
+                                  ? 'text-green-700'
+                                  : isDraft
+                                  ? 'text-amber-700'
+                                  : 'text-gray-600'
                               }`}
                             >
                               {isCompleted
                                 ? `Completed on ${new Date(
+                                    completion.completedAt
+                                  ).toLocaleDateString()}`
+                                : isDraft
+                                ? `Started on ${new Date(
                                     completion.completedAt
                                   ).toLocaleDateString()}`
                                 : `Skipped on ${new Date(
@@ -315,8 +337,8 @@ export default function WeekView({
                       </div>
                     </div>
                   </Link>
-                  {/* Skip button for incomplete workouts */}
-                  {!hasStatus && (
+                  {/* Skip button for incomplete workouts (not draft) */}
+                  {!hasStatus && !isDraft && (
                     <button
                       onClick={(e) => {
                         e.preventDefault()


### PR DESCRIPTION
Add visual distinction and controls for in-progress workouts across detail and week views.

**WorkoutDetail changes:**
- Add status detection (isDraft, isWorkoutCompleted)
- Show amber clock badge with set count for draft workouts
- Add side-by-side "Continue Logging" + "Reset" buttons for drafts
- Display logged sets for both draft and completed workouts
- Remove isCompleted prop, derive state from completion.status

**WeekView changes:**
- Add amber outline and background for draft workouts
- Show clock icon and "IN PROGRESS" badge
- Display "Started on [date]" for draft workouts
- Hide Skip button for in-progress workouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)