### PR TITLE
Remove temporary push trigger from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - dev
       - main
-  push:
-    branches:
-      - fix/test-workflow-timeout
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Remove push trigger for `fix/test-workflow-timeout` branch that was added for testing

## Changes
- Cleaned up `.github/workflows/test.yml` to only trigger on PRs to `dev` and `main`

## Context
The push trigger was added temporarily in #150 to test the workflow without creating a PR. Now that the fix is merged, the trigger is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)