### PR TITLE
infra: set function region to cle1 (Cleveland)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,9 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "prisma generate && next build",
   "devCommand": "next dev",
   "installCommand": "npm install",
   "framework": "nextjs",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "regions": ["cle1"]
 }


### PR DESCRIPTION
## Summary
- Configure Vercel Functions to execute in `cle1` (Cleveland, us-east-2)
- Add JSON schema to vercel.json for better IDE validation

## Rationale
Lower latency by running serverless functions closer to data sources in us-east-2 region.

## Test plan
- [ ] Verify deployment succeeds with new region setting
- [ ] Monitor function execution latency after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)