### PR TITLE
fix: resolve image URLs and community program exercise IDs

### DIFF
--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
@@ -99,6 +100,7 @@ export default function ExerciseDisplayTabs({
   onDeleteSet,
   loggingForm,
 }: ExerciseDisplayTabsProps) {
+  const [expandedImage, setExpandedImage] = useState<string | null>(null)
   const loggedCount = loggedSets.length
   const totalCount = prescribedSets.length
   const hasNotes = !!exercise.notes
@@ -146,17 +148,25 @@ export default function ExerciseDisplayTabs({
           {exercise.exerciseDefinition?.imageUrls && exercise.exerciseDefinition.imageUrls.length > 0 && (
             <div>
               <div className="grid grid-cols-2 gap-3">
-                {exercise.exerciseDefinition.imageUrls.map((url, i) => (
-                  <div key={url} className="relative aspect-square rounded-lg overflow-hidden bg-muted">
-                    <Image
-                      src={url}
-                      alt={`${exercise.name} - ${i === 0 ? 'start' : 'end'} position`}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 640px) 45vw, 300px"
-                    />
-                  </div>
-                ))}
+                {exercise.exerciseDefinition.imageUrls.map((url, i) => {
+                  const src = url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
+                  return (
+                    <button
+                      key={url}
+                      type="button"
+                      onClick={() => setExpandedImage(src)}
+                      className="relative aspect-square rounded-lg overflow-hidden bg-muted cursor-pointer"
+                    >
+                      <Image
+                        src={src}
+                        alt={`${exercise.name} - ${i === 0 ? 'start' : 'end'} position`}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 640px) 45vw, 300px"
+                      />
+                    </button>
+                  )
+                })}
               </div>
             </div>
           )}
@@ -287,6 +297,24 @@ export default function ExerciseDisplayTabs({
           </div>
         )}
       </TabsContent>
+
+      {expandedImage && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+          onClick={() => setExpandedImage(null)}
+        >
+          <div className="relative w-[90vw] max-w-lg aspect-square">
+            <Image
+              src={expandedImage}
+              alt={exercise.name}
+              fill
+              className="object-contain"
+              sizes="90vw"
+            />
+          </div>
+        </div>
+      )}
     </Tabs>
   )
 }

--- a/prisma/seeds/curated/seed-community-programs.ts
+++ b/prisma/seeds/curated/seed-community-programs.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { type Prisma, PrismaClient } from '@prisma/client'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
@@ -96,71 +96,137 @@ const CURATED_PROGRAMS: CuratedMeta[] = [
   },
 ]
 
-const DISPLAY_NAME = 'Iron Works Fitness'
+const DISPLAY_NAME = 'Ripit Fitness'
+
+const updateMode = process.argv.includes('--update')
+
+// Resolve exerciseDefinitionIds in programData to match the target database.
+// Snapshots contain IDs from the environment where they were generated, which
+// may not exist in staging/prod. This rewrites them using normalizedName lookups.
+function resolveExerciseIds(
+  programData: Record<string, unknown>,
+  idLookup: Map<string, string>
+): { resolved: Record<string, unknown>; missing: string[] } {
+  const missing: string[] = []
+  const data = JSON.parse(JSON.stringify(programData)) // deep clone
+
+  for (const week of (data.weeks || []) as Array<Record<string, unknown>>) {
+    for (const workout of (week.workouts || []) as Array<Record<string, unknown>>) {
+      for (const exercise of (workout.exercises || []) as Array<Record<string, unknown>>) {
+        const name = exercise.name as string
+        const normalized = name.toLowerCase()
+        const resolvedId = idLookup.get(normalized)
+        if (resolvedId) {
+          exercise.exerciseDefinitionId = resolvedId
+        } else {
+          missing.push(name)
+        }
+      }
+    }
+  }
+
+  return { resolved: data, missing }
+}
+
+function buildProgramData(
+  meta: CuratedMeta,
+  snapshotDir: string,
+  idLookup: Map<string, string>
+) {
+  const raw = readFileSync(join(snapshotDir, meta.file), 'utf-8')
+  const rawProgramData = JSON.parse(raw)
+
+  const { resolved: programData, missing } = resolveExerciseIds(rawProgramData, idLookup)
+
+  if (missing.length > 0) {
+    console.warn(`  WARNING: ${rawProgramData.name} has ${missing.length} unresolved exercises:`)
+    for (const name of [...new Set(missing)]) {
+      console.warn(`    - ${name}`)
+    }
+  }
+
+  const weeks = (programData.weeks || []) as Array<Record<string, unknown>>
+  const weekCount = weeks.length
+  const firstWeekWorkouts = (weeks[0]?.workouts || []) as Array<Record<string, unknown>>
+  const workoutsPerWeek = firstWeekWorkouts.length
+  const workoutCount = weekCount * workoutsPerWeek
+  let exerciseCount = 0
+  for (const week of weeks) {
+    for (const workout of (week.workouts || []) as Array<Record<string, unknown>>) {
+      exerciseCount += ((workout.exercises || []) as unknown[]).length
+    }
+  }
+
+  const durationDisplay = weekCount === 1
+    ? '1 week (repeating)'
+    : `${weekCount} weeks`
+
+  return {
+    name: (programData.name || '') as string,
+    description: (programData.description || '') as string,
+    programType: (programData.programType || 'strength') as string,
+    displayName: DISPLAY_NAME,
+    programData: programData as Prisma.InputJsonValue,
+    curated: true,
+    weekCount,
+    workoutCount,
+    exerciseCount,
+    level: meta.level,
+    goals: meta.goals,
+    targetDaysPerWeek: meta.targetDaysPerWeek,
+    durationWeeks: weekCount,
+    durationDisplay,
+    equipmentNeeded: meta.equipmentNeeded,
+    focusAreas: meta.focusAreas,
+  }
+}
 
 async function main() {
+  if (updateMode) {
+    console.log('Running in --update mode (will replace existing programs)\n')
+  }
+
+  // Build normalizedName → id lookup from the target database
+  const allDefs = await prisma.exerciseDefinition.findMany({
+    select: { id: true, normalizedName: true },
+  })
+  const idLookup = new Map(allDefs.map((d) => [d.normalizedName, d.id]))
+  console.log(`Loaded ${idLookup.size} exercise definitions for ID resolution\n`)
+
   const snapshotDir = join(__dirname, 'snapshots')
 
   let created = 0
+  let updated = 0
   let skipped = 0
 
   for (const meta of CURATED_PROGRAMS) {
-    const raw = readFileSync(join(snapshotDir, meta.file), 'utf-8')
-    const programData = JSON.parse(raw)
+    const data = buildProgramData(meta, snapshotDir, idLookup)
 
-    // Check if already exists by name
     const existing = await prisma.communityProgram.findFirst({
-      where: { name: programData.name, curated: true },
+      where: { name: data.name, curated: true },
     })
 
     if (existing) {
-      console.log(`  SKIP (exists): ${programData.name}`)
-      skipped++
+      if (updateMode) {
+        await prisma.communityProgram.update({
+          where: { id: existing.id },
+          data,
+        })
+        console.log(`  UPDATED: ${data.name} (${data.weekCount}w, ${data.workoutCount} workouts, ${data.exerciseCount} exercises)`)
+        updated++
+      } else {
+        console.log(`  SKIP (exists): ${data.name}`)
+        skipped++
+      }
       continue
     }
 
-    // Count exercises and workouts from the snapshot
-    const weeks = programData.weeks || []
-    const weekCount = weeks.length
-    const workoutsPerWeek = weeks[0]?.workouts?.length || 0
-    const workoutCount = weekCount * workoutsPerWeek
-    let exerciseCount = 0
-    for (const week of weeks) {
-      for (const workout of week.workouts || []) {
-        exerciseCount += (workout.exercises || []).length
-      }
-    }
-
-    const durationDisplay = weekCount === 1
-      ? '1 week (repeating)'
-      : `${weekCount} weeks`
-
-    await prisma.communityProgram.create({
-      data: {
-        name: programData.name,
-        description: programData.description || '',
-        programType: programData.programType || 'strength',
-        displayName: DISPLAY_NAME,
-        programData,
-        curated: true,
-        weekCount,
-        workoutCount,
-        exerciseCount,
-        level: meta.level,
-        goals: meta.goals,
-        targetDaysPerWeek: meta.targetDaysPerWeek,
-        durationWeeks: weekCount,
-        durationDisplay,
-        equipmentNeeded: meta.equipmentNeeded,
-        focusAreas: meta.focusAreas,
-      },
-    })
-
-    console.log(`  CREATED: ${programData.name} (${weekCount}w, ${workoutCount} workouts, ${exerciseCount} exercises)`)
+    await prisma.communityProgram.create({ data })
+    console.log(`  CREATED: ${data.name} (${data.weekCount}w, ${data.workoutCount} workouts, ${data.exerciseCount} exercises)`)
     created++
   }
 
-  console.log(`\nDone. Created ${created}, skipped ${skipped}.`)
+  console.log(`\nDone. Created ${created}, updated ${updated}, skipped ${skipped}.`)
 }
 
 main().catch(console.error).finally(() => prisma.$disconnect())


### PR DESCRIPTION
## Summary
- Prefix relative `imageUrls` with `https://cdn.ripit.fit/exercise-images/` in ExerciseDisplayTabs (images were stored as relative paths, not full URLs)
- Add tap-to-expand lightbox for exercise images on mobile
- Resolve `exerciseDefinitionId` by name lookup in `seed-community-programs.ts` — fixes FK violations when cloning community programs across environments (snapshots contained env-specific CUIDs)
- Add `--update` mode to re-seed existing community programs
- Update publisher name from "Iron Works Fitness" to "Ripit Fitness"

## Test plan
- [ ] Exercise images render on staging Info tab
- [ ] Tap image to expand, tap backdrop to dismiss
- [ ] Clone a community program successfully on staging
- [ ] Re-run seed script with `--update` — existing programs get replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)