### PR TITLE
feat: add imageUrls to ExerciseDefinition

### DIFF
--- a/cloud-functions/clone-program/prisma/schema.prisma
+++ b/cloud-functions/clone-program/prisma/schema.prisma
@@ -68,6 +68,7 @@ model ExerciseDefinition {
   updatedAt      DateTime   @updatedAt
   equipment      String[]   @default([])
   instructions   String?
+  imageUrls      String[]   @default([])
   primaryFAUs    String[]   @default([])
   secondaryFAUs  String[]   @default([])
   userId         String

--- a/prisma/migrations/20260319000000_add_image_urls_to_exercise_definition/migration.sql
+++ b/prisma/migrations/20260319000000_add_image_urls_to_exercise_definition/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "imageUrls" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model ExerciseDefinition {
   equipment      String[]   @default([])
   instructions   String?
   notes          String?
+  imageUrls      String[]   @default([])
   primaryFAUs    String[]   @default([])
   secondaryFAUs  String[]   @default([])
   userId         String


### PR DESCRIPTION
## Summary
- Adds imageUrls String[] field with empty default to ExerciseDefinition in both main and clone-worker Prisma schemas
- Includes migration file for production deploy (ALTER TABLE ExerciseDefinition ADD COLUMN imageUrls TEXT[])
- URLs will point to MinIO-hosted exercise demonstration images

## Test plan
- [x] TypeScript type check passes
- [x] Prisma client generates successfully
- [x] Verify migration applies cleanly on staging deploy

Fixes #238