### PR TITLE
fix: add userId columns to database schema

### DIFF
--- a/__tests__/api/draft.test.ts
+++ b/__tests__/api/draft.test.ts
@@ -337,6 +337,7 @@ async function simulateDraftAPI(
           }) => ({
             exerciseId: set.exerciseId,
             completionId: draftCompletion.id,
+            userId,
             setNumber: set.setNumber,
             reps: set.reps,
             weight: set.weight,

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -120,6 +120,7 @@ export async function POST(
         data: loggedSets.map((set) => ({
           exerciseId: set.exerciseId,
           completionId: completionRecord.id,
+          userId: user.id,
           setNumber: set.setNumber,
           reps: set.reps,
           weight: set.weight,

--- a/app/api/workouts/[workoutId]/draft/route.ts
+++ b/app/api/workouts/[workoutId]/draft/route.ts
@@ -154,6 +154,7 @@ export async function POST(
           data: loggedSets.map((set) => ({
             exerciseId: set.exerciseId,
             completionId: draftCompletion.id,
+            userId: user.id,
             setNumber: set.setNumber,
             reps: set.reps,
             weight: set.weight,

--- a/lib/test/factories.ts
+++ b/lib/test/factories.ts
@@ -39,12 +39,12 @@ export async function createTestUser(): Promise<TestUser> {
 }
 
 export async function createTestExerciseDefinition(
-  prisma: PrismaClient, 
+  prisma: PrismaClient,
   overrides: Partial<{ name: string; aliases: string[] }> = {}
 ): Promise<TestExerciseDefinition> {
   const name = overrides.name || 'Barbell Bench Press'
   const normalizedName = name.toLowerCase().replace(/[^a-z0-9]/g, '')
-  
+
   const exerciseDefinition = await prisma.exerciseDefinition.create({
     data: {
       name,
@@ -52,10 +52,11 @@ export async function createTestExerciseDefinition(
       aliases: overrides.aliases || ['bench press', 'bench'],
       category: 'chest',
       isSystem: true,
-      createdBy: null
+      createdBy: null,
+      userId: '00000000-0000-0000-0000-000000000000' // System exercises use special UUID
     }
   })
-  
+
   return {
     id: exerciseDefinition.id,
     name: exerciseDefinition.name,
@@ -179,15 +180,17 @@ export async function createTestLoggedSets(
   prisma: PrismaClient,
   completionId: string,
   exerciseId: string,
+  userId: string,
   setCount: number = 3
 ) {
   const loggedSets = []
-  
+
   for (let i = 1; i <= setCount; i++) {
     const loggedSet = await prisma.loggedSet.create({
       data: {
         completionId,
         exerciseId,
+        userId,
         setNumber: i,
         reps: 10,
         weight: 135.0,
@@ -198,7 +201,7 @@ export async function createTestLoggedSets(
     })
     loggedSets.push(loggedSet)
   }
-  
+
   return loggedSets
 }
 
@@ -260,9 +263,10 @@ export async function createCompleteTestScenario(
     prisma,
     completion.id,
     exercise.id,
+    userId,
     loggedSetCount
   )
-  
+
   return {
     program,
     workout,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Empty Turbopack config to silence webpack config warning
+  // Turbopack automatically handles Node.js module exclusions in browser builds
+  turbopack: {},
+  // Keep webpack config for backward compatibility when using --webpack flag
+  webpack: (config) => {
+    // Add fallbacks for Node.js modules not available in browser
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      path: false,
+      crypto: false,
+    };
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/prisma/migrations/add_userid_to_exercisedefinition.sql
+++ b/prisma/migrations/add_userid_to_exercisedefinition.sql
@@ -1,0 +1,30 @@
+-- Migration: Add userId to ExerciseDefinition for PowerSync support
+-- Date: 2026-01-17
+-- System exercises will use a special system user ID: 00000000-0000-0000-0000-000000000000
+
+-- Step 1: Add userId column (nullable initially)
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "userId" TEXT;
+
+-- Step 2: Backfill system exercises with the special system user ID
+UPDATE "ExerciseDefinition"
+SET "userId" = '00000000-0000-0000-0000-000000000000'
+WHERE "isSystem" = true;
+
+-- Step 3: Backfill user-created exercises with their actual creator ID
+UPDATE "ExerciseDefinition"
+SET "userId" = "createdBy"
+WHERE "isSystem" = false AND "createdBy" IS NOT NULL;
+
+-- Step 4: Make userId NOT NULL
+ALTER TABLE "ExerciseDefinition" ALTER COLUMN "userId" SET NOT NULL;
+
+-- Step 5: Add index for efficient queries
+CREATE INDEX "ExerciseDefinition_userId_idx" ON "ExerciseDefinition"("userId");
+
+-- Verify the migration
+SELECT
+  "isSystem",
+  COUNT(*) as count,
+  COUNT(DISTINCT "userId") as distinct_users
+FROM "ExerciseDefinition"
+GROUP BY "isSystem";

--- a/prisma/migrations/add_userid_to_loggedset.sql
+++ b/prisma/migrations/add_userid_to_loggedset.sql
@@ -1,0 +1,23 @@
+-- Migration: Add userId to LoggedSet for PowerSync support
+-- Date: 2026-01-17
+-- Reason: PowerSync requires single-table queries without JOINs
+-- LoggedSet needs userId denormalized from WorkoutCompletion.userId
+
+-- Step 1: Add userId column (nullable initially)
+ALTER TABLE "LoggedSet" ADD COLUMN "userId" TEXT;
+
+-- Step 2: Backfill existing rows with userId from WorkoutCompletion
+UPDATE "LoggedSet" ls
+SET "userId" = wc."userId"
+FROM "WorkoutCompletion" wc
+WHERE ls."completionId" = wc.id;
+
+-- Step 3: Make userId NOT NULL now that all rows are backfilled
+ALTER TABLE "LoggedSet" ALTER COLUMN "userId" SET NOT NULL;
+
+-- Step 4: Add index for efficient queries
+CREATE INDEX "LoggedSet_userId_idx" ON "LoggedSet"("userId");
+
+-- Verify the migration
+SELECT COUNT(*) as total_logged_sets, COUNT("userId") as sets_with_userid
+FROM "LoggedSet";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model ExerciseDefinition {
   instructions   String?  // Setup and execution notes
   isSystem       Boolean  @default(false) // System vs user-created
   createdBy      String?  // User ID (null for system exercises)
+  userId         String   // System exercises: 00000000-0000-0000-0000-000000000000, User exercises: actual userId (for PowerSync)
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
@@ -86,6 +87,7 @@ model ExerciseDefinition {
   @@index([isSystem])
   @@index([createdBy])
   @@index([primaryFAUs])
+  @@index([userId])
 }
 
 model Exercise {
@@ -151,10 +153,12 @@ model LoggedSet {
   exercise     Exercise          @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
   completionId String
   completion   WorkoutCompletion @relation(fields: [completionId], references: [id], onDelete: Cascade)
+  userId       String            // Denormalized from WorkoutCompletion for PowerSync/RLS
   createdAt    DateTime          @default(now())
 
   @@index([exerciseId])
   @@index([completionId])
+  @@index([userId])
 }
 
 // ============================================

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -143,7 +143,8 @@ async function seedExerciseDefinitions() {
         aliases: ex.aliases,
         category: ex.category,
         isSystem: true,
-        createdBy: null
+        createdBy: null,
+        userId: '00000000-0000-0000-0000-000000000000' // System exercises use special UUID
       },
       update: {
         aliases: ex.aliases,


### PR DESCRIPTION
## Summary

Adds `userId` columns to `LoggedSet` and `ExerciseDefinition` tables for proper data isolation and future RLS policies.

## Changes

### Database Schema
- Add `userId` to `LoggedSet` table (denormalized from `WorkoutCompletion`)
- Add `userId` to `ExerciseDefinition` table (system exercises: `00000000-0000-0000-0000-000000000000`, user exercises: creator ID)
- Migration files included to add columns and backfill existing data

### API Updates
- Complete route: Add `userId` when creating LoggedSets
- Draft route: Add `userId` when creating LoggedSets
- Seed data: Add userId for system exercises
- Test factories: Include userId in test data

### Config
- Add Turbopack config for Next.js 16 build compatibility

## Migration Notes

**Safe to deploy** - Migrations include:
1. Add column as nullable
2. Backfill from existing data
3. Make column NOT NULL
4. Add index

No data loss, no downtime required.

## Context

These schema changes improve data organization and prepare for future RLS policies. Originally developed for PowerSync integration but useful standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)