### PR TITLE
feat: Add Supabase local development setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,15 +26,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # ALWAYS use Doppler for environment variables
 doppler run -- [command]
 
-# Development server
+# Start all services (recommended)
+overmind start                                # Starts Supabase, PubSub emulator, worker, Next.js
+
+# Development server (if running services individually)
 doppler run -- npm run dev
+
+# Supabase local development
+supabase start                                # Start local Supabase stack
+supabase stop                                 # Stop local Supabase stack
+supabase status                               # Check status and connection details
+supabase status -o env                        # Export connection details as env vars
+supabase db pull                              # Pull schema from linked production project
 
 # Database operations
 doppler run -- npx prisma studio              # Database GUI
-doppler run -- npx prisma migrate dev         # Create migration (for features)
-doppler run -- npx prisma db push             # Prototype only (no migration files)
 doppler run -- npx prisma generate            # Generate Prisma client
-doppler run -- npx prisma migrate deploy      # Apply migrations (production)
+supabase db reset                             # Reset local DB (runs migrations + seeds)
 
 # Testing
 doppler run -- npm test
@@ -44,10 +52,54 @@ doppler run -- npm run lint
 
 ### Database Migration Strategy
 
-- **Prototyping**: `npx prisma db push` (experimenting, no migration files)
-- **Features**: `npx prisma migrate dev --name feature_name` (creates migration files)
-- **Production**: ONLY deploy via migration files, never `db push`
-- **Always commit migration files** with schema changes
+We use **Prisma + Supabase CLI** for schema management. See `/docs/DATABASE_MIGRATIONS.md` for complete workflow.
+
+**Quick Reference:**
+
+```bash
+# 1. Update prisma/schema.prisma with your changes
+
+# 2. Create new migration file
+supabase migration new describe_your_change
+
+# 3. Generate SQL diff
+doppler run -- npx prisma migrate diff \
+  --from-url "$DATABASE_URL" \
+  --to-schema-datamodel ./prisma/schema.prisma \
+  --script > supabase/migrations/[TIMESTAMP]_describe_your_change.sql
+
+# 4. Test locally
+supabase db reset
+
+# 5. Commit migration files
+git add prisma/schema.prisma supabase/migrations/[TIMESTAMP]_*.sql
+git commit -m "feat: describe your change"
+```
+
+**CRITICAL - Claude's Role in Migrations:**
+
+When the user asks Claude to make schema changes:
+
+1. ✅ **Claude CAN**:
+   - Update `prisma/schema.prisma`
+   - Create migration file with `supabase migration new`
+   - Generate SQL diff with `npx prisma migrate diff`
+   - Test locally with `supabase db reset`
+   - Commit migration files to git
+
+2. ❌ **Claude MUST NEVER**:
+   - Run `supabase db push` (pushes to production)
+   - Apply migrations directly to production
+   - Execute SQL in production environment
+   - Use `prisma migrate deploy` (production command)
+
+3. 🛑 **When Claude completes a migration**:
+   - Always end with: "Migration ready. **You must manually review and push to production** with `supabase db push`."
+   - Never proceed to production deployment automatically
+
+**Local Development**:
+- Prototyping: Edit schema → `supabase db reset` (no migration files needed for experiments)
+- Features: Follow the 5-step workflow above (creates versioned migration files)
 
 ## Project Structure
 
@@ -474,12 +526,14 @@ git commit -m "feat: add feature"
 ## Reference Documents
 
 ### Active Documentation
+- `/docs/DATABASE_MIGRATIONS.md` - **CRITICAL**: Database migration workflow with Prisma + Supabase CLI
 - `/docs/STYLING.md` - DOOM theme color system and styling guide
 - `/docs/features/CARDIO_DESIGN.md` - Cardio tracking system design
 - `/docs/features/EXERCISE_PERFORMANCE_TRACKING.md` - Exercise tracking features
 - `/docs/features/PROGRAM_MANAGEMENT_IMPROVEMENTS.md` - Program management enhancements
 - `/docs/features/PERFORMANCE_ANALYSIS.md` - Performance analysis and optimizations
 - `/docs/gcp/` - GCP Pub/Sub setup, clone worker architecture, and operations guides
+- `/WORKTREE_SETUP.md` - Multi-worktree setup with isolated Supabase instances
 
 ### Reference Material
 - `/NEW_PROJECT_REFERENCE.md` - Next.js + Supabase best practices (reference only, contains multi-tenant patterns we're NOT using)
@@ -492,6 +546,7 @@ git commit -m "feat: add feature"
 - RLS policies must be created for all user-owned tables
 - No emojis in code or commits unless explicitly requested
 - Keep solutions simple - avoid over-engineering
+- **Local development**: Uses Supabase CLI for local PostgreSQL + Auth stack (replaces raw psql). Run `overmind start` to launch all services, or `supabase start` individually. The `dev_personal` Doppler config points to local Supabase (postgres@127.0.0.1:54322)
 - **Prisma version**: Stay on v6.x (Supabase recommendation). Use `npx prisma@6.19.0` to avoid installing v7
 - **Prisma migrations**: If `migrate dev` fails with "permission denied to terminate process", use `db push` instead (Supabase pooler limitation)
 - For local testing, use the doppler config `dev_test`. Example: `doppler run --config dev_test -- npm run test` This will ensure that the proper Testcontainer with the test database is utilized.

--- a/Procfile
+++ b/Procfile
@@ -6,6 +6,7 @@
 # Run with: overmind start
 # Individual process control: overmind restart worker | overmind connect app
 
-emulator: ./scripts/start-pubsub-emulator.sh
-worker: sleep 5 && cd cloud-functions/clone-program && PORT=8082 doppler run --config dev_personal -- npm run dev
-app: doppler run --config dev_personal -- npm run dev
+supabase: supabase start && tail -f /dev/null
+emulator: sleep 3 && ./scripts/start-pubsub-emulator.sh
+worker: sleep 8 && cd cloud-functions/clone-program && PORT=8082 doppler run -- npm run dev
+app: sleep 5 && doppler run -- npm run dev

--- a/WORKTREE_SETUP.md
+++ b/WORKTREE_SETUP.md
@@ -4,19 +4,30 @@ When setting up a new git worktree, follow these steps:
 
 ## Quick Setup
 
+**Important**: Name your worktrees with `-wt2` or `-wt3` suffix (e.g., `fitcsv-wt2`, `fitcsv-feature-wt3`) to enable automatic detection.
+
 ```bash
-# 1. Copy Doppler token from original directory
-cd /Users/dustin/repos/fitcsv  # or your original directory
+# 1. Copy Doppler token from primary worktree
+cd /Users/dustin/repos/fitcsv  # primary worktree (wt1)
 doppler configure get token --plain
 
-# 2. In the new worktree, set the token
-cd /Users/dustin/repos/fitcsv-theming-work  # your new worktree
+# 2. Create and configure new worktree
+cd /Users/dustin/repos/fitcsv-wt2  # your new worktree
 doppler configure set token <TOKEN_FROM_STEP_1>
-doppler configure set project fitcsv
-doppler configure set config dev_personal
 
-# 3. Run the setup script
+# 3. Run Supabase worktree setup (configures ports and Doppler)
+./scripts/setup-worktree-supabase.sh
+
+# 4. Run standard setup (npm install, Prisma generate)
 ./scripts/setup-worktree.sh
+
+# 5. Start Supabase and get JWT keys
+supabase start
+supabase status -o env | grep -E '(ANON_KEY|SERVICE_ROLE_KEY)'
+
+# 6. Set JWT keys in Doppler (replace with actual values)
+doppler secrets set NEXT_PUBLIC_SUPABASE_ANON_KEY='<anon_key_from_above>'
+doppler secrets set SUPABASE_SERVICE_ROLE_KEY='<service_role_key_from_above>'
 ```
 
 ## What the Setup Script Does
@@ -26,11 +37,56 @@ doppler configure set config dev_personal
 3. Generates Prisma client for root
 4. Generates Prisma client for worker
 
+## Supabase Multi-Worktree Setup
+
+Each worktree runs its own isolated Supabase instance on unique ports to avoid conflicts:
+
+| Worktree | API Port | DB Port | Studio Port | Doppler Config |
+|----------|----------|---------|-------------|----------------|
+| wt1 (primary) | 54321 | 54322 | 54323 | `dev_personal_worktree1` |
+| wt2 | 54331 | 54332 | 54333 | `dev_personal_worktree2` |
+| wt3 | 54341 | 54342 | 54343 | `dev_personal_worktree3` |
+
+### How It Works
+
+1. **Port Isolation**: Each worktree's `supabase/config.toml` is configured with unique ports
+2. **Separate Databases**: Each Supabase instance has its own PostgreSQL database
+3. **Independent JWT Keys**: Each instance generates its own authentication keys
+4. **Doppler Configs**: Three configs store the appropriate URLs for each worktree
+
+### Setup Script
+
+The `setup-worktree-supabase.sh` script automatically:
+- Detects worktree number (1, 2, or 3) from directory name
+- Updates `supabase/config.toml` with correct ports
+- Configures Doppler to use the appropriate worktree config
+
+### Manual Setup (if auto-detection fails)
+
+```bash
+# Manually specify worktree number
+./scripts/setup-worktree-supabase.sh
+# Follow prompts to enter worktree number
+
+# Or populate Doppler config manually
+./scripts/populate-worktree-doppler.sh 2  # for worktree 2
+```
+
+### Starting Supabase
+
+The `Procfile` automatically starts Supabase when you run `overmind start`. Each worktree's Supabase will run on its configured ports.
+
+**Access your worktree's services**:
+- wt1: Studio at `http://127.0.0.1:54323`
+- wt2: Studio at `http://127.0.0.1:54333`
+- wt3: Studio at `http://127.0.0.1:54343`
+
 ## Requirements
 
 - **Doppler** configured with valid token (see above)
-- **Docker** running (for Pub/Sub emulator)
+- **Docker** running (for Pub/Sub emulator and Supabase)
 - **Node.js** v20+
+- **Supabase CLI** installed (`brew install supabase/tap/supabase`)
 
 ## Start Development
 
@@ -45,10 +101,13 @@ overmind start
 This means Doppler isn't providing `DATABASE_URL`. Verify:
 
 ```bash
-doppler secrets --config dev_personal --only-names
+doppler secrets --only-names
 ```
 
-Should show `DATABASE_URL` and other secrets. If not, recopy the token from the original directory.
+Should show `DATABASE_URL` and other secrets. If not:
+1. Verify Doppler config is set correctly: `doppler configure get config`
+2. Should show `dev_personal_worktree1`, `dev_personal_worktree2`, or `dev_personal_worktree3`
+3. If wrong, run `./scripts/setup-worktree-supabase.sh` again
 
 ### "command not found: next" or "command not found: tsx"
 
@@ -56,4 +115,35 @@ Run the setup script again:
 
 ```bash
 ./scripts/setup-worktree.sh
+```
+
+### Running Multiple Worktrees Simultaneously
+
+You can run up to 3 worktrees at the same time without port conflicts:
+
+```bash
+# In wt1 (primary)
+cd ~/repos/fitcsv
+overmind start
+
+# In wt2 (separate terminal)
+cd ~/repos/fitcsv-wt2
+overmind start
+
+# In wt3 (separate terminal)
+cd ~/repos/fitcsv-wt3
+overmind start
+```
+
+Each will have its own:
+- Next.js dev server (ports 3000, 3001, 3002 - you may need to update package.json dev script)
+- Supabase instance (isolated databases on different ports)
+- PubSub emulator (same emulator, different projects)
+- Clone worker (different ports: 8082, 8083, 8084)
+
+**Note**: Update your `package.json` dev script if running multiple Next.js instances:
+```json
+"dev": "next dev -p 3000"  // wt1
+"dev": "next dev -p 3001"  // wt2
+"dev": "next dev -p 3002"  // wt3
 ```

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -1,0 +1,230 @@
+# Database Migration Workflow
+
+This document describes how to manage database schema changes using Prisma + Supabase CLI.
+
+## Overview
+
+We use a hybrid approach:
+- **Prisma** as the source of truth for schema (ORM, type safety)
+- **Supabase migrations** for applying changes (local and production)
+
+## Local Development
+
+### Initial Setup (New Worktree)
+
+```bash
+# 1. Start Supabase
+supabase start
+
+# 2. Apply all migrations and seeds
+supabase db reset
+
+# 3. Generate Prisma client
+doppler run -- npx prisma generate
+```
+
+### Making Schema Changes
+
+**Step 1: Update Prisma Schema**
+
+Edit `prisma/schema.prisma` with your changes.
+
+**Step 2: Create Migration File**
+
+```bash
+# Create a new timestamped migration file
+supabase migration new describe_your_change
+
+# Example: supabase migration new add_exercise_categories
+# Creates: supabase/migrations/20260202123456_add_exercise_categories.sql
+```
+
+**Step 3: Generate Migration SQL**
+
+```bash
+# Generate SQL diff from current local DB to new Prisma schema
+doppler run -- npx prisma migrate diff \
+  --from-url "$DATABASE_URL" \
+  --to-schema-datamodel ./prisma/schema.prisma \
+  --script > supabase/migrations/[TIMESTAMP]_describe_your_change.sql
+
+# Replace [TIMESTAMP] with the actual timestamp from step 2
+```
+
+**Step 4: Test Locally**
+
+```bash
+# Apply the new migration to local Supabase
+supabase db reset
+
+# Verify it works
+doppler run -- npx prisma generate
+doppler run -- npm run dev
+```
+
+**Step 5: Commit Migration**
+
+```bash
+git add prisma/schema.prisma
+git add supabase/migrations/[TIMESTAMP]_describe_your_change.sql
+git commit -m "feat: add exercise categories"
+```
+
+## Production Deployment
+
+**IMPORTANT**: Production pushes should ONLY be done manually by the developer, never automated.
+
+### Option 1: Via Supabase CLI (Recommended)
+
+```bash
+# 1. Verify you're linked to production
+supabase link --project-ref [YOUR_PROJECT_REF]
+
+# 2. Review pending migrations
+supabase db diff
+
+# 3. Push to production
+supabase db push
+```
+
+### Option 2: Via Supabase Dashboard
+
+1. Go to Supabase Dashboard → SQL Editor
+2. Copy migration file contents from `supabase/migrations/[TIMESTAMP]_*.sql`
+3. Paste and execute
+4. Verify changes in Table Editor
+
+### Post-Deployment
+
+```bash
+# Update Prisma client in production (Vercel auto-deploys on git push)
+git push origin main
+```
+
+## Pulling Changes from Production
+
+If changes were made directly in production (via SQL Editor), pull them down:
+
+```bash
+# Pull schema changes from production and create a migration file
+supabase db remote commit
+
+# This creates a new migration file with the diff
+# Review the file, then commit it
+git add supabase/migrations/[NEW_TIMESTAMP]_*.sql
+git commit -m "chore: pull production schema changes"
+```
+
+## Troubleshooting
+
+### "Migration already applied"
+
+If you see errors about migrations already being applied:
+
+```bash
+# Check migration status
+supabase migration list
+
+# Repair if needed
+supabase migration repair [VERSION] --status applied
+```
+
+### "Relation already exists"
+
+This usually means you're trying to apply a migration that was already manually applied via SQL Editor.
+
+Options:
+1. **Skip it**: Mark migration as applied without running it
+   ```bash
+   supabase migration repair [VERSION] --status applied
+   ```
+
+2. **Remove it**: Delete the redundant migration file and regenerate from current state
+
+### Seed Data Missing After Reset
+
+Seeds are applied automatically during `supabase db reset`. If exercises are missing:
+
+```bash
+cd prisma/seeds
+./reseed_supabase_local.sh
+```
+
+## Best Practices
+
+### DO:
+- ✅ Always update `prisma/schema.prisma` first
+- ✅ Test migrations locally with `supabase db reset` before production
+- ✅ Commit migration files with schema changes
+- ✅ Use descriptive migration names
+- ✅ Review generated SQL before applying
+
+### DON'T:
+- ❌ Never manually edit production database without creating a migration
+- ❌ Don't skip migration files in sequence
+- ❌ Don't use `prisma db push` in production (only for local prototyping)
+- ❌ Don't apply migrations via SQL Editor without pulling them down with `supabase db remote commit`
+
+## Migration File Naming
+
+Supabase uses timestamp-based naming:
+
+```
+[TIMESTAMP]_[description].sql
+
+Examples:
+20260202123456_add_exercise_categories.sql
+20260202134512_create_workout_templates.sql
+```
+
+The timestamp ensures migrations are applied in order.
+
+## RLS Policies
+
+When creating new tables, always add RLS policies in the same migration:
+
+```sql
+-- Enable RLS
+ALTER TABLE "NewTable" ENABLE ROW LEVEL SECURITY;
+
+-- User can only access their own data
+CREATE POLICY "users_own_data" ON "NewTable"
+  FOR ALL USING (auth.uid() = "userId");
+```
+
+## Indexes
+
+For local development, omit `CONCURRENTLY`:
+
+```sql
+-- Local/Migration
+CREATE INDEX "table_column_idx" ON "Table"("column");
+
+-- Production (manual via SQL Editor)
+CREATE INDEX CONCURRENTLY "table_column_idx" ON "Table"("column");
+```
+
+`CONCURRENTLY` prevents table locking but can't run in transactions (migrations are transactional).
+
+## Emergency Rollback
+
+If a production migration fails:
+
+```bash
+# 1. Check migration status
+supabase migration list
+
+# 2. Revert to previous version (if possible)
+supabase db reset --version [PREVIOUS_VERSION]
+
+# 3. Fix the migration file locally
+# 4. Test with supabase db reset
+# 5. Push corrected version
+supabase db push
+```
+
+## References
+
+- [Supabase CLI Migrations](https://supabase.com/docs/guides/local-development)
+- [Prisma Migrate Diff](https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-diff)
+- Seed documentation: `prisma/seeds/README.md`

--- a/prisma/migrations/00_base_schema.sql
+++ b/prisma/migrations/00_base_schema.sql
@@ -1,0 +1,463 @@
+warn The configuration property `package.json#prisma` is deprecated and will be removed in Prisma 7. Please migrate to a Prisma config file (e.g., `prisma.config.ts`).
+For more information, see: https://pris.ly/prisma-config
+
+-- CreateTable
+CREATE TABLE "Program" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "isUserCreated" BOOLEAN NOT NULL DEFAULT false,
+    "programType" TEXT NOT NULL DEFAULT 'strength',
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" TIMESTAMP(3),
+    "copyStatus" TEXT DEFAULT 'ready',
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "Program_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Week" (
+    "id" TEXT NOT NULL,
+    "weekNumber" INTEGER NOT NULL,
+    "programId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Week_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Workout" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "dayNumber" INTEGER NOT NULL,
+    "weekId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Workout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ExerciseDefinition" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "aliases" TEXT[],
+    "category" TEXT,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "equipment" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "instructions" TEXT,
+    "primaryFAUs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "secondaryFAUs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ExerciseDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Exercise" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "exerciseDefinitionId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "exerciseGroup" TEXT,
+    "workoutId" TEXT,
+    "notes" TEXT,
+    "userId" TEXT NOT NULL,
+    "isOneOff" BOOLEAN NOT NULL DEFAULT false,
+    "workoutCompletionId" TEXT,
+
+    CONSTRAINT "Exercise_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PrescribedSet" (
+    "id" TEXT NOT NULL,
+    "setNumber" INTEGER NOT NULL,
+    "reps" TEXT NOT NULL,
+    "weight" TEXT,
+    "rpe" INTEGER,
+    "rir" INTEGER,
+    "exerciseId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "PrescribedSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkoutCompletion" (
+    "id" TEXT NOT NULL,
+    "workoutId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL,
+    "notes" TEXT,
+
+    CONSTRAINT "WorkoutCompletion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LoggedSet" (
+    "id" TEXT NOT NULL,
+    "setNumber" INTEGER NOT NULL,
+    "reps" INTEGER NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "weightUnit" TEXT NOT NULL DEFAULT 'lbs',
+    "rpe" INTEGER,
+    "rir" INTEGER,
+    "exerciseId" TEXT NOT NULL,
+    "completionId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "LoggedSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CardioProgram" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" TIMESTAMP(3),
+    "isUserCreated" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "copyStatus" TEXT DEFAULT 'ready',
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "CardioProgram_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CardioWeek" (
+    "id" TEXT NOT NULL,
+    "weekNumber" INTEGER NOT NULL,
+    "cardioProgramId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "CardioWeek_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PrescribedCardioSession" (
+    "id" TEXT NOT NULL,
+    "weekId" TEXT NOT NULL,
+    "dayNumber" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "targetDuration" INTEGER NOT NULL,
+    "intensityZone" TEXT,
+    "equipment" TEXT,
+    "targetHRRange" TEXT,
+    "targetPowerRange" TEXT,
+    "intervalStructure" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "PrescribedCardioSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LoggedCardioSession" (
+    "id" TEXT NOT NULL,
+    "prescribedSessionId" TEXT,
+    "userId" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'completed',
+    "name" TEXT NOT NULL,
+    "equipment" TEXT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "avgHR" INTEGER,
+    "peakHR" INTEGER,
+    "avgPower" INTEGER,
+    "peakPower" INTEGER,
+    "distance" DOUBLE PRECISION,
+    "elevationGain" INTEGER,
+    "elevationLoss" INTEGER,
+    "avgPace" TEXT,
+    "cadence" INTEGER,
+    "strokeRate" INTEGER,
+    "strokeCount" INTEGER,
+    "calories" INTEGER,
+    "intensityZone" TEXT,
+    "intervalStructure" TEXT,
+    "notes" TEXT,
+
+    CONSTRAINT "LoggedCardioSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserCardioMetricPreferences" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "equipment" TEXT NOT NULL,
+    "customMetrics" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserCardioMetricPreferences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "displayName" TEXT,
+    "defaultWeightUnit" TEXT NOT NULL DEFAULT 'lbs',
+    "defaultIntensityRating" TEXT NOT NULL DEFAULT 'rpe',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CommunityProgram" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "programType" TEXT NOT NULL DEFAULT 'strength',
+    "authorUserId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "originalProgramId" TEXT NOT NULL,
+    "programData" JSONB NOT NULL,
+    "weekCount" INTEGER NOT NULL,
+    "workoutCount" INTEGER NOT NULL,
+    "exerciseCount" INTEGER NOT NULL,
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "community_programs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isActive_idx" ON "Program"("userId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_idx" ON "Program"("userId");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isUserCreated_idx" ON "Program"("userId", "isUserCreated");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isArchived_idx" ON "Program"("userId", "isArchived");
+
+-- CreateIndex
+CREATE INDEX "Week_programId_idx" ON "Week"("programId");
+
+-- CreateIndex
+CREATE INDEX "Week_userId_idx" ON "Week"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Week_programId_weekNumber_key" ON "Week"("programId", "weekNumber");
+
+-- CreateIndex
+CREATE INDEX "Workout_weekId_idx" ON "Workout"("weekId");
+
+-- CreateIndex
+CREATE INDEX "Workout_userId_idx" ON "Workout"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workout_weekId_dayNumber_key" ON "Workout"("weekId", "dayNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExerciseDefinition_normalizedName_key" ON "ExerciseDefinition"("normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_normalizedName_idx" ON "ExerciseDefinition"("normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_isSystem_idx" ON "ExerciseDefinition"("isSystem");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_createdBy_idx" ON "ExerciseDefinition"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_primaryFAUs_idx" ON "ExerciseDefinition"("primaryFAUs");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_userId_idx" ON "ExerciseDefinition"("userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_workoutId_idx" ON "Exercise"("workoutId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_exerciseDefinitionId_idx" ON "Exercise"("exerciseDefinitionId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_userId_idx" ON "Exercise"("userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_exerciseDefinitionId_userId_idx" ON "Exercise"("exerciseDefinitionId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_workoutCompletionId_idx" ON "Exercise"("workoutCompletionId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedSet_exerciseId_idx" ON "PrescribedSet"("exerciseId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedSet_userId_idx" ON "PrescribedSet"("userId");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_workoutId_userId_idx" ON "WorkoutCompletion"("workoutId", "userId");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_userId_completedAt_idx" ON "WorkoutCompletion"("userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_userId_status_completedAt_idx" ON "WorkoutCompletion"("userId", "status", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_exerciseId_idx" ON "LoggedSet"("exerciseId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_completionId_idx" ON "LoggedSet"("completionId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_userId_idx" ON "LoggedSet"("userId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_completionId_exerciseId_idx" ON "LoggedSet"("completionId", "exerciseId");
+
+-- CreateIndex
+CREATE INDEX "CardioProgram_userId_isActive_idx" ON "CardioProgram"("userId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "CardioProgram_userId_isArchived_idx" ON "CardioProgram"("userId", "isArchived");
+
+-- CreateIndex
+CREATE INDEX "CardioWeek_cardioProgramId_idx" ON "CardioWeek"("cardioProgramId");
+
+-- CreateIndex
+CREATE INDEX "CardioWeek_userId_idx" ON "CardioWeek"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CardioWeek_cardioProgramId_weekNumber_key" ON "CardioWeek"("cardioProgramId", "weekNumber");
+
+-- CreateIndex
+CREATE INDEX "PrescribedCardioSession_weekId_idx" ON "PrescribedCardioSession"("weekId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedCardioSession_userId_idx" ON "PrescribedCardioSession"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrescribedCardioSession_weekId_dayNumber_key" ON "PrescribedCardioSession"("weekId", "dayNumber");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_prescribedSessionId_idx" ON "LoggedCardioSession"("prescribedSessionId");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_userId_completedAt_idx" ON "LoggedCardioSession"("userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_userId_status_completedAt_idx" ON "LoggedCardioSession"("userId", "status", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_prescribedSessionId_userId_completedAt_idx" ON "LoggedCardioSession"("prescribedSessionId", "userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "UserCardioMetricPreferences_userId_idx" ON "UserCardioMetricPreferences"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserCardioMetricPreferences_userId_equipment_key" ON "UserCardioMetricPreferences"("userId", "equipment");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSettings_userId_key" ON "UserSettings"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserSettings_userId_idx" ON "UserSettings"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "community_programs_original_program_id_key" ON "CommunityProgram"("originalProgramId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_programType_idx" ON "CommunityProgram"("programType");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_publishedAt_idx" ON "CommunityProgram"("publishedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_authorUserId_idx" ON "CommunityProgram"("authorUserId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_originalProgramId_idx" ON "CommunityProgram"("originalProgramId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_level_idx" ON "CommunityProgram"("level");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_goals_idx" ON "CommunityProgram" USING GIN ("goals");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_equipmentNeeded_idx" ON "CommunityProgram" USING GIN ("equipmentNeeded");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_programType_publishedAt_idx" ON "CommunityProgram"("programType", "publishedAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "Week" ADD CONSTRAINT "Week_programId_fkey" FOREIGN KEY ("programId") REFERENCES "Program"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_weekId_fkey" FOREIGN KEY ("weekId") REFERENCES "Week"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_exerciseDefinitionId_fkey" FOREIGN KEY ("exerciseDefinitionId") REFERENCES "ExerciseDefinition"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_workoutCompletionId_fkey" FOREIGN KEY ("workoutCompletionId") REFERENCES "WorkoutCompletion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_workoutId_fkey" FOREIGN KEY ("workoutId") REFERENCES "Workout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrescribedSet" ADD CONSTRAINT "PrescribedSet_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutCompletion" ADD CONSTRAINT "WorkoutCompletion_workoutId_fkey" FOREIGN KEY ("workoutId") REFERENCES "Workout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedSet" ADD CONSTRAINT "LoggedSet_completionId_fkey" FOREIGN KEY ("completionId") REFERENCES "WorkoutCompletion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedSet" ADD CONSTRAINT "LoggedSet_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CardioWeek" ADD CONSTRAINT "CardioWeek_cardioProgramId_fkey" FOREIGN KEY ("cardioProgramId") REFERENCES "CardioProgram"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrescribedCardioSession" ADD CONSTRAINT "PrescribedCardioSession_weekId_fkey" FOREIGN KEY ("weekId") REFERENCES "CardioWeek"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedCardioSession" ADD CONSTRAINT "LoggedCardioSession_prescribedSessionId_fkey" FOREIGN KEY ("prescribedSessionId") REFERENCES "PrescribedCardioSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/seeds/README.md
+++ b/prisma/seeds/README.md
@@ -25,7 +25,22 @@ These files provide **~257 total exercises** including legacy exercises and comp
 
 **CRITICAL:** Legacy exercises MUST be seeded FIRST to preserve their CUID IDs for existing programs.
 
-### Option 1: All at Once (Recommended)
+### Option 1: Automated Script (Recommended for Local Supabase)
+
+For local Supabase development with Doppler:
+
+```bash
+cd prisma/seeds
+./reseed_supabase_local.sh
+```
+
+This script:
+- Reads DATABASE_URL from Doppler automatically
+- Clears existing data
+- Seeds all 257 exercises in correct order
+- Verifies counts
+
+### Option 2: Manual SQL Files
 
 Run all files sequentially in Supabase SQL Editor:
 

--- a/prisma/seeds/reseed_supabase_local.sh
+++ b/prisma/seeds/reseed_supabase_local.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Reseed Local Supabase Database Script
+# This script clears and reseeds exercises in your local Supabase database
+
+set -e  # Exit on error
+
+echo "=========================================="
+echo "Reseed Local Supabase Database"
+echo "=========================================="
+echo ""
+echo "WARNING: This will DELETE all programs and exercises from your local database!"
+echo ""
+
+# Get DATABASE_URL from Doppler
+DB_URL=$(doppler secrets get DATABASE_URL --plain)
+
+if [ -z "$DB_URL" ]; then
+  echo "ERROR: DATABASE_URL not found in Doppler config"
+  echo "Make sure Doppler is configured correctly"
+  exit 1
+fi
+
+echo "Database: $DB_URL"
+echo "Press Ctrl+C to cancel, or Enter to continue..."
+read
+
+echo ""
+echo "Step 1/9: Clearing existing data..."
+psql "$DB_URL" -f clear_local_database.sql
+
+echo ""
+echo "Step 2/9: Seeding legacy exercises (27 exercises)..."
+psql "$DB_URL" -f 00_legacy_exercises.sql
+
+echo ""
+echo "Step 3/9: Seeding bodyweight exercises (42 exercises)..."
+psql "$DB_URL" -f 01_bodyweight_exercises.sql
+
+echo ""
+echo "Step 4/9: Seeding dumbbell exercises (50 exercises)..."
+psql "$DB_URL" -f 02_dumbbell_exercises.sql
+
+echo ""
+echo "Step 5/9: Seeding resistance band exercises (32 exercises)..."
+psql "$DB_URL" -f 03_resistance_band_exercises.sql
+
+echo ""
+echo "Step 6/9: Seeding kettlebell exercises (27 exercises)..."
+psql "$DB_URL" -f 04_kettlebell_exercises.sql
+
+echo ""
+echo "Step 7/9: Seeding climbing exercises (21 exercises)..."
+psql "$DB_URL" -f 05_climbing_exercises.sql
+
+echo ""
+echo "Step 8/9: Seeding cable/machine exercises (34 exercises)..."
+psql "$DB_URL" -f 06_cable_machine_exercises.sql
+
+echo ""
+echo "Step 9/9: Seeding core/mobility exercises (24 exercises)..."
+psql "$DB_URL" -f 07_core_mobility_exercises.sql
+
+echo ""
+echo "=========================================="
+echo "Verification"
+echo "=========================================="
+psql "$DB_URL" -c "SELECT COUNT(*) as total_system_exercises FROM \"ExerciseDefinition\" WHERE \"isSystem\" = true;"
+psql "$DB_URL" -c "SELECT COUNT(*) as legacy_exercises FROM \"ExerciseDefinition\" WHERE \"isSystem\" = true AND id NOT LIKE 'ex_%' AND id NOT LIKE 'exdef_%';"
+
+echo ""
+echo "=========================================="
+echo "Done!"
+echo "Expected: 257 total exercises (27 legacy)"
+echo "=========================================="

--- a/scripts/populate-worktree-doppler.sh
+++ b/scripts/populate-worktree-doppler.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+if [ -z "$1" ]; then
+  echo -e "${RED}Usage: $0 <worktree_number>${NC}"
+  echo "Example: $0 1"
+  exit 1
+fi
+
+WORKTREE_NUM=$1
+DOPPLER_CONFIG="dev_personal_worktree$WORKTREE_NUM"
+
+# Port configuration
+case $WORKTREE_NUM in
+  1)
+    API_PORT=54321
+    DB_PORT=54322
+    ;;
+  2)
+    API_PORT=54331
+    DB_PORT=54332
+    ;;
+  3)
+    API_PORT=54341
+    DB_PORT=54342
+    ;;
+  *)
+    echo -e "${RED}Invalid worktree number. Must be 1, 2, or 3${NC}"
+    exit 1
+    ;;
+esac
+
+echo -e "${GREEN}=== Populating Doppler Config: $DOPPLER_CONFIG ===${NC}\n"
+
+# Get shared secrets from dev_personal (GCP, etc.)
+echo -e "${YELLOW}Copying shared secrets from dev_personal...${NC}"
+
+GCP_PROJECT_ID=$(doppler secrets get GCP_PROJECT_ID --config dev_personal --plain 2>/dev/null)
+GCP_SERVICE_ACCOUNT_KEY=$(doppler secrets get GCP_SERVICE_ACCOUNT_KEY --config dev_personal --plain 2>/dev/null)
+PUBSUB_EMULATOR_HOST=$(doppler secrets get PUBSUB_EMULATOR_HOST --config dev_personal --plain 2>/dev/null)
+
+# Set shared secrets
+doppler secrets set GCP_PROJECT_ID="$GCP_PROJECT_ID" --config "$DOPPLER_CONFIG"
+doppler secrets set GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" --config "$DOPPLER_CONFIG"
+doppler secrets set PUBSUB_EMULATOR_HOST="$PUBSUB_EMULATOR_HOST" --config "$DOPPLER_CONFIG"
+
+echo -e "${GREEN}✓ Shared secrets copied${NC}"
+
+# Set Supabase connection URLs (ports vary per worktree)
+echo -e "\n${YELLOW}Setting Supabase connection URLs for worktree $WORKTREE_NUM...${NC}"
+
+doppler secrets set DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:$DB_PORT/postgres" --config "$DOPPLER_CONFIG"
+doppler secrets set DIRECT_URL="postgresql://postgres:postgres@127.0.0.1:$DB_PORT/postgres" --config "$DOPPLER_CONFIG"
+doppler secrets set NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:$API_PORT" --config "$DOPPLER_CONFIG"
+
+echo -e "${GREEN}✓ Supabase URLs configured${NC}"
+
+# Placeholder for JWT keys (must be set after starting Supabase)
+echo -e "\n${YELLOW}⚠ JWT keys must be set manually after starting Supabase:${NC}"
+echo -e "1. Start Supabase: ${YELLOW}supabase start${NC}"
+echo -e "2. Get keys: ${YELLOW}supabase status -o env | grep -E '(ANON_KEY|SERVICE_ROLE_KEY)'${NC}"
+echo -e "3. Set keys:"
+echo -e "   ${YELLOW}doppler secrets set NEXT_PUBLIC_SUPABASE_ANON_KEY='<anon_key>' --config $DOPPLER_CONFIG${NC}"
+echo -e "   ${YELLOW}doppler secrets set SUPABASE_SERVICE_ROLE_KEY='<service_role_key>' --config $DOPPLER_CONFIG${NC}"
+
+echo -e "\n${GREEN}✓ Base configuration complete for $DOPPLER_CONFIG${NC}"

--- a/scripts/setup-worktree-supabase.sh
+++ b/scripts/setup-worktree-supabase.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== Supabase Worktree Setup ===${NC}\n"
+
+# Detect worktree number by checking git worktree path
+REPO_PATH=$(git rev-parse --show-toplevel)
+REPO_NAME=$(basename "$REPO_PATH")
+
+# Determine worktree number
+if [[ "$REPO_NAME" == "fitcsv" ]]; then
+  WORKTREE_NUM=1
+  echo -e "${GREEN}Detected: Primary worktree (wt1)${NC}"
+elif [[ "$REPO_NAME" =~ fitcsv.*-wt2 ]] || [[ "$REPO_NAME" =~ fitcsv-2 ]]; then
+  WORKTREE_NUM=2
+  echo -e "${GREEN}Detected: Worktree 2 (wt2)${NC}"
+elif [[ "$REPO_NAME" =~ fitcsv.*-wt3 ]] || [[ "$REPO_NAME" =~ fitcsv-3 ]]; then
+  WORKTREE_NUM=3
+  echo -e "${GREEN}Detected: Worktree 3 (wt3)${NC}"
+else
+  echo -e "${YELLOW}Could not auto-detect worktree number from path: $REPO_PATH${NC}"
+  read -p "Enter worktree number (1, 2, or 3): " WORKTREE_NUM
+fi
+
+# Port configuration
+case $WORKTREE_NUM in
+  1)
+    API_PORT=54321
+    DB_PORT=54322
+    STUDIO_PORT=54323
+    DOPPLER_CONFIG="dev_personal_worktree1"
+    ;;
+  2)
+    API_PORT=54331
+    DB_PORT=54332
+    STUDIO_PORT=54333
+    DOPPLER_CONFIG="dev_personal_worktree2"
+    ;;
+  3)
+    API_PORT=54341
+    DB_PORT=54342
+    STUDIO_PORT=54343
+    DOPPLER_CONFIG="dev_personal_worktree3"
+    ;;
+  *)
+    echo -e "${RED}Invalid worktree number. Must be 1, 2, or 3${NC}"
+    exit 1
+    ;;
+esac
+
+echo -e "\n${GREEN}Configuration for worktree $WORKTREE_NUM:${NC}"
+echo "  API Port:    $API_PORT"
+echo "  DB Port:     $DB_PORT"
+echo "  Studio Port: $STUDIO_PORT"
+echo "  Doppler:     $DOPPLER_CONFIG"
+
+# Update supabase/config.toml with correct ports
+echo -e "\n${YELLOW}Updating supabase/config.toml with ports...${NC}"
+if [ ! -f "supabase/config.toml" ]; then
+  echo -e "${RED}Error: supabase/config.toml not found. Run 'supabase init' first.${NC}"
+  exit 1
+fi
+
+# Update ports in config.toml
+sed -i.bak "s/^port = 54321$/port = $API_PORT/" supabase/config.toml
+sed -i.bak "s/^port = 54322$/port = $DB_PORT/" supabase/config.toml
+sed -i.bak "s/^port = 54323$/port = $STUDIO_PORT/" supabase/config.toml
+rm supabase/config.toml.bak
+
+echo -e "${GREEN}✓ Updated supabase/config.toml${NC}"
+
+# Configure Doppler
+echo -e "\n${YELLOW}Configuring Doppler...${NC}"
+doppler configure set project fitcsv
+doppler configure set config "$DOPPLER_CONFIG"
+echo -e "${GREEN}✓ Doppler configured to use $DOPPLER_CONFIG${NC}"
+
+# Check if Doppler secrets are populated
+SECRET_COUNT=$(doppler secrets --config "$DOPPLER_CONFIG" 2>/dev/null | grep -c "│" | awk '{print $1}')
+if [ "$SECRET_COUNT" -lt 5 ]; then
+  echo -e "\n${YELLOW}⚠ Doppler config $DOPPLER_CONFIG needs to be populated with secrets${NC}"
+  echo -e "${YELLOW}Run the populate script: ./scripts/populate-worktree-doppler.sh $WORKTREE_NUM${NC}"
+fi
+
+# Instructions for starting Supabase
+echo -e "\n${GREEN}=== Next Steps ===${NC}"
+echo -e "1. Start Supabase: ${YELLOW}supabase start${NC}"
+echo -e "2. Get JWT keys and update Doppler:"
+echo -e "   ${YELLOW}supabase status -o env | grep -E '(ANON_KEY|SERVICE_ROLE_KEY)'${NC}"
+echo -e "   ${YELLOW}doppler secrets set NEXT_PUBLIC_SUPABASE_ANON_KEY='<value>' --config $DOPPLER_CONFIG${NC}"
+echo -e "   ${YELLOW}doppler secrets set SUPABASE_SERVICE_ROLE_KEY='<value>' --config $DOPPLER_CONFIG${NC}"
+echo -e "3. Start all services: ${YELLOW}overmind start${NC}"
+echo -e "\n${GREEN}Supabase Studio will be available at: ${YELLOW}http://127.0.0.1:$STUDIO_PORT${NC}"

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,393 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "fitcsv"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Migrations are automatically discovered in supabase/migrations/
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = [
+  "../prisma/seeds/00_legacy_exercises.sql",
+  "../prisma/seeds/01_bodyweight_exercises.sql",
+  "../prisma/seeds/02_dumbbell_exercises.sql",
+  "../prisma/seeds/03_resistance_band_exercises.sql",
+  "../prisma/seeds/04_kettlebell_exercises.sql",
+  "../prisma/seeds/05_climbing_exercises.sql",
+  "../prisma/seeds/06_cable_machine_exercises.sql",
+  "../prisma/seeds/07_core_mobility_exercises.sql"
+]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/migrations/20240101000000_base_schema.sql
+++ b/supabase/migrations/20240101000000_base_schema.sql
@@ -1,0 +1,460 @@
+-- CreateTable
+CREATE TABLE "Program" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "isUserCreated" BOOLEAN NOT NULL DEFAULT false,
+    "programType" TEXT NOT NULL DEFAULT 'strength',
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" TIMESTAMP(3),
+    "copyStatus" TEXT DEFAULT 'ready',
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "Program_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Week" (
+    "id" TEXT NOT NULL,
+    "weekNumber" INTEGER NOT NULL,
+    "programId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Week_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Workout" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "dayNumber" INTEGER NOT NULL,
+    "weekId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Workout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ExerciseDefinition" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "aliases" TEXT[],
+    "category" TEXT,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "equipment" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "instructions" TEXT,
+    "primaryFAUs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "secondaryFAUs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ExerciseDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Exercise" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "exerciseDefinitionId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "exerciseGroup" TEXT,
+    "workoutId" TEXT,
+    "notes" TEXT,
+    "userId" TEXT NOT NULL,
+    "isOneOff" BOOLEAN NOT NULL DEFAULT false,
+    "workoutCompletionId" TEXT,
+
+    CONSTRAINT "Exercise_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PrescribedSet" (
+    "id" TEXT NOT NULL,
+    "setNumber" INTEGER NOT NULL,
+    "reps" TEXT NOT NULL,
+    "weight" TEXT,
+    "rpe" INTEGER,
+    "rir" INTEGER,
+    "exerciseId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "PrescribedSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkoutCompletion" (
+    "id" TEXT NOT NULL,
+    "workoutId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL,
+    "notes" TEXT,
+
+    CONSTRAINT "WorkoutCompletion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LoggedSet" (
+    "id" TEXT NOT NULL,
+    "setNumber" INTEGER NOT NULL,
+    "reps" INTEGER NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "weightUnit" TEXT NOT NULL DEFAULT 'lbs',
+    "rpe" INTEGER,
+    "rir" INTEGER,
+    "exerciseId" TEXT NOT NULL,
+    "completionId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "LoggedSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CardioProgram" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" TIMESTAMP(3),
+    "isUserCreated" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "copyStatus" TEXT DEFAULT 'ready',
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "CardioProgram_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CardioWeek" (
+    "id" TEXT NOT NULL,
+    "weekNumber" INTEGER NOT NULL,
+    "cardioProgramId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "CardioWeek_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PrescribedCardioSession" (
+    "id" TEXT NOT NULL,
+    "weekId" TEXT NOT NULL,
+    "dayNumber" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "targetDuration" INTEGER NOT NULL,
+    "intensityZone" TEXT,
+    "equipment" TEXT,
+    "targetHRRange" TEXT,
+    "targetPowerRange" TEXT,
+    "intervalStructure" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "PrescribedCardioSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LoggedCardioSession" (
+    "id" TEXT NOT NULL,
+    "prescribedSessionId" TEXT,
+    "userId" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'completed',
+    "name" TEXT NOT NULL,
+    "equipment" TEXT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "avgHR" INTEGER,
+    "peakHR" INTEGER,
+    "avgPower" INTEGER,
+    "peakPower" INTEGER,
+    "distance" DOUBLE PRECISION,
+    "elevationGain" INTEGER,
+    "elevationLoss" INTEGER,
+    "avgPace" TEXT,
+    "cadence" INTEGER,
+    "strokeRate" INTEGER,
+    "strokeCount" INTEGER,
+    "calories" INTEGER,
+    "intensityZone" TEXT,
+    "intervalStructure" TEXT,
+    "notes" TEXT,
+
+    CONSTRAINT "LoggedCardioSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserCardioMetricPreferences" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "equipment" TEXT NOT NULL,
+    "customMetrics" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserCardioMetricPreferences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "displayName" TEXT,
+    "defaultWeightUnit" TEXT NOT NULL DEFAULT 'lbs',
+    "defaultIntensityRating" TEXT NOT NULL DEFAULT 'rpe',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CommunityProgram" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "programType" TEXT NOT NULL DEFAULT 'strength',
+    "authorUserId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "originalProgramId" TEXT NOT NULL,
+    "programData" JSONB NOT NULL,
+    "weekCount" INTEGER NOT NULL,
+    "workoutCount" INTEGER NOT NULL,
+    "exerciseCount" INTEGER NOT NULL,
+    "goals" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "level" TEXT,
+    "durationWeeks" INTEGER,
+    "durationDisplay" TEXT,
+    "targetDaysPerWeek" INTEGER,
+    "equipmentNeeded" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "focusAreas" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "community_programs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isActive_idx" ON "Program"("userId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_idx" ON "Program"("userId");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isUserCreated_idx" ON "Program"("userId", "isUserCreated");
+
+-- CreateIndex
+CREATE INDEX "Program_userId_isArchived_idx" ON "Program"("userId", "isArchived");
+
+-- CreateIndex
+CREATE INDEX "Week_programId_idx" ON "Week"("programId");
+
+-- CreateIndex
+CREATE INDEX "Week_userId_idx" ON "Week"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Week_programId_weekNumber_key" ON "Week"("programId", "weekNumber");
+
+-- CreateIndex
+CREATE INDEX "Workout_weekId_idx" ON "Workout"("weekId");
+
+-- CreateIndex
+CREATE INDEX "Workout_userId_idx" ON "Workout"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workout_weekId_dayNumber_key" ON "Workout"("weekId", "dayNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExerciseDefinition_normalizedName_key" ON "ExerciseDefinition"("normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_normalizedName_idx" ON "ExerciseDefinition"("normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_isSystem_idx" ON "ExerciseDefinition"("isSystem");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_createdBy_idx" ON "ExerciseDefinition"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_primaryFAUs_idx" ON "ExerciseDefinition"("primaryFAUs");
+
+-- CreateIndex
+CREATE INDEX "ExerciseDefinition_userId_idx" ON "ExerciseDefinition"("userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_workoutId_idx" ON "Exercise"("workoutId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_exerciseDefinitionId_idx" ON "Exercise"("exerciseDefinitionId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_userId_idx" ON "Exercise"("userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_exerciseDefinitionId_userId_idx" ON "Exercise"("exerciseDefinitionId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Exercise_workoutCompletionId_idx" ON "Exercise"("workoutCompletionId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedSet_exerciseId_idx" ON "PrescribedSet"("exerciseId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedSet_userId_idx" ON "PrescribedSet"("userId");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_workoutId_userId_idx" ON "WorkoutCompletion"("workoutId", "userId");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_userId_completedAt_idx" ON "WorkoutCompletion"("userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_userId_status_completedAt_idx" ON "WorkoutCompletion"("userId", "status", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_exerciseId_idx" ON "LoggedSet"("exerciseId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_completionId_idx" ON "LoggedSet"("completionId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_userId_idx" ON "LoggedSet"("userId");
+
+-- CreateIndex
+CREATE INDEX "LoggedSet_completionId_exerciseId_idx" ON "LoggedSet"("completionId", "exerciseId");
+
+-- CreateIndex
+CREATE INDEX "CardioProgram_userId_isActive_idx" ON "CardioProgram"("userId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "CardioProgram_userId_isArchived_idx" ON "CardioProgram"("userId", "isArchived");
+
+-- CreateIndex
+CREATE INDEX "CardioWeek_cardioProgramId_idx" ON "CardioWeek"("cardioProgramId");
+
+-- CreateIndex
+CREATE INDEX "CardioWeek_userId_idx" ON "CardioWeek"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CardioWeek_cardioProgramId_weekNumber_key" ON "CardioWeek"("cardioProgramId", "weekNumber");
+
+-- CreateIndex
+CREATE INDEX "PrescribedCardioSession_weekId_idx" ON "PrescribedCardioSession"("weekId");
+
+-- CreateIndex
+CREATE INDEX "PrescribedCardioSession_userId_idx" ON "PrescribedCardioSession"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrescribedCardioSession_weekId_dayNumber_key" ON "PrescribedCardioSession"("weekId", "dayNumber");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_prescribedSessionId_idx" ON "LoggedCardioSession"("prescribedSessionId");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_userId_completedAt_idx" ON "LoggedCardioSession"("userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_userId_status_completedAt_idx" ON "LoggedCardioSession"("userId", "status", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedCardioSession_prescribedSessionId_userId_completedAt_idx" ON "LoggedCardioSession"("prescribedSessionId", "userId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "UserCardioMetricPreferences_userId_idx" ON "UserCardioMetricPreferences"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserCardioMetricPreferences_userId_equipment_key" ON "UserCardioMetricPreferences"("userId", "equipment");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSettings_userId_key" ON "UserSettings"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserSettings_userId_idx" ON "UserSettings"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "community_programs_original_program_id_key" ON "CommunityProgram"("originalProgramId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_programType_idx" ON "CommunityProgram"("programType");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_publishedAt_idx" ON "CommunityProgram"("publishedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_authorUserId_idx" ON "CommunityProgram"("authorUserId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_originalProgramId_idx" ON "CommunityProgram"("originalProgramId");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_level_idx" ON "CommunityProgram"("level");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_goals_idx" ON "CommunityProgram" USING GIN ("goals");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_equipmentNeeded_idx" ON "CommunityProgram" USING GIN ("equipmentNeeded");
+
+-- CreateIndex
+CREATE INDEX "CommunityProgram_programType_publishedAt_idx" ON "CommunityProgram"("programType", "publishedAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "Week" ADD CONSTRAINT "Week_programId_fkey" FOREIGN KEY ("programId") REFERENCES "Program"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_weekId_fkey" FOREIGN KEY ("weekId") REFERENCES "Week"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_exerciseDefinitionId_fkey" FOREIGN KEY ("exerciseDefinitionId") REFERENCES "ExerciseDefinition"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_workoutCompletionId_fkey" FOREIGN KEY ("workoutCompletionId") REFERENCES "WorkoutCompletion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_workoutId_fkey" FOREIGN KEY ("workoutId") REFERENCES "Workout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrescribedSet" ADD CONSTRAINT "PrescribedSet_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutCompletion" ADD CONSTRAINT "WorkoutCompletion_workoutId_fkey" FOREIGN KEY ("workoutId") REFERENCES "Workout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedSet" ADD CONSTRAINT "LoggedSet_completionId_fkey" FOREIGN KEY ("completionId") REFERENCES "WorkoutCompletion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedSet" ADD CONSTRAINT "LoggedSet_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CardioWeek" ADD CONSTRAINT "CardioWeek_cardioProgramId_fkey" FOREIGN KEY ("cardioProgramId") REFERENCES "CardioProgram"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrescribedCardioSession" ADD CONSTRAINT "PrescribedCardioSession_weekId_fkey" FOREIGN KEY ("weekId") REFERENCES "CardioWeek"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoggedCardioSession" ADD CONSTRAINT "LoggedCardioSession_prescribedSessionId_fkey" FOREIGN KEY ("prescribedSessionId") REFERENCES "PrescribedCardioSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/supabase/migrations/20240106000000_optimize_program_indexes.sql
+++ b/supabase/migrations/20240106000000_optimize_program_indexes.sql
@@ -1,0 +1,62 @@
+-- Migration: Optimize Program Listing Indexes
+-- Created: 2026-01-29
+--
+-- Problem: Current indexes cover WHERE clauses but not ORDER BY columns,
+-- forcing PostgreSQL to do a separate sort operation after filtering.
+--
+-- Solution: Create partial indexes that cover both filtering AND sorting
+-- for the most common query pattern (active, non-archived programs).
+--
+-- Benefits:
+-- - Smaller indexes (only non-archived rows, typically 90%+ of queries)
+-- - No separate sort operation needed (index already in correct order)
+-- - 5-20x faster queries on program listings
+--
+-- Reference: https://www.postgresql.org/docs/current/indexes-partial.html
+
+-- ============================================================================
+-- PROGRAM (Strength) INDEXES
+-- ============================================================================
+
+-- Partial index for the most common query:
+-- WHERE userId = X AND isArchived = false ORDER BY createdAt DESC
+--
+-- This covers the /programs page listing query perfectly
+CREATE INDEX IF NOT EXISTS "Program_active_listing_idx"
+ON "Program" ("userId", "createdAt" DESC)
+WHERE "isArchived" = false;
+
+-- ============================================================================
+-- CARDIO PROGRAM INDEXES
+-- ============================================================================
+
+-- Partial index for cardio program listing:
+-- WHERE userId = X AND isArchived = false ORDER BY isActive DESC, createdAt DESC
+--
+-- This covers the /programs page cardio tab query
+CREATE INDEX IF NOT EXISTS "CardioProgram_active_listing_idx"
+ON "CardioProgram" ("userId", "isActive" DESC, "createdAt" DESC)
+WHERE "isArchived" = false;
+
+-- ============================================================================
+-- VERIFICATION QUERIES
+-- ============================================================================
+
+-- After running, verify indexes exist:
+-- SELECT indexname, indexdef FROM pg_indexes WHERE tablename IN ('Program', 'CardioProgram');
+
+-- Test that queries use the new indexes:
+-- EXPLAIN ANALYZE SELECT * FROM "Program" WHERE "userId" = 'test' AND "isArchived" = false ORDER BY "createdAt" DESC;
+-- EXPLAIN ANALYZE SELECT * FROM "CardioProgram" WHERE "userId" = 'test' AND "isArchived" = false ORDER BY "isActive" DESC, "createdAt" DESC;
+
+-- ============================================================================
+-- OPTIONAL: Remove redundant indexes (run after verifying new indexes work)
+-- ============================================================================
+
+-- The new partial indexes make these somewhat redundant for active listings,
+-- but keep them for now since they're still useful for:
+-- - Archived program queries
+-- - Queries that don't filter on isArchived
+--
+-- DROP INDEX IF EXISTS "Program_userId_isArchived_idx";
+-- DROP INDEX IF EXISTS "CardioProgram_userId_isArchived_idx";

--- a/supabase/migrations/20240107000000_optimize_rls_policies.sql
+++ b/supabase/migrations/20240107000000_optimize_rls_policies.sql
@@ -1,0 +1,148 @@
+-- Migration: Optimize RLS Policies for Performance
+-- Created: 2026-01-29
+--
+-- Problem: auth.uid() is called per-row in RLS policy checks, causing
+-- significant performance degradation on tables with many rows.
+--
+-- Solution: Wrap auth.uid() in (SELECT auth.uid()) to evaluate it once
+-- and cache the result. This can provide 5-10x performance improvement.
+--
+-- Reference: https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations
+
+-- ============================================================================
+-- STRENGTH TRAINING TABLES
+-- ============================================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "users_own_programs" ON "Program";
+DROP POLICY IF EXISTS "users_own_weeks" ON "Week";
+DROP POLICY IF EXISTS "users_own_workouts" ON "Workout";
+DROP POLICY IF EXISTS "users_own_exercises" ON "Exercise";
+DROP POLICY IF EXISTS "users_own_prescribed_sets" ON "PrescribedSet";
+DROP POLICY IF EXISTS "users_own_completions" ON "WorkoutCompletion";
+DROP POLICY IF EXISTS "users_own_logged_sets" ON "LoggedSet";
+
+-- Program: Users can only access their own programs
+CREATE POLICY "users_own_programs" ON "Program"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- Week: Users can access weeks from their programs
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_weeks" ON "Week"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- Workout: Users can access workouts from their weeks
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_workouts" ON "Workout"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- Exercise: Users can access exercises from their workouts
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_exercises" ON "Exercise"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- PrescribedSet: Users can access prescribed sets from their exercises
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_prescribed_sets" ON "PrescribedSet"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- WorkoutCompletion: Users can only access their own completions
+CREATE POLICY "users_own_completions" ON "WorkoutCompletion"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- LoggedSet: Users can access logged sets from their completions
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_logged_sets" ON "LoggedSet"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- ============================================================================
+-- CARDIO TABLES
+-- ============================================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "users_own_cardio_programs" ON "CardioProgram";
+DROP POLICY IF EXISTS "users_own_cardio_weeks" ON "CardioWeek";
+DROP POLICY IF EXISTS "users_own_prescribed_cardio" ON "PrescribedCardioSession";
+DROP POLICY IF EXISTS "users_own_logged_cardio" ON "LoggedCardioSession";
+DROP POLICY IF EXISTS "users_own_cardio_metric_prefs" ON "UserCardioMetricPreferences";
+
+-- CardioProgram: Users can only access their own cardio programs
+CREATE POLICY "users_own_cardio_programs" ON "CardioProgram"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- CardioWeek: Users can access weeks from their cardio programs
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_cardio_weeks" ON "CardioWeek"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- PrescribedCardioSession: Users can access sessions from their cardio weeks
+-- Optimized: Uses userId column directly instead of subquery join
+CREATE POLICY "users_own_prescribed_cardio" ON "PrescribedCardioSession"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- LoggedCardioSession: Users can only access their own logged sessions
+CREATE POLICY "users_own_logged_cardio" ON "LoggedCardioSession"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- UserCardioMetricPreferences: Users can only access their own preferences
+CREATE POLICY "users_own_cardio_metric_prefs" ON "UserCardioMetricPreferences"
+  FOR ALL
+  USING ((SELECT auth.uid())::text = "userId")
+  WITH CHECK ((SELECT auth.uid())::text = "userId");
+
+-- ============================================================================
+-- COMMUNITY PROGRAMS
+-- ============================================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "CommunityProgram_select_policy" ON "CommunityProgram";
+DROP POLICY IF EXISTS "CommunityProgram_insert_policy" ON "CommunityProgram";
+DROP POLICY IF EXISTS "CommunityProgram_delete_policy" ON "CommunityProgram";
+
+-- CommunityProgram: Anyone authenticated can read, only author can insert/delete
+CREATE POLICY "CommunityProgram_select_policy"
+  ON "CommunityProgram"
+  FOR SELECT
+  USING ((SELECT auth.uid()) IS NOT NULL);
+
+CREATE POLICY "CommunityProgram_insert_policy"
+  ON "CommunityProgram"
+  FOR INSERT
+  WITH CHECK ((SELECT auth.uid())::text = "authorUserId");
+
+CREATE POLICY "CommunityProgram_delete_policy"
+  ON "CommunityProgram"
+  FOR DELETE
+  USING ((SELECT auth.uid())::text = "authorUserId");
+
+-- ============================================================================
+-- VERIFICATION QUERIES (run after migration to verify)
+-- ============================================================================
+
+-- Check that all policies are created correctly:
+-- SELECT schemaname, tablename, policyname, permissive, roles, cmd, qual, with_check
+-- FROM pg_policies
+-- WHERE schemaname = 'public'
+-- ORDER BY tablename, policyname;

--- a/supabase/migrations/20240108000000_optimize_training_cardio_indexes.sql
+++ b/supabase/migrations/20240108000000_optimize_training_cardio_indexes.sql
@@ -1,0 +1,55 @@
+-- Migration: Optimize Training/Cardio Page Indexes
+-- Created: 2026-01-29
+--
+-- Problem: The getCurrentStrengthWeek and getCurrentCardioWeek functions
+-- use raw SQL queries with correlated subqueries that filter on (programId, userId)
+-- and order by weekNumber. Current indexes don't cover this pattern efficiently.
+--
+-- Solution: Add composite indexes that cover the full query pattern.
+
+-- ============================================================================
+-- WEEK TABLE INDEXES (Strength Training)
+-- ============================================================================
+
+-- Composite index for finding weeks by program + user, ordered by weekNumber
+-- Used by: getCurrentStrengthWeek raw SQL query
+-- Pattern: WHERE programId = X AND userId = Y ORDER BY weekNumber
+CREATE INDEX IF NOT EXISTS "Week_program_user_weekNum_idx"
+ON "Week" ("programId", "userId", "weekNumber");
+
+-- ============================================================================
+-- CARDIO WEEK TABLE INDEXES
+-- ============================================================================
+
+-- Composite index for finding cardio weeks by program + user, ordered by weekNumber
+-- Used by: getCurrentCardioWeek raw SQL query
+-- Pattern: WHERE cardioProgramId = X AND userId = Y ORDER BY weekNumber
+CREATE INDEX IF NOT EXISTS "CardioWeek_program_user_weekNum_idx"
+ON "CardioWeek" ("cardioProgramId", "userId", "weekNumber");
+
+-- ============================================================================
+-- WORKOUT COMPLETION INDEXES
+-- ============================================================================
+
+-- Index for counting completed workouts per week (used in correlated subquery)
+-- Pattern: COUNT(DISTINCT workoutId) WHERE workoutId IN (...) AND userId = X AND status = 'completed'
+-- The existing WorkoutCompletion_workoutId_userId_idx helps, but adding status improves filtering
+CREATE INDEX IF NOT EXISTS "WorkoutCompletion_workout_user_status_idx"
+ON "WorkoutCompletion" ("workoutId", "userId", "status");
+
+-- ============================================================================
+-- LOGGED CARDIO SESSION INDEXES
+-- ============================================================================
+
+-- Index for counting completed cardio sessions per prescribed session
+-- Pattern: COUNT(DISTINCT prescribedSessionId) WHERE prescribedSessionId IN (...) AND userId = X AND status = 'completed'
+-- Existing index covers (prescribedSessionId, userId, completedAt) but adding status helps
+CREATE INDEX IF NOT EXISTS "LoggedCardioSession_prescribed_user_status_idx"
+ON "LoggedCardioSession" ("prescribedSessionId", "userId", "status");
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+
+-- After running, verify with:
+-- SELECT indexname FROM pg_indexes WHERE indexname LIKE '%program_user%' OR indexname LIKE '%workout_user_status%' OR indexname LIKE '%prescribed_user_status%';


### PR DESCRIPTION
## Summary

- Migrates local development from raw PostgreSQL to Supabase CLI
- Adds multi-worktree support with isolated Supabase instances (3 worktrees on unique ports)
- Configures automatic migrations and exercise seeding (257 exercises)
- Documents database migration workflow with safety guardrails

## Changes

### Supabase Setup
- Initialize Supabase CLI with `supabase/config.toml`
- Generate base schema migration from Prisma (`00_base_schema.sql`)
- Copy optimization migrations (indexes, RLS policies)
- Configure automatic seeding from `prisma/seeds/*.sql`

### Multi-Worktree Support
- Create 3 Doppler configs (`dev_personal_worktree1/2/3`)
- Each worktree uses unique ports (API: 54321/54331/54341, DB: 54322/54332/54342)
- Add worktree detection script (`scripts/setup-worktree-supabase.sh`)
- Add Doppler population script (`scripts/populate-worktree-doppler.sh`)

### Documentation
- Add comprehensive migration guide (`docs/DATABASE_MIGRATIONS.md`)
- Update `CLAUDE.md` with migration workflow and safety rules
- Update `WORKTREE_SETUP.md` with Supabase multi-worktree instructions
- Add Supabase-compatible reseed script (`prisma/seeds/reseed_supabase_local.sh`)

### Process Updates
- Update `Procfile` to manage Supabase lifecycle via overmind
- Configure Doppler to use directory-scoped configs (inherited by subdirectories)

## Benefits

- ✅ Production-like local environment (Postgres + Auth + Storage)
- ✅ Isolated databases per worktree (no conflicts when testing different features)
- ✅ Automatic schema application via migrations
- ✅ Automatic exercise seeding (257 exercises)
- ✅ One-command setup: `supabase db reset`
- ✅ Safety guardrails: Claude cannot push to production

## Test Plan

- [x] `supabase db reset` applies migrations and seeds successfully
- [x] Exercise definitions seeded (verified 257 exercises)
- [x] Doppler configs work for worktree 1
- [x] Procfile updated to use directory-scoped Doppler configs
- [ ] Test worktree 2 and 3 setup in separate directories
- [ ] Test `overmind start` launches all services

## Migration Notes

This PR includes the base schema migration generated from current Prisma schema. The existing manual migrations (`add_program_metadata.sql`, etc.) are already reflected in dev and don't need to be re-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)