### PR TITLE
feat: add skeleton loading screens for main pages

### DIFF
--- a/app/(app)/cardio/loading.tsx
+++ b/app/(app)/cardio/loading.tsx
@@ -1,0 +1,80 @@
+export default function CardioLoading() {
+  return (
+    <div className="min-h-screen bg-background px-6 py-4">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header skeleton */}
+        <div className="flex justify-between items-start">
+          <div className="space-y-2">
+            <div className="h-10 bg-muted animate-pulse rounded w-72" />
+            <div className="h-5 bg-muted animate-pulse rounded w-96" />
+          </div>
+          <div className="flex gap-2">
+            <div className="h-10 w-32 bg-muted animate-pulse rounded" />
+            <div className="h-10 w-32 bg-muted animate-pulse rounded" />
+          </div>
+        </div>
+
+        {/* Current Week Card skeleton */}
+        <div className="bg-card border border-border rounded-lg p-6 space-y-4">
+          {/* Week header */}
+          <div className="flex justify-between items-center">
+            <div className="h-7 bg-muted animate-pulse rounded w-48" />
+            <div className="h-9 w-32 bg-muted animate-pulse rounded" />
+          </div>
+
+          {/* Sessions grid */}
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="bg-background border border-border rounded-lg p-4 space-y-3"
+              >
+                <div className="h-6 bg-muted animate-pulse rounded w-3/4" />
+                <div className="h-4 bg-muted animate-pulse rounded w-1/2" />
+                <div className="h-4 bg-muted animate-pulse rounded w-2/3" />
+                <div className="h-10 bg-muted animate-pulse rounded w-full mt-4" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Session History skeleton */}
+        <div className="space-y-4">
+          <div className="h-8 bg-muted animate-pulse rounded w-56" />
+
+          {/* History items */}
+          <div className="space-y-3">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-lg p-4 space-y-3"
+              >
+                {/* Date and type */}
+                <div className="flex justify-between items-start">
+                  <div className="space-y-2">
+                    <div className="h-5 bg-muted animate-pulse rounded w-32" />
+                    <div className="h-6 bg-muted animate-pulse rounded w-48" />
+                  </div>
+                  <div className="h-6 w-20 bg-muted animate-pulse rounded" />
+                </div>
+
+                {/* Session details */}
+                <div className="space-y-2">
+                  <div className="h-4 bg-muted animate-pulse rounded w-full" />
+                  <div className="h-4 bg-muted animate-pulse rounded w-3/4" />
+                </div>
+
+                {/* Metrics */}
+                <div className="flex gap-4 pt-2">
+                  <div className="h-4 bg-muted animate-pulse rounded w-24" />
+                  <div className="h-4 bg-muted animate-pulse rounded w-24" />
+                  <div className="h-4 bg-muted animate-pulse rounded w-24" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/programs/loading.tsx
+++ b/app/(app)/programs/loading.tsx
@@ -1,0 +1,66 @@
+export default function ProgramsLoading() {
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header skeleton */}
+        <div className="flex justify-between items-start">
+          <div className="space-y-2">
+            <div className="h-10 bg-muted animate-pulse rounded w-64" />
+            <div className="h-5 bg-muted animate-pulse rounded w-96" />
+          </div>
+          <div className="flex gap-3">
+            <div className="h-12 w-32 bg-muted animate-pulse rounded" />
+            <div className="h-12 w-32 bg-muted animate-pulse rounded" />
+          </div>
+        </div>
+
+        {/* Tabs skeleton */}
+        <div className="flex gap-2 border-b border-border">
+          <div className="h-10 w-32 bg-muted animate-pulse rounded-t" />
+          <div className="h-10 w-32 bg-muted animate-pulse rounded-t" />
+        </div>
+
+        {/* Programs grid skeleton */}
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="bg-card border border-border rounded-lg p-6 space-y-4"
+            >
+              {/* Program title */}
+              <div className="h-7 bg-muted animate-pulse rounded w-3/4" />
+
+              {/* Stats */}
+              <div className="space-y-2">
+                <div className="h-4 bg-muted animate-pulse rounded w-1/2" />
+                <div className="h-4 bg-muted animate-pulse rounded w-2/3" />
+              </div>
+
+              {/* Buttons */}
+              <div className="flex gap-2 pt-4">
+                <div className="h-10 bg-muted animate-pulse rounded flex-1" />
+                <div className="h-10 w-10 bg-muted animate-pulse rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Archived section skeleton */}
+        <div className="pt-8 space-y-4">
+          <div className="h-8 bg-muted animate-pulse rounded w-48" />
+          <div className="space-y-3">
+            {[1, 2].map((i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-lg p-4 flex justify-between items-center"
+              >
+                <div className="h-5 bg-muted animate-pulse rounded w-48" />
+                <div className="h-9 w-24 bg-muted animate-pulse rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/training/loading.tsx
+++ b/app/(app)/training/loading.tsx
@@ -1,0 +1,70 @@
+export default function TrainingLoading() {
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header skeleton */}
+        <div className="flex justify-between items-start">
+          <div className="space-y-2">
+            <div className="h-10 bg-muted animate-pulse rounded w-80" />
+            <div className="h-5 bg-muted animate-pulse rounded w-96" />
+          </div>
+          <div className="h-12 w-36 bg-muted animate-pulse rounded" />
+        </div>
+
+        {/* Current Week Card skeleton */}
+        <div className="bg-card border border-border rounded-lg p-6 space-y-4">
+          {/* Week header */}
+          <div className="flex justify-between items-center">
+            <div className="h-7 bg-muted animate-pulse rounded w-48" />
+            <div className="h-9 w-32 bg-muted animate-pulse rounded" />
+          </div>
+
+          {/* Workouts grid */}
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="bg-background border border-border rounded-lg p-4 space-y-3"
+              >
+                <div className="h-6 bg-muted animate-pulse rounded w-3/4" />
+                <div className="h-4 bg-muted animate-pulse rounded w-1/2" />
+                <div className="h-10 bg-muted animate-pulse rounded w-full mt-4" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Workout History skeleton */}
+        <div className="space-y-4">
+          <div className="h-8 bg-muted animate-pulse rounded w-56" />
+
+          {/* History items */}
+          <div className="space-y-3">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-lg p-4 space-y-3"
+              >
+                {/* Date and status */}
+                <div className="flex justify-between items-start">
+                  <div className="space-y-2">
+                    <div className="h-5 bg-muted animate-pulse rounded w-32" />
+                    <div className="h-6 bg-muted animate-pulse rounded w-48" />
+                  </div>
+                  <div className="h-6 w-24 bg-muted animate-pulse rounded" />
+                </div>
+
+                {/* Exercise list */}
+                <div className="space-y-2">
+                  <div className="h-4 bg-muted animate-pulse rounded w-full" />
+                  <div className="h-4 bg-muted animate-pulse rounded w-5/6" />
+                  <div className="h-4 bg-muted animate-pulse rounded w-4/5" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds Next.js `loading.tsx` files for programs, training, and cardio pages
- Provides immediate visual feedback with skeleton screens during data loading
- Uses theme-aware CSS variables (`bg-muted`, `bg-card`, etc.) for consistency across themes
- Skeletons match actual page layouts for smooth transitions

## Changes
**Programs page skeleton:** Header + program cards grid + archived section
**Training page skeleton:** Header + current week card + workout history list
**Cardio page skeleton:** Header + current week card + session history list

All skeletons use Tailwind's `animate-pulse` for loading animation.

## Test plan
- [x] Navigate to `/programs` and verify skeleton shows before content loads
- [x] Navigate to `/training` and verify skeleton shows before content loads
- [x] Navigate to `/cardio` and verify skeleton shows before content loads
- [x] Verify skeletons adapt to different themes (DOOM, CYBER, FOREST, etc.)
- [x] Test on mobile network to see longer loading states
- [x] Verify smooth transition from skeleton to actual content

## Benefits
- Improves perceived performance on mobile
- Eliminates blank white screen during loading
- Shows expected page structure immediately
- Better UX on slower connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)