### PR TITLE
feat: custom input controls for workout logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install dependencies
         run: |
           npm ci --prefer-offline --no-audit --loglevel verbose

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -371,6 +371,24 @@ export default function ExerciseLoggingModal({
     }
   }
 
+  const performDeleteSet = useCallback((exerciseId: string, setNumber: number) => {
+    console.log(`Deleting set ${setNumber} for exercise ${exerciseId}`)
+
+    const beforeCount = loggedSets.length
+    setLoggedSets(prev =>
+      prev.filter(
+        (s) => !(s.exerciseId === exerciseId && s.setNumber === setNumber)
+      )
+    )
+
+    const afterCount = loggedSets.length - 1
+    console.log(`Deletion impact: ${beforeCount} -> ${afterCount} total sets`)
+
+    setHasUnsavedChanges(true)
+
+    console.log('Set deleted locally - will sync with next batch or manual sync')
+  }, [loggedSets, setLoggedSets])
+
   const handleDeleteSet = useCallback((setNumber: number) => {
     if (!currentExercise) return
 
@@ -391,24 +409,6 @@ export default function ExerciseLoggingModal({
     // Direct deletion for safe operations
     performDeleteSet(exerciseId, setNumber)
   }, [currentExercise?.id, loggedSets, currentExercise, performDeleteSet])
-
-  const performDeleteSet = useCallback((exerciseId: string, setNumber: number) => {
-    console.log(`Deleting set ${setNumber} for exercise ${exerciseId}`)
-
-    const beforeCount = loggedSets.length
-    setLoggedSets(prev =>
-      prev.filter(
-        (s) => !(s.exerciseId === exerciseId && s.setNumber === setNumber)
-      )
-    )
-
-    const afterCount = loggedSets.length - 1
-    console.log(`Deletion impact: ${beforeCount} -> ${afterCount} total sets`)
-
-    setHasUnsavedChanges(true)
-
-    console.log('Set deleted locally - will sync with next batch or manual sync')
-  }, [loggedSets, setLoggedSets])
 
   const handleConfirmDelete = useCallback(() => {
     if (showDeleteConfirm.exerciseId && showDeleteConfirm.setNumber) {

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { AlertTriangle } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { type Exercise, type ExerciseHistory, useProgressiveExercises } from '@/hooks/useProgressiveExercises'
 import { useSyncState } from '@/hooks/useSyncState'
 // Import LoggedSet type from the hook to ensure consistency
 import { type LoggedSet, useWorkoutStorage } from '@/hooks/useWorkoutStorage'
+import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
 import { useWorkoutSyncService } from '@/lib/sync/workoutSync'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
 import SyncDetailsModal from './SyncDetailsModal'
@@ -174,6 +175,39 @@ export default function ExerciseLoggingModal({
   const hasRpe = currentPrescribedSets.some((s) => s.rpe !== null)
   const hasRir = currentPrescribedSets.some((s) => s.rir !== null)
 
+  // Pre-fill form when exercise loads or set number changes
+  const lastPrefillKey = useRef<string>('')
+  useEffect(() => {
+    if (!currentExercise) return
+
+    const prefillKey = `${currentExercise.id}-${nextSetNumber}`
+    if (lastPrefillKey.current === prefillKey) return
+    lastPrefillKey.current = prefillKey
+
+    const targetPrescribed = currentPrescribedSets.find(s => s.setNumber === nextSetNumber)
+
+    // Pre-fill reps from prescribed set (high end of range)
+    const prefillReps = parseRepsFromPrescribed(targetPrescribed?.reps)
+
+    // Weight: carry forward from last logged set, or default to 0
+    const lastLogged = currentExerciseLoggedSets.length > 0
+      ? currentExerciseLoggedSets[currentExerciseLoggedSets.length - 1]
+      : null
+    const prefillWeight = lastLogged ? String(lastLogged.weight) : '0'
+
+    // Intensity: pre-fill from prescribed
+    const prefillRpe = targetPrescribed?.rpe != null ? String(targetPrescribed.rpe) : ''
+    const prefillRir = targetPrescribed?.rir != null ? String(targetPrescribed.rir) : ''
+
+    setCurrentSet(prev => ({
+      ...prev,
+      reps: prefillReps,
+      weight: prefillWeight,
+      rpe: prefillRpe,
+      rir: prefillRir,
+    }))
+  }, [currentExercise, nextSetNumber, currentPrescribedSets, currentExerciseLoggedSets])
+
   const handleLogSet = useCallback(() => {
     if (!currentSet.reps || !currentSet.weight || !currentExercise) return
 
@@ -203,36 +237,48 @@ export default function ExerciseLoggingModal({
       return updatedSets
     })
 
-    // Reset form
+    // Pre-fill for next set: reps from next prescribed, weight carried forward
+    const nextNextSetNumber = nextSetNumber + 1
+    const nextPrescribed = currentPrescribedSets.find(s => s.setNumber === nextNextSetNumber)
+    const nextReps = parseRepsFromPrescribed(nextPrescribed?.reps || prescribedSet?.reps)
+    const nextRpe = nextPrescribed?.rpe != null ? String(nextPrescribed.rpe) : ''
+    const nextRir = nextPrescribed?.rir != null ? String(nextPrescribed.rir) : ''
+
+    // Update prefill key so the useEffect doesn't overwrite
+    lastPrefillKey.current = `${currentExercise.id}-${nextNextSetNumber}`
+
     setCurrentSet({
-      reps: '',
-      weight: '',
+      reps: nextReps,
+      weight: currentSet.weight, // carry forward weight from just-logged set
       weightUnit: currentSet.weightUnit,
-      rpe: '',
-      rir: '',
+      rpe: nextRpe,
+      rir: nextRir,
     })
-  }, [currentSet, currentExercise, nextSetNumber, setLoggedSets, addSets, addPendingSets])
+  }, [currentSet, currentExercise, nextSetNumber, currentPrescribedSets, prescribedSet, setLoggedSets, addSets, addPendingSets])
 
   const handleNextExercise = () => {
+    // Reset prefill key so the useEffect will pre-fill for the new exercise
+    lastPrefillKey.current = ''
     goToNext()
-    setCurrentSet({
+    setCurrentSet(prev => ({
       reps: '',
       weight: '',
-      weightUnit: 'lbs',
+      weightUnit: prev.weightUnit,
       rpe: '',
       rir: '',
-    })
+    }))
   }
 
   const handlePreviousExercise = () => {
+    lastPrefillKey.current = ''
     goToPrevious()
-    setCurrentSet({
+    setCurrentSet(prev => ({
       reps: '',
       weight: '',
-      weightUnit: 'lbs',
+      weightUnit: prev.weightUnit,
       rpe: '',
       rir: '',
-    })
+    }))
   }
 
   const handleReplaceExercise = () => {

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -217,7 +217,7 @@ export default function ExerciseLoggingModal({
       reps: parseInt(currentSet.reps, 10),
       weight: parseFloat(currentSet.weight),
       weightUnit: currentSet.weightUnit,
-      rpe: currentSet.rpe ? parseInt(currentSet.rpe, 10) : null,
+      rpe: currentSet.rpe ? parseFloat(currentSet.rpe) : null,
       rir: currentSet.rir ? parseInt(currentSet.rir, 10) : null,
     }
 

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -581,8 +581,8 @@ export default function ExerciseLoggingModal({
             ) : null}
           </div>
 
-          {/* Actions Footer */}
-          <ExerciseActionsFooter
+          {/* Actions Footer - hidden when an input is expanded */}
+          {expandedInput === null && <ExerciseActionsFooter
             currentExerciseName={currentExercise?.name || 'Exercise'}
             nextSetNumber={nextSetNumber}
             totalLoggedSets={totalLoggedSets}
@@ -596,7 +596,7 @@ export default function ExerciseLoggingModal({
             onReplaceExercise={handleReplaceExercise}
             onDeleteExercise={handleDeleteExercise}
             onExitWorkout={handleExitWorkout}
-          />
+          />}
 
           {/* Workout completion confirmation modal */}
           {isConfirming && (

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -16,7 +16,7 @@ import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from './workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from './workout-logging/ExerciseLoggingHeader'
 import ExerciseNavigation from './workout-logging/ExerciseNavigation'
-import SetLoggingForm from './workout-logging/SetLoggingForm'
+import SetLoggingForm, { type ExpandedInput } from './workout-logging/SetLoggingForm'
 import { AddExerciseWizard } from './workout-logging/wizards/AddExerciseWizard'
 import { DeleteExerciseWizard } from './workout-logging/wizards/DeleteExerciseWizard'
 import { EditExerciseWizard } from './workout-logging/wizards/EditExerciseWizard'
@@ -80,6 +80,9 @@ export default function ExerciseLoggingModal({
     isDeleteAll?: boolean
   }>({ show: false })
   const [showExitConfirm, setShowExitConfirm] = useState(false)
+
+  // Input expansion state (lifted from SetLoggingForm for SetList visibility)
+  const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
 
   // Wizard state
   const [activeWizard, setActiveWizard] = useState<'add' | 'swap' | 'edit' | 'delete' | null>(null)
@@ -387,8 +390,7 @@ export default function ExerciseLoggingModal({
 
     // Direct deletion for safe operations
     performDeleteSet(exerciseId, setNumber)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentExercise?.id, loggedSets, currentExercise])
+  }, [currentExercise?.id, loggedSets, currentExercise, performDeleteSet])
 
   const performDeleteSet = useCallback((exerciseId: string, setNumber: number) => {
     console.log(`Deleting set ${setNumber} for exercise ${exerciseId}`)
@@ -562,6 +564,7 @@ export default function ExerciseLoggingModal({
                 historyState={currentHistoryState}
                 hasHistoryIndicator={hasHistoryForCurrentExercise}
                 onDeleteSet={handleDeleteSet}
+                isInputExpanded={expandedInput !== null}
                 loggingForm={
                   <SetLoggingForm
                     prescribedSet={prescribedSet}
@@ -570,6 +573,8 @@ export default function ExerciseLoggingModal({
                     hasRir={hasRir}
                     currentSet={currentSet}
                     onSetChange={setCurrentSet}
+                    expandedInput={expandedInput}
+                    onExpandedInputChange={setExpandedInput}
                   />
                 }
               />

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -4,6 +4,7 @@ import { Plus, Trash } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
 import { useUserSettings } from '@/hooks/useUserSettings'
+import { RIR_PRESETS, RPE_PRESETS } from '@/lib/constants/intensity-presets'
 import type { ExerciseDefinition } from './ExerciseSearchInterface'
 
 type Tab = 'sets' | 'notes'
@@ -48,26 +49,7 @@ const REP_PRESETS = [
   { value: 'AMRAP', label: 'AMRAP', description: 'As Many Reps As Possible' }
 ]
 
-const RIR_PRESETS = [
-  { value: 0, label: '0', description: 'Max effort, failure reached. Use sparingly' },
-  { value: 1, label: '1', description: '1 rep left in the tank' },
-  { value: 2, label: '2', description: '2 reps left in the tank' },
-  { value: 3, label: '3', description: '3 reps left in the tank' },
-  { value: 4, label: '4', description: '4 reps left in the tank' },
-  { value: 5, label: '5+', description: 'Warmup / Deload sets' }
-]
-
-const RPE_PRESETS = [
-  { value: 6.0, label: '6', description: 'Light effort, easy reps' },
-  { value: 6.5, label: '6.5', description: 'Light to moderate effort' },
-  { value: 7.0, label: '7', description: 'Moderate effort, could do several more' },
-  { value: 7.5, label: '7.5', description: 'Moderate to challenging' },
-  { value: 8.0, label: '8', description: 'Challenging, 2-3 reps left' },
-  { value: 8.5, label: '8.5', description: 'Very challenging, 1-2 reps left' },
-  { value: 9.0, label: '9', description: 'Very hard, 1 rep left' },
-  { value: 9.5, label: '9.5', description: 'Near maximal, failure on next rep' },
-  { value: 10, label: '10', description: 'Max effort, failure reached. Use sparingly' }
-]
+// RPE_PRESETS and RIR_PRESETS imported from @/lib/constants/intensity-presets
 
 export function SetConfigurationInterface({
   exercise,

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,12 +1,12 @@
 'use client'
 
+import Image from 'next/image'
 import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/hooks/useWorkoutStorage'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
-import Image from 'next/image'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -55,6 +55,7 @@ interface ExerciseDisplayTabsProps {
   hasHistoryIndicator?: boolean // Pre-computed indicator for dot (updates reactively)
   onDeleteSet: (setNumber: number) => void
   loggingForm: React.ReactNode
+  isInputExpanded?: boolean
 }
 
 const FAU_DISPLAY_NAMES: Record<string, string> = {
@@ -99,6 +100,7 @@ export default function ExerciseDisplayTabs({
   hasHistoryIndicator = false,
   onDeleteSet,
   loggingForm,
+  isInputExpanded = false,
 }: ExerciseDisplayTabsProps) {
   const [expandedImage, setExpandedImage] = useState<string | null>(null)
   const loggedCount = loggedSets.length
@@ -134,12 +136,14 @@ export default function ExerciseDisplayTabs({
       </TabsList>
 
       <TabsContent value="log-sets" className="flex-1 overflow-y-auto px-4 flex flex-col gap-3">
-        <SetList
-          prescribedSets={prescribedSets}
-          loggedSets={loggedSets}
-          exerciseHistory={null}
-          onDeleteSet={onDeleteSet}
-        />
+        {!isInputExpanded && (
+          <SetList
+            prescribedSets={prescribedSets}
+            loggedSets={loggedSets}
+            exerciseHistory={null}
+            onDeleteSet={onDeleteSet}
+          />
+        )}
         {loggingForm}
       </TabsContent>
 
@@ -300,9 +304,12 @@ export default function ExerciseDisplayTabs({
 
       {expandedImage && (
         <div
+          role="button"
+          tabIndex={0}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
           style={{ position: 'fixed', inset: 0, zIndex: 50 }}
           onClick={() => setExpandedImage(null)}
+          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setExpandedImage(null) }}
         >
           <div className="relative w-[90vw] max-w-lg aspect-square">
             <Image

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -59,19 +59,26 @@ export default function SetList({
         </div>
       )}
 
-      {/* Prescribed Sets Reference */}
-      <div>
-        <h4 className="text-base sm:text-lg font-bold text-foreground mb-2 uppercase tracking-wider">Target</h4>
-        <div className="bg-muted p-3 sm:p-4 space-y-2 border-2 border-border">
-          {prescribedSets.map((set) => (
-            <div key={set.id} className="text-base sm:text-lg text-foreground">
-              Set {set.setNumber}: {set.reps} reps @ {set.weight || '—'}
-              {set.rir !== null && ` • RIR ${set.rir}`}
-              {set.rpe !== null && ` • RPE ${set.rpe}`}
+      {/* Prescribed Sets Reference - only show sets not yet logged */}
+      {(() => {
+        const loggedSetNumbers = new Set(loggedSets.map(s => s.setNumber))
+        const remainingSets = prescribedSets.filter(s => !loggedSetNumbers.has(s.setNumber))
+        if (remainingSets.length === 0) return null
+        return (
+          <div>
+            <h4 className="text-base sm:text-lg font-bold text-foreground mb-2 uppercase tracking-wider">Target</h4>
+            <div className="bg-muted p-3 sm:p-4 space-y-2 border-2 border-border">
+              {remainingSets.map((set) => (
+                <div key={set.id} className="text-base sm:text-lg text-foreground">
+                  Set {set.setNumber}: {set.reps} reps @ {set.weight || '—'}
+                  {set.rir !== null && ` • RIR ${set.rir}`}
+                  {set.rpe !== null && ` • RPE ${set.rpe}`}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
+        )
+      })()}
 
       {/* Logged Sets */}
       {loggedSets.length > 0 && (

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useUserSettings } from '@/hooks/useUserSettings'
+import { IntensitySelector } from './inputs/IntensitySelector'
+import { RepsStepper } from './inputs/RepsStepper'
+import { WeightKeypad } from './inputs/WeightKeypad'
 
 interface PrescribedSet {
   id: string
@@ -33,6 +36,8 @@ interface SetLoggingFormProps {
   }) => void
 }
 
+type ExpandedInput = 'weight' | 'rpe' | 'rir' | null
+
 export default function SetLoggingForm({
   prescribedSet,
   hasLoggedAllPrescribed,
@@ -42,13 +47,14 @@ export default function SetLoggingForm({
   onSetChange,
 }: SetLoggingFormProps) {
   const { settings } = useUserSettings()
+  const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
 
   // Update weight unit when settings change
   useEffect(() => {
     if (settings?.defaultWeightUnit && currentSet.weightUnit !== settings.defaultWeightUnit) {
       onSetChange({
         ...currentSet,
-        weightUnit: settings.defaultWeightUnit
+        weightUnit: settings.defaultWeightUnit,
       })
     }
   }, [settings?.defaultWeightUnit, currentSet, onSetChange])
@@ -66,92 +72,65 @@ export default function SetLoggingForm({
     )
   }
 
+  const handleExpand = (input: ExpandedInput) => {
+    setExpandedInput(input)
+  }
+
+  const handleCollapse = () => {
+    setExpandedInput(null)
+  }
+
+  const showReps = expandedInput === null || expandedInput === 'weight'
+  const showWeight = true // always visible, either compact or expanded
+  const showIntensity = expandedInput === null || expandedInput === 'rpe' || expandedInput === 'rir'
+
   return (
     <div className="flex-shrink-0">
       <div className="space-y-3">
-        {/* Reps and Weight - Side by side */}
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label htmlFor="log-reps" className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
-              Reps *
-            </label>
-            <input
-              id="log-reps"
-              type="number"
-              inputMode="numeric"
-              value={currentSet.reps}
-              onChange={(e) =>
-                onSetChange({ ...currentSet, reps: e.target.value })
-              }
-              placeholder={prescribedSet?.reps.toString() || '0'}
-              className="w-full px-4 py-3 text-lg border-2 border-input focus:ring-2 focus:ring-primary focus:border-primary bg-muted text-foreground"
-            />
-          </div>
+        {/* Reps stepper - always visible when no input is expanded, hidden when intensity is expanded */}
+        {showReps && (
+          <RepsStepper
+            value={currentSet.reps}
+            onChange={(val) => onSetChange({ ...currentSet, reps: val })}
+            placeholder={prescribedSet?.reps?.toString()}
+          />
+        )}
 
-          <div>
-            <label htmlFor="log-weight" className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
-              Weight * ({currentSet.weightUnit})
-            </label>
-            <input
-              id="log-weight"
-              type="number"
-              inputMode="decimal"
-              step="0.5"
-              value={currentSet.weight}
-              onChange={(e) =>
-                onSetChange({ ...currentSet, weight: e.target.value })
-              }
-              placeholder={prescribedSet?.weight?.replace(/[^0-9.]/g, '') || '0'}
-              className="w-full px-4 py-3 text-lg border-2 border-input focus:ring-2 focus:ring-primary focus:border-primary bg-muted text-foreground"
-            />
-          </div>
-        </div>
+        {/* Weight keypad - always visible (compact or expanded) */}
+        {showWeight && (
+          <WeightKeypad
+            value={currentSet.weight}
+            weightUnit={currentSet.weightUnit}
+            onChange={(val) => onSetChange({ ...currentSet, weight: val })}
+            isExpanded={expandedInput === 'weight'}
+            onExpand={() => handleExpand('weight')}
+            onCollapse={handleCollapse}
+          />
+        )}
 
-        {/* Optional RPE/RIR */}
-        {(hasRpe || hasRir) && (
-          <div className="grid grid-cols-2 gap-3">
-            {hasRir && (
-              <div>
-                <label htmlFor="log-rir" className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
-                  RIR (optional)
-                </label>
-                <input
-                  id="log-rir"
-                  type="number"
-                  inputMode="numeric"
-                  min="0"
-                  max="10"
-                  value={currentSet.rir}
-                  onChange={(e) =>
-                    onSetChange({ ...currentSet, rir: e.target.value })
-                  }
-                  placeholder={prescribedSet?.rir?.toString() || '—'}
-                  className="w-full px-4 py-3 text-lg border-2 border-input focus:ring-2 focus:ring-primary focus:border-primary bg-muted text-foreground"
-                />
-              </div>
-            )}
+        {/* Intensity selectors - only when exercise uses them */}
+        {showIntensity && hasRir && (
+          <IntensitySelector
+            type="rir"
+            value={currentSet.rir}
+            onChange={(val) => onSetChange({ ...currentSet, rir: val })}
+            prescribedValue={prescribedSet?.rir}
+            isExpanded={expandedInput === 'rir'}
+            onExpand={() => handleExpand('rir')}
+            onCollapse={handleCollapse}
+          />
+        )}
 
-            {hasRpe && (
-              <div>
-                <label htmlFor="log-rpe" className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
-                  RPE (optional)
-                </label>
-                <input
-                  id="log-rpe"
-                  type="number"
-                  inputMode="numeric"
-                  min="1"
-                  max="10"
-                  value={currentSet.rpe}
-                  onChange={(e) =>
-                    onSetChange({ ...currentSet, rpe: e.target.value })
-                  }
-                  placeholder={prescribedSet?.rpe?.toString() || '—'}
-                  className="w-full px-4 py-3 text-lg border-2 border-input focus:ring-2 focus:ring-primary focus:border-primary bg-muted text-foreground"
-                />
-              </div>
-            )}
-          </div>
+        {showIntensity && hasRpe && (
+          <IntensitySelector
+            type="rpe"
+            value={currentSet.rpe}
+            onChange={(val) => onSetChange({ ...currentSet, rpe: val })}
+            prescribedValue={prescribedSet?.rpe}
+            isExpanded={expandedInput === 'rpe'}
+            onExpand={() => handleExpand('rpe')}
+            onCollapse={handleCollapse}
+          />
         )}
       </div>
     </div>

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -83,8 +83,8 @@ export default function SetLoggingForm({
     onExpandedInputChange(null)
   }
 
-  const showReps = expandedInput === null || expandedInput === 'weight'
-  const showWeight = true // always visible, either compact or expanded
+  const showReps = expandedInput === null
+  const showWeight = expandedInput === null || expandedInput === 'weight'
   const showIntensity = expandedInput === null || expandedInput === 'rpe' || expandedInput === 'rir'
 
   return (
@@ -99,41 +99,83 @@ export default function SetLoggingForm({
           />
         )}
 
-        {/* Weight keypad - always visible (compact or expanded) */}
-        {showWeight && (
-          <WeightKeypad
-            value={currentSet.weight}
-            weightUnit={currentSet.weightUnit}
-            onChange={(val) => onSetChange({ ...currentSet, weight: val })}
-            isExpanded={expandedInput === 'weight'}
-            onExpand={() => handleExpand('weight')}
-            onCollapse={handleCollapse}
-          />
-        )}
+        {/* Weight + Intensity: side by side when compact, stacked when expanded */}
+        {expandedInput === null && (hasRir || hasRpe) ? (
+          <div className="flex gap-3">
+            <div className="flex-1">
+              <WeightKeypad
+                value={currentSet.weight}
+                weightUnit={currentSet.weightUnit}
+                onChange={(val) => onSetChange({ ...currentSet, weight: val })}
+                isExpanded={false}
+                onExpand={() => handleExpand('weight')}
+                onCollapse={handleCollapse}
+              />
+            </div>
+            <div className="flex-1">
+              {hasRir && (
+                <IntensitySelector
+                  type="rir"
+                  value={currentSet.rir}
+                  onChange={(val) => onSetChange({ ...currentSet, rir: val })}
+                  prescribedValue={prescribedSet?.rir}
+                  isExpanded={false}
+                  onExpand={() => handleExpand('rir')}
+                  onCollapse={handleCollapse}
+                />
+              )}
+              {hasRpe && (
+                <IntensitySelector
+                  type="rpe"
+                  value={currentSet.rpe}
+                  onChange={(val) => onSetChange({ ...currentSet, rpe: val })}
+                  prescribedValue={prescribedSet?.rpe}
+                  isExpanded={false}
+                  onExpand={() => handleExpand('rpe')}
+                  onCollapse={handleCollapse}
+                />
+              )}
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Weight keypad - full width when expanded or no intensity */}
+            {showWeight && (
+              <WeightKeypad
+                value={currentSet.weight}
+                weightUnit={currentSet.weightUnit}
+                onChange={(val) => onSetChange({ ...currentSet, weight: val })}
+                isExpanded={expandedInput === 'weight'}
+                onExpand={() => handleExpand('weight')}
+                onCollapse={handleCollapse}
+              />
+            )}
 
-        {/* Intensity selectors - only when exercise uses them */}
-        {showIntensity && hasRir && (
-          <IntensitySelector
-            type="rir"
-            value={currentSet.rir}
-            onChange={(val) => onSetChange({ ...currentSet, rir: val })}
-            prescribedValue={prescribedSet?.rir}
-            isExpanded={expandedInput === 'rir'}
-            onExpand={() => handleExpand('rir')}
-            onCollapse={handleCollapse}
-          />
-        )}
+            {/* Intensity selectors - full width when expanded */}
+            {showIntensity && hasRir && (
+              <IntensitySelector
+                type="rir"
+                value={currentSet.rir}
+                onChange={(val) => onSetChange({ ...currentSet, rir: val })}
+                prescribedValue={prescribedSet?.rir}
+                isExpanded={expandedInput === 'rir'}
+                onExpand={() => handleExpand('rir')}
+                onCollapse={handleCollapse}
+              />
+            )}
 
-        {showIntensity && hasRpe && (
-          <IntensitySelector
-            type="rpe"
-            value={currentSet.rpe}
-            onChange={(val) => onSetChange({ ...currentSet, rpe: val })}
-            prescribedValue={prescribedSet?.rpe}
-            isExpanded={expandedInput === 'rpe'}
-            onExpand={() => handleExpand('rpe')}
-            onCollapse={handleCollapse}
-          />
+            {showIntensity && hasRpe && (
+              <IntensitySelector
+                type="rpe"
+                value={currentSet.rpe}
+                onChange={(val) => onSetChange({ ...currentSet, rpe: val })}
+                prescribedValue={prescribedSet?.rpe}
+                isExpanded={expandedInput === 'rpe'}
+                onExpand={() => handleExpand('rpe')}
+                onCollapse={handleCollapse}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -88,8 +88,8 @@ export default function SetLoggingForm({
   const showIntensity = expandedInput === null || expandedInput === 'rpe' || expandedInput === 'rir'
 
   return (
-    <div className="flex-shrink-0">
-      <div className="space-y-3">
+    <div className={expandedInput !== null ? 'flex-1 flex flex-col' : 'flex-shrink-0'}>
+      <div className={expandedInput !== null ? 'flex-1 flex flex-col' : 'space-y-3'}>
         {/* Reps stepper - always visible when no input is expanded, hidden when intensity is expanded */}
         {showReps && (
           <RepsStepper

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { IntensitySelector } from './inputs/IntensitySelector'
 import { RepsStepper } from './inputs/RepsStepper'
@@ -14,6 +14,8 @@ interface PrescribedSet {
   rpe: number | null
   rir: number | null
 }
+
+export type ExpandedInput = 'weight' | 'rpe' | 'rir' | null
 
 interface SetLoggingFormProps {
   prescribedSet: PrescribedSet | undefined
@@ -34,9 +36,9 @@ interface SetLoggingFormProps {
     rpe: string
     rir: string
   }) => void
+  expandedInput: ExpandedInput
+  onExpandedInputChange: (input: ExpandedInput) => void
 }
-
-type ExpandedInput = 'weight' | 'rpe' | 'rir' | null
 
 export default function SetLoggingForm({
   prescribedSet,
@@ -45,9 +47,10 @@ export default function SetLoggingForm({
   hasRir,
   currentSet,
   onSetChange,
+  expandedInput,
+  onExpandedInputChange,
 }: SetLoggingFormProps) {
   const { settings } = useUserSettings()
-  const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
 
   // Update weight unit when settings change
   useEffect(() => {
@@ -73,11 +76,11 @@ export default function SetLoggingForm({
   }
 
   const handleExpand = (input: ExpandedInput) => {
-    setExpandedInput(input)
+    onExpandedInputChange(input)
   }
 
   const handleCollapse = () => {
-    setExpandedInput(null)
+    onExpandedInputChange(null)
   }
 
   const showReps = expandedInput === null || expandedInput === 'weight'

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -16,7 +16,6 @@ export function IntensitySelector({
   type,
   value,
   onChange,
-  prescribedValue,
   isExpanded,
   onExpand,
   onCollapse,
@@ -25,9 +24,6 @@ export function IntensitySelector({
   const label = type === 'rpe' ? 'RPE' : 'RIR'
 
   const numericValue = value ? parseFloat(value) : null
-  const selectedPreset = numericValue !== null
-    ? presets.find(p => p.value === numericValue)
-    : null
 
   const handleSelect = (preset: IntensityPreset) => {
     onChange(String(preset.value))

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { type IntensityPreset, RIR_PRESETS, RPE_PRESETS } from '@/lib/constants/intensity-presets'
+
+interface IntensitySelectorProps {
+  type: 'rpe' | 'rir'
+  value: string
+  onChange: (value: string) => void
+  prescribedValue?: number | null
+  isExpanded: boolean
+  onExpand: () => void
+  onCollapse: () => void
+}
+
+export function IntensitySelector({
+  type,
+  value,
+  onChange,
+  prescribedValue,
+  isExpanded,
+  onExpand,
+  onCollapse,
+}: IntensitySelectorProps) {
+  const presets: IntensityPreset[] = type === 'rpe' ? RPE_PRESETS : RIR_PRESETS
+  const label = type === 'rpe' ? 'RPE' : 'RIR'
+
+  const numericValue = value ? parseFloat(value) : null
+  const selectedPreset = numericValue !== null
+    ? presets.find(p => p.value === numericValue)
+    : null
+
+  const handleSelect = (preset: IntensityPreset) => {
+    onChange(String(preset.value))
+    onCollapse()
+  }
+
+  // Compact view
+  if (!isExpanded) {
+    return (
+      <div>
+        <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
+          {label} (optional)
+        </span>
+        <button
+          type="button"
+          onClick={onExpand}
+          className="w-full h-14 px-4 flex items-center justify-between
+            bg-muted border-2 border-input
+            hover:border-primary active:bg-secondary transition-colors text-left"
+        >
+          <span className="text-2xl font-bold text-foreground tabular-nums">
+            {value || (prescribedValue != null ? String(prescribedValue) : '--')}
+          </span>
+          {selectedPreset && (
+            <span className="text-xs text-muted-foreground font-semibold uppercase tracking-wider truncate ml-2">
+              {selectedPreset.description}
+            </span>
+          )}
+        </button>
+      </div>
+    )
+  }
+
+  // Expanded view with preset grid
+  return (
+    <div>
+      <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
+        {label} (optional)
+      </span>
+
+      <div className="space-y-1">
+        {presets.map((preset) => {
+          const isSelected = numericValue === preset.value
+          return (
+            <button
+              key={preset.value}
+              type="button"
+              onClick={() => handleSelect(preset)}
+              className={`w-full px-4 py-3 flex items-center gap-3
+                border-2 transition-colors text-left
+                active:bg-primary active:text-primary-foreground active:border-primary
+                ${isSelected
+                  ? 'bg-primary/10 border-primary text-foreground shadow-[0_0_10px_rgba(var(--primary-rgb),0.2)]'
+                  : 'bg-muted border-input text-foreground hover:border-primary hover:bg-secondary'
+                }`}
+            >
+              <span className={`text-xl font-bold tabular-nums min-w-[40px] ${
+                isSelected ? 'text-primary' : ''
+              }`}>
+                {preset.label}
+              </span>
+              <span className="text-sm text-muted-foreground font-medium">
+                {preset.description}
+              </span>
+            </button>
+          )
+        })}
+
+        {/* Clear / Skip button */}
+        <button
+          type="button"
+          onClick={() => {
+            onChange('')
+            onCollapse()
+          }}
+          className="w-full px-4 py-3 bg-muted border-2 border-input
+            text-muted-foreground font-bold uppercase tracking-wider text-sm
+            hover:border-primary hover:bg-secondary transition-colors"
+        >
+          Skip {label}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -44,18 +44,14 @@ export function IntensitySelector({
         <button
           type="button"
           onClick={onExpand}
-          className="w-full h-14 px-4 flex items-center justify-between
-            bg-muted border-2 border-input
-            hover:border-primary active:bg-secondary transition-colors text-left"
+          className="w-full h-14 px-4 flex items-center justify-center
+            bg-muted border-2 border-input border-b-4
+            hover:border-primary active:bg-secondary active:border-b-2 active:translate-y-[2px]
+            transition-all duration-75"
         >
           <span className="text-2xl font-bold text-foreground tabular-nums">
-            {value || (prescribedValue != null ? String(prescribedValue) : '--')}
+            {value || '--'}
           </span>
-          {selectedPreset && (
-            <span className="text-xs text-muted-foreground font-semibold uppercase tracking-wider truncate ml-2">
-              {selectedPreset.description}
-            </span>
-          )}
         </button>
       </div>
     )
@@ -89,7 +85,7 @@ export function IntensitySelector({
               }`}>
                 {preset.label}
               </span>
-              <span className="text-sm text-muted-foreground font-medium">
+              <span className="text-base text-muted-foreground font-medium">
                 {preset.description}
               </span>
             </button>
@@ -104,7 +100,7 @@ export function IntensitySelector({
             onCollapse()
           }}
           className="w-full px-4 py-3 bg-muted border-2 border-input
-            text-muted-foreground font-bold uppercase tracking-wider text-sm
+            text-muted-foreground font-bold uppercase tracking-wider text-base
             hover:border-primary hover:bg-secondary transition-colors"
         >
           Skip {label}

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { Minus, Plus } from 'lucide-react'
+
+interface RepsStepperProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) {
+  const numericValue = value ? parseInt(value, 10) : 0
+  const hasValue = value !== ''
+
+  const handleDecrement = () => {
+    if (!hasValue) return
+    const next = Math.max(0, numericValue - 1)
+    onChange(next === 0 ? '' : String(next))
+  }
+
+  const handleIncrement = () => {
+    const next = hasValue ? numericValue + 1 : 1
+    onChange(String(next))
+  }
+
+  return (
+    <div>
+      <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
+        Reps
+      </span>
+      <div className="flex items-center gap-0">
+        <button
+          type="button"
+          onClick={handleDecrement}
+          disabled={!hasValue || numericValue <= 0}
+          className="flex-shrink-0 w-14 h-14 flex items-center justify-center
+            bg-muted border-2 border-input border-r-0
+            text-foreground hover:bg-secondary hover:border-primary
+            active:bg-primary active:text-primary-foreground
+            disabled:opacity-30 disabled:hover:bg-muted disabled:hover:border-input
+            transition-colors"
+          aria-label="Decrease reps"
+        >
+          <Minus size={24} strokeWidth={3} />
+        </button>
+
+        <div
+          className="flex-1 h-14 flex items-center justify-center
+            bg-muted border-2 border-input
+            text-2xl font-bold text-foreground tabular-nums min-w-[60px]"
+        >
+          {hasValue ? numericValue : (
+            <span className="text-muted-foreground text-lg">
+              {placeholder || '0'}
+            </span>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleIncrement}
+          className="flex-shrink-0 w-14 h-14 flex items-center justify-center
+            bg-muted border-2 border-input border-l-0
+            text-foreground hover:bg-secondary hover:border-primary
+            active:bg-primary active:text-primary-foreground
+            transition-colors"
+          aria-label="Increase reps"
+        >
+          <Plus size={24} strokeWidth={3} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -28,17 +28,17 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
       <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
         Reps
       </span>
-      <div className="flex items-center gap-0">
+      <div className="flex items-center gap-2">
         <button
           type="button"
           onClick={handleDecrement}
           disabled={!hasValue || numericValue <= 0}
           className="flex-shrink-0 w-14 h-14 flex items-center justify-center
-            bg-muted border-2 border-input border-r-0
-            text-foreground hover:bg-secondary hover:border-primary
-            active:bg-primary active:text-primary-foreground
-            disabled:opacity-30 disabled:hover:bg-muted disabled:hover:border-input
-            transition-colors"
+            bg-error/15 border-2 border-error/40 border-b-4
+            text-error hover:bg-error/25 hover:border-error
+            active:bg-error active:text-white active:border-b-2 active:translate-y-[2px]
+            disabled:opacity-30 disabled:hover:bg-error/15 disabled:hover:border-error/40
+            transition-all duration-75"
           aria-label="Decrease reps"
         >
           <Minus size={24} strokeWidth={3} />
@@ -60,10 +60,10 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
           type="button"
           onClick={handleIncrement}
           className="flex-shrink-0 w-14 h-14 flex items-center justify-center
-            bg-muted border-2 border-input border-l-0
-            text-foreground hover:bg-secondary hover:border-primary
-            active:bg-primary active:text-primary-foreground
-            transition-colors"
+            bg-success/15 border-2 border-success/40 border-b-4
+            text-success hover:bg-success/25 hover:border-success
+            active:bg-success active:text-white active:border-b-2 active:translate-y-[2px]
+            transition-all duration-75"
           aria-label="Increase reps"
         >
           <Plus size={24} strokeWidth={3} />

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -92,9 +92,10 @@ export function WeightKeypad({
           type="button"
           onClick={handleExpand}
           className="w-full h-14 px-4 flex items-center justify-center
-            bg-muted border-2 border-input
+            bg-muted border-2 border-input border-b-4
             text-2xl font-bold text-foreground tabular-nums
-            hover:border-primary active:bg-secondary transition-colors"
+            hover:border-primary active:bg-secondary active:border-b-2 active:translate-y-[2px]
+            transition-all duration-75"
         >
           {value || '0'}
           <span className="text-sm font-semibold text-muted-foreground ml-2">

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Delete } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 interface WeightKeypadProps {
   value: string
@@ -27,24 +27,30 @@ export function WeightKeypad({
   onExpand,
   onCollapse,
 }: WeightKeypadProps) {
-  const [replaceOnNext, setReplaceOnNext] = useState(false)
+  const replaceOnNext = useRef(false)
+
+  // Set replaceOnNext when expanding
+  useEffect(() => {
+    if (isExpanded) {
+      replaceOnNext.current = true
+    }
+  }, [isExpanded])
 
   const handleExpand = () => {
-    setReplaceOnNext(true)
     onExpand()
   }
 
   const handleKeyPress = useCallback((key: string) => {
     if (key === 'CLR') {
       onChange('')
-      setReplaceOnNext(false)
+      replaceOnNext.current = false
       return
     }
 
     if (key === 'DEL') {
-      if (replaceOnNext) {
+      if (replaceOnNext.current) {
         onChange('')
-        setReplaceOnNext(false)
+        replaceOnNext.current = false
         return
       }
       const newValue = value.slice(0, -1)
@@ -53,10 +59,10 @@ export function WeightKeypad({
     }
 
     // Digit
-    if (replaceOnNext) {
+    if (replaceOnNext.current) {
       // First keystroke replaces the pre-filled value
       onChange(key === '0' ? '0' : key)
-      setReplaceOnNext(false)
+      replaceOnNext.current = false
       return
     }
 
@@ -74,10 +80,10 @@ export function WeightKeypad({
     }
 
     onChange(candidate)
-  }, [value, onChange, replaceOnNext])
+  }, [value, onChange])
 
   const handleDone = () => {
-    setReplaceOnNext(false)
+    replaceOnNext.current = false
     onCollapse()
   }
 

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { Delete } from 'lucide-react'
+import { useCallback, useState } from 'react'
+
+interface WeightKeypadProps {
+  value: string
+  weightUnit: 'lbs' | 'kg'
+  onChange: (value: string) => void
+  isExpanded: boolean
+  onExpand: () => void
+  onCollapse: () => void
+}
+
+const KEYPAD_KEYS = [
+  '1', '2', '3',
+  '4', '5', '6',
+  '7', '8', '9',
+  'CLR', '0', 'DEL',
+] as const
+
+export function WeightKeypad({
+  value,
+  weightUnit,
+  onChange,
+  isExpanded,
+  onExpand,
+  onCollapse,
+}: WeightKeypadProps) {
+  const [replaceOnNext, setReplaceOnNext] = useState(false)
+
+  const handleExpand = () => {
+    setReplaceOnNext(true)
+    onExpand()
+  }
+
+  const handleKeyPress = useCallback((key: string) => {
+    if (key === 'CLR') {
+      onChange('')
+      setReplaceOnNext(false)
+      return
+    }
+
+    if (key === 'DEL') {
+      if (replaceOnNext) {
+        onChange('')
+        setReplaceOnNext(false)
+        return
+      }
+      const newValue = value.slice(0, -1)
+      onChange(newValue)
+      return
+    }
+
+    // Digit
+    if (replaceOnNext) {
+      // First keystroke replaces the pre-filled value
+      onChange(key === '0' ? '0' : key)
+      setReplaceOnNext(false)
+      return
+    }
+
+    const candidate = value + key
+    const numericCandidate = parseInt(candidate, 10)
+
+    // Clamp to 0-999
+    if (numericCandidate > 999) return
+
+    // Prevent leading zeros (allow single "0")
+    if (value === '0' && key === '0') return
+    if (value === '0' && key !== '0') {
+      onChange(key)
+      return
+    }
+
+    onChange(candidate)
+  }, [value, onChange, replaceOnNext])
+
+  const handleDone = () => {
+    setReplaceOnNext(false)
+    onCollapse()
+  }
+
+  // Compact view
+  if (!isExpanded) {
+    return (
+      <div>
+        <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
+          Weight ({weightUnit})
+        </span>
+        <button
+          type="button"
+          onClick={handleExpand}
+          className="w-full h-14 px-4 flex items-center justify-center
+            bg-muted border-2 border-input
+            text-2xl font-bold text-foreground tabular-nums
+            hover:border-primary active:bg-secondary transition-colors"
+        >
+          {value || '0'}
+          <span className="text-sm font-semibold text-muted-foreground ml-2">
+            {weightUnit}
+          </span>
+        </button>
+      </div>
+    )
+  }
+
+  // Expanded view with keypad
+  return (
+    <div>
+      <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
+        Weight ({weightUnit})
+      </span>
+
+      {/* Current value display */}
+      <div
+        className="w-full h-14 px-4 flex items-center justify-center
+          bg-card border-2 border-primary
+          text-2xl font-bold text-foreground tabular-nums
+          shadow-[0_0_10px_rgba(var(--primary-rgb),0.3)]"
+      >
+        {value || '0'}
+        <span className="text-sm font-semibold text-muted-foreground ml-2">
+          {weightUnit}
+        </span>
+      </div>
+
+      {/* Number keypad grid */}
+      <div className="grid grid-cols-3 gap-1 mt-1">
+        {KEYPAD_KEYS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => handleKeyPress(key)}
+            className={`h-12 flex items-center justify-center
+              font-bold text-lg border-2 transition-colors
+              active:bg-primary active:text-primary-foreground active:border-primary
+              ${key === 'CLR'
+                ? 'bg-muted text-muted-foreground border-input hover:border-primary text-sm uppercase tracking-wider'
+                : key === 'DEL'
+                  ? 'bg-muted text-muted-foreground border-input hover:border-primary'
+                  : 'bg-muted text-foreground border-input hover:border-primary hover:bg-secondary'
+              }`}
+          >
+            {key === 'DEL' ? <Delete size={20} /> : key}
+          </button>
+        ))}
+      </div>
+
+      {/* Done button */}
+      <button
+        type="button"
+        onClick={handleDone}
+        className="w-full mt-1 h-12 bg-primary text-primary-foreground
+          font-bold uppercase tracking-wider text-base
+          hover:bg-primary/90 active:bg-primary/80
+          transition-colors doom-button-3d"
+      >
+        Done
+      </button>
+    </div>
+  )
+}

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -112,9 +112,9 @@ export function WeightKeypad({
     )
   }
 
-  // Expanded view with keypad
+  // Expanded view with keypad - mt-auto pushes to bottom of flex container
   return (
-    <div>
+    <div className="mt-auto">
       <span className="block text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
         Weight ({weightUnit})
       </span>

--- a/lib/constants/intensity-presets.ts
+++ b/lib/constants/intensity-presets.ts
@@ -1,0 +1,56 @@
+export type IntensityPreset = {
+  value: number
+  label: string
+  description: string
+}
+
+export const RIR_PRESETS: IntensityPreset[] = [
+  { value: 0, label: '0', description: 'Max effort, failure reached. Use sparingly' },
+  { value: 1, label: '1', description: '1 rep left in the tank' },
+  { value: 2, label: '2', description: '2 reps left in the tank' },
+  { value: 3, label: '3', description: '3 reps left in the tank' },
+  { value: 4, label: '4', description: '4 reps left in the tank' },
+  { value: 5, label: '5+', description: 'Warmup / Deload sets' },
+]
+
+export const RPE_PRESETS: IntensityPreset[] = [
+  { value: 6.0, label: '6', description: 'Light effort, easy reps' },
+  { value: 6.5, label: '6.5', description: 'Light to moderate effort' },
+  { value: 7.0, label: '7', description: 'Moderate effort, could do several more' },
+  { value: 7.5, label: '7.5', description: 'Moderate to challenging' },
+  { value: 8.0, label: '8', description: 'Challenging, 2-3 reps left' },
+  { value: 8.5, label: '8.5', description: 'Very challenging, 1-2 reps left' },
+  { value: 9.0, label: '9', description: 'Very hard, 1 rep left' },
+  { value: 9.5, label: '9.5', description: 'Near maximal, failure on next rep' },
+  { value: 10, label: '10', description: 'Max effort, failure reached. Use sparingly' },
+]
+
+/**
+ * Parse prescribed reps string to a numeric pre-fill value.
+ * - "8-12" -> "12" (high end of range — hitting top signals time to increase weight)
+ * - "15+" -> "15"
+ * - "AMRAP" -> "" (user must enter)
+ * - "10" -> "10"
+ */
+export function parseRepsFromPrescribed(reps: string | undefined): string {
+  if (!reps) return ''
+
+  const trimmed = reps.trim()
+
+  // AMRAP — no pre-fill
+  if (trimmed.toUpperCase() === 'AMRAP') return ''
+
+  // Range like "8-12" — use high end
+  const rangeMatch = trimmed.match(/^(\d+)-(\d+)$/)
+  if (rangeMatch) return rangeMatch[2]
+
+  // Plus notation like "15+" — use the number
+  const plusMatch = trimmed.match(/^(\d+)\+$/)
+  if (plusMatch) return plusMatch[1]
+
+  // Single number like "10"
+  const singleMatch = trimmed.match(/^(\d+)$/)
+  if (singleMatch) return singleMatch[1]
+
+  return ''
+}

--- a/lib/test/database.ts
+++ b/lib/test/database.ts
@@ -158,8 +158,10 @@ let globalTestDb: TestDatabase | null = null
 
 export async function getTestDatabase(): Promise<TestDatabase> {
   if (!globalTestDb) {
-    globalTestDb = new TestDatabase()
-    await globalTestDb.start()
+    const db = new TestDatabase()
+    await db.start()
+    // Only assign after successful start so a failed attempt can be retried
+    globalTestDb = db
   }
   return globalTestDb
 }


### PR DESCRIPTION
## Summary

- Replace standard text inputs in the workout logging modal with purpose-built, keyboard-free controls
- **Reps stepper**: +/- buttons with large thumb-friendly tap targets, pre-filled from prescribed reps (high end of range for ranges like "8-12")
- **Weight keypad**: inline 0-9 number keypad that replaces the system keyboard entirely, with expand/collapse UX. Supports 0-999 range, CLR, and backspace
- **Intensity selector**: tappable button grid for RPE (6-10 scale with half steps) and RIR (0-5) with descriptive phrases for each value
- **Pre-fill logic**: reps from prescribed set, weight carried forward from last logged set (set 1 defaults to 0), intensity from prescribed values
- **Expand/collapse**: only one input expanded at a time to manage vertical space on mobile
- Extract RPE_PRESETS/RIR_PRESETS to shared constants file (`lib/constants/intensity-presets.ts`) for reuse between configuration and logging UIs

## Test plan

- [ ] Open workout logging modal, verify reps stepper shows pre-filled value from prescribed set
- [ ] Tap +/- on reps stepper, verify increment/decrement works
- [ ] Tap weight display, verify keypad expands and reps/intensity collapse
- [ ] Enter weight via keypad (e.g. 1-3-5 for 135), verify display updates
- [ ] Tap Done on keypad, verify it collapses back to compact view
- [ ] Log a set, verify weight carries forward to next set
- [ ] Tap intensity selector, verify preset grid expands with descriptions
- [ ] Select an intensity value, verify it collapses back showing the value
- [ ] Verify "AMRAP" prescribed reps leave the stepper blank
- [ ] Verify exercise navigation pre-fills correctly for each exercise
- [ ] Verify set configuration interface still works (uses shared presets)

Fixes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)