### PR TITLE
Pre-fetch exercise images on workout logger load

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { LoadingFrog } from '@/components/ui/loading-frog'
+import { useImagePrefetch } from '@/hooks/useImagePrefetch'
 import { type Exercise, type ExerciseHistory, useProgressiveExercises } from '@/hooks/useProgressiveExercises'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import { useWorkoutDraft } from '@/hooks/useWorkoutDraft'
@@ -82,6 +83,7 @@ export default function ExerciseLoggingModal({
     goToExercise,
     goToNext,
     goToPrevious,
+    loadedExercises,
     currentExerciseHistory,
     currentHistoryState,
     hasHistoryForCurrentExercise,
@@ -90,6 +92,9 @@ export default function ExerciseLoggingModal({
     initialExercise: initialExercise ?? undefined,
     initialHistory: initialHistory ?? undefined,
   })
+
+  // Pre-fetch exercise images so Info tab loads instantly
+  useImagePrefetch(loadedExercises)
 
   // DB-first persistence with write-through localStorage cache
   const {

--- a/hooks/useImagePrefetch.ts
+++ b/hooks/useImagePrefetch.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { Exercise } from '@/hooks/useProgressiveExercises'
+
+const CDN_BASE = 'https://cdn.ripit.fit/exercise-images/'
+const MAX_CONCURRENT = 2
+
+function resolveImageUrl(url: string): string {
+  return url.startsWith('http') ? url : `${CDN_BASE}${url}`
+}
+
+/**
+ * Pre-fetches exercise images in the background so they are cached
+ * by the time the user navigates to an exercise's Info tab.
+ *
+ * - Waits until at least one exercise is loaded before starting
+ * - Limits concurrent fetches to avoid saturating slow gym WiFi
+ * - Deduplicates URLs so each image is only fetched once
+ */
+export function useImagePrefetch(loadedExercises: Map<number, Exercise>) {
+  const prefetchedUrls = useRef<Set<string>>(new Set())
+  const activeCount = useRef(0)
+  const queue = useRef<string[]>([])
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    // Don't start until at least one exercise is loaded
+    if (loadedExercises.size === 0) return
+
+    // Collect new URLs to prefetch
+    const newUrls: string[] = []
+    for (const exercise of loadedExercises.values()) {
+      const imageUrls = exercise.exerciseDefinition?.imageUrls
+      if (!imageUrls) continue
+
+      for (const url of imageUrls) {
+        const resolved = resolveImageUrl(url)
+        if (!prefetchedUrls.current.has(resolved)) {
+          prefetchedUrls.current.add(resolved)
+          newUrls.push(resolved)
+        }
+      }
+    }
+
+    if (newUrls.length === 0) return
+
+    // Add new URLs to queue
+    queue.current.push(...newUrls)
+
+    // Process queue with concurrency limit
+    function processNext() {
+      if (!mountedRef.current) return
+      if (activeCount.current >= MAX_CONCURRENT) return
+
+      const url = queue.current.shift()
+      if (!url) return
+
+      activeCount.current++
+      const img = new Image()
+      img.onload = () => {
+        activeCount.current--
+        processNext()
+      }
+      img.onerror = () => {
+        activeCount.current--
+        processNext()
+      }
+      img.src = url
+
+      // Start another if we have capacity
+      processNext()
+    }
+
+    processNext()
+  }, [loadedExercises])
+}


### PR DESCRIPTION
## Summary
- Adds `useImagePrefetch` hook that triggers browser-level image caching via `new Image().src` after exercise data loads
- Integrates the hook into `ExerciseLoggingModal` so images are cached by the time the user swipes to an exercise and opens the Info tab
- Limits concurrent pre-fetches to 2 to avoid saturating slow gym WiFi

## Test plan
- [ ] Open workout logger with exercises that have images
- [ ] Navigate to a later exercise's Info tab — images should load instantly from browser cache
- [ ] Verify first exercise loads without delay (prefetch doesn't block initial render)
- [ ] Test on throttled network to confirm concurrent limit prevents connection saturation

Fixes #310

Generated with [Claude Code](https://claude.com/claude-code)