### PR TITLE
feat: add learning infrastructure schema

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -16,6 +16,16 @@ You are a code reviewer for a Next.js 15 / TypeScript / Prisma application. Your
 - Always specify `--config` with `doppler run`. NEVER use `--config preview` or `--config prd`.
 - Prisma v6.x only — use `npx prisma@6.19.0` to avoid installing v7.
 
+### Doppler setup (IMPORTANT — do this first)
+
+Doppler must be bound to a project in the working directory before any `doppler run` commands will work. In worktrees (or any fresh checkout), run this once before anything else:
+
+```bash
+doppler setup --project fitcsv --config dev_personal --no-interactive
+```
+
+If `doppler run` fails with "You must specify a project", this is why.
+
 ### Things to watch for in this codebase
 
 - **Next.js 15 params**: Dynamic route params must be `Promise`-based — `const { id } = await params;`

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -46,6 +46,16 @@ export const auth = betterAuth({
       },
     },
   },
+  user: {
+    additionalFields: {
+      role: {
+        type: "string",
+        defaultValue: "user",
+        required: false,
+        input: false, // users cannot set their own role via signup
+      },
+    },
+  },
   advanced: {
     database: {
       generateId: false, // Use database default (uuid) — allows explicit ID setting in B2 migration

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -5,9 +5,12 @@ import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 
+export type UserRole = 'user' | 'author' | 'editor' | 'admin'
+
 export interface AuthUser {
   id: string
   email?: string
+  role: UserRole
 }
 
 export interface AuthResult {
@@ -29,6 +32,7 @@ export async function getCurrentUser(): Promise<AuthResult> {
       user: {
         id: mockUserId,
         email: 'dev@local.dev',
+        role: (process.env.MOCK_USER_ROLE as UserRole) || 'user',
       },
       error: null,
     }
@@ -47,6 +51,7 @@ export async function getCurrentUser(): Promise<AuthResult> {
       user: {
         id: session.user.id,
         email: session.user.email,
+        role: (session.user.role as UserRole) || 'user',
       },
       error: null,
     }

--- a/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
+++ b/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
@@ -94,7 +94,6 @@ CREATE TABLE "ArticleComment" (
 CREATE UNIQUE INDEX "Article_slug_key" ON "Article"("slug");
 CREATE INDEX "Article_authorId_idx" ON "Article"("authorId");
 CREATE INDEX "Article_status_idx" ON "Article"("status");
-CREATE INDEX "Article_slug_idx" ON "Article"("slug");
 CREATE INDEX "Article_level_idx" ON "Article"("level");
 CREATE INDEX "Article_publishedAt_idx" ON "Article"("publishedAt" DESC);
 CREATE INDEX "Article_status_publishedAt_idx" ON "Article"("status", "publishedAt" DESC);

--- a/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
+++ b/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
@@ -1,0 +1,136 @@
+-- CreateEnum: UserRole
+CREATE TYPE "UserRole" AS ENUM ('user', 'author', 'editor', 'admin');
+
+-- AddColumn: role on BetterAuth user table
+ALTER TABLE "user" ADD COLUMN "role" "UserRole" NOT NULL DEFAULT 'user';
+
+-- CreateEnum: ArticleLevel
+CREATE TYPE "ArticleLevel" AS ENUM ('beginner', 'intermediate', 'advanced');
+
+-- CreateEnum: ArticleStatus
+CREATE TYPE "ArticleStatus" AS ENUM ('draft', 'pending_review', 'published', 'rejected');
+
+-- CreateEnum: TagCategory
+CREATE TYPE "TagCategory" AS ENUM ('topic', 'body_area', 'context');
+
+-- CreateTable: Article
+CREATE TABLE "Article" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "level" "ArticleLevel" NOT NULL,
+    "status" "ArticleStatus" NOT NULL DEFAULT 'draft',
+    "authorId" TEXT NOT NULL,
+    "reviewNote" TEXT,
+    "readTimeMinutes" INTEGER,
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Article_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: Tag
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" "TagCategory" NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: ArticleTag
+CREATE TABLE "ArticleTag" (
+    "articleId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+
+    CONSTRAINT "ArticleTag_pkey" PRIMARY KEY ("articleId","tagId")
+);
+
+-- CreateTable: ContentReadStatus
+CREATE TABLE "ContentReadStatus" (
+    "userId" TEXT NOT NULL,
+    "articleId" TEXT NOT NULL,
+    "firstReadAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastReadAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContentReadStatus_pkey" PRIMARY KEY ("userId","articleId")
+);
+
+-- CreateTable: Collection
+CREATE TABLE "Collection" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "displayOrder" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Collection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: CollectionArticle
+CREATE TABLE "CollectionArticle" (
+    "collectionId" TEXT NOT NULL,
+    "articleId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "CollectionArticle_pkey" PRIMARY KEY ("collectionId","articleId")
+);
+
+-- CreateTable: ArticleComment
+CREATE TABLE "ArticleComment" (
+    "id" TEXT NOT NULL,
+    "articleId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ArticleComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: Article
+CREATE UNIQUE INDEX "Article_slug_key" ON "Article"("slug");
+CREATE INDEX "Article_authorId_idx" ON "Article"("authorId");
+CREATE INDEX "Article_status_idx" ON "Article"("status");
+CREATE INDEX "Article_slug_idx" ON "Article"("slug");
+CREATE INDEX "Article_level_idx" ON "Article"("level");
+CREATE INDEX "Article_publishedAt_idx" ON "Article"("publishedAt" DESC);
+CREATE INDEX "Article_status_publishedAt_idx" ON "Article"("status", "publishedAt" DESC);
+
+-- CreateIndex: Tag
+CREATE UNIQUE INDEX "Tag_name_category_key" ON "Tag"("name", "category");
+CREATE INDEX "Tag_category_idx" ON "Tag"("category");
+
+-- CreateIndex: ArticleTag
+CREATE INDEX "ArticleTag_tagId_idx" ON "ArticleTag"("tagId");
+
+-- CreateIndex: ContentReadStatus
+CREATE INDEX "ContentReadStatus_userId_idx" ON "ContentReadStatus"("userId");
+CREATE INDEX "ContentReadStatus_articleId_idx" ON "ContentReadStatus"("articleId");
+
+-- CreateIndex: Collection
+CREATE INDEX "Collection_displayOrder_idx" ON "Collection"("displayOrder");
+
+-- CreateIndex: CollectionArticle
+CREATE INDEX "CollectionArticle_articleId_idx" ON "CollectionArticle"("articleId");
+
+-- CreateIndex: ArticleComment
+CREATE INDEX "ArticleComment_articleId_idx" ON "ArticleComment"("articleId");
+CREATE INDEX "ArticleComment_userId_idx" ON "ArticleComment"("userId");
+CREATE INDEX "ArticleComment_articleId_createdAt_idx" ON "ArticleComment"("articleId", "createdAt");
+
+-- AddForeignKey: ArticleTag
+ALTER TABLE "ArticleTag" ADD CONSTRAINT "ArticleTag_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ArticleTag" ADD CONSTRAINT "ArticleTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: ContentReadStatus
+ALTER TABLE "ContentReadStatus" ADD CONSTRAINT "ContentReadStatus_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: CollectionArticle
+ALTER TABLE "CollectionArticle" ADD CONSTRAINT "CollectionArticle_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "Collection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CollectionArticle" ADD CONSTRAINT "CollectionArticle_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: ArticleComment
+ALTER TABLE "ArticleComment" ADD CONSTRAINT "ArticleComment_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
+++ b/prisma/migrations/20260327211219_add_learning_infrastructure/migration.sql
@@ -62,7 +62,7 @@ CREATE TABLE "ContentReadStatus" (
 CREATE TABLE "Collection" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
-    "description" TEXT NOT NULL,
+    "description" VARCHAR(280) NOT NULL,
     "displayOrder" INTEGER NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -404,7 +404,6 @@ model Article {
 
   @@index([authorId])
   @@index([status])
-  @@index([slug])
   @@index([level])
   @@index([publishedAt(sort: Desc)])
   @@index([status, publishedAt(sort: Desc)])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -445,7 +445,7 @@ model ContentReadStatus {
 model Collection {
   id           String   @id @default(cuid())
   name         String
-  description  String
+  description  String   @db.VarChar(280)
   displayOrder Int
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -361,3 +361,121 @@ model ExercisePerformanceLog {
   @@index([userId, equipment, completedAt])
   @@index([userId, type, completedAt])
 }
+
+// -- Learning Infrastructure --
+
+enum ArticleLevel {
+  beginner
+  intermediate
+  advanced
+}
+
+enum ArticleStatus {
+  draft
+  pending_review
+  published
+  rejected
+}
+
+enum TagCategory {
+  topic
+  body_area
+  context
+}
+
+model Article {
+  id              String        @id @default(cuid())
+  title           String
+  slug            String        @unique
+  body            String
+  level           ArticleLevel
+  status          ArticleStatus @default(draft)
+  authorId        String
+  reviewNote      String?
+  readTimeMinutes Int?
+  publishedAt     DateTime?
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+
+  tags               ArticleTag[]
+  readStatuses       ContentReadStatus[]
+  collectionArticles CollectionArticle[]
+  comments           ArticleComment[]
+
+  @@index([authorId])
+  @@index([status])
+  @@index([slug])
+  @@index([level])
+  @@index([publishedAt(sort: Desc)])
+  @@index([status, publishedAt(sort: Desc)])
+}
+
+model Tag {
+  id       String      @id @default(cuid())
+  name     String
+  category TagCategory
+
+  articles ArticleTag[]
+
+  @@unique([name, category])
+  @@index([category])
+}
+
+model ArticleTag {
+  articleId String
+  tagId     String
+  article   Article @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  tag       Tag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([articleId, tagId])
+  @@index([tagId])
+}
+
+model ContentReadStatus {
+  userId      String
+  articleId   String
+  firstReadAt DateTime @default(now())
+  lastReadAt  DateTime @default(now())
+  article     Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@id([userId, articleId])
+  @@index([userId])
+  @@index([articleId])
+}
+
+model Collection {
+  id           String   @id @default(cuid())
+  name         String
+  description  String
+  displayOrder Int
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  articles CollectionArticle[]
+
+  @@index([displayOrder])
+}
+
+model CollectionArticle {
+  collectionId String
+  articleId    String
+  order        Int
+  collection   Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  article      Article    @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@id([collectionId, articleId])
+  @@index([articleId])
+}
+
+model ArticleComment {
+  id        String   @id @default(cuid())
+  articleId String
+  userId    String
+  body      String
+  createdAt DateTime @default(now())
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@index([articleId])
+  @@index([userId])
+  @@index([articleId, createdAt])
+}


### PR DESCRIPTION
## Summary
- Add foundation data model for the learning system: Article, Tag, Collection tables with enums and join tables
- Add `role` enum (`user`/`author`/`editor`/`admin`) to BetterAuth user table for admin panel access control
- Update BetterAuth config with `additionalFields` and `AuthUser` interface to include role
- Migration SQL included for all new tables, enums, indexes, and foreign keys

## Schema additions
- **Article** - markdown content with level (beginner/intermediate/advanced), status (draft/pending_review/published/rejected), slug, author FK
- **Tag** - name + category (topic/body_area/context) with unique constraint
- **ArticleTag** - join table (composite PK)
- **ContentReadStatus** - tracks first/last read per user per article (composite PK)
- **Collection** - curated reading paths with display ordering
- **CollectionArticle** - join table with reading order
- **ArticleComment** - user comments on articles

## Test plan
- [ ] Verify `prisma generate` succeeds with new schema
- [ ] Verify type-check passes
- [ ] Verify migration SQL applies cleanly on staging deploy
- [ ] Verify BetterAuth session includes `role` field after deploy

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)