### PR TITLE
fix: Dockerfile build failure from esbuild version conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Prisma migrations + exercise data sync (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
-RUN npm install prisma@6.19.0 tsx@4.19.4 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund
+RUN npm install prisma@6.19.0 tsx@4.19.4 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund --ignore-scripts
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
 COPY scripts/sync-exercise-data.ts ./scripts/sync-exercise-data.ts
 COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json


### PR DESCRIPTION
## Summary
Fix Docker build failure caused by esbuild version conflict when installing tsx alongside vite's bundled esbuild.

Added `--ignore-scripts` to the tsx/typescript install step in the runner stage to skip esbuild's postinstall version validation.

## Test plan
- [ ] Docker build succeeds on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)