### PR TITLE
Clean up settings page for beta launch

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Dumbbell, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { KeyRound, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useThemePreference } from '@/hooks/useThemePreference'
@@ -9,26 +9,39 @@ import { useUserSettings } from '@/hooks/useUserSettings'
 import { useSession } from '@/lib/auth-client'
 import { THEME_LABELS, THEMES } from '@/lib/theme'
 
+type ConnectedAccounts = {
+  email: string
+  providers: string[]
+}
+
 export default function SettingsPage() {
   const { data: session } = useSession()
   const { settings, isLoading, updateSettings } = useUserSettings()
   const { preference, updateTheme } = useThemePreference()
   const userRole = (session?.user as Record<string, unknown>)?.role as string | undefined
   const isAdmin = userRole === 'admin' || userRole === 'editor'
-  const [displayName, setDisplayName] = useState('')
   const [weightUnit, setWeightUnit] = useState<'lbs' | 'kg'>('lbs')
-  const [intensityRating, setIntensityRating] = useState<'rpe' | 'rir'>('rpe')
+  const [intensityRating, setIntensityRating] = useState<'rpe' | 'rir'>('rir')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
+  const [connectedAccounts, setConnectedAccounts] = useState<ConnectedAccounts | null>(null)
 
   useEffect(() => {
     if (settings) {
-      setDisplayName(settings.displayName || '')
       setWeightUnit(settings.defaultWeightUnit)
       setIntensityRating(settings.defaultIntensityRating)
     }
   }, [settings])
+
+  useEffect(() => {
+    fetch('/api/settings/connected-accounts')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.email) setConnectedAccounts(data)
+      })
+      .catch(() => {})
+  }, [])
 
   const handleSave = async () => {
     setIsSaving(true)
@@ -37,7 +50,6 @@ export default function SettingsPage() {
 
     try {
       await updateSettings({
-        displayName: displayName.trim() || null,
         defaultWeightUnit: weightUnit,
         defaultIntensityRating: intensityRating,
       })
@@ -52,13 +64,12 @@ export default function SettingsPage() {
 
   const isDirty =
     settings &&
-    (displayName !== (settings.displayName || '') ||
-      weightUnit !== settings.defaultWeightUnit ||
+    (weightUnit !== settings.defaultWeightUnit ||
       intensityRating !== settings.defaultIntensityRating)
 
   return (
     <div className="min-h-screen bg-background px-4 sm:px-6 py-8">
-      <div className="max-w-md mx-auto space-y-6">
+      <div className="max-w-md md:max-w-2xl mx-auto space-y-6">
         <h1 className="text-xl font-bold">Settings</h1>
 
         {isLoading ? (
@@ -67,105 +78,84 @@ export default function SettingsPage() {
           <>
             {/* Theme + Mode */}
             <div className="flex gap-2">
-              {/* Theme selector — 2/3 */}
-              <div className="flex-[2]">
-                <span className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
-                  Theme
-                </span>
-                <DropdownMenu.Root>
-                  <DropdownMenu.Trigger asChild>
-                    <button
-                      type="button"
-                      className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
-                    >
-                      <Palette className="w-4 h-4" />
-                      {preference ? THEME_LABELS[preference.themeName] : '...'}
-                    </button>
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Portal>
-                    <DropdownMenu.Content
-                      className="bg-card border-2 border-primary shadow-lg z-50 min-w-[180px]"
-                      sideOffset={5}
-                      align="start"
-                    >
-                      {THEMES.map((themeName) => (
-                        <DropdownMenu.Item
-                          key={themeName}
-                          onClick={() =>
-                            preference &&
-                            updateTheme({ ...preference, themeName })
-                          }
-                          className={`w-full px-4 py-2.5 text-left text-sm font-semibold uppercase tracking-wider transition-colors cursor-pointer outline-none ${
-                            preference?.themeName === themeName
-                              ? 'bg-primary text-primary-foreground'
-                              : 'hover:bg-muted text-foreground'
-                          }`}
-                        >
-                          {THEME_LABELS[themeName]}
-                        </DropdownMenu.Item>
-                      ))}
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Portal>
-                </DropdownMenu.Root>
-              </div>
+                {/* Theme selector — 2/3 */}
+                <div className="flex-[2]">
+                  <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                    Theme
+                  </span>
+                  <DropdownMenu.Root>
+                    <DropdownMenu.Trigger asChild>
+                      <button
+                        type="button"
+                        className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
+                      >
+                        <Palette className="w-4 h-4" />
+                        {preference ? THEME_LABELS[preference.themeName] : '...'}
+                      </button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.Content
+                        className="bg-card border-2 border-primary shadow-lg z-50 min-w-[180px]"
+                        sideOffset={5}
+                        align="start"
+                      >
+                        {THEMES.map((themeName) => (
+                          <DropdownMenu.Item
+                            key={themeName}
+                            onClick={() =>
+                              preference &&
+                              updateTheme({ ...preference, themeName })
+                            }
+                            className={`w-full px-4 py-2.5 text-left text-sm font-semibold uppercase tracking-wider transition-colors cursor-pointer outline-none ${
+                              preference?.themeName === themeName
+                                ? 'bg-primary text-primary-foreground'
+                                : 'hover:bg-muted text-foreground'
+                            }`}
+                          >
+                            {THEME_LABELS[themeName]}
+                          </DropdownMenu.Item>
+                        ))}
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Root>
+                </div>
 
-              {/* Light/Dark toggle — 1/3 */}
-              <div className="flex-1">
-                <span className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
-                  Mode
-                </span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    preference &&
-                    updateTheme({
-                      ...preference,
-                      mode: preference.mode === 'dark' ? 'light' : 'dark',
-                    })
-                  }
-                  className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
-                >
-                  {preference?.mode === 'dark' ? (
-                    <>
-                      <Moon className="w-4 h-4" />
-                      Dark
-                    </>
-                  ) : (
-                    <>
-                      <Sun className="w-4 h-4" />
-                      Light
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {/* Display Name */}
-            <div>
-              <label
-                htmlFor="displayName"
-                className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
-              >
-                Display Name
-              </label>
-              <input
-                id="displayName"
-                type="text"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="Enter display name"
-                className="w-full px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Used for community program attribution
-              </p>
+                {/* Light/Dark toggle — 1/3 */}
+                <div className="flex-1">
+                  <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                    Mode
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      preference &&
+                      updateTheme({
+                        ...preference,
+                        mode: preference.mode === 'dark' ? 'light' : 'dark',
+                      })
+                    }
+                    className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
+                  >
+                    {preference?.mode === 'dark' ? (
+                      <>
+                        <Moon className="w-4 h-4" />
+                        Dark
+                      </>
+                    ) : (
+                      <>
+                        <Sun className="w-4 h-4" />
+                        Light
+                      </>
+                    )}
+                  </button>
+                </div>
             </div>
 
             {/* Weight Unit */}
             <div>
               <span
                 id="weight-unit-label"
-                className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
+                className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
               >
                 Default Weight Unit
               </span>
@@ -202,7 +192,7 @@ export default function SettingsPage() {
             <div>
               <span
                 id="intensity-rating-label"
-                className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
+                className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
               >
                 Default Intensity Rating
               </span>
@@ -233,7 +223,7 @@ export default function SettingsPage() {
                   RIR
                 </button>
               </fieldset>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-sm text-muted-foreground mt-1">
                 RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
               </p>
             </div>
@@ -249,7 +239,7 @@ export default function SettingsPage() {
               type="button"
               onClick={handleSave}
               disabled={isSaving || !isDirty}
-              className={`w-full px-4 py-3 border-2 font-semibold uppercase tracking-wider flex items-center justify-center gap-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 disabled:cursor-not-allowed ${
+              className={`w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 font-semibold uppercase tracking-wider flex items-center justify-center gap-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 disabled:cursor-not-allowed ${
                 saved
                   ? 'bg-success text-white border-success'
                   : 'bg-primary text-primary-foreground border-primary hover:bg-primary-hover'
@@ -259,25 +249,63 @@ export default function SettingsPage() {
               {isSaving ? 'Saving...' : saved ? 'Saved' : 'Save'}
             </button>
 
+            {/* Account Section */}
+            <div className="pt-4 border-t border-border space-y-4">
+              <span className="block text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                Account
+              </span>
+
+              {/* Email */}
+              {connectedAccounts?.email && (
+                <div className="text-sm text-foreground">
+                  <span className="text-muted-foreground">Email: </span>
+                  {connectedAccounts.email}
+                </div>
+              )}
+
+              {/* Connected providers */}
+              <div className="space-y-2">
+                <span className="block text-sm text-muted-foreground">
+                  Connected sign-in methods
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  <ProviderBadge
+                    name="Google"
+                    connected={connectedAccounts?.providers.includes('google') ?? false}
+                  />
+                  <ProviderBadge
+                    name="Discord"
+                    connected={connectedAccounts?.providers.includes('discord') ?? false}
+                  />
+                </div>
+              </div>
+
+              {/* Change Password — stub */}
+              <button
+                type="button"
+                disabled
+                className="px-4 py-2 border-2 border-border bg-muted text-muted-foreground font-semibold uppercase tracking-wider text-sm flex items-center gap-2 opacity-50 cursor-not-allowed"
+              >
+                <KeyRound size={16} />
+                Change Password
+                <span className="text-sm font-normal normal-case tracking-normal ml-1">
+                  (coming soon)
+                </span>
+              </button>
+            </div>
+
             {/* Admin — visible to admin/editor roles only */}
             {isAdmin && (
               <div className="pt-4 border-t border-border space-y-2">
-                <span className="block text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
                   Admin
                 </span>
                 <Link
                   href="/admin"
-                  className="w-full px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
                 >
                   <Shield size={18} />
                   Admin Panel
-                </Link>
-                <Link
-                  href="/admin/exercises"
-                  className="w-full px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
-                >
-                  <Dumbbell size={18} />
-                  Manage Exercise Definitions
                 </Link>
               </div>
             )}
@@ -287,7 +315,7 @@ export default function SettingsPage() {
               <form action="/api/auth/signout" method="POST">
                 <button
                   type="submit"
-                  className="w-full px-4 py-3 bg-danger text-danger-foreground hover:bg-danger-hover doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider text-sm"
+                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm"
                 >
                   Sign Out
                 </button>
@@ -297,5 +325,22 @@ export default function SettingsPage() {
         )}
       </div>
     </div>
+  )
+}
+
+function ProviderBadge({ name, connected }: { name: string; connected: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 border-2 text-sm font-semibold uppercase tracking-wider ${
+        connected
+          ? 'border-success bg-success/10 text-success'
+          : 'border-border bg-muted text-muted-foreground'
+      }`}
+    >
+      <span
+        className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-success' : 'bg-muted-foreground'}`}
+      />
+      {name}
+    </span>
   )
 }

--- a/app/(auth)/complete-profile/page.tsx
+++ b/app/(auth)/complete-profile/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState, Suspense } from 'react'
+import { Suspense, useState } from 'react'
 import { Button } from '@/components/ui/Button'
 
 function CompleteProfileForm() {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState, Suspense } from 'react'
-import { Button } from '@/components/ui/Button'
+import { Suspense, useState } from 'react'
 import { OAuthButtons } from '@/components/features/auth/OAuthButtons'
+import { Button } from '@/components/ui/Button'
 import { signIn } from '@/lib/auth-client'
 
 function getOAuthError(errorParam: string | null): string | null {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -3,8 +3,8 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { Button } from '@/components/ui/Button'
 import { OAuthButtons } from '@/components/features/auth/OAuthButtons'
+import { Button } from '@/components/ui/Button'
 import { signUp } from '@/lib/auth-client'
 
 export default function SignupPage() {

--- a/app/api/auth/complete-profile/route.ts
+++ b/app/api/auth/complete-profile/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { getCurrentUser } from '@/lib/auth/server'
 import { Pool } from 'pg'
+import { getCurrentUser } from '@/lib/auth/server'
 import { logger } from '@/lib/logger'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })

--- a/app/api/settings/connected-accounts/route.ts
+++ b/app/api/settings/connected-accounts/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { Pool } from 'pg'
+import { getCurrentUser } from '@/lib/auth/server'
+import { logger } from '@/lib/logger'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+export async function GET(_request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const result = await pool.query(
+      'SELECT "providerId" FROM "account" WHERE "userId" = $1',
+      [user.id]
+    )
+
+    const providers = result.rows
+      .map((row) => row.providerId)
+      .filter((id) => id !== 'credential')
+
+    return NextResponse.json({
+      email: user.email,
+      providers,
+    })
+  } catch (err) {
+    logger.error({ error: err, context: 'connected-accounts' }, 'Failed to fetch connected accounts')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -26,7 +26,7 @@ export async function GET(_request: NextRequest) {
           userId: user.id,
           displayName: null,
           defaultWeightUnit: 'lbs',
-          defaultIntensityRating: 'rpe'
+          defaultIntensityRating: 'rir'
         }
       })
     } catch (upsertError: unknown) {
@@ -92,7 +92,7 @@ export async function PUT(request: NextRequest) {
         userId: user.id,
         displayName: displayName?.trim() || null,
         defaultWeightUnit: defaultWeightUnit || 'lbs',
-        defaultIntensityRating: defaultIntensityRating || 'rpe'
+        defaultIntensityRating: defaultIntensityRating || 'rir'
       }
     })
 

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -11,7 +11,7 @@ type UseUserSettingsReturn = {
   isLoading: boolean
   error: string | null
   refetch: () => Promise<void>
-  updateSettings: (settings: UserSettings) => Promise<void>
+  updateSettings: (settings: Partial<UserSettings>) => Promise<void>
 }
 
 export function useUserSettings(): UseUserSettingsReturn {
@@ -40,7 +40,7 @@ export function useUserSettings(): UseUserSettingsReturn {
     }
   }, [])
 
-  const updateSettings = useCallback(async (newSettings: UserSettings) => {
+  const updateSettings = useCallback(async (newSettings: Partial<UserSettings>) => {
     try {
       setError(null)
 

--- a/prisma/migrations/20260330014220_default_intensity_rir/migration.sql
+++ b/prisma/migrations/20260330014220_default_intensity_rir/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: change default intensity rating from RPE to RIR
+ALTER TABLE "UserSettings" ALTER COLUMN "defaultIntensityRating" SET DEFAULT 'rir';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -288,7 +288,7 @@ model UserSettings {
   userId                 String   @unique
   displayName            String?
   defaultWeightUnit      String   @default("lbs")
-  defaultIntensityRating String   @default("rpe")
+  defaultIntensityRating String   @default("rir")
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- Default intensity rating changed from RPE to RIR (schema + migration + API)
- Removed display name input and redundant "Manage Exercise Definitions" link
- Added Account section: email display, connected Google/Discord provider badges, disabled "Change Password (coming soon)" stub
- Widened layout for desktop (`max-w-2xl`), bumped font sizes (`text-xs` -> `text-sm`) for readability
- Flattened sign-out button style to match other settings buttons
- Fixed biome lint issues from #317 OAuth changes (import types, aria attributes)

Closes #314

## Test plan
- [ ] Settings page renders cleanly on mobile and desktop
- [ ] RIR is default for new users (check API upsert)
- [ ] Connected accounts section shows correct Google/Discord status
- [ ] Change Password button is visible but disabled
- [ ] Display name input is gone
- [ ] Exercise definitions link is gone
- [ ] Migration applies cleanly on staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)