### PR TITLE
feat: add Clyde and 90s Kid themes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ doppler run --config dev_personal -- [command]
 overmind start                                # Starts PostgreSQL, Redis, worker, Next.js
 overmind start -l postgres,app                # Just DB + app (skip redis/worker)
 
-# Worktree: must specify Doppler config with correct BETTER_AUTH_URL for the worktree's port
+# Worktree: port and auth URLs are auto-derived from worktree slot
 DOPPLER_CONFIG=dev_personal_worktree1 overmind start -l postgres,app
 
 # Database operations

--- a/Procfile
+++ b/Procfile
@@ -7,13 +7,16 @@
 #   overmind start                              # All services (primary repo)
 #   overmind start -l postgres,app              # Just DB + app (skip redis/worker)
 #
-# Worktree usage (requires a separate Doppler config with correct BETTER_AUTH_URL):
+# Worktree usage:
 #   DOPPLER_CONFIG=dev_personal_worktree1 overmind start -l postgres,app
 #
 # Individual process control: overmind restart worker | overmind connect app
+#
+# Port assignment: primary repo = 3000, worktrees = 3000 + (slot * 100)
+# BETTER_AUTH_URL and NEXT_PUBLIC_APP_URL are auto-overridden to match.
 
 postgres: ./scripts/start-postgres.sh
 redis: sleep 3 && ./scripts/start-redis.sh
 worker: sleep 8 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' REDIS_URL='${R_URL}' && cd cloud-functions/clone-program && npm run dev"
 minio: sleep 2 && ./scripts/start-minio.sh
-app: sleep 5 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" M_PORT=$((9000 + WORKTREE_SLOT)) && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' REDIS_URL='${R_URL}' MINIO_ENDPOINT='http://localhost:${M_PORT}' MINIO_ROOT_USER='minioadmin' MINIO_ROOT_PASSWORD='minioadmin' && npm run dev"
+app: sleep 5 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" M_PORT=$((9000 + WORKTREE_SLOT)) APP_PORT=$((3000 + WORKTREE_SLOT * 100)) APP_URL="http://localhost:${APP_PORT}" && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' REDIS_URL='${R_URL}' BETTER_AUTH_URL='${APP_URL}' NEXT_PUBLIC_APP_URL='${APP_URL}' MINIO_ENDPOINT='http://localhost:${M_PORT}' MINIO_ROOT_USER='minioadmin' MINIO_ROOT_PASSWORD='minioadmin' && npx next dev --turbopack --port ${APP_PORT}"

--- a/WORKTREE_SETUP.md
+++ b/WORKTREE_SETUP.md
@@ -4,10 +4,10 @@
 
 Worktrees auto-detect their identity using `git rev-parse` and derive unique Docker container names and ports via `scripts/worktree-env.sh`. No manual port configuration needed — the same `Procfile` and start scripts work in the primary repo and all worktrees.
 
-| Location | Slot | Postgres Port | Redis Port | PG Container | Redis Container |
-|----------|------|---------------|------------|--------------|-----------------|
-| Primary repo | 0 | 5433 | 6379 | fitcsv-postgres | fitcsv-redis |
-| Any worktree | 1-9 (hashed) | 5434-5442 | 6380-6388 | fitcsv-postgres-wt{N} | fitcsv-redis-wt{N} |
+| Location | Slot | App Port | Postgres Port | Redis Port | PG Container | Redis Container |
+|----------|------|----------|---------------|------------|--------------|-----------------|
+| Primary repo | 0 | 3000 | 5433 | 6379 | fitcsv-postgres | fitcsv-redis |
+| Any worktree | 1-9 (hashed) | 3100-3900 | 5434-5442 | 6380-6388 | fitcsv-postgres-wt{N} | fitcsv-redis-wt{N} |
 
 To check which slot a worktree gets:
 ```bash
@@ -16,13 +16,6 @@ echo "Slot: $WORKTREE_SLOT, PG: $PG_PORT, Redis: $REDIS_PORT"
 ```
 
 ## Quick Setup (New Worktree)
-
-### Prerequisites
-
-Each worktree that runs on a different port needs a **Doppler config** with the correct `BETTER_AUTH_URL`. Create one if it doesn't exist:
-
-1. Duplicate `dev_personal` in Doppler as `dev_personal_worktree1` (or similar)
-2. Update `BETTER_AUTH_URL` and `NEXT_PUBLIC_APP_URL` to match the worktree's app port (e.g., `http://localhost:5300`)
 
 ### Setup Steps
 
@@ -73,7 +66,7 @@ overmind restart app
 
 Just start overmind in each worktree. Each gets its own postgres and redis containers on unique ports. No conflicts.
 
-**Note**: Next.js port is NOT auto-isolated. Each worktree's Doppler config should specify a unique port via `NEXT_PUBLIC_APP_URL` / `BETTER_AUTH_URL`.
+All ports (including Next.js, `BETTER_AUTH_URL`, and `NEXT_PUBLIC_APP_URL`) are auto-derived from the worktree slot. No per-worktree Doppler config needed for port differences.
 
 ## Troubleshooting
 
@@ -90,7 +83,7 @@ overmind restart app
 ```
 
 ### "Invalid origin" on signup/login
-Your Doppler config's `BETTER_AUTH_URL` doesn't match the app's actual URL/port. Update it in Doppler.
+`BETTER_AUTH_URL` is auto-set from the worktree slot. If you still see this, check that nothing is overriding the port (e.g., a Doppler config that hardcodes a different `BETTER_AUTH_URL`).
 
 ### ECONNREFUSED on signup/login
 The app can't reach postgres. Check that `DATABASE_URL` port matches the actual postgres container port:

--- a/app/globals.css
+++ b/app/globals.css
@@ -1304,6 +1304,282 @@
   --accent-rgb: 148, 226, 213;
 }
 
+/* CLYDE Theme - Light Mode (Claude App) */
+[data-theme="clyde"] {
+  /* Base colors - warm cream canvas */
+  --background: #FAF9F7;  /* warm off-white */
+  --foreground: #1a1a1a;  /* near-black text */
+
+  /* Surface colors */
+  --card: #FFFFFF;
+  --card-foreground: #1a1a1a;
+  --muted: #F0EDE8;       /* warm light beige */
+  --muted-foreground: #6B6560;
+
+  /* Border colors */
+  --border: #E0DBD4;      /* warm light border */
+  --input: #E0DBD4;
+
+  /* Primary (Claude Terracotta/Coral) */
+  --primary: #D97757;     /* Claude signature warm coral */
+  --primary-foreground: #FFFFFF;
+  --primary-hover: #C4653F;
+  --primary-active: #B05A38;
+  --primary-muted: #FDF0EB;
+  --primary-muted-dark: #D97757;
+  --primary-rgb: 217, 119, 87;
+
+  /* Secondary (Warm Gray) */
+  --secondary: #8A8480;
+  --secondary-foreground: #FFFFFF;
+  --secondary-hover: #706B67;
+  --secondary-active: #5C5753;
+  --secondary-muted: #F0EDE8;
+
+  /* Success (Soft Teal) */
+  --success: #2D9C83;
+  --success-foreground: #FFFFFF;
+  --success-hover: #258270;
+  --success-muted: #E6F5F1;
+  --success-text: #2D9C83;
+  --success-border: #2D9C83;
+  --success-rgb: 45, 156, 131;
+
+  /* Warning (Warm Amber) */
+  --warning: #D4922A;
+  --warning-foreground: #FFFFFF;
+  --warning-hover: #B87D23;
+  --warning-muted: #FDF3E0;
+  --warning-text: #D4922A;
+  --warning-border: #D4922A;
+  --warning-rgb: 212, 146, 42;
+
+  /* Error (Soft Red) */
+  --error: #CC4E4E;
+  --error-foreground: #FFFFFF;
+  --error-hover: #B33E3E;
+  --error-muted: #FCE8E8;
+  --error-text: #CC4E4E;
+  --error-border: #CC4E4E;
+  --error-rgb: 204, 78, 78;
+
+  /* Accent (Claude Warm Blue) */
+  --accent: #5B8AC4;
+  --accent-foreground: #FFFFFF;
+  --accent-hover: #4A76AD;
+  --accent-active: #3D6599;
+  --accent-muted: #EBF1F8;
+  --accent-text: #5B8AC4;
+  --accent-rgb: 91, 138, 196;
+}
+
+/* CLYDE Theme - Dark Mode (Claude Dark) */
+[data-theme="clyde"][data-mode="dark"] {
+  /* Base colors - warm dark surface */
+  --background: #2B2522;  /* warm deep brown-black */
+  --foreground: #F0EBE4;  /* warm off-white */
+
+  /* Surface colors */
+  --card: #352F2B;        /* warm dark card */
+  --card-foreground: #F0EBE4;
+  --muted: #3F3833;       /* warm dark muted */
+  --muted-foreground: #A09890;
+
+  /* Border colors */
+  --border: #4A433D;      /* warm dark border */
+  --input: #4A433D;
+
+  /* Primary (Claude Terracotta/Coral - bright in dark) */
+  --primary: #E0845F;     /* brighter coral for dark bg */
+  --primary-foreground: #1a1a1a;
+  --primary-hover: #D97757;
+  --primary-active: #C4653F;
+  --primary-muted: #3D2A22;
+  --primary-muted-dark: #E0845F;
+  --primary-rgb: 224, 132, 95;
+
+  /* Secondary (Warm Gray) */
+  --secondary: #9A9490;
+  --secondary-foreground: #1a1a1a;
+  --secondary-hover: #8A8480;
+  --secondary-active: #706B67;
+  --secondary-muted: #3F3833;
+
+  /* Success (Soft Teal) */
+  --success: #3DB896;
+  --success-foreground: #1a1a1a;
+  --success-hover: #2D9C83;
+  --success-muted: #1E342E;
+  --success-text: #3DB896;
+  --success-border: #3DB896;
+  --success-rgb: 61, 184, 150;
+
+  /* Warning (Warm Amber) */
+  --warning: #E0A43A;
+  --warning-foreground: #1a1a1a;
+  --warning-hover: #D4922A;
+  --warning-muted: #3A3020;
+  --warning-text: #E0A43A;
+  --warning-border: #E0A43A;
+  --warning-rgb: 224, 164, 58;
+
+  /* Error (Soft Red) */
+  --error: #E06060;
+  --error-foreground: #FFFFFF;
+  --error-hover: #CC4E4E;
+  --error-muted: #3A2222;
+  --error-text: #E06060;
+  --error-border: #E06060;
+  --error-rgb: 224, 96, 96;
+
+  /* Accent (Claude Warm Blue) */
+  --accent: #6E9AD0;
+  --accent-foreground: #1a1a1a;
+  --accent-hover: #5B8AC4;
+  --accent-active: #4A76AD;
+  --accent-muted: #253040;
+  --accent-text: #6E9AD0;
+  --accent-rgb: 110, 154, 208;
+}
+
+/* 90s KID Theme - Light Mode (Nickelodeon) */
+[data-theme="ninety"] {
+  /* Base colors - bright white with teal tint */
+  --background: #F5FBF9;  /* very light teal tint */
+  --foreground: #0c344d;  /* deep teal-navy from palette */
+
+  /* Surface colors */
+  --card: #FFFFFF;
+  --card-foreground: #0c344d;
+  --muted: #E8F5F0;       /* light minty */
+  --muted-foreground: #4A6B5D;
+
+  /* Border colors */
+  --border: #C8E6DA;      /* light green-teal border */
+  --input: #C8E6DA;
+
+  /* Primary (Nick Orange) */
+  --primary: #f5782a;     /* orange from palette - iconic Nick */
+  --primary-foreground: #FFFFFF;
+  --primary-hover: #E06620;
+  --primary-active: #C7581A;
+  --primary-muted: #FEF0E7;
+  --primary-muted-dark: #f5782a;
+  --primary-rgb: 245, 120, 42;
+
+  /* Secondary (Deep Teal) */
+  --secondary: #0c344d;   /* deep navy-teal from palette */
+  --secondary-foreground: #FFFFFF;
+  --secondary-hover: #0A2B40;
+  --secondary-active: #082233;
+  --secondary-muted: #E0EEF4;
+
+  /* Success (Slime Green) */
+  --success: #6cc314;     /* lime green from palette */
+  --success-foreground: #FFFFFF;
+  --success-hover: #5BAA10;
+  --success-muted: #EBF7DE;
+  --success-text: #4DA812;
+  --success-border: #6cc314;
+  --success-rgb: 108, 195, 20;
+
+  /* Warning (Golden Yellow) */
+  --warning: #f5be2a;     /* golden yellow from palette */
+  --warning-foreground: #0c344d;
+  --warning-hover: #E0AC20;
+  --warning-muted: #FEF6E0;
+  --warning-text: #D4A020;
+  --warning-border: #f5be2a;
+  --warning-rgb: 245, 190, 42;
+
+  /* Error (Hot Red) */
+  --error: #E04520;
+  --error-foreground: #FFFFFF;
+  --error-hover: #C73B1A;
+  --error-muted: #FDE8E3;
+  --error-text: #E04520;
+  --error-border: #E04520;
+  --error-rgb: 224, 69, 32;
+
+  /* Accent (90s Purple) */
+  --accent: #9B30FF;      /* electric purple - 90s pop */
+  --accent-foreground: #FFFFFF;
+  --accent-hover: #8526E0;
+  --accent-active: #7020C7;
+  --accent-muted: #F0E4FF;
+  --accent-text: #7B20D4;
+  --accent-rgb: 155, 48, 255;
+}
+
+/* 90s KID Theme - Dark Mode (Midnight Nick) */
+[data-theme="ninety"][data-mode="dark"] {
+  /* Base colors - deep teal-navy */
+  --background: #071E2E;  /* very dark teal */
+  --foreground: #fbff90;  /* pale yellow from palette - neon feel */
+
+  /* Surface colors */
+  --card: #0c344d;        /* deep teal from palette */
+  --card-foreground: #F0F8F0;
+  --muted: #123D56;       /* slightly lighter teal */
+  --muted-foreground: #8AB8A0;
+
+  /* Border colors */
+  --border: #1A4D66;      /* medium teal border */
+  --input: #1A4D66;
+
+  /* Primary (Nick Orange - vivid in dark) */
+  --primary: #FF8A40;     /* bright orange for dark bg */
+  --primary-foreground: #071E2E;
+  --primary-hover: #f5782a;
+  --primary-active: #E06620;
+  --primary-muted: #3A2210;
+  --primary-muted-dark: #FF8A40;
+  --primary-rgb: 255, 138, 64;
+
+  /* Secondary (Pale Yellow) */
+  --secondary: #fbff90;   /* pale yellow from palette */
+  --secondary-foreground: #071E2E;
+  --secondary-hover: #E8EB80;
+  --secondary-active: #D4D770;
+  --secondary-muted: #2A2E18;
+
+  /* Success (Slime Green - bright) */
+  --success: #7CD424;
+  --success-foreground: #071E2E;
+  --success-hover: #6cc314;
+  --success-muted: #1A3318;
+  --success-text: #7CD424;
+  --success-border: #6cc314;
+  --success-rgb: 124, 212, 36;
+
+  /* Warning (Golden Yellow) */
+  --warning: #f5be2a;     /* golden yellow from palette */
+  --warning-foreground: #071E2E;
+  --warning-hover: #FFD040;
+  --warning-muted: #2E2A10;
+  --warning-text: #FFD040;
+  --warning-border: #f5be2a;
+  --warning-rgb: 245, 190, 42;
+
+  /* Error (Hot Red) */
+  --error: #FF5533;
+  --error-foreground: #FFFFFF;
+  --error-hover: #E04520;
+  --error-muted: #3A1A12;
+  --error-text: #FF5533;
+  --error-border: #FF5533;
+  --error-rgb: 255, 85, 51;
+
+  /* Accent (90s Purple - neon) */
+  --accent: #B44FFF;      /* bright electric purple */
+  --accent-foreground: #071E2E;
+  --accent-hover: #C870FF;
+  --accent-active: #9B30FF;
+  --accent-muted: #2A1840;
+  --accent-text: #C870FF;
+  --accent-rgb: 180, 79, 255;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -10,7 +10,7 @@
 // Type Definitions
 // ============================================================================
 
-export type ThemeName = 'doom' | 'cyber' | 'forest' | 'synthwave' | 'dracula' | 'github' | 'ripit' | 'catppuccin';
+export type ThemeName = 'doom' | 'cyber' | 'forest' | 'synthwave' | 'dracula' | 'github' | 'ripit' | 'catppuccin' | 'clyde' | 'ninety';
 export type ThemeMode = 'light' | 'dark';
 
 export interface ThemePreference {
@@ -22,7 +22,7 @@ export interface ThemePreference {
 // Constants
 // ============================================================================
 
-export const THEMES: ThemeName[] = ['ripit', 'doom', 'catppuccin', 'cyber', 'forest', 'synthwave', 'dracula', 'github'];
+export const THEMES: ThemeName[] = ['ripit', 'doom', 'catppuccin', 'cyber', 'forest', 'synthwave', 'dracula', 'github', 'clyde', 'ninety'];
 export const MODES: ThemeMode[] = ['light', 'dark'];
 
 export const DEFAULT_THEME: ThemePreference = {
@@ -39,6 +39,8 @@ export const THEME_LABELS: Record<ThemeName, string> = {
   synthwave: 'SYNTHWAVE \'84',
   dracula: 'DRACULA',
   github: 'GITHUB',
+  clyde: 'CLYDE',
+  ninety: '90s KID',
 };
 
 const STORAGE_KEY = 'themePreference';


### PR DESCRIPTION
## Summary
- **Clyde theme**: Claude app-inspired warm coral/teal palette with light and dark variants
- **90s Kid theme**: Nickelodeon-inspired with Nick orange primary, slime green success, electric purple accent (light + dark)
- **Worktree port fix**: App port now deterministic (`3000 + slot * 100`), `BETTER_AUTH_URL` and `NEXT_PUBLIC_APP_URL` auto-overridden in Procfile — no more per-worktree Doppler config needed for port differences

## Test plan
- [ ] Switch to Clyde theme (light + dark) and verify colors throughout app
- [ ] Switch to 90s Kid theme (light + dark) and verify colors throughout app
- [ ] Verify existing themes still work correctly
- [ ] Test worktree startup with `overmind start` and confirm app port is deterministic
- [ ] Verify auth works on the auto-derived port (login/signup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)