### PR TITLE
Add support/donate link in Settings

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -341,7 +341,7 @@ export default function SettingsPage() {
                 href={`https://venmo.com/${process.env.NEXT_PUBLIC_VENMO_HANDLE}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                className="w-full md:w-auto md:inline-flex md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
               >
                 <Heart size={18} />
                 Support Ripit

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -312,45 +312,34 @@ export default function SettingsPage() {
               </div>
             )}
 
-            {/* Feedback */}
+            {/* Feedback & Donate */}
             <div className="pt-4 border-t border-border">
               <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
-                Feedback
+                Feedback & Support
               </span>
-              <button
-                type="button"
-                onClick={() => setFeedbackOpen(true)}
-                className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
-              >
-                <MessageSquarePlus size={18} />
-                Send Feedback
-              </button>
-              <p className="text-sm text-muted-foreground mt-1">
-                Report bugs, request features, or let us know what you think
-              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setFeedbackOpen(true)}
+                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                >
+                  <MessageSquarePlus size={18} />
+                  Send Feedback
+                </button>
+                {process.env.NEXT_PUBLIC_VENMO_HANDLE && (
+                <a
+                  href={`https://venmo.com/${process.env.NEXT_PUBLIC_VENMO_HANDLE}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                >
+                  <Heart size={18} />
+                  Support Ripit
+                </a>
+                )}
+              </div>
               <FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
             </div>
-
-            {/* Donate */}
-            {process.env.NEXT_PUBLIC_VENMO_HANDLE && (
-            <div className="pt-4 border-t border-border">
-              <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
-                Donate
-              </span>
-              <a
-                href={`https://venmo.com/${process.env.NEXT_PUBLIC_VENMO_HANDLE}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="w-full md:w-auto md:inline-flex md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
-              >
-                <Heart size={18} />
-                Support Ripit
-              </a>
-              <p className="text-sm text-muted-foreground mt-1">
-                Ripit is built by a local developer who loves lifting. If it helps your training, consider buying him a coffee.
-              </p>
-            </div>
-            )}
 
             {/* Sign Out */}
             <div className="pt-4 border-t border-border">

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -329,6 +329,25 @@ export default function SettingsPage() {
                 Report bugs, request features, or let us know what you think
               </p>
               <FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+            </div>
+
+            {/* Support */}
+            <div className="pt-4 border-t border-border">
+              <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                Support
+              </span>
+              <a
+                href="https://venmo.com/dusty-maze"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+              >
+                <Heart size={18} />
+                Support Ripit
+              </a>
+              <p className="text-sm text-muted-foreground mt-1">
+                Ripit is built by a local developer who loves lifting. If it helps your training, consider buying him a coffee.
+              </p>
             </div>
 
             {/* Sign Out */}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -331,13 +331,14 @@ export default function SettingsPage() {
               <FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
             </div>
 
-            {/* Support */}
+            {/* Donate */}
+            {process.env.NEXT_PUBLIC_VENMO_HANDLE && (
             <div className="pt-4 border-t border-border">
               <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
-                Support
+                Donate
               </span>
               <a
-                href="https://venmo.com/dusty-maze"
+                href={`https://venmo.com/${process.env.NEXT_PUBLIC_VENMO_HANDLE}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
@@ -349,6 +350,7 @@ export default function SettingsPage() {
                 Ripit is built by a local developer who loves lifting. If it helps your training, consider buying him a coffee.
               </p>
             </div>
+            )}
 
             {/* Sign Out */}
             <div className="pt-4 border-t border-border">


### PR DESCRIPTION
## Summary
- Adds a new "Support" section to the Settings page between Feedback and Sign Out
- Includes a "Support Ripit" button linking to Venmo (opens in new tab)
- Follows existing section pattern with Heart icon and subtitle text

## Test plan
- [ ] Visit Settings page and verify the new Support section appears between Feedback and Sign Out
- [ ] Click "Support Ripit" button and verify it opens https://venmo.com/dusty-maze in a new tab
- [ ] Verify styling matches the existing Feedback section pattern

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)