### PR TITLE
feat: relax BetterAuth rate limits for staging

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,23 @@
 import { betterAuth } from "better-auth"
 import { Pool } from "pg"
+import { logger } from "@/lib/logger"
+
+const isRelaxedRateLimits = process.env.RELAXED_RATE_LIMITS === "true"
+
+if (isRelaxedRateLimits) {
+  logger.warn("BetterAuth rate limits relaxed — 100 req/60s for auth endpoints")
+}
+
+const rateLimitConfig = isRelaxedRateLimits
+  ? {
+      customRules: {
+        "/sign-up/*": { window: 60, max: 100 },
+        "/sign-in/*": { window: 60, max: 100 },
+        "/change-password": { window: 60, max: 100 },
+        "/change-email": { window: 60, max: 100 },
+      },
+    }
+  : undefined
 
 // Allow Vercel preview deploy origins alongside the configured BETTER_AUTH_URL
 const trustedOrigins = [
@@ -33,6 +51,7 @@ export const auth = betterAuth({
       generateId: false, // Use database default (uuid) — allows explicit ID setting in B2 migration
     },
   },
+  ...(rateLimitConfig && { rateLimit: rateLimitConfig }),
   session: {
     expiresIn: 60 * 60 * 24 * 7, // 7 days
     updateAge: 60 * 60 * 24, // refresh every 24h


### PR DESCRIPTION
## Summary

- Gate auth endpoint rate limits behind `RELAXED_RATE_LIMITS` env var (set in Doppler staging config)
- When enabled, allows 100 req/60s on `/sign-in/*`, `/sign-up/*`, `/change-password`, `/change-email` (vs default 3 req/10s)
- Logs a warning at startup so relaxed limits are visible in pod logs
- Production keeps strict defaults (env var unset)

Closes #214

## Test plan

- [ ] Verify staging pod logs show: `BetterAuth rate limits relaxed — 100 req/60s for auth endpoints`
- [ ] Run k6 load test against staging with concurrent VU sign-in/sign-up
- [ ] Confirm production does NOT log the warning (env var unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)