### PR TITLE
chore: add staging CI builds with GitHub Environments

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'dev' && 'staging' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-clone-worker.yml
+++ b/.github/workflows/deploy-clone-worker.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'dev' && 'staging' || '' }}
 
     env:
       IMAGE_NAME: ghcr.io/aptx-health/clone-program


### PR DESCRIPTION
## Summary
- Trigger app and clone worker image builds on merge to `dev` branch
- Staging builds tag images as `:staging`, production stays pinned to `:sha-<sha>`
- Uses GitHub Environments (`staging`/`production`) for environment-specific variables
- Removed stale Supabase build-args from app workflow
- Explicit branch matching — fails on unexpected branches

## Test plan
- [ ] Merge to `dev` and verify staging images are built and pushed to GHCR
- [ ] Verify production builds still trigger on merge to `main` with `sha-<sha>` tags
- [ ] Confirm environment variables resolve correctly per environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)