### PR TITLE
Fix: Route REVIEW button to preview modal

### DIFF
--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -125,7 +125,7 @@ export default function WorkoutCard({
             </button>
           ) : (
             <button
-              onClick={() => onLog(workout.id)}
+              onClick={() => isCompleted ? onView(workout.id) : onLog(workout.id)}
               disabled={isLoading}
               className={`px-4 py-2 ${
                 isDraft


### PR DESCRIPTION
## Summary
- Fixed REVIEW button on completed workouts to open preview/summary modal instead of logging modal

## Problem
When clicking the REVIEW button on a completed workout in the week view, the logging modal was opening instead of showing a summary/review of the completed workout.

## Root Cause
`WorkoutCard.tsx` line 128 was always calling `onLog()` regardless of workout status, even when the button text showed "REVIEW" for completed workouts.

## Solution
Added conditional routing: `isCompleted ? onView(workout.id) : onLog(workout.id)` so completed workouts open the preview modal (review) instead of the logging modal.

## Testing
Manual testing: Click REVIEW button on completed workout → now opens preview modal with workout summary ✅