### PR TITLE
fix: remove spike link from header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -54,14 +54,6 @@ export default function Header({ userEmail }: Props) {
                   </Link>
                 )
               })}
-              {process.env.NODE_ENV === 'development' && (
-                <Link
-                  href="/dev/mobile-spike"
-                  className="text-xs font-mono text-muted-foreground hover:text-accent transition-colors"
-                >
-                  spike
-                </Link>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

- Remove the dev-only "spike" link from the desktop header nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)