### PR TITLE
Fix test workflow timeout during dependency installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - dev
       - main
+  push:
+    branches:
+      - fix/test-workflow-timeout
 
 jobs:
   test:
@@ -23,7 +26,9 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci --prefer-offline --no-audit --loglevel verbose
+        timeout-minutes: 5
 
       - name: Generate Prisma Client
         run: npx prisma generate


### PR DESCRIPTION
## Summary
- Add 5-minute timeout to npm install step to prevent indefinite hanging
- Add verbose logging and offline-first mode for better diagnostics
- Add push trigger for fix branch to enable testing without PR

## Changes
- Updated `.github/workflows/test.yml` with:
  - `timeout-minutes: 5` on Install dependencies step
  - `--prefer-offline --no-audit --loglevel verbose` flags for npm ci
  - Push trigger for `fix/test-workflow-timeout` branch

## Test Plan
- [x] Workflow runs successfully on push to fix branch
- [x] Dependencies install without timeout
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)