### PR TITLE
feat: collections reading experience with navigation and authoring guide

### DIFF
--- a/app/(app)/admin/articles/page.tsx
+++ b/app/(app)/admin/articles/page.tsx
@@ -105,6 +105,7 @@ export default function AdminArticlesPage() {
       <div className="flex gap-1 mb-6 overflow-x-auto">
         {STATUS_TABS.map((tab) => (
           <button
+            type="button"
             key={tab}
             onClick={() => setActiveStatus(tab)}
             className={`px-3 py-1.5 text-xs font-semibold uppercase tracking-wider border-2 transition-colors ${

--- a/app/(app)/admin/articles/page.tsx
+++ b/app/(app)/admin/articles/page.tsx
@@ -60,11 +60,11 @@ export default function AdminArticlesPage() {
 
   const statusColor = (status: string) => {
     switch (status) {
-      case 'published': return 'text-green-400 bg-green-900/30 border-green-700'
-      case 'draft': return 'text-zinc-400 bg-zinc-800 border-zinc-600'
-      case 'pending_review': return 'text-yellow-400 bg-yellow-900/30 border-yellow-700'
-      case 'rejected': return 'text-red-400 bg-red-900/30 border-red-700'
-      default: return 'text-zinc-400 bg-zinc-800 border-zinc-600'
+      case 'published': return 'text-green-800 bg-green-100 border-green-300 dark:text-green-400 dark:bg-green-900/30 dark:border-green-700'
+      case 'draft': return 'text-zinc-700 bg-zinc-100 border-zinc-300 dark:text-zinc-400 dark:bg-zinc-800 dark:border-zinc-600'
+      case 'pending_review': return 'text-yellow-800 bg-yellow-100 border-yellow-300 dark:text-yellow-400 dark:bg-yellow-900/30 dark:border-yellow-700'
+      case 'rejected': return 'text-red-800 bg-red-100 border-red-300 dark:text-red-400 dark:bg-red-900/30 dark:border-red-700'
+      default: return 'text-zinc-700 bg-zinc-100 border-zinc-300 dark:text-zinc-400 dark:bg-zinc-800 dark:border-zinc-600'
     }
   }
 

--- a/app/(app)/dev/mobile-spike/components.tsx
+++ b/app/(app)/dev/mobile-spike/components.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { ChevronUp, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export type Tab = 'training' | 'programs' | 'learn' | 'settings'
 
@@ -62,6 +62,7 @@ function TrainingContent({
         'Day 6: Active Recovery',
       ].map((day, i) => (
         <button
+          type="button"
           key={i}
           onClick={() => {
             if (hasDraft) {
@@ -211,6 +212,7 @@ function SettingsContent({
       <div className="pt-2 border-t border-border">
         <h2 className="text-sm font-bold mb-2">Test Controls</h2>
         <button
+          type="button"
           onClick={onToggleDraft}
           className="px-4 py-2 rounded-lg border-2 border-border bg-card text-sm hover:border-accent transition-colors"
         >
@@ -256,6 +258,7 @@ export function FullScreenModal({
         </div>
         <div className="flex items-center gap-2">
           <button
+            type="button"
             onClick={onMinimize}
             className="min-h-10 min-w-10 flex items-center justify-center rounded-lg border-2 border-border hover:border-accent transition-colors"
             aria-label="Minimize workout"
@@ -263,6 +266,7 @@ export function FullScreenModal({
             <ChevronUp className="h-4 w-4 rotate-180" />
           </button>
           <button
+            type="button"
             onClick={() => {
               if (confirm('Exit workout? Your draft will be saved.')) {
                 onClose()
@@ -311,6 +315,7 @@ export function FullScreenModal({
               }}
             />
             <button
+              type="button"
               onClick={() => {
                 const input = document.getElementById(
                   'set-input'
@@ -351,10 +356,10 @@ export function FullScreenModal({
           paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.75rem)',
         }}
       >
-        <button className="flex-1 py-3 rounded-lg bg-accent text-white font-bold text-sm">
+        <button type="button" className="flex-1 py-3 rounded-lg bg-accent text-white font-bold text-sm">
           Log Set
         </button>
-        <button className="flex-1 py-3 rounded-lg bg-success text-white font-bold text-sm">
+        <button type="button" className="flex-1 py-3 rounded-lg bg-success text-white font-bold text-sm">
           Complete
         </button>
       </div>
@@ -384,7 +389,7 @@ export function DebugOverlay({ onClose }: { onClose: () => void }) {
         standalone:
           'standalone' in window.navigator &&
           (window.navigator as Navigator & { standalone: boolean }).standalone,
-        userAgent: navigator.userAgent.slice(0, 60) + '...',
+        userAgent: `${navigator.userAgent.slice(0, 60)}...`,
       })
     }
     update()
@@ -405,6 +410,7 @@ export function DebugOverlay({ onClose }: { onClose: () => void }) {
       }}
     >
       <button
+        type="button"
         onClick={onClose}
         className="absolute top-1 right-2 text-white text-xs"
         style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}

--- a/app/(app)/dev/mobile-spike/page.tsx
+++ b/app/(app)/dev/mobile-spike/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { Activity, BookOpen, Dumbbell, LayoutGrid, Settings } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Dumbbell, Activity, LayoutGrid, BookOpen, Settings } from 'lucide-react'
 import {
-  type Tab,
-  Z,
-  TabContent,
-  FullScreenModal,
   DebugOverlay,
+  FullScreenModal,
+  type Tab,
+  TabContent,
+  Z,
 } from './components'
 
 /**
@@ -91,6 +91,7 @@ export default function MobileSpikePage() {
 
           {hasDraft && (
             <button
+              type="button"
               onClick={() => {
                 if (confirm('Reopen draft workout?')) {
                   setModalOpen(true)
@@ -138,6 +139,7 @@ export default function MobileSpikePage() {
               const isActive = activeTab === id
               return (
                 <button
+                  type="button"
                   key={id}
                   onClick={() => handleTabSwitch(id)}
                   className={`flex-1 flex flex-col items-center justify-center gap-0.5 min-h-12 min-w-12 transition-colors ${
@@ -173,6 +175,7 @@ export default function MobileSpikePage() {
       {/* Toggle debug button — bottom right, above nav */}
       {!showDebug && !modalOpen && (
         <button
+          type="button"
           onClick={() => setShowDebug(true)}
           className="md:hidden fixed right-3 bg-accent text-white rounded-full min-h-8 min-w-8 flex items-center justify-center text-xs font-bold shadow-lg"
           style={{

--- a/app/(app)/learn/[slug]/page.tsx
+++ b/app/(app)/learn/[slug]/page.tsx
@@ -1,13 +1,15 @@
 import { redirect } from 'next/navigation'
+import ArticleDetail from '@/components/features/learn/ArticleDetail'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
-import ArticleDetail from '@/components/features/learn/ArticleDetail'
 
 export default async function ArticlePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ slug: string }>
+  searchParams: Promise<{ collection?: string }>
 }) {
   const { user, error } = await getCurrentUser()
   if (error || !user) {
@@ -15,6 +17,7 @@ export default async function ArticlePage({
   }
 
   const { slug } = await params
+  const { collection: collectionId } = await searchParams
 
   const article = await prisma.article.findUnique({
     where: { slug, status: 'published' },
@@ -44,9 +47,63 @@ export default async function ArticlePage({
     redirect('/learn')
   }
 
+  // If opened from a collection, fetch collection context for prev/next nav
+  let collectionContext: {
+    id: string
+    name: string
+    articles: { slug: string; title: string }[]
+    currentIndex: number
+  } | null = null
+
+  if (collectionId) {
+    try {
+      const collection = await prisma.collection.findUnique({
+        where: { id: collectionId },
+        select: {
+          id: true,
+          name: true,
+          articles: {
+            orderBy: { order: 'asc' },
+            select: {
+              article: {
+                select: {
+                  slug: true,
+                  title: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      })
+
+      if (collection) {
+        const publishedArticles = collection.articles
+          .filter((ca) => ca.article.status === 'published')
+          .map((ca) => ({
+            slug: ca.article.slug,
+            title: ca.article.title,
+          }))
+
+        const currentIndex = publishedArticles.findIndex((a) => a.slug === slug)
+
+        if (currentIndex !== -1) {
+          collectionContext = {
+            id: collection.id,
+            name: collection.name,
+            articles: publishedArticles,
+            currentIndex,
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ error: err, context: 'article-collection-context' }, 'Failed to fetch collection context')
+    }
+  }
+
   const tagIds = article.tags.map((at) => at.tag.id)
 
-  // Find related articles sharing at least one tag
+  // Find related articles sharing at least one tag (skip if in collection context)
   let relatedArticles: {
     id: string
     title: string
@@ -55,7 +112,7 @@ export default async function ArticlePage({
     readTimeMinutes: number | null
   }[] = []
 
-  if (tagIds.length > 0) {
+  if (!collectionContext && tagIds.length > 0) {
     try {
       relatedArticles = await prisma.article.findMany({
         where: {
@@ -93,6 +150,7 @@ export default async function ArticlePage({
     <ArticleDetail
       article={formattedArticle}
       relatedArticles={relatedArticles}
+      collectionContext={collectionContext}
     />
   )
 }

--- a/app/(app)/learn/collections/[id]/page.tsx
+++ b/app/(app)/learn/collections/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { redirect } from 'next/navigation'
+import CollectionDetail from '@/components/features/learn/CollectionDetail'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+
+export default async function CollectionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { user, error } = await getCurrentUser()
+  if (error || !user) {
+    redirect('/login')
+  }
+
+  const { id } = await params
+
+  const collection = await prisma.collection.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      articles: {
+        orderBy: { order: 'asc' },
+        select: {
+          order: true,
+          article: {
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              level: true,
+              readTimeMinutes: true,
+              status: true,
+              readStatuses: {
+                where: { userId: user.id },
+                select: { lastReadAt: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!collection) {
+    redirect('/learn')
+  }
+
+  const articles = collection.articles
+    .filter((ca) => ca.article.status === 'published')
+    .map((ca) => ({
+      id: ca.article.id,
+      title: ca.article.title,
+      slug: ca.article.slug,
+      level: ca.article.level,
+      readTimeMinutes: ca.article.readTimeMinutes,
+      order: ca.order,
+      isRead: ca.article.readStatuses.length > 0,
+    }))
+
+  return (
+    <CollectionDetail
+      collection={{
+        id: collection.id,
+        name: collection.name,
+        description: collection.description,
+      }}
+      articles={articles}
+      readCount={articles.filter((a) => a.isRead).length}
+      totalCount={articles.length}
+    />
+  )
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -20,6 +20,7 @@ export async function GET(request: NextRequest) {
 
     // Build where clause for published articles only
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: Prisma where clause built dynamically
     const where: any = {
       status: 'published',
     }
@@ -132,7 +133,7 @@ export async function GET(request: NextRequest) {
       },
     })
 
-    // Fetch collections with their articles for the collections section
+    // Fetch collections with their articles and read status for the collections section
     const collections = await prisma.collection.findMany({
       orderBy: { displayOrder: 'asc' },
       select: {
@@ -141,7 +142,6 @@ export async function GET(request: NextRequest) {
         description: true,
         articles: {
           orderBy: { order: 'asc' },
-          take: 4,
           select: {
             article: {
               select: {
@@ -150,6 +150,11 @@ export async function GET(request: NextRequest) {
                 slug: true,
                 level: true,
                 readTimeMinutes: true,
+                status: true,
+                readStatuses: {
+                  where: { userId: user.id },
+                  select: { lastReadAt: true },
+                },
               },
             },
           },
@@ -157,11 +162,38 @@ export async function GET(request: NextRequest) {
       },
     })
 
+    // Format collections with read progress
+    const formattedCollections = collections.map((col) => {
+      const publishedArticles = col.articles.filter(
+        (ca) => ca.article.status === 'published'
+      )
+      const readCount = publishedArticles.filter(
+        (ca) => ca.article.readStatuses.length > 0
+      ).length
+      return {
+        id: col.id,
+        name: col.name,
+        description: col.description,
+        readCount,
+        totalCount: publishedArticles.length,
+        articles: publishedArticles.slice(0, 4).map(({ article }) => ({
+          article: {
+            id: article.id,
+            title: article.title,
+            slug: article.slug,
+            level: article.level,
+            readTimeMinutes: article.readTimeMinutes,
+            isRead: article.readStatuses.length > 0,
+          },
+        })),
+      }
+    })
+
     return NextResponse.json({
       success: true,
       articles: formatted,
       tags,
-      collections,
+      collections: formattedCollections,
     })
   } catch (err) {
     logger.error({ error: err, context: 'articles-browse' }, 'Failed to fetch articles')

--- a/app/api/collections/[id]/route.ts
+++ b/app/api/collections/[id]/route.ts
@@ -1,0 +1,82 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+/**
+ * GET /api/collections/[id]
+ * Public endpoint: fetch a collection with articles and user's read status.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { id } = await params
+
+    const collection = await prisma.collection.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        articles: {
+          orderBy: { order: 'asc' },
+          select: {
+            order: true,
+            article: {
+              select: {
+                id: true,
+                title: true,
+                slug: true,
+                level: true,
+                readTimeMinutes: true,
+                status: true,
+                readStatuses: {
+                  where: { userId: user.id },
+                  select: { lastReadAt: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    if (!collection) {
+      return NextResponse.json({ error: 'Collection not found' }, { status: 404 })
+    }
+
+    // Only include published articles, flatten structure
+    const articles = collection.articles
+      .filter((ca) => ca.article.status === 'published')
+      .map((ca) => ({
+        id: ca.article.id,
+        title: ca.article.title,
+        slug: ca.article.slug,
+        level: ca.article.level,
+        readTimeMinutes: ca.article.readTimeMinutes,
+        order: ca.order,
+        isRead: ca.article.readStatuses.length > 0,
+      }))
+
+    const readCount = articles.filter((a) => a.isRead).length
+
+    return NextResponse.json({
+      id: collection.id,
+      name: collection.name,
+      description: collection.description,
+      articles,
+      readCount,
+      totalCount: articles.length,
+    })
+  } catch (err) {
+    logger.error({ error: err, context: 'collection-detail' }, 'Failed to fetch collection')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -91,6 +91,7 @@ export async function POST(
     const maxOrder = Math.max(0, ...workout.exercises.map(e => e.order))
     const nextOrder = maxOrder + 1
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: complex Prisma return type varies by branch
     let addedExercise: any
     let addedToCount = 0
 

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Activity, LayoutGrid, BookOpen, Settings } from 'lucide-react'
+import { Activity, BookOpen, LayoutGrid, Settings } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 

--- a/components/FloatingDraftButton.tsx
+++ b/components/FloatingDraftButton.tsx
@@ -12,6 +12,7 @@ export default function FloatingDraftButton() {
 
   return (
     <button
+      type="button"
       onClick={() => {
         if (confirm(`Resume "${activeDraft.workoutName}"?`)) {
           router.push(`/training?resume=${activeDraft.workoutId}`)

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -168,19 +168,7 @@ export default function StrengthWeekView({
   const [isRestarting, setIsRestarting] = useState(false)
   const [isProgramComplete, setIsProgramComplete] = useState(false)
 
-  // Auto-resume draft workout when navigated with ?resume= param
   const resumeWorkoutId = searchParams.get('resume')
-  useEffect(() => {
-    if (resumeWorkoutId && !modalMode) {
-      // Clear the param from URL without triggering a navigation
-      const url = new URL(window.location.href)
-      url.searchParams.delete('resume')
-      window.history.replaceState(null, '', url.toString())
-
-      handleOpenLogging(resumeWorkoutId)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resumeWorkoutId])
 
   const checkProgramCompletion = useCallback(async (openModal = false) => {
     // Skip check if we're currently restarting
@@ -295,6 +283,18 @@ export default function StrengthWeekView({
 
     setModalMode('logging')
   }
+
+  // Auto-resume draft workout when navigated with ?resume= param
+  useEffect(() => {
+    if (resumeWorkoutId && !modalMode) {
+      // Clear the param from URL without triggering a navigation
+      const url = new URL(window.location.href)
+      url.searchParams.delete('resume')
+      window.history.replaceState(null, '', url.toString())
+
+      handleOpenLogging(resumeWorkoutId)
+    }
+  }, [resumeWorkoutId, handleOpenLogging, modalMode])
 
   const handleCloseModal = (workoutUpdated = false) => {
     const workoutId = selectedWorkoutId

--- a/components/WorkoutHistoryList.tsx
+++ b/components/WorkoutHistoryList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 type Exercise = {
   name: string
@@ -46,16 +46,7 @@ export default function WorkoutHistoryList({ count }: Props) {
   const [isLoading, setIsLoading] = useState(true)
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
-  // Fetch workout history on mount
-  useEffect(() => {
-    if (count > 0) {
-      fetchWorkoutHistory()
-    } else {
-      setIsLoading(false)
-    }
-  }, [count])
-
-  const fetchWorkoutHistory = async () => {
+  const fetchWorkoutHistory = useCallback(async () => {
     setIsLoading(true)
     try {
       const response = await fetch('/api/workouts/history?limit=5')
@@ -70,7 +61,16 @@ export default function WorkoutHistoryList({ count }: Props) {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [])
+
+  // Fetch workout history on mount
+  useEffect(() => {
+    if (count > 0) {
+      fetchWorkoutHistory()
+    } else {
+      setIsLoading(false)
+    }
+  }, [count, fetchWorkoutHistory])
 
   const toggleExpanded = (id: string) => {
     setExpandedIds(prev => {

--- a/components/admin/MarkdownEditor.tsx
+++ b/components/admin/MarkdownEditor.tsx
@@ -2,17 +2,15 @@
 
 import { Eye, Pencil } from 'lucide-react'
 import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
+import remarkGfm from 'remark-gfm'
 
 interface MarkdownEditorProps {
   value: string
   onChange: (value: string) => void
 }
 
-/**
- * Split-pane markdown editor with raw text and basic preview.
- * Preview renders a simplified version — full markdown rendering
- * happens on the article detail page.
- */
 export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
   const [showPreview, setShowPreview] = useState(false)
 
@@ -41,8 +39,14 @@ export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps)
       </div>
 
       {showPreview ? (
-        <div className="min-h-[400px] p-4 bg-card border-2 border-border overflow-auto prose-invert">
-          <MarkdownPreview content={value} />
+        <div className="min-h-[400px] p-4 bg-card border-2 border-border overflow-auto prose-learn">
+          {value.trim() ? (
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+              {value}
+            </ReactMarkdown>
+          ) : (
+            <p className="text-muted-foreground italic">Nothing to preview</p>
+          )}
         </div>
       ) : (
         <textarea
@@ -54,162 +58,4 @@ export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps)
       )}
     </div>
   )
-}
-
-function MarkdownPreview({ content }: { content: string }) {
-  if (!content.trim()) {
-    return <p className="text-muted-foreground italic">Nothing to preview</p>
-  }
-
-  // Basic markdown rendering — headings, bold, italic, images, links, code blocks, lists
-  const lines = content.split('\n')
-  const elements: React.ReactNode[] = []
-  let inCodeBlock = false
-  let codeLines: string[] = []
-  let listItems: string[] = []
-  let listType: 'ul' | 'ol' | null = null
-
-  const flushList = () => {
-    if (listItems.length > 0 && listType) {
-      const Tag = listType
-      elements.push(
-        <Tag key={elements.length} className={`${listType === 'ul' ? 'list-disc' : 'list-decimal'} pl-6 my-2 space-y-1`}>
-          {listItems.map((item, i) => (
-            <li key={i} className="text-sm text-foreground">
-              <InlineMarkdown text={item} />
-            </li>
-          ))}
-        </Tag>
-      )
-      listItems = []
-      listType = null
-    }
-  }
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-
-    if (line.startsWith('```')) {
-      if (inCodeBlock) {
-        elements.push(
-          <pre key={elements.length} className="bg-zinc-900 border border-border p-3 my-2 overflow-x-auto">
-            <code className="text-xs text-green-400">{codeLines.join('\n')}</code>
-          </pre>
-        )
-        codeLines = []
-        inCodeBlock = false
-      } else {
-        flushList()
-        inCodeBlock = true
-      }
-      continue
-    }
-
-    if (inCodeBlock) {
-      codeLines.push(line)
-      continue
-    }
-
-    // Check for list items
-    const ulMatch = line.match(/^[-*]\s+(.+)/)
-    const olMatch = line.match(/^\d+\.\s+(.+)/)
-
-    if (ulMatch) {
-      if (listType !== 'ul') flushList()
-      listType = 'ul'
-      listItems.push(ulMatch[1])
-      continue
-    }
-
-    if (olMatch) {
-      if (listType !== 'ol') flushList()
-      listType = 'ol'
-      listItems.push(olMatch[1])
-      continue
-    }
-
-    flushList()
-
-    if (line.startsWith('### ')) {
-      elements.push(<h3 key={i} className="text-lg font-bold mt-4 mb-2 text-foreground">{line.slice(4)}</h3>)
-    } else if (line.startsWith('## ')) {
-      elements.push(<h2 key={i} className="text-xl font-bold mt-5 mb-2 text-foreground">{line.slice(3)}</h2>)
-    } else if (line.startsWith('# ')) {
-      elements.push(<h1 key={i} className="text-2xl font-bold mt-6 mb-3 text-foreground">{line.slice(2)}</h1>)
-    } else if (line.trim() === '') {
-      elements.push(<div key={i} className="h-3" />)
-    } else {
-      elements.push(
-        <p key={i} className="text-sm text-foreground leading-relaxed">
-          <InlineMarkdown text={line} />
-        </p>
-      )
-    }
-  }
-  flushList()
-
-  return <div>{elements}</div>
-}
-
-function InlineMarkdown({ text }: { text: string }) {
-  // Process: images, links, bold, italic, inline code
-  const parts: React.ReactNode[] = []
-  let remaining = text
-  let key = 0
-
-  while (remaining) {
-    // Image: ![alt](url)
-    const imgMatch = remaining.match(/!\[([^\]]*)\]\(([^)]+)\)/)
-    if (imgMatch && imgMatch.index !== undefined) {
-      if (imgMatch.index > 0) {
-        parts.push(<span key={key++}>{processInline(remaining.slice(0, imgMatch.index))}</span>)
-      }
-      parts.push(
-        // biome-ignore lint/performance/noImgElement: markdown preview renders user-provided URLs
-        <img key={key++} src={imgMatch[2]} alt={imgMatch[1]} className="max-w-full h-auto my-2 border border-border" />
-      )
-      remaining = remaining.slice(imgMatch.index + imgMatch[0].length)
-      continue
-    }
-
-    // Link: [text](url)
-    const linkMatch = remaining.match(/\[([^\]]+)\]\(([^)]+)\)/)
-    if (linkMatch && linkMatch.index !== undefined) {
-      if (linkMatch.index > 0) {
-        parts.push(<span key={key++}>{processInline(remaining.slice(0, linkMatch.index))}</span>)
-      }
-      parts.push(
-        <a key={key++} href={linkMatch[2]} className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
-          {linkMatch[1]}
-        </a>
-      )
-      remaining = remaining.slice(linkMatch.index + linkMatch[0].length)
-      continue
-    }
-
-    parts.push(<span key={key++}>{processInline(remaining)}</span>)
-    break
-  }
-
-  return <>{parts}</>
-}
-
-function processInline(text: string): React.ReactNode {
-  // Bold: **text**
-  // Italic: *text*
-  // Inline code: `text`
-  return text
-    .split(/(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/)
-    .map((part, i) => {
-      if (part.startsWith('`') && part.endsWith('`')) {
-        return <code key={i} className="bg-zinc-800 px-1 py-0.5 text-xs text-green-400">{part.slice(1, -1)}</code>
-      }
-      if (part.startsWith('**') && part.endsWith('**')) {
-        return <strong key={i} className="font-bold">{part.slice(2, -2)}</strong>
-      }
-      if (part.startsWith('*') && part.endsWith('*')) {
-        return <em key={i} className="italic">{part.slice(1, -1)}</em>
-      }
-      return part
-    })
 }

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowLeft, Clock } from 'lucide-react'
+import { ArrowLeft, ChevronLeft, ChevronRight, Clock } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -32,9 +32,17 @@ interface ArticleData {
   tags: Tag[]
 }
 
+interface CollectionContext {
+  id: string
+  name: string
+  articles: { slug: string; title: string }[]
+  currentIndex: number
+}
+
 interface ArticleDetailProps {
   article: ArticleData
   relatedArticles: RelatedArticle[]
+  collectionContext?: CollectionContext | null
 }
 
 function levelColor(level: string) {
@@ -50,7 +58,11 @@ function levelColor(level: string) {
   }
 }
 
-export default function ArticleDetail({ article, relatedArticles }: ArticleDetailProps) {
+export default function ArticleDetail({
+  article,
+  relatedArticles,
+  collectionContext,
+}: ArticleDetailProps) {
   // Auto-mark as read when article is viewed
   useEffect(() => {
     async function markRead() {
@@ -63,17 +75,41 @@ export default function ArticleDetail({ article, relatedArticles }: ArticleDetai
     markRead()
   }, [article.slug])
 
+  const prevArticle = collectionContext && collectionContext.currentIndex > 0
+    ? collectionContext.articles[collectionContext.currentIndex - 1]
+    : null
+  const nextArticle = collectionContext && collectionContext.currentIndex < collectionContext.articles.length - 1
+    ? collectionContext.articles[collectionContext.currentIndex + 1]
+    : null
+
   return (
-    <div className="min-h-screen bg-background px-4 sm:px-6 py-8">
+    <div className={`min-h-screen bg-background px-4 sm:px-6 py-8 ${collectionContext ? 'pb-24 sm:pb-8' : ''}`}>
       <div className="max-w-2xl mx-auto">
-        {/* Back navigation */}
-        <Link
-          href="/learn"
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors mb-6 uppercase tracking-wider font-semibold"
-        >
-          <ArrowLeft className="h-3 w-3" />
-          Back to Learn
-        </Link>
+        {/* Back navigation — contextual */}
+        {collectionContext ? (
+          <div className="mb-6">
+            <Link
+              href={`/learn/collections/${collectionContext.id}`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground
+                hover:text-primary transition-colors uppercase tracking-wider font-semibold"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              {collectionContext.name}
+            </Link>
+            <p className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wider font-semibold">
+              Article {collectionContext.currentIndex + 1} of {collectionContext.articles.length}
+            </p>
+          </div>
+        ) : (
+          <Link
+            href="/learn"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground
+              hover:text-primary transition-colors mb-6 uppercase tracking-wider font-semibold"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Back to Learn
+          </Link>
+        )}
 
         {/* Article header */}
         <div className="mb-6">
@@ -116,8 +152,66 @@ export default function ArticleDetail({ article, relatedArticles }: ArticleDetai
           </ReactMarkdown>
         </div>
 
-        {/* Related articles */}
-        {relatedArticles.length > 0 && (
+        {/* Collection prev/next — inline for desktop */}
+        {collectionContext && (
+          <div className="hidden sm:flex border-t-2 border-border pt-6 mb-8 items-stretch gap-3">
+            {prevArticle ? (
+              <Link
+                href={`/learn/${prevArticle.slug}?collection=${collectionContext.id}`}
+                className="flex-1 flex items-center gap-3 p-4 bg-card border-2 border-border
+                  hover:border-primary/50 transition-all group"
+              >
+                <ChevronLeft className="h-5 w-5 flex-shrink-0 text-muted-foreground group-hover:text-primary transition-colors" />
+                <div className="min-w-0">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
+                    Previous
+                  </span>
+                  <span className="text-sm font-semibold text-foreground group-hover:text-primary transition-colors truncate block">
+                    {prevArticle.title}
+                  </span>
+                </div>
+              </Link>
+            ) : (
+              <div className="flex-1" />
+            )}
+            {nextArticle ? (
+              <Link
+                href={`/learn/${nextArticle.slug}?collection=${collectionContext.id}`}
+                className="flex-1 flex items-center justify-end gap-3 p-4 bg-card border-2 border-border
+                  hover:border-primary/50 transition-all group text-right"
+              >
+                <div className="min-w-0">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
+                    Next
+                  </span>
+                  <span className="text-sm font-semibold text-foreground group-hover:text-primary transition-colors truncate block">
+                    {nextArticle.title}
+                  </span>
+                </div>
+                <ChevronRight className="h-5 w-5 flex-shrink-0 text-muted-foreground group-hover:text-primary transition-colors" />
+              </Link>
+            ) : (
+              <Link
+                href={`/learn/collections/${collectionContext.id}`}
+                className="flex-1 flex items-center justify-end gap-3 p-4 bg-card border-2 border-green-900/50
+                  hover:border-green-700 transition-all group text-right"
+              >
+                <div className="min-w-0">
+                  <span className="text-[10px] text-green-400 uppercase tracking-wider font-semibold block">
+                    Complete
+                  </span>
+                  <span className="text-sm font-semibold text-green-400 group-hover:text-green-300 transition-colors truncate block">
+                    Back to Collection
+                  </span>
+                </div>
+                <ChevronRight className="h-5 w-5 flex-shrink-0 text-green-400 group-hover:text-green-300 transition-colors" />
+              </Link>
+            )}
+          </div>
+        )}
+
+        {/* Related articles — only shown outside collection context */}
+        {!collectionContext && relatedArticles.length > 0 && (
           <div className="border-t-2 border-border pt-8">
             <h2 className="text-sm font-bold text-foreground mb-4 doom-heading uppercase tracking-wider">
               Related Articles
@@ -149,6 +243,69 @@ export default function ArticleDetail({ article, relatedArticles }: ArticleDetai
           </div>
         )}
       </div>
+
+      {/* Mobile fixed bottom nav — collection prev/next */}
+      {collectionContext && (
+        <div className="fixed bottom-16 left-0 right-0 sm:hidden bg-card border-t-2 border-border z-40">
+          <div className="flex items-stretch">
+            {prevArticle ? (
+              <Link
+                href={`/learn/${prevArticle.slug}?collection=${collectionContext.id}`}
+                className="flex-1 flex items-center gap-2 px-4 py-3 border-r border-border
+                  active:bg-muted transition-colors"
+              >
+                <ChevronLeft className="h-4 w-4 flex-shrink-0 text-primary" />
+                <div className="min-w-0">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
+                    Prev
+                  </span>
+                  <span className="text-xs text-foreground truncate block">
+                    {prevArticle.title}
+                  </span>
+                </div>
+              </Link>
+            ) : (
+              <div className="flex-1 px-4 py-3 border-r border-border" />
+            )}
+
+            {/* Position indicator */}
+            <div className="flex items-center px-3">
+              <span className="text-[10px] text-muted-foreground font-bold uppercase tracking-wider whitespace-nowrap">
+                {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
+              </span>
+            </div>
+
+            {nextArticle ? (
+              <Link
+                href={`/learn/${nextArticle.slug}?collection=${collectionContext.id}`}
+                className="flex-1 flex items-center justify-end gap-2 px-4 py-3 border-l border-border
+                  active:bg-muted transition-colors"
+              >
+                <div className="min-w-0 text-right">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
+                    Next
+                  </span>
+                  <span className="text-xs text-foreground truncate block">
+                    {nextArticle.title}
+                  </span>
+                </div>
+                <ChevronRight className="h-4 w-4 flex-shrink-0 text-primary" />
+              </Link>
+            ) : (
+              <Link
+                href={`/learn/collections/${collectionContext.id}`}
+                className="flex-1 flex items-center justify-end gap-2 px-4 py-3 border-l border-border
+                  active:bg-muted transition-colors"
+              >
+                <span className="text-xs text-green-400 font-semibold uppercase tracking-wider">
+                  Done
+                </span>
+                <ChevronRight className="h-4 w-4 flex-shrink-0 text-green-400" />
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ChevronLeft, ChevronRight, Clock } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 import { clientLogger } from '@/lib/client-logger'
 
@@ -147,7 +148,7 @@ export default function ArticleDetail({
 
         {/* Article body - markdown */}
         <div className="prose-learn mb-12">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
             {article.body}
           </ReactMarkdown>
         </div>

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowLeft, ChevronLeft, ChevronRight, Clock } from 'lucide-react'
+import { ArrowLeft, BookOpen, ChevronLeft, ChevronRight, Clock } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -83,37 +83,82 @@ export default function ArticleDetail({
     ? collectionContext.articles[collectionContext.currentIndex + 1]
     : null
 
+  const backHref = collectionContext
+    ? `/learn/collections/${collectionContext.id}`
+    : '/learn'
+
   return (
     <div className={`min-h-screen bg-background px-4 sm:px-6 py-8 ${collectionContext ? 'pb-24 sm:pb-8' : ''}`}>
       <div className="max-w-2xl mx-auto">
-        {/* Back navigation — contextual */}
+
+        {/* Mobile: floating back button (top-left, mirrors draft button pattern) */}
         {collectionContext ? (
-          <div className="mb-6">
+          <Link
+            href={backHref}
+            className="sm:hidden fixed left-3 flex items-center gap-2 px-3 py-2
+              bg-card border-2 border-border text-foreground
+              shadow-[2px_2px_0_rgba(0,0,0,0.3)]"
+            style={{
+              top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)',
+              zIndex: 45,
+            }}
+            aria-label={`Back to ${collectionContext.name}`}
+          >
+            <BookOpen className="h-4 w-4 text-primary flex-shrink-0" />
+            <span className="text-[10px] font-bold uppercase tracking-wider max-w-[120px] truncate">
+              {collectionContext.name}
+            </span>
+            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+              {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
+            </span>
+          </Link>
+        ) : (
+          <Link
+            href={backHref}
+            className="sm:hidden fixed left-3 flex items-center justify-center
+              min-h-10 min-w-10 bg-card border-2 border-border text-muted-foreground
+              shadow-[2px_2px_0_rgba(0,0,0,0.3)]"
+            style={{
+              top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)',
+              zIndex: 45,
+            }}
+            aria-label="Back to Learn"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        )}
+
+        {/* Desktop: inline breadcrumb nav */}
+        <div className="hidden sm:block mb-6">
+          {collectionContext ? (
             <Link
-              href={`/learn/collections/${collectionContext.id}`}
+              href={backHref}
+              className="inline-flex items-center gap-2 px-3 py-1.5
+                bg-card border-2 border-border text-foreground
+                hover:border-primary/50 transition-all group"
+            >
+              <BookOpen className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+              <span className="text-xs font-semibold uppercase tracking-wider group-hover:text-primary transition-colors">
+                {collectionContext.name}
+              </span>
+              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
+              </span>
+            </Link>
+          ) : (
+            <Link
+              href={backHref}
               className="inline-flex items-center gap-1 text-xs text-muted-foreground
                 hover:text-primary transition-colors uppercase tracking-wider font-semibold"
             >
               <ArrowLeft className="h-3 w-3" />
-              {collectionContext.name}
+              Back to Learn
             </Link>
-            <p className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wider font-semibold">
-              Article {collectionContext.currentIndex + 1} of {collectionContext.articles.length}
-            </p>
-          </div>
-        ) : (
-          <Link
-            href="/learn"
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground
-              hover:text-primary transition-colors mb-6 uppercase tracking-wider font-semibold"
-          >
-            <ArrowLeft className="h-3 w-3" />
-            Back to Learn
-          </Link>
-        )}
+          )}
+        </div>
 
         {/* Article header */}
-        <div className="mb-6">
+        <div className="mb-6 mt-14 sm:mt-0">
           <div className="flex items-center gap-3 mb-3">
             <span
               className={`text-[10px] px-2 py-0.5 font-semibold uppercase tracking-wider doom-label ${levelColor(article.level)}`}

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -48,11 +48,11 @@ interface ArticleDetailProps {
 function levelColor(level: string) {
   switch (level) {
     case 'beginner':
-      return 'bg-green-900/40 text-green-400 border-2 border-green-700'
+      return 'bg-green-100 text-green-800 border-2 border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-700'
     case 'intermediate':
-      return 'bg-orange-900/40 text-orange-400 border-2 border-orange-700'
+      return 'bg-orange-100 text-orange-800 border-2 border-orange-300 dark:bg-orange-900/40 dark:text-orange-400 dark:border-orange-700'
     case 'advanced':
-      return 'bg-red-900/40 text-red-400 border-2 border-red-700'
+      return 'bg-red-100 text-red-800 border-2 border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-700'
     default:
       return 'bg-muted text-muted-foreground'
   }

--- a/components/features/learn/CollectionDetail.tsx
+++ b/components/features/learn/CollectionDetail.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { ArrowLeft, Check, ChevronRight, Clock } from 'lucide-react'
+import Link from 'next/link'
+
+interface CollectionArticle {
+  id: string
+  title: string
+  slug: string
+  level: string
+  readTimeMinutes: number | null
+  order: number
+  isRead: boolean
+}
+
+interface CollectionDetailProps {
+  collection: {
+    id: string
+    name: string
+    description: string
+  }
+  articles: CollectionArticle[]
+  readCount: number
+  totalCount: number
+}
+
+function levelColor(level: string) {
+  switch (level) {
+    case 'beginner':
+      return 'bg-green-900/40 text-green-400 border-2 border-green-700'
+    case 'intermediate':
+      return 'bg-orange-900/40 text-orange-400 border-2 border-orange-700'
+    case 'advanced':
+      return 'bg-red-900/40 text-red-400 border-2 border-red-700'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+export default function CollectionDetail({
+  collection,
+  articles,
+  readCount,
+  totalCount,
+}: CollectionDetailProps) {
+  const progressPercent = totalCount > 0 ? (readCount / totalCount) * 100 : 0
+  const isComplete = readCount === totalCount && totalCount > 0
+
+  // Find the first unread article for "Continue" button
+  const nextUnread = articles.find((a) => !a.isRead)
+
+  return (
+    <div className="min-h-screen bg-background doom-page-enter">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        {/* Back navigation */}
+        <Link
+          href="/learn"
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground
+            hover:text-primary transition-colors mb-6 uppercase tracking-wider font-semibold"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back to Learn
+        </Link>
+
+        {/* Collection header */}
+        <div className="bg-card border-2 border-border p-6 doom-noise doom-corners mb-6">
+          <h1 className="text-2xl font-bold text-foreground doom-title uppercase tracking-wider mb-2">
+            {collection.name}
+          </h1>
+          <p className="text-sm text-muted-foreground mb-4">
+            {collection.description}
+          </p>
+
+          {/* Progress bar */}
+          <div className="mb-3">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Progress
+              </span>
+              <span
+                className={`text-xs font-bold uppercase tracking-wider ${
+                  isComplete ? 'text-green-400' : 'text-foreground'
+                }`}
+              >
+                {readCount} of {totalCount} read
+              </span>
+            </div>
+            <div className="h-2 bg-muted border border-border overflow-hidden">
+              <div
+                className={`h-full transition-all duration-500 ${
+                  isComplete
+                    ? 'bg-green-500 shadow-[0_0_10px_rgba(34,197,94,0.5)]'
+                    : 'bg-primary shadow-[0_0_10px_rgba(var(--primary-rgb),0.3)]'
+                }`}
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Continue reading button */}
+          {nextUnread && (
+            <Link
+              href={`/learn/${nextUnread.slug}?collection=${collection.id}`}
+              className="inline-flex items-center gap-2 mt-2 px-4 py-2 bg-primary text-primary-foreground
+                text-xs font-bold uppercase tracking-wider doom-button-3d
+                hover:bg-primary/90 transition-colors"
+            >
+              {readCount === 0 ? 'Start Reading' : 'Continue Reading'}
+              <ChevronRight className="h-3 w-3" />
+            </Link>
+          )}
+        </div>
+
+        {/* Article list */}
+        <div className="space-y-2">
+          {articles.map((article, index) => (
+            <Link
+              key={article.id}
+              href={`/learn/${article.slug}?collection=${collection.id}`}
+              className={`flex items-center gap-3 p-4 border-2 transition-all group ${
+                article.isRead
+                  ? 'bg-card border-green-900/50 hover:border-green-700'
+                  : 'bg-card border-border hover:border-primary/50'
+              }`}
+            >
+              {/* Number / check indicator */}
+              <div
+                className={`flex-shrink-0 w-8 h-8 flex items-center justify-center border-2
+                  text-xs font-bold ${
+                    article.isRead
+                      ? 'bg-green-900/40 border-green-700 text-green-400'
+                      : 'bg-muted border-border text-muted-foreground'
+                  }`}
+              >
+                {article.isRead ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  index + 1
+                )}
+              </div>
+
+              {/* Article info */}
+              <div className="flex-1 min-w-0">
+                <h3
+                  className={`text-sm font-semibold truncate transition-colors ${
+                    article.isRead
+                      ? 'text-muted-foreground group-hover:text-green-400'
+                      : 'text-foreground group-hover:text-primary'
+                  }`}
+                >
+                  {article.title}
+                </h3>
+                <div className="flex items-center gap-2 mt-1">
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 font-semibold uppercase tracking-wider ${levelColor(article.level)}`}
+                  >
+                    {article.level}
+                  </span>
+                  {article.readTimeMinutes && (
+                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                      <Clock className="h-2.5 w-2.5" />
+                      {article.readTimeMinutes} min
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Arrow */}
+              <ChevronRight
+                className={`h-4 w-4 flex-shrink-0 transition-colors ${
+                  article.isRead
+                    ? 'text-green-700 group-hover:text-green-400'
+                    : 'text-muted-foreground group-hover:text-primary'
+                }`}
+              />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/learn/CollectionDetail.tsx
+++ b/components/features/learn/CollectionDetail.tsx
@@ -52,10 +52,25 @@ export default function CollectionDetail({
   return (
     <div className="min-h-screen bg-background doom-page-enter">
       <div className="max-w-2xl mx-auto px-4 py-8">
-        {/* Back navigation */}
+        {/* Mobile: floating back button */}
         <Link
           href="/learn"
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground
+          className="sm:hidden fixed left-3 flex items-center justify-center
+            min-h-10 min-w-10 bg-card border-2 border-border text-muted-foreground
+            shadow-[2px_2px_0_rgba(0,0,0,0.3)]"
+          style={{
+            top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)',
+            zIndex: 45,
+          }}
+          aria-label="Back to Learn"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+
+        {/* Desktop: inline back link */}
+        <Link
+          href="/learn"
+          className="hidden sm:inline-flex items-center gap-1 text-xs text-muted-foreground
             hover:text-primary transition-colors mb-6 uppercase tracking-wider font-semibold"
         >
           <ArrowLeft className="h-3 w-3" />
@@ -63,7 +78,7 @@ export default function CollectionDetail({
         </Link>
 
         {/* Collection header */}
-        <div className="bg-card border-2 border-border p-6 doom-noise doom-corners mb-6">
+        <div className="bg-card border-2 border-border p-6 doom-noise doom-corners mb-6 mt-14 sm:mt-0">
           <h1 className="text-2xl font-bold text-foreground doom-title uppercase tracking-wider mb-2">
             {collection.name}
           </h1>

--- a/components/features/learn/CollectionDetail.tsx
+++ b/components/features/learn/CollectionDetail.tsx
@@ -27,11 +27,11 @@ interface CollectionDetailProps {
 function levelColor(level: string) {
   switch (level) {
     case 'beginner':
-      return 'bg-green-900/40 text-green-400 border-2 border-green-700'
+      return 'bg-green-100 text-green-800 border-2 border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-700'
     case 'intermediate':
-      return 'bg-orange-900/40 text-orange-400 border-2 border-orange-700'
+      return 'bg-orange-100 text-orange-800 border-2 border-orange-300 dark:bg-orange-900/40 dark:text-orange-400 dark:border-orange-700'
     case 'advanced':
-      return 'bg-red-900/40 text-red-400 border-2 border-red-700'
+      return 'bg-red-100 text-red-800 border-2 border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-700'
     default:
       return 'bg-muted text-muted-foreground'
   }

--- a/components/features/learn/LearnBrowser.tsx
+++ b/components/features/learn/LearnBrowser.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { BookOpen, Check, ChevronRight, Clock, Search, X } from 'lucide-react'
+import { BookOpen, Clock, Search, X } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
@@ -28,16 +28,6 @@ interface CollectionData {
   description: string
   readCount: number
   totalCount: number
-  articles: {
-    article: {
-      id: string
-      title: string
-      slug: string
-      level: string
-      readTimeMinutes: number | null
-      isRead: boolean
-    }
-  }[]
 }
 
 type FilterCategory = 'topic' | 'body_area' | 'context'
@@ -302,12 +292,11 @@ export default function LearnBrowser() {
                         {col.readCount}/{col.totalCount}
                       </span>
                     </div>
-                    <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
+                    <p className="text-xs text-muted-foreground mb-2 line-clamp-2">
                       {col.description}
                     </p>
-
                     {/* Progress bar */}
-                    <div className="h-1 bg-muted border border-border overflow-hidden mb-3">
+                    <div className="h-1 bg-muted border border-border overflow-hidden">
                       <div
                         className={`h-full transition-all duration-500 ${
                           isComplete
@@ -316,24 +305,6 @@ export default function LearnBrowser() {
                         }`}
                         style={{ width: `${progressPercent}%` }}
                       />
-                    </div>
-
-                    <div className="space-y-1">
-                      {col.articles.map(({ article }) => (
-                        <div
-                          key={article.id}
-                          className="flex items-center gap-2 text-xs text-muted-foreground"
-                        >
-                          {article.isRead ? (
-                            <Check className="h-3 w-3 text-green-400 flex-shrink-0" />
-                          ) : (
-                            <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                          )}
-                          <span className={`truncate ${article.isRead ? 'text-muted-foreground' : ''}`}>
-                            {article.title}
-                          </span>
-                        </div>
-                      ))}
                     </div>
                   </Link>
                 )

--- a/components/features/learn/LearnBrowser.tsx
+++ b/components/features/learn/LearnBrowser.tsx
@@ -42,11 +42,11 @@ const FILTER_CATEGORIES: { key: FilterCategory; label: string }[] = [
 function levelColor(level: string) {
   switch (level) {
     case 'beginner':
-      return 'bg-green-900/40 text-green-400 border-2 border-green-700'
+      return 'bg-green-100 text-green-800 border-2 border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-700'
     case 'intermediate':
-      return 'bg-orange-900/40 text-orange-400 border-2 border-orange-700'
+      return 'bg-orange-100 text-orange-800 border-2 border-orange-300 dark:bg-orange-900/40 dark:text-orange-400 dark:border-orange-700'
     case 'advanced':
-      return 'bg-red-900/40 text-red-400 border-2 border-red-700'
+      return 'bg-red-100 text-red-800 border-2 border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-700'
     default:
       return 'bg-muted text-muted-foreground'
   }

--- a/components/features/learn/LearnBrowser.tsx
+++ b/components/features/learn/LearnBrowser.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { BookOpen, ChevronRight, Clock, Search, X } from 'lucide-react'
+import { BookOpen, Check, ChevronRight, Clock, Search, X } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
@@ -26,6 +26,8 @@ interface CollectionData {
   id: string
   name: string
   description: string
+  readCount: number
+  totalCount: number
   articles: {
     article: {
       id: string
@@ -33,6 +35,7 @@ interface CollectionData {
       slug: string
       level: string
       readTimeMinutes: number | null
+      isRead: boolean
     }
   }[]
 }
@@ -274,31 +277,67 @@ export default function LearnBrowser() {
               Collections
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {collections.map((col) => (
-                <div
-                  key={col.id}
-                  className="bg-card border-2 border-border p-4 doom-noise doom-corners"
-                >
-                  <h3 className="text-sm font-semibold text-foreground mb-1 uppercase tracking-wider">
-                    {col.name}
-                  </h3>
-                  <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
-                    {col.description}
-                  </p>
-                  <div className="space-y-1">
-                    {col.articles.map(({ article }) => (
-                      <Link
-                        key={article.id}
-                        href={`/learn/${article.slug}`}
-                        className="flex items-center gap-2 text-xs text-muted-foreground hover:text-primary transition-colors"
+              {collections.map((col) => {
+                const isComplete = col.readCount === col.totalCount && col.totalCount > 0
+                const progressPercent = col.totalCount > 0 ? (col.readCount / col.totalCount) * 100 : 0
+                return (
+                  <Link
+                    key={col.id}
+                    href={`/learn/collections/${col.id}`}
+                    className={`block bg-card border-2 p-4 doom-noise doom-corners transition-all group ${
+                      isComplete
+                        ? 'border-green-900/50 hover:border-green-700'
+                        : 'border-border hover:border-primary/50'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2 mb-1">
+                      <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider group-hover:text-primary transition-colors">
+                        {col.name}
+                      </h3>
+                      <span
+                        className={`text-[10px] font-bold uppercase tracking-wider whitespace-nowrap flex-shrink-0 ${
+                          isComplete ? 'text-green-400' : 'text-muted-foreground'
+                        }`}
                       >
-                        <ChevronRight className="h-3 w-3" />
-                        <span className="truncate">{article.title}</span>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ))}
+                        {col.readCount}/{col.totalCount}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
+                      {col.description}
+                    </p>
+
+                    {/* Progress bar */}
+                    <div className="h-1 bg-muted border border-border overflow-hidden mb-3">
+                      <div
+                        className={`h-full transition-all duration-500 ${
+                          isComplete
+                            ? 'bg-green-500'
+                            : 'bg-primary'
+                        }`}
+                        style={{ width: `${progressPercent}%` }}
+                      />
+                    </div>
+
+                    <div className="space-y-1">
+                      {col.articles.map(({ article }) => (
+                        <div
+                          key={article.id}
+                          className="flex items-center gap-2 text-xs text-muted-foreground"
+                        >
+                          {article.isRead ? (
+                            <Check className="h-3 w-3 text-green-400 flex-shrink-0" />
+                          ) : (
+                            <ChevronRight className="h-3 w-3 flex-shrink-0" />
+                          )}
+                          <span className={`truncate ${article.isRead ? 'text-muted-foreground' : ''}`}>
+                            {article.title}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </Link>
+                )
+              })}
             </div>
           </div>
         )}

--- a/components/programs/ArchivedProgramsSection.tsx
+++ b/components/programs/ArchivedProgramsSection.tsx
@@ -47,7 +47,7 @@ export default function ArchivedProgramsSection({
       }
       fetchArchivedPrograms()
     }
-  }, [isExpanded, programs.length, apiPath])
+  }, [isExpanded, programs.length])
 
   const handleUnarchive = async (programId: string, programName: string) => {
     if (

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -3,8 +3,8 @@
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
-import { clientLogger } from '@/lib/client-logger'
 import { useToast } from '@/components/ToastProvider'
+import { clientLogger } from '@/lib/client-logger'
 import StrengthActivationModal from '../StrengthActivationModal'
 import ArchivedProgramsSection from './ArchivedProgramsSection'
 import ProgramCard from './ProgramCard'
@@ -48,69 +48,15 @@ export default function ConsolidatedProgramsView({
   const [activationProgramId, setActivationProgramId] = useState<string | null>(null)
   const [existingActiveProgram, setExistingActiveProgram] = useState<{ id: string; name: string } | null>(null)
 
-  // On mount, resume polling for any programs already in cloning state
-  useEffect(() => {
-    const cloningPrograms = strengthPrograms.filter(p =>
-      p.copyStatus === 'cloning' || p.copyStatus?.startsWith('cloning_week_')
-    )
-
-    // Resume polling for first cloning program found
-    if (cloningPrograms.length > 0 && !cloningProgramId) {
-      const programId = cloningPrograms[0].id
-      if (!completedClones.has(programId)) {
-        setCloningProgramId(programId)
-        startPolling(programId)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // Only run on mount
-
-  // Poll for cloning status if programId is in URL
-  useEffect(() => {
-    const cloningId = searchParams.get('cloning')
-
-    // Don't start polling if already completed
-    if (cloningId && completedClones.has(cloningId)) {
-      return
+  const cleanupCloningState = () => {
+    // Clear the polling interval first
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current)
+      pollingIntervalRef.current = null
     }
 
-    if (cloningId && cloningId !== cloningProgramId) {
-      setCloningProgramId(cloningId)
-      startPolling(cloningId)
-    }
-
-    return () => {
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current)
-        pollingIntervalRef.current = null
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, cloningProgramId])
-
-  const startPolling = async (programId: string) => {
-    // Check immediately
-    const shouldContinue = await checkCopyStatus(programId)
-
-    if (!shouldContinue) {
-      return
-    }
-
-    // Then poll every 2 seconds
-    const intervalId = setInterval(async () => {
-      const shouldContinue = await checkCopyStatus(programId)
-
-      if (!shouldContinue) {
-        clearInterval(intervalId)
-        // Also clear the ref if it still exists
-        if (pollingIntervalRef.current === intervalId) {
-          pollingIntervalRef.current = null
-        }
-      }
-    }, 2000)
-
-    // Store in ref for external cleanup
-    pollingIntervalRef.current = intervalId
+    setCloningProgramId(null)
+    window.history.replaceState(null, '', '/programs')
   }
 
   const handleCloneFailed = (programId: string, message?: string) => {
@@ -180,16 +126,70 @@ export default function ConsolidatedProgramsView({
     }
   }
 
-  const cleanupCloningState = () => {
-    // Clear the polling interval first
-    if (pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current)
-      pollingIntervalRef.current = null
+  const startPolling = async (programId: string) => {
+    // Check immediately
+    const shouldContinue = await checkCopyStatus(programId)
+
+    if (!shouldContinue) {
+      return
     }
 
-    setCloningProgramId(null)
-    window.history.replaceState(null, '', '/programs')
+    // Then poll every 2 seconds
+    const intervalId = setInterval(async () => {
+      const shouldContinue = await checkCopyStatus(programId)
+
+      if (!shouldContinue) {
+        clearInterval(intervalId)
+        // Also clear the ref if it still exists
+        if (pollingIntervalRef.current === intervalId) {
+          pollingIntervalRef.current = null
+        }
+      }
+    }, 2000)
+
+    // Store in ref for external cleanup
+    pollingIntervalRef.current = intervalId
   }
+
+  // On mount, resume polling for any programs already in cloning state
+  useEffect(() => {
+    const cloningPrograms = strengthPrograms.filter(p =>
+      p.copyStatus === 'cloning' || p.copyStatus?.startsWith('cloning_week_')
+    )
+
+    // Resume polling for first cloning program found
+    if (cloningPrograms.length > 0 && !cloningProgramId) {
+      const programId = cloningPrograms[0].id
+      if (!completedClones.has(programId)) {
+        setCloningProgramId(programId)
+        startPolling(programId)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cloningProgramId, completedClones.has, startPolling, strengthPrograms.filter]) // Only run on mount
+
+  // Poll for cloning status if programId is in URL
+  useEffect(() => {
+    const cloningId = searchParams.get('cloning')
+
+    // Don't start polling if already completed
+    if (cloningId && completedClones.has(cloningId)) {
+      return
+    }
+
+    if (cloningId && cloningId !== cloningProgramId) {
+      setCloningProgramId(cloningId)
+      startPolling(cloningId)
+    }
+
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current)
+        pollingIntervalRef.current = null
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, cloningProgramId, completedClones.has, startPolling])
 
   // Sort programs: active first, then by creation date
   // Filter out locally deleted programs

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -103,8 +103,6 @@ export default function ExerciseDisplayTabs({
   isInputExpanded = false,
 }: ExerciseDisplayTabsProps) {
   const [expandedImage, setExpandedImage] = useState<string | null>(null)
-  const loggedCount = loggedSets.length
-  const totalCount = prescribedSets.length
   const hasNotes = !!exercise.notes
 
   return (

--- a/docs/ARTICLE_AUTHORING.md
+++ b/docs/ARTICLE_AUTHORING.md
@@ -1,0 +1,170 @@
+# Article Authoring Guide
+
+Reference for writing and formatting articles in the Learn tab. Articles are stored as markdown in the database and rendered with `react-markdown` + `remark-gfm` + `rehype-raw`.
+
+## Markdown Features
+
+Standard markdown plus GitHub-Flavored Markdown (tables, strikethrough, task lists) is supported. Raw HTML is also supported via `rehype-raw`, which enables layout control beyond what plain markdown offers.
+
+## Layout Patterns
+
+### Image Sizing
+
+Markdown `![alt](url)` renders full-width. Use HTML for specific sizes:
+
+```html
+<img src="/path/to/image.jpg" alt="Bench press form" width="400" />
+```
+
+### Image with Text Wrap
+
+Float an image so body text wraps around it:
+
+```html
+<img src="/path/to/image.jpg" alt="Squat depth" width="250" style="float: right; margin: 0 0 1rem 1rem;" />
+
+Your paragraph text here wraps around the image naturally. This works well
+for form cues or equipment photos that accompany explanatory text.
+```
+
+Use `float: left` with `margin: 0 1rem 1rem 0` for left-aligned images.
+
+**Clear the float** after the wrapping section if needed:
+
+```html
+<div style="clear: both;"></div>
+```
+
+### Side-by-Side Comparison
+
+Two images or content blocks next to each other:
+
+```html
+<div style="display: flex; gap: 1rem; margin: 1rem 0;">
+  <div style="flex: 1;">
+    <img src="/good-form.jpg" alt="Correct form" width="100%" />
+    <p><strong>Correct:</strong> Neutral spine, chest up</p>
+  </div>
+  <div style="flex: 1;">
+    <img src="/bad-form.jpg" alt="Incorrect form" width="100%" />
+    <p><strong>Incorrect:</strong> Rounded back, head down</p>
+  </div>
+</div>
+```
+
+### Callout / Highlight Box
+
+Draw attention to safety tips, key points, or warnings:
+
+```html
+<div style="border-left: 3px solid var(--primary); padding: 0.75rem 1rem; margin: 1rem 0; background: var(--muted);">
+
+**Key Point:** Always brace your core before initiating the lift. This applies to every compound movement, not just squats and deadlifts.
+
+</div>
+```
+
+For warnings, use a red accent:
+
+```html
+<div style="border-left: 3px solid #ef4444; padding: 0.75rem 1rem; margin: 1rem 0; background: var(--muted);">
+
+**Warning:** Never sacrifice form for heavier weight. If you can't maintain proper technique, reduce the load.
+
+</div>
+```
+
+### Centered Content
+
+Center a single image, caption, or block:
+
+```html
+<div style="text-align: center; margin: 1.5rem 0;">
+  <img src="/diagram.jpg" alt="Muscle groups" width="500" />
+  <p style="font-size: 0.8rem; color: var(--muted-foreground); margin-top: 0.5rem;">Primary muscles targeted in the conventional deadlift</p>
+</div>
+```
+
+### Compact Table Alternative
+
+For simple key-value data where a full GFM table feels heavy:
+
+```html
+<dl style="display: grid; grid-template-columns: auto 1fr; gap: 0.25rem 1rem; margin: 1rem 0;">
+  <dt><strong>Sets</strong></dt><dd>3-4</dd>
+  <dt><strong>Reps</strong></dt><dd>8-12</dd>
+  <dt><strong>Rest</strong></dt><dd>60-90 seconds</dd>
+  <dt><strong>RPE</strong></dt><dd>7-8</dd>
+</dl>
+```
+
+## Styling Notes
+
+- The article body renders inside a `.prose-learn` container (see `app/globals.css`)
+- Use CSS variables (`var(--primary)`, `var(--muted)`, `var(--border)`, `var(--foreground)`, `var(--muted-foreground)`) for theme-aware colors
+- Avoid hardcoded colors except for semantic meaning (red for warnings, green for success)
+- Images from MinIO use URLs from the media uploader in the admin panel
+- Max content width is `max-w-2xl` (672px) — images wider than this will be constrained
+
+## Writing Style
+
+Articles are fitness education content for people who are new to or progressing in strength training. Write clearly and directly.
+
+### Voice and Tone
+
+- Write in second person ("you") when giving instructions
+- Be direct. State the thing, then explain why if needed
+- Assume the reader is motivated but may lack context — explain the "why" without being condescending
+- Use concrete numbers and examples over vague guidance ("rest 2-3 minutes between heavy sets" not "rest adequately")
+
+### AI Writing Tropes to Avoid
+
+When using AI to draft or edit articles, watch for and remove these patterns:
+
+#### Word choice
+- **Magic adverbs**: "quietly", "deeply", "fundamentally", "remarkably". Cut them.
+- **"Delve" and friends**: "delve", "utilize", "leverage", "robust", "streamline", "harness". Use plain words.
+- **Grandiose nouns**: "tapestry", "landscape", "paradigm", "synergy", "ecosystem". Say what you mean.
+- **"Serves as" dodge**: Replacing "is" with "serves as", "stands as", "marks", "represents". Just use "is".
+
+#### Sentence structure
+- **Negative parallelism**: "It's not X -- it's Y." One per article max. Ten is insulting.
+- **Dramatic countdown**: "Not X. Not Y. Just Z."
+- **Self-answered questions**: "The result? Devastating." Nobody asked.
+- **Anaphora abuse**: "They could expose... They could offer... They could provide..." Vary your openings.
+- **Tricolon abuse**: Groups of three are fine. Five back-to-back tricolons are not.
+- **Filler transitions**: "It's worth noting", "Importantly", "Interestingly", "Notably". Delete them.
+- **Superficial "-ing" analysis**: "highlighting its importance", "reflecting broader trends", "underscoring its role". These say nothing.
+- **False ranges**: "From X to Y" where X and Y aren't on a real scale.
+
+#### Paragraph structure
+- **Short punchy fragments**: One-sentence paragraphs for fake emphasis. "Platforms do." Don't.
+- **Listicle in a trench coat**: "The first takeaway... The second takeaway... The third takeaway..." Just use a list or write real paragraphs.
+
+#### Tone
+- **"Here's the kicker"**: False suspense. Also "Here's the thing", "Here's where it gets interesting".
+- **Patronizing analogies**: "Think of it as a highway for data." If the concept is clear, skip the metaphor.
+- **"Imagine a world where..."**: Don't open with this. Ever.
+- **False vulnerability**: "And yes, I'm openly in love with..." Performative honesty is worse than none.
+- **"The truth is simple"**: If you have to say it's obvious, it isn't.
+- **Stakes inflation**: Not everything is "fundamentally reshaping how we think about everything."
+- **"Let's break this down"**: Don't narrate your own structure. Just write it.
+- **Vague attributions**: "Experts say", "Industry reports suggest". Name the source or cut the claim.
+- **Invented labels**: "The supervision paradox", "the acceleration trap". If it's not an established term, don't coin one.
+
+#### Formatting
+- **Em-dash addiction**: 2-3 per article is fine. 20 is AI slop.
+- **Bold-first bullets**: Not every list item needs a bold keyword prefix.
+- **Unicode arrows**: Use `->` not `→`. Write like someone typing, not typesetting.
+
+#### Composition
+- **Fractal summaries**: Don't introduce what you're about to say, then summarize what you said.
+- **Dead metaphors**: Don't use the same metaphor 10 times. Use it once, move on.
+- **Historical analogy stacking**: "Apple didn't build Uber. Facebook didn't build Spotify." Stop.
+- **One-point dilution**: One argument restated 10 ways is still one argument. Keep it tight.
+- **Signposted conclusions**: "In conclusion..." The reader knows it's the end. Just end.
+- **"Despite its challenges..."**: Acknowledging problems only to immediately dismiss them.
+
+**The rule**: Any of these used once might be fine. Multiple tropes together or repeated use of one is the problem. Write varied, imperfect, specific prose.
+
+Source: [tropes.fyi](https://tropes.fyi)

--- a/lib/community/validation.ts
+++ b/lib/community/validation.ts
@@ -158,6 +158,7 @@ export async function isProgramPublished(
  * Validates program metadata (level, goals, etc.)
  * This should only be called when actually publishing, not during initial validation
  */
+// biome-ignore lint/suspicious/noExplicitAny: dynamic program metadata fields
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function validateProgramMetadata(program: Record<string, any>): ValidationResult {
   const errors: string[] = [];


### PR DESCRIPTION
## Summary
- Collection detail page (`/learn/collections/[id]`) with progress bar, ordered article list, read/unread indicators, and "Start/Continue Reading" button
- Collection-aware article view with prev/next navigation: floating bottom bar on mobile, inline cards on desktop
- Floating context-aware back button on mobile (top-left, mirrors draft workout button pattern) for both article and collection detail pages; inline breadcrumb on desktop
- Collection cards on Learn dashboard show read progress count and progress bar
- Public API endpoint (`/api/collections/[id]`) for collection data with user read status
- Enable `rehype-raw` for HTML layout control in article markdown
- Article authoring guide (`docs/ARTICLE_AUTHORING.md`) with HTML layout patterns and AI writing tropes to avoid
- Fix level badges and status badges unreadable in light mode across Learn tab and admin panel
- Fix lint issues across codebase (button types, import ordering, unused variables, useEffect dependency ordering)

Fixes #296

## Test plan
- [ ] Browse Learn tab — collection cards show progress count and bar
- [ ] Click collection card — navigates to detail page with article list
- [ ] Open article from collection — floating back button (mobile) or breadcrumb chip (desktop) shows collection name + position
- [ ] Navigate prev/next via bottom bar (mobile) or inline cards (desktop)
- [ ] Last article shows "Done" in bottom bar, "Back to Collection" on desktop
- [ ] Open article outside collection — simple back arrow, no collection UI
- [ ] Verify level badges readable in both light and dark mode
- [ ] Verify admin article status badges readable in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)