### PR TITLE
fix: order exercises by order field in program editor

### DIFF
--- a/app/(app)/programs/[id]/edit/page.tsx
+++ b/app/(app)/programs/[id]/edit/page.tsx
@@ -67,7 +67,8 @@ export default async function EditProgramPage({ params, searchParams }: Props) {
                   secondaryFAUs: true
                 }
               }
-            }
+            },
+            orderBy: { order: 'asc' }
           }
         },
         orderBy: { dayNumber: 'asc' }


### PR DESCRIPTION
## Summary
- Added missing `orderBy: { order: 'asc' }` to the exercises query in the program editor page
- Exercises now display in the correct user-defined order from drag-and-drop reordering

## Test plan
- [x] Open the program editor for a program with reordered exercises
- [x] Verify exercises appear in the correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)