### PR TITLE
fix: generate Prisma engines and fix permissions in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # Prisma migrations + exercise data sync (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
 RUN npm install prisma@6.19.0 tsx@4.19.4 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund --ignore-scripts
+RUN npx prisma@6.19.0 generate
+RUN chown -R nextjs:nodejs /app/node_modules/.prisma /app/node_modules/@prisma
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
 COPY scripts/sync-exercise-data.ts ./scripts/sync-exercise-data.ts
 COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json


### PR DESCRIPTION
## Summary

- Run `prisma generate` in Dockerfile runner stage to download Prisma engines before switching to non-root user
- `chown` the Prisma directories to `nextjs:nodejs` so the init container can run `prisma migrate deploy`

## Problem

The init container running `prisma migrate deploy` as the `nextjs` user was failing with `Error: Can't write to /app/node_modules/@prisma/engines`. The `npm install --ignore-scripts` skipped engine download, and the directory was owned by root.

## Test plan

- [ ] Merge to dev, verify staging deploy succeeds
- [ ] Init container runs `prisma migrate deploy` without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)