### PR TITLE
chore: add workflow to remove in-progress label on issue close

### DIFF
--- a/.github/workflows/issue-cleanup.yml
+++ b/.github/workflows/issue-cleanup.yml
@@ -1,0 +1,24 @@
+name: Remove in-progress on close
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  cleanup-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'in-progress';
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (labels.includes(label)) {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.issue.number,
+                name: label,
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically removes the `in-progress` label from issues when they are closed (manually or via merged PR)

## Test plan
- [ ] Close an issue with the `in-progress` label and verify the label is removed
- [ ] Close an issue without the label and verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)