### PR TITLE
feat: display exercise images in workout logger

### DIFF
--- a/app/api/exercises/search/route.ts
+++ b/app/api/exercises/search/route.ts
@@ -99,6 +99,7 @@ export async function GET(request: NextRequest) {
         secondaryFAUs: true,
         equipment: true,
         instructions: true,
+        imageUrls: true,
         isSystem: true,
         createdBy: true,
       },

--- a/app/api/workouts/[workoutId]/exercises/[order]/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/[order]/route.ts
@@ -102,6 +102,7 @@ export async function GET(
             secondaryFAUs: true,
             equipment: true,
             instructions: true,
+            imageUrls: true,
             isSystem: true,
             createdBy: true,
           },

--- a/app/api/workouts/[workoutId]/metadata/route.ts
+++ b/app/api/workouts/[workoutId]/metadata/route.ts
@@ -85,6 +85,7 @@ export async function GET(
             secondaryFAUs: true,
             equipment: true,
             instructions: true,
+            imageUrls: true,
             isSystem: true,
             createdBy: true,
           },

--- a/app/api/workouts/[workoutId]/route.ts
+++ b/app/api/workouts/[workoutId]/route.ts
@@ -94,6 +94,7 @@ export async function GET(
             secondaryFAUs: true,
             equipment: true,
             instructions: true,
+            imageUrls: true,
             isSystem: true,
             createdBy: true,
           },

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/hooks/useWorkoutStorage'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
+import Image from 'next/image'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -25,6 +26,7 @@ interface Exercise {
     secondaryFAUs: string[]
     equipment: string[]
     instructions?: string
+    imageUrls?: string[]
   }
 }
 
@@ -141,6 +143,24 @@ export default function ExerciseDisplayTabs({
 
       <TabsContent value="info" className="flex-1 overflow-y-auto px-4">
         <div className="space-y-6">
+          {exercise.exerciseDefinition?.imageUrls && exercise.exerciseDefinition.imageUrls.length > 0 && (
+            <div>
+              <div className="grid grid-cols-2 gap-3">
+                {exercise.exerciseDefinition.imageUrls.map((url, i) => (
+                  <div key={url} className="relative aspect-square rounded-lg overflow-hidden bg-muted">
+                    <Image
+                      src={url}
+                      alt={`${exercise.name} - ${i === 0 ? 'start' : 'end'} position`}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 640px) 45vw, 300px"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {exercise.exerciseDefinition?.instructions && (
             <div>
               <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Instructions</h4>
@@ -198,7 +218,8 @@ export default function ExerciseDisplayTabs({
             </div>
           )}
 
-          {!exercise.exerciseDefinition?.instructions &&
+          {!exercise.exerciseDefinition?.imageUrls?.length &&
+            !exercise.exerciseDefinition?.instructions &&
             !exercise.exerciseDefinition?.primaryFAUs?.length &&
             !exercise.exerciseDefinition?.secondaryFAUs?.length &&
             !exercise.exerciseDefinition?.equipment?.length && (

--- a/hooks/useProgressiveExercises.ts
+++ b/hooks/useProgressiveExercises.ts
@@ -27,6 +27,7 @@ export type Exercise = {
     secondaryFAUs: string[]
     equipment: string[]
     instructions?: string
+    imageUrls?: string[]
     isSystem: boolean
     createdBy: string | null
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,14 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.ripit.fit',
+      },
+    ],
+  },
   // Externalize server-only packages to prevent bundling in client/edge
   serverExternalPackages: [
     'pino',


### PR DESCRIPTION
## Summary
- Add `imageUrls` to Prisma selects in all 4 workout/exercise API routes
- Render start/end position images in a 2-column grid on the exercise Info tab
- Add `cdn.ripit.fit` to Next.js `images.remotePatterns` for image optimization
- Handle empty `imageUrls` gracefully (no section shown)

Closes #261

## Test plan
- [x] Open workout logger, tap Info tab on an exercise with images — verify 2 images render side-by-side
- [x] Check an exercise without images — verify no image section and no broken UI
- [x] Verify images load from `cdn.ripit.fit` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)