### PR TITLE
fix: format equipment names from snake_case to display labels

### DIFF
--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -3,6 +3,7 @@
 import { Filter, Search } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
+import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
 
 export type ExerciseDefinition = {
   id: string
@@ -314,7 +315,7 @@ export function ExerciseSearchInterface({
                     {exercise.equipment.length > 0 && (
                       <div className="mb-2">
                         <span className="text-sm font-bold text-muted-foreground">Equipment: </span>
-                        <span className="text-sm text-foreground">{exercise.equipment.join(', ')}</span>
+                        <span className="text-sm text-foreground">{exercise.equipment.map(eq => EQUIPMENT_LABELS[eq] || eq.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())).join(', ')}</span>
                       </div>
                     )}
                   </div>

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -4,6 +4,7 @@ import { LoadingFrog } from '@/components/ui/loading-frog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/hooks/useWorkoutStorage'
+import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -190,7 +191,7 @@ export default function ExerciseDisplayTabs({
                     key={item}
                     className="px-3 py-1.5 text-base sm:text-lg font-medium bg-muted text-foreground rounded-full border border-border"
                   >
-                    {item}
+                    {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Use `EQUIPMENT_LABELS` lookup to display equipment names as readable labels (e.g., "Pull-Up Bar" instead of `pull_up_bar`)
- Fix applies to the Info tab in workout logger and the exercise search interface
- Falls back to auto-formatting (`snake_case` -> `Title Case`) for any unlisted equipment

Closes #229

## Test plan
- [x] Verified equipment names display correctly in the Info tab
- [x] Verified equipment names display correctly in exercise search results
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)