### PR TITLE
Fix: iOS PWA safe area padding

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header({ userEmail }: Props) {
 
   return (
     <>
-      <nav className="bg-card border-b border-border">
+      <nav className="bg-card border-b border-border" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             {/* Left: Logo + Nav Links */}
@@ -122,7 +122,8 @@ export default function Header({ userEmail }: Props) {
         `}
         style={{
           maxHeight: isMenuOpen ? '80vh' : '0',
-          overflow: isMenuOpen ? 'visible' : 'hidden'
+          overflow: isMenuOpen ? 'visible' : 'hidden',
+          paddingBottom: 'env(safe-area-inset-bottom)'
         }}
       >
         <div className="p-6 space-y-6 doom-noise">


### PR DESCRIPTION
## Summary

Fixes header content being hidden under the iPhone notch/status bar in PWA mode.

## Issue

When running as a PWA on iPhone, the header content was overlapping with the notch/camera cutout and status bar, making the top of the app unusable.

## Root Cause

The viewport is set to `viewportFit: "cover"` in `app/layout.tsx` which allows content to extend into the notch area, but the Header component didn't have safe area padding.

## Fix

Added CSS environment variables for safe area insets:
- `paddingTop: 'env(safe-area-inset-top)'` to Header nav element
- `paddingBottom: 'env(safe-area-inset-bottom)'` to mobile menu bottom sheet

These automatically apply the correct padding based on device safe areas (0 on devices without notches).

## Testing

- [x] Type check passes
- [x] Header sits below notch on iPhone PWA
- [x] No visual changes on non-notched devices
- [x] Mobile menu doesn't overlap with home indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)