### PR TITLE
Fix race conditions in program clone flow

### DIFF
--- a/app/api/programs/[programId]/copy-status/route.ts
+++ b/app/api/programs/[programId]/copy-status/route.ts
@@ -54,7 +54,6 @@ export async function GET(
         }
       }
 
-      // Failed state — worker set this before returning 500
       if (copyStatus === 'failed') {
         return NextResponse.json({
           status: 'failed',

--- a/app/api/programs/[programId]/copy-status/route.ts
+++ b/app/api/programs/[programId]/copy-status/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '@/lib/auth/server';
 import { prisma } from '@/lib/db';
+import { logger } from '@/lib/logger';
 
 /**
  * GET /api/programs/[programId]/copy-status
@@ -109,7 +110,7 @@ export async function GET(
     }, { status: 404 });
 
   } catch (error) {
-    console.error('Error checking copy status:', error);
+    logger.error({ error, context: 'copy-status' }, 'Error checking copy status');
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -41,6 +41,22 @@ async function processCloneJob(job: Job<ProgramCloneJob>): Promise<void> {
 
   console.log(`Processing clone job: communityProgramId=${communityProgramId} programId=${programId} type=${programType}`)
 
+  // Verify the shell program exists before proceeding
+  const shellProgram = await prisma.program.findUnique({
+    where: { id: programId },
+    select: { id: true, copyStatus: true },
+  })
+
+  if (!shellProgram) {
+    throw new Error(`Shell program not found: ${programId}. It may not be committed yet — will retry.`)
+  }
+
+  // Skip if already completed or failed (idempotency guard)
+  if (shellProgram.copyStatus === 'ready' || shellProgram.copyStatus === 'failed') {
+    console.log(`Program ${programId} already has copyStatus=${shellProgram.copyStatus}, skipping`)
+    return
+  }
+
   const communityProgram = await prisma.communityProgram.findUnique({
     where: { id: communityProgramId },
     select: { programData: true },

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
+import { clientLogger } from '@/lib/client-logger'
 import { useToast } from '@/components/ToastProvider'
 import StrengthActivationModal from '../StrengthActivationModal'
 import ArchivedProgramsSection from './ArchivedProgramsSection'
@@ -112,8 +113,17 @@ export default function ConsolidatedProgramsView({
     pollingIntervalRef.current = intervalId
   }
 
+  const handleCloneFailed = (programId: string, message?: string) => {
+    if (completedClonesRef.current.has(programId)) return
+    completedClonesRef.current.add(programId)
+    setCompletedClones(prev => new Set(prev).add(programId))
+    setDeletedPrograms(prev => new Set(prev).add(programId))
+    toast.error('Failed to copy program', message || 'The program cloning failed. Please try again.')
+    cleanupCloningState()
+    router.refresh()
+  }
+
   const checkCopyStatus = async (programId: string): Promise<boolean> => {
-    // Don't check again if we've already completed this clone (use ref for synchronous check)
     if (completedClonesRef.current.has(programId)) {
       return false
     }
@@ -122,40 +132,27 @@ export default function ConsolidatedProgramsView({
       const response = await fetch(`/api/programs/${programId}/copy-status`)
 
       if (!response.ok) {
-        // Program not found - likely failed and was deleted
-        if (!completedClonesRef.current.has(programId)) {
-          completedClonesRef.current.add(programId)
-          setCompletedClones(prev => new Set(prev).add(programId))
-          setDeletedPrograms(prev => new Set(prev).add(programId))
-          toast.error('Failed to copy program', 'The program cloning failed. Please try again.')
-          cleanupCloningState()
-          router.refresh()
-        }
+        handleCloneFailed(programId)
         return false
       }
 
       const data = await response.json()
 
-      // Update progress info if available
       if (data.progress) {
         setCloningProgress(prev => ({ ...prev, [programId]: data.progress }))
       }
 
       if (data.status === 'ready') {
-        // Cloning complete!
         if (!completedClonesRef.current.has(programId)) {
           completedClonesRef.current.add(programId)
           setCompletedClones(prev => new Set(prev).add(programId))
-          // Update local state immediately so card updates
           setLocalCopyStatuses(prev => ({ ...prev, [programId]: 'ready' }))
-          // Clear progress info
           setCloningProgress(prev => {
             const updated = { ...prev }
             delete updated[programId]
             return updated
           })
 
-          // Show activation modal
           const activeProgram = strengthPrograms.find(p => p.isActive && p.id !== programId)
           if (activeProgram) {
             setExistingActiveProgram({ id: activeProgram.id, name: activeProgram.name })
@@ -170,37 +167,15 @@ export default function ConsolidatedProgramsView({
         return false
       }
 
-      if (data.status === 'failed') {
-        // Clone failed — worker exhausted retries or marked as failed
-        if (!completedClonesRef.current.has(programId)) {
-          completedClonesRef.current.add(programId)
-          setCompletedClones(prev => new Set(prev).add(programId))
-          setDeletedPrograms(prev => new Set(prev).add(programId))
-          toast.error('Failed to copy program', data.error || 'The program cloning failed. Please try again.')
-          cleanupCloningState()
-          router.refresh()
-        }
-        return false
-      }
-
-      if (data.status === 'not_found') {
-        // Program was deleted (cloning failed)
-        if (!completedClonesRef.current.has(programId)) {
-          completedClonesRef.current.add(programId)
-          setCompletedClones(prev => new Set(prev).add(programId))
-          setDeletedPrograms(prev => new Set(prev).add(programId))
-          toast.error('Failed to copy program', 'The program cloning failed. Please try again.')
-          cleanupCloningState()
-          router.refresh()
-        }
+      if (data.status === 'failed' || data.status === 'not_found') {
+        handleCloneFailed(programId, data.error)
         return false
       }
 
       // Still cloning
       return true
     } catch (error) {
-      console.error('Error checking copy status:', error)
-      // Continue polling on error
+      clientLogger.error('Error checking copy status:', error)
       return true
     }
   }

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -170,6 +170,19 @@ export default function ConsolidatedProgramsView({
         return false
       }
 
+      if (data.status === 'failed') {
+        // Clone failed — worker exhausted retries or marked as failed
+        if (!completedClonesRef.current.has(programId)) {
+          completedClonesRef.current.add(programId)
+          setCompletedClones(prev => new Set(prev).add(programId))
+          setDeletedPrograms(prev => new Set(prev).add(programId))
+          toast.error('Failed to copy program', data.error || 'The program cloning failed. Please try again.')
+          cleanupCloningState()
+          router.refresh()
+        }
+        return false
+      }
+
       if (data.status === 'not_found') {
         // Program was deleted (cloning failed)
         if (!completedClonesRef.current.has(programId)) {

--- a/lib/community/cloning.ts
+++ b/lib/community/cloning.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from '@prisma/client';
+import { logger } from '@/lib/logger';
 import { publishProgramCloneJob } from '@/lib/queue/clone-jobs';
 
 export interface CloneResult {
@@ -109,19 +110,35 @@ export async function cloneCommunityProgram(
     });
 
     // Publish clone job to queue
-    await publishProgramCloneJob({
-      communityProgramId: communityProgram.id,
-      programId: shellProgram.id,
-      userId: userId,
-      programType: 'strength',
-    });
+    try {
+      await publishProgramCloneJob({
+        communityProgramId: communityProgram.id,
+        programId: shellProgram.id,
+        userId: userId,
+        programType: 'strength',
+      });
+    } catch (publishError) {
+      // Job enqueue failed — mark shell program as failed so it doesn't stay stuck in 'cloning'
+      logger.error(
+        { error: publishError, programId: shellProgram.id },
+        'Failed to publish clone job, marking program as failed'
+      );
+      await prisma.program.update({
+        where: { id: shellProgram.id },
+        data: { copyStatus: 'failed' },
+      });
+      return {
+        success: false,
+        error: 'Failed to start program cloning',
+      };
+    }
 
     return {
       success: true,
       programId: shellProgram.id,
     };
   } catch (error) {
-    console.error('Failed to clone community program:', error);
+    logger.error({ error }, 'Failed to clone community program');
     return {
       success: false,
       error: 'Failed to add program',


### PR DESCRIPTION
## Summary
- **Frontend handles 'failed' status**: Previously, `checkCopyStatus` only handled 'ready' and 'not_found' statuses, causing infinite polling when the worker marked a clone as failed
- **Mark shell program as failed if job publish fails**: If the BullMQ job enqueue throws (e.g., Redis down), the shell program is now marked as 'failed' instead of staying stuck in 'cloning' forever
- **Worker verifies shell program exists**: Defensive check before processing — if the shell program doesn't exist yet (timing issue), the job will throw and retry via BullMQ's exponential backoff
- **Worker skips completed/failed programs**: Idempotency guard to avoid reprocessing programs that already reached a terminal state
- **Use structured logger**: Replaced console.error with pino logger in API routes per project conventions

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Clone a community program — verify it completes and shows activation modal
- [ ] Verify failed clones show error toast (not infinite polling)
- [ ] Verify stuck detection still works (5-minute timeout)

Fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)