### PR TITLE
fix: Prisma engine permissions + PR build verification

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - dev
       - main
+  pull_request:
+    branches:
+      - dev
 
 env:
   REGISTRY: ghcr.io
@@ -34,7 +37,10 @@ jobs:
       - name: Determine image tags
         id: tags
         run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
             echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" = "dev" ]; then
             echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging" >> "$GITHUB_OUTPUT"
@@ -50,7 +56,7 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
-            NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL || 'https://staging.ripit.fit' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # Prisma migrations + exercise data sync (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
 RUN npm install prisma@6.19.0 tsx@4.19.4 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund --ignore-scripts
+# Copy Prisma engines from deps stage (already downloaded via prisma generate in stage 1)
+# This avoids needing @prisma/client in the runner — only the CLI + engines are needed for migrations
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
 COPY scripts/sync-exercise-data.ts ./scripts/sync-exercise-data.ts
 COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json


### PR DESCRIPTION
## Summary

- Copy Prisma engines from deps stage instead of running `prisma generate` in runner (which lacks `@prisma/client`)
- Add PR build verification: Docker images built on PRs to dev, tagged as `pr-{number}-sha-{short_sha}`

## Prisma fix

The init container running `prisma migrate deploy` as the `nextjs` user failed with `Error: Can't write to /app/node_modules/@prisma/engines`. The engines weren't present because `--ignore-scripts` skipped the download.

Fix: `COPY --from=deps` the engines that were already downloaded in stage 1 (`prisma generate`), with `--chown=nextjs:nodejs`.

## PR build verification

PRs to dev now trigger the Docker build workflow. This catches Dockerfile/build issues before merge. Images are published to GHCR as `pr-{number}-sha-{short_sha}` for identification.

## Test plan

- [ ] This PR itself should trigger the build workflow and validate the Prisma fix
- [ ] Merge to dev should still produce `:staging` tag
- [ ] Merge to main should still produce `:sha-{full_sha}` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)