### PR TITLE
feat: Google and Discord OAuth sign-in

### DIFF
--- a/app/(auth)/complete-profile/page.tsx
+++ b/app/(auth)/complete-profile/page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState, Suspense } from 'react'
+import { Button } from '@/components/ui/Button'
+
+function CompleteProfileForm() {
+  const _router = useRouter()
+  const searchParams = useSearchParams()
+  const provider = searchParams.get('provider') || 'Discord'
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [needsPassword, setNeedsPassword] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    try {
+      const res = await fetch('/api/auth/complete-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: needsPassword ? password : undefined }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        if (data.code === 'EMAIL_EXISTS') {
+          setNeedsPassword(true)
+          setError(null)
+          setLoading(false)
+          return
+        }
+        setError(data.error || 'Something went wrong')
+        setLoading(false)
+        return
+      }
+
+      // If account was linked, user needs to re-authenticate
+      if (data.linked) {
+        window.location.href = '/login'
+        return
+      }
+
+      window.location.href = '/'
+    } catch {
+      setError('An unexpected error occurred')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="max-w-md w-full space-y-8 p-8 bg-card rounded-lg shadow-lg border border-border">
+        <div>
+          <h2 className="text-3xl font-bold text-center text-foreground">Almost there</h2>
+          <p className="mt-2 text-center text-muted-foreground">
+            {provider} didn&apos;t share your email. Enter it below to finish setting up your account.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="bg-error-muted border border-error-border text-error-text px-4 py-3 rounded">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-foreground">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  if (needsPassword) {
+                    setNeedsPassword(false)
+                    setPassword('')
+                  }
+                }}
+                className="mt-1 block w-full px-3 py-2 bg-background border border-input rounded-md shadow-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                placeholder="you@example.com"
+                disabled={loading}
+              />
+            </div>
+
+            {needsPassword && (
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-foreground">
+                  Password
+                </label>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  An account with this email already exists. Enter your password to link it with {provider}.
+                </p>
+                <input
+                  id="password"
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="mt-1 block w-full px-3 py-2 bg-background border border-input rounded-md shadow-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  placeholder="Your existing password"
+                  disabled={loading}
+                />
+              </div>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            disabled={loading}
+            loading={loading}
+            variant="primary"
+            className="w-full"
+          >
+            {needsPassword ? 'Link account' : 'Continue'}
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default function CompleteProfilePage() {
+  return (
+    <Suspense>
+      <CompleteProfileForm />
+    </Suspense>
+  )
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,16 +1,25 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState, Suspense } from 'react'
 import { Button } from '@/components/ui/Button'
+import { OAuthButtons } from '@/components/features/auth/OAuthButtons'
 import { signIn } from '@/lib/auth-client'
 
-export default function LoginPage() {
+function getOAuthError(errorParam: string | null): string | null {
+  if (!errorParam) return null
+  if (errorParam === 'access_denied') return 'Sign-in was cancelled. Please try again.'
+  return 'Could not complete sign-in. Please try again or sign in with email.'
+}
+
+function LoginForm() {
   const _router = useRouter()
+  const searchParams = useSearchParams()
+  const oauthError = getOAuthError(searchParams.get('error'))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(oauthError)
   const [loading, setLoading] = useState(false)
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -45,7 +54,18 @@ export default function LoginPage() {
           <p className="mt-2 text-center text-muted-foreground">Sign in to your account</p>
         </div>
 
-        <form onSubmit={handleLogin} className="mt-8 space-y-6">
+        <OAuthButtons />
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="px-2 bg-card text-muted-foreground">or</span>
+          </div>
+        </div>
+
+        <form onSubmit={handleLogin} className="space-y-6">
           {error && (
             <div className="bg-error-muted border border-error-border text-error-text px-4 py-3 rounded">
               {error}
@@ -103,5 +123,13 @@ export default function LoginPage() {
         </form>
       </div>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   )
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
+import { OAuthButtons } from '@/components/features/auth/OAuthButtons'
 import { signUp } from '@/lib/auth-client'
 
 export default function SignupPage() {
@@ -61,7 +62,18 @@ export default function SignupPage() {
           <p className="mt-2 text-center text-muted-foreground">Create your account</p>
         </div>
 
-        <form onSubmit={handleSignup} className="mt-8 space-y-6">
+        <OAuthButtons />
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="px-2 bg-card text-muted-foreground">or</span>
+          </div>
+        </div>
+
+        <form onSubmit={handleSignup} className="space-y-6">
           {error && (
             <div className="bg-error-muted border border-error-border text-error-text px-4 py-3 rounded">
               {error}

--- a/app/api/auth/complete-profile/route.ts
+++ b/app/api/auth/complete-profile/route.ts
@@ -1,0 +1,91 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { Pool } from 'pg'
+import { logger } from '@/lib/logger'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+export async function POST(request: NextRequest) {
+  try {
+    const { user, error: authError } = await getCurrentUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { email, password } = await request.json()
+
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    }
+
+    const normalizedEmail = email.toLowerCase().trim()
+
+    // Check if another user already has this email
+    const existing = await pool.query(
+      'SELECT id FROM "user" WHERE email = $1 AND id != $2',
+      [normalizedEmail, user.id]
+    )
+
+    if (existing.rows.length > 0) {
+      // Existing account — need password to link
+      if (!password) {
+        return NextResponse.json(
+          { error: 'This email is associated with an existing account', code: 'EMAIL_EXISTS' },
+          { status: 409 }
+        )
+      }
+
+      // Verify the password against the existing account
+      const existingUserId = existing.rows[0].id
+      const accountRow = await pool.query(
+        'SELECT "password" FROM "account" WHERE "userId" = $1 AND "providerId" = $2',
+        [existingUserId, 'credential']
+      )
+
+      if (!accountRow.rows.length || !accountRow.rows[0].password) {
+        return NextResponse.json(
+          { error: 'This account does not have a password. Try signing in with Google instead.' },
+          { status: 400 }
+        )
+      }
+
+      // Verify password using BetterAuth's configured password verify
+      const bcrypt = await import('bcrypt')
+      const isValid = await bcrypt.default.compare(password, accountRow.rows[0].password)
+
+      if (!isValid) {
+        return NextResponse.json({ error: 'Incorrect password' }, { status: 401 })
+      }
+
+      // Link: move the OAuth account from the temp user to the existing user
+      await pool.query(
+        'UPDATE "account" SET "userId" = $1 WHERE "userId" = $2 AND "providerId" != $3',
+        [existingUserId, user.id, 'credential']
+      )
+
+      // Delete the temp user (created by OAuth without email)
+      await pool.query('DELETE FROM "session" WHERE "userId" = $1', [user.id])
+      await pool.query('DELETE FROM "user" WHERE id = $1', [user.id])
+
+      // Create a new session for the existing user via BetterAuth
+      // The user will need to re-authenticate — redirect to login
+      logger.info({ existingUserId, provider: 'discord' }, 'Linked Discord account to existing user via complete-profile')
+
+      return NextResponse.json({ success: true, linked: true, redirect: '/login' })
+    }
+
+    // No conflict — just update the current user's email
+    await pool.query(
+      'UPDATE "user" SET email = $1, "emailVerified" = false WHERE id = $2',
+      [normalizedEmail, user.id]
+    )
+
+    logger.info({ userId: user.id }, 'Updated email via complete-profile interstitial')
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ error, context: 'complete-profile' }, 'Failed to complete profile')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/components/features/auth/OAuthButtons.tsx
+++ b/components/features/auth/OAuthButtons.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from '@/lib/auth-client'
+
+export function OAuthButtons() {
+  const [loadingProvider, setLoadingProvider] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleOAuth = async (provider: 'google' | 'discord') => {
+    setError(null)
+    setLoadingProvider(provider)
+
+    try {
+      await signIn.social({
+        provider,
+        callbackURL: '/',
+        errorCallbackURL: '/login',
+      })
+    } catch {
+      setError(`Could not connect to ${provider === 'google' ? 'Google' : 'Discord'}. Please try again or sign in with email.`)
+      setLoadingProvider(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="bg-error-muted border border-error-border text-error-text px-4 py-3 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => handleOAuth('google')}
+        disabled={loadingProvider !== null}
+        className="w-full flex items-center justify-center gap-3 px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {loadingProvider === 'google' ? (
+          <LoadingSpinner />
+        ) : (
+          <GoogleIcon />
+        )}
+        Continue with Google
+      </button>
+
+      <button
+        type="button"
+        onClick={() => handleOAuth('discord')}
+        disabled={loadingProvider !== null}
+        className="w-full flex items-center justify-center gap-3 px-4 py-2.5 bg-[#5865F2] border border-[#5865F2] rounded-lg text-white font-medium hover:bg-[#4752C4] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#5865F2] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {loadingProvider === 'discord' ? (
+          <LoadingSpinner />
+        ) : (
+          <DiscordIcon />
+        )}
+        Continue with Discord
+      </button>
+    </div>
+  )
+}
+
+function LoadingSpinner() {
+  return (
+    <svg aria-hidden="true" className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+    </svg>
+  )
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  )
+}
+
+function DiscordIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z" />
+    </svg>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -46,6 +46,20 @@ export const auth = betterAuth({
       },
     },
   },
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+    discord: {
+      clientId: process.env.DISCORD_CLIENT_ID!,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+    },
+  },
+  accountLinking: {
+    enabled: true,
+    trustedProviders: ["google"],
+  },
   user: {
     additionalFields: {
       role: {

--- a/lib/auth/middleware.ts
+++ b/lib/auth/middleware.ts
@@ -22,6 +22,7 @@ export async function updateSession(request: NextRequest) {
   if (!hasSession &&
       !pathname.startsWith('/login') &&
       !pathname.startsWith('/signup') &&
+      !pathname.startsWith('/auth/complete-profile') &&
       !pathname.startsWith('/_next') &&
       !pathname.startsWith('/api')) {
     const url = request.nextUrl.clone()
@@ -29,8 +30,9 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
-  // Authenticated user trying to access auth pages
+  // Authenticated user trying to access auth pages (except complete-profile which needs a session)
   if (hasSession &&
+      !pathname.startsWith('/auth/complete-profile') &&
       (pathname.startsWith('/login') || pathname.startsWith('/signup'))) {
     const url = request.nextUrl.clone()
     url.pathname = '/'


### PR DESCRIPTION
## Summary
- Configure BetterAuth social providers (Google, Discord) with account linking
- Google is trusted for auto-linking by verified email; Discord includes a complete-profile interstitial for missing email
- OAuth buttons on login and signup pages with "or" divider
- Error handling for cancelled consent and provider failures

Closes #317

## Test plan
- [x] Google OAuth sign-in creates account and redirects to dashboard
- [x] Discord OAuth sign-in works end-to-end
- [ ] Discord no-email flow redirects to complete-profile interstitial
- [ ] Account linking: existing email/password user signs in with Google, account is linked
- [ ] Cancelled consent screen shows error on login page
- [ ] Verify Doppler secrets are set for staging before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)