### PR TITLE
Fix: Add safe area padding to all modals

### DIFF
--- a/components/ui/radix/dialog.tsx
+++ b/components/ui/radix/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
       style={!fullScreenMobile ? { position: 'fixed', left: '50%', top: '50%', transform: 'translate(-50%, -50%)' } : undefined}
       className={`z-[70] bg-card border border-border rounded-xl shadow-xl overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ${
         fullScreenMobile
-          ? 'fixed inset-0 h-[100dvh] sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] pb-[env(safe-area-inset-bottom)]'
+          ? 'fixed inset-0 h-[100dvh] sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]'
           : position === 'bottom'
           ? 'w-full h-full sm:h-auto sm:max-h-[90vh] sm:max-w-2xl'
           : 'w-[90vw] max-w-lg max-h-[90vh]'

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -23,7 +23,10 @@ export default function ExerciseLoggingHeader({
   onSyncClick,
 }: ExerciseLoggingHeaderProps) {
   return (
-    <div className="bg-primary text-white px-4 py-3 border-b border-primary-muted-dark flex-shrink-0 sm:rounded-t-2xl">
+    <div
+      className="bg-primary text-white px-4 py-3 border-b border-primary-muted-dark flex-shrink-0 sm:rounded-t-2xl"
+      style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.75rem)' }}
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="text-sm text-primary-foreground opacity-80">
           Exercise {currentExerciseIndex + 1} of {totalExercises} • {totalLoggedSets}/


### PR DESCRIPTION
## Summary

Extends the iOS PWA safe area fix to include all modals (exercise logging modal and wizard modals).

## Issue

Following PR #101, the main app header was fixed, but modals (exercise logging, add/swap/edit/delete wizards) still had content overlapping with the iPhone notch/status bar.

## Fix

Added safe area padding to:
1. **ExerciseLoggingHeader** - `paddingTop: calc(env(safe-area-inset-top) + 0.75rem)` to push content below notch while maintaining spacing
2. **Dialog component (fullScreenMobile mode)** - `pt-[env(safe-area-inset-top)]` so all wizard modals respect safe area

## Testing

- [x] Type check passes
- [x] Exercise logging modal header sits below notch
- [x] All wizard modals (Add/Swap/Edit/Delete) sit below notch
- [x] No visual changes on non-notched devices
- [x] Maintains existing spacing and layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)