### PR TITLE
feat: prefetch training and cardio pages for faster navigation

### DIFF
--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -73,6 +73,24 @@ export default function ConsolidatedProgramsView({
     }
   }, [searchParams])
 
+  // Prefetch likely next pages for faster navigation
+  useEffect(() => {
+    // Prefetch main training/cardio pages
+    router.prefetch('/training')
+    router.prefetch('/cardio')
+
+    // Prefetch active program pages for even faster access
+    const activeStrengthProgram = strengthPrograms.find(p => p.isActive)
+    const activeCardioProgram = cardioPrograms.find(p => p.isActive)
+
+    if (activeStrengthProgram) {
+      router.prefetch(`/programs/${activeStrengthProgram.id}`)
+    }
+    if (activeCardioProgram) {
+      router.prefetch(`/cardio/programs/${activeCardioProgram.id}`)
+    }
+  }, [router, strengthPrograms, cardioPrograms])
+
   const handleTabChange = (tab: 'strength' | 'cardio') => {
     setActiveTab(tab)
     router.push(`/programs?tab=${tab}`, { scroll: false })


### PR DESCRIPTION
## Summary
Adds prefetching for `/training` and `/cardio` pages when `/programs` loads to improve perceived navigation speed.

## Changes
- Added prefetch logic to `ConsolidatedProgramsView` component
- Preloads `/training` and `/cardio` pages in background
- Also prefetches active strength and cardio program pages if they exist

## Performance Impact
When users land on `/programs`, the app now preloads likely next navigation targets in the background. This should make navigation feel nearly instant, especially helpful given the Supabase latency.

## How It Works
- Uses Next.js router's built-in `prefetch()` method
- Runs on component mount via `useEffect`
- Non-blocking, happens in background
- Pages are cached and ready when user clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)