### PR TITLE
chore: remove in-progress label on issue close

### DIFF
--- a/.github/workflows/issue-cleanup.yml
+++ b/.github/workflows/issue-cleanup.yml
@@ -1,0 +1,30 @@
+name: Issue Cleanup
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  remove-in-progress-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove in-progress label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelName = 'in-progress';
+            const labels = context.payload.issue.labels.map(l => l.name);
+
+            if (!labels.includes(labelName)) {
+              console.log(`Label "${labelName}" not found on issue #${context.issue.number}, skipping.`);
+              return;
+            }
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: labelName,
+            });
+
+            console.log(`Removed "${labelName}" label from issue #${context.issue.number}.`);


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically removes the `in-progress` label when an issue is closed
- Uses `actions/github-script` — no-ops gracefully if the label isn't present
- Cherry-pick of #235 to dev (keeping branches independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)