### PR TITLE
feat: modernize workout logger and exercise editor UI

### DIFF
--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -217,22 +217,22 @@ export function SetConfigurationInterface({
   return (
     <div className="flex-1 overflow-y-auto min-h-0">
       {/* Exercise Details */}
-      <div className="py-4 pb-0 bg-muted">
+      <div className="py-3 pb-0 bg-card">
         <div className="px-4 sm:px-6">
           {/* Exercise name */}
-          <h3 className="font-bold text-foreground text-lg tracking-wide uppercase">
+          <h3 className="font-bold text-foreground text-lg tracking-wide uppercase doom-heading">
             {exercise.name}
           </h3>
 
-          {/* Folder-style Tabs */}
-          <div className="flex gap-1 mt-2 -mb-[2px] relative z-10">
+          {/* Tabs */}
+          <div className="flex mt-2 border-b border-border">
             <button
               type="button"
               onClick={() => setActiveTab('sets')}
               className={`relative px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all ${
                 activeTab === 'sets'
-                  ? 'text-primary border-2 border-b-0 border-primary bg-card shadow-[0_0_10px_rgba(var(--primary-rgb),0.3)]'
-                  : 'text-muted-foreground border-2 border-border bg-muted/50 hover:text-primary hover:shadow-[0_0_8px_rgba(var(--primary-rgb),0.2)]'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               Sets
@@ -242,8 +242,8 @@ export function SetConfigurationInterface({
               onClick={() => setActiveTab('notes')}
               className={`relative px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all ${
                 activeTab === 'notes'
-                  ? 'text-primary border-2 border-b-0 border-primary bg-card shadow-[0_0_10px_rgba(var(--primary-rgb),0.3)]'
-                  : 'text-muted-foreground border-2 border-border bg-muted/50 hover:text-primary hover:shadow-[0_0_8px_rgba(var(--primary-rgb),0.2)]'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               Notes
@@ -255,7 +255,7 @@ export function SetConfigurationInterface({
               <button
                 type="button"
                 onClick={onEditExercise}
-                className="relative px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all text-muted-foreground border-2 border-border bg-muted/50 hover:text-primary hover:shadow-[0_0_8px_rgba(var(--primary-rgb),0.2)]"
+                className="relative px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all text-muted-foreground hover:text-foreground"
                 aria-label="Edit exercise definition"
               >
                 Edit
@@ -266,55 +266,62 @@ export function SetConfigurationInterface({
       </div>
 
       {/* Tab Content */}
-      <div className="px-4 sm:px-6 py-4 bg-card border-t-2 border-border">
+      <div className="px-4 sm:px-6 py-4 bg-card">
         {activeTab === 'sets' ? (
           <div className="space-y-4">
             {/* Exercise-level Intensity Type */}
-          <div>
-            <label htmlFor="exercise-intensity-type" className="block text-base font-bold text-foreground mb-2 tracking-wide uppercase">
-              Intensity Type (All Sets)
-            </label>
-            <select
-              id="exercise-intensity-type"
-              value={exerciseIntensityType}
-              onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
-              className="w-full px-3 py-2 border-2 border-input focus:outline-none focus:border-primary focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] bg-muted text-foreground doom-input"
-            >
-              <option value="NONE">None</option>
-              <option value="RIR">RIR (Reps in Reserve)</option>
-              <option value="RPE">RPE (Rate of Perceived Exertion)</option>
-            </select>
-          </div>
+            <div>
+              <label htmlFor="exercise-intensity-type" className="block text-sm font-bold text-muted-foreground mb-1.5 uppercase tracking-wider">
+                INTENSITY TYPE
+              </label>
+              <select
+                id="exercise-intensity-type"
+                value={exerciseIntensityType}
+                onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
+                className="w-full px-3 py-2.5 border border-border focus:outline-none focus:border-primary bg-card text-foreground text-base"
+              >
+                <option value="NONE">None</option>
+                <option value="RIR">RIR (Reps in Reserve)</option>
+                <option value="RPE">RPE (Rate of Perceived Exertion)</option>
+              </select>
+            </div>
 
-          {/* Individual Set Configuration */}
-          <div>
-            <h4 className="text-base font-bold text-foreground mb-3 tracking-wide uppercase">Sets</h4>
-            <div className="space-y-2">
-              {sets.map((set, index) => (
-                <div key={set.setNumber} className="border-2 border-border p-3 bg-muted">
-                  <div className="flex items-center gap-4">
-                    <div className="flex-shrink-0 w-16">
-                      <span className="text-base font-bold text-foreground tracking-wide uppercase">Set {set.setNumber}</span>
-                    </div>
+            {/* Individual Set Configuration - Table Layout */}
+            <div>
+              <h4 className="text-sm font-bold text-muted-foreground mb-2 uppercase tracking-wider">SETS</h4>
+              <div className="border border-border divide-y divide-border">
+                {/* Table header */}
+                <div className="flex items-center px-3 py-1.5 bg-muted/50">
+                  <span className="w-12 text-sm font-bold text-muted-foreground uppercase tracking-wider">#</span>
+                  <span className="flex-1 text-sm font-bold text-muted-foreground uppercase tracking-wider">REPS</span>
+                  {exerciseIntensityType !== 'NONE' && (
+                    <span className="flex-1 text-sm font-bold text-muted-foreground uppercase tracking-wider">{exerciseIntensityType}</span>
+                  )}
+                  <span className="w-10" />
+                </div>
+
+                {/* Set rows */}
+                {sets.map((set, index) => (
+                  <div key={set.setNumber} className="flex items-center px-3 py-2.5 gap-2">
+                    <span className="w-12 text-base font-bold text-muted-foreground">{set.setNumber}</span>
 
                     {/* Reps */}
                     <div className="flex-1">
-                      <span className="block text-base font-bold text-foreground mb-1 tracking-wide uppercase">Reps</span>
                       <Popover>
                         <PopoverTrigger asChild>
                           <button
                             type="button"
-                            className="w-full px-3 py-2 text-sm border-2 border-input hover:border-primary focus:outline-none focus:border-primary focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] bg-card text-foreground text-left"
+                            className="w-full px-3 py-2 text-base border border-border hover:border-primary bg-card text-foreground text-left font-semibold transition-colors"
                           >
                             {set.reps || '8-12'}
                           </button>
                         </PopoverTrigger>
-                        <PopoverContent className="w-80 p-3" align="start">
+                        <PopoverContent className="w-72 p-3" align="start">
                           <div className="space-y-2">
-                            <div className="text-sm font-bold text-foreground uppercase tracking-wide mb-2">
-                              Select Reps
+                            <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">
+                              SELECT REPS
                             </div>
-                            <div className="grid grid-cols-4 gap-2">
+                            <div className="grid grid-cols-4 gap-1.5">
                               {REP_PRESETS.map((preset) => (
                                 <button
                                   key={preset.value}
@@ -324,10 +331,10 @@ export function SetConfigurationInterface({
                                     setCustomRepInput({ ...customRepInput, [index]: '' })
                                     setRepValidationError({ ...repValidationError, [index]: '' })
                                   }}
-                                  className={`px-3 py-2 text-sm border-2 transition-colors font-bold ${
+                                  className={`px-2 py-1.5 text-sm border transition-colors font-bold ${
                                     set.reps === preset.value
                                       ? 'bg-primary text-primary-foreground border-primary'
-                                      : 'bg-muted text-foreground border-input hover:border-primary'
+                                      : 'bg-card text-foreground border-border hover:border-primary'
                                   }`}
                                 >
                                   {preset.label}
@@ -335,15 +342,13 @@ export function SetConfigurationInterface({
                               ))}
                             </div>
                             {REP_PRESETS.find(p => p.value === set.reps) && (
-                              <div className="px-2 py-2 bg-primary/10 border border-primary/30 rounded">
-                                <div className="text-sm text-primary font-bold">
-                                  {REP_PRESETS.find(p => p.value === set.reps)?.description}
-                                </div>
+                              <div className="px-2 py-1.5 bg-primary/10 border border-primary/30 text-xs text-primary font-bold">
+                                {REP_PRESETS.find(p => p.value === set.reps)?.description}
                               </div>
                             )}
-                            <div className="pt-2 border-t-2 border-border">
-                              <div className="text-sm font-bold text-foreground uppercase tracking-wide mb-2">
-                                Custom
+                            <div className="pt-2 border-t border-border">
+                              <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-1.5">
+                                CUSTOM
                               </div>
                               <input
                                 type="text"
@@ -352,7 +357,6 @@ export function SetConfigurationInterface({
                                   const value = e.target.value
                                   setCustomRepInput({ ...customRepInput, [index]: value })
                                   handleSetUpdate(index, 'reps', value)
-
                                   const error = validateRepFormat(value)
                                   setRepValidationError({ ...repValidationError, [index]: error || '' })
                                 }}
@@ -362,10 +366,10 @@ export function SetConfigurationInterface({
                                 }}
                                 onFocus={(e) => e.target.select()}
                                 placeholder="e.g., 5, 8-12, 20+"
-                                className={`w-full px-3 py-2 text-sm border-2 focus:outline-none focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] bg-card text-foreground ${
+                                className={`w-full px-3 py-1.5 text-sm border focus:outline-none bg-card text-foreground ${
                                   repValidationError[index]
                                     ? 'border-error focus:border-error'
-                                    : 'border-input focus:border-primary'
+                                    : 'border-border focus:border-primary'
                                 }`}
                               />
                               {repValidationError[index] && (
@@ -382,42 +386,39 @@ export function SetConfigurationInterface({
                     {/* Intensity Value */}
                     {exerciseIntensityType !== 'NONE' && (
                       <div className="flex-1">
-                        <span className="block text-base font-bold text-foreground mb-1 tracking-wide uppercase">
-                          {exerciseIntensityType} Value
-                        </span>
                         <Popover>
                           <PopoverTrigger asChild>
                             <button
                               type="button"
-                              className="w-full px-3 py-2 text-sm border-2 border-input hover:border-primary focus:outline-none focus:border-primary focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] bg-card text-foreground text-left"
+                              className="w-full px-3 py-2 text-base border border-border hover:border-primary bg-card text-foreground text-left font-semibold transition-colors"
                             >
                               {set.intensityValue !== undefined ? set.intensityValue : exerciseIntensityType === 'RIR' ? '0-5' : '6-10'}
                             </button>
                           </PopoverTrigger>
-                          <PopoverContent className="w-80 p-3" align="start">
+                          <PopoverContent className="w-72 p-3" align="start">
                             <div className="space-y-2">
-                              <div className="mb-3">
-                                <div className="text-sm font-bold text-foreground uppercase tracking-wide">
-                                  Select {exerciseIntensityType}
+                              <div className="mb-2">
+                                <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                                  SELECT {exerciseIntensityType}
                                 </div>
-                                <div className="text-xs text-muted-foreground mt-1 font-medium">
+                                <div className="text-xs text-muted-foreground mt-1">
                                   {exerciseIntensityType === 'RIR'
-                                    ? 'Reps in Reserve: How many more reps you could do'
-                                    : 'Rate of Perceived Exertion: How hard the set feels (1-10 scale)'
+                                    ? 'How many more reps you could do'
+                                    : 'How hard the set feels (1-10)'
                                   }
                                 </div>
                               </div>
-                              <div className={`grid gap-2 ${exerciseIntensityType === 'RIR' ? 'grid-cols-6' : 'grid-cols-5'}`}>
+                              <div className={`grid gap-1.5 ${exerciseIntensityType === 'RIR' ? 'grid-cols-6' : 'grid-cols-5'}`}>
                                 {exerciseIntensityType === 'RIR' ? (
                                   RIR_PRESETS.map((preset) => (
                                     <button
                                       key={preset.value}
                                       type="button"
                                       onClick={() => handleSetUpdate(index, 'intensityValue', preset.value)}
-                                      className={`px-3 py-2 text-sm border-2 transition-colors font-bold ${
+                                      className={`px-2 py-1.5 text-sm border transition-colors font-bold ${
                                         set.intensityValue === preset.value
                                           ? 'bg-primary text-primary-foreground border-primary'
-                                          : 'bg-muted text-foreground border-input hover:border-primary'
+                                          : 'bg-card text-foreground border-border hover:border-primary'
                                       }`}
                                     >
                                       {preset.label}
@@ -429,10 +430,10 @@ export function SetConfigurationInterface({
                                       key={preset.value}
                                       type="button"
                                       onClick={() => handleSetUpdate(index, 'intensityValue', preset.value)}
-                                      className={`px-3 py-2 text-sm border-2 transition-colors font-bold ${
+                                      className={`px-2 py-1.5 text-sm border transition-colors font-bold ${
                                         set.intensityValue === preset.value
                                           ? 'bg-primary text-primary-foreground border-primary'
-                                          : 'bg-muted text-foreground border-input hover:border-primary'
+                                          : 'bg-card text-foreground border-border hover:border-primary'
                                       }`}
                                     >
                                       {preset.label}
@@ -441,13 +442,11 @@ export function SetConfigurationInterface({
                                 )}
                               </div>
                               {set.intensityValue !== undefined && (
-                                <div className="px-2 py-2 bg-primary/10 border border-primary/30 rounded">
-                                  <div className="text-sm text-primary font-bold">
-                                    {exerciseIntensityType === 'RIR'
-                                      ? RIR_PRESETS.find(p => p.value === set.intensityValue)?.description
-                                      : RPE_PRESETS.find(p => p.value === set.intensityValue)?.description
-                                    }
-                                  </div>
+                                <div className="px-2 py-1.5 bg-primary/10 border border-primary/30 text-xs text-primary font-bold">
+                                  {exerciseIntensityType === 'RIR'
+                                    ? RIR_PRESETS.find(p => p.value === set.intensityValue)?.description
+                                    : RPE_PRESETS.find(p => p.value === set.intensityValue)?.description
+                                  }
                                 </div>
                               )}
                             </div>
@@ -458,54 +457,51 @@ export function SetConfigurationInterface({
 
                     {/* Duplicate Button - Only for existing sets */}
                     {showDuplicateButton && set.id && onDuplicateSet && (
-                      <div className="flex-shrink-0">
-                        <button
-                          type="button"
-                          onClick={() => handleDuplicateSet(set.id!)}
-                          disabled={duplicatingSetId !== null}
-                          className="p-2 text-primary hover:text-primary-hover hover:bg-primary-muted border-2 border-transparent hover:border-primary transition-colors disabled:opacity-50"
-                          title="Duplicate this set"
-                        >
-                          <Plus size={20} />
-                        </button>
-                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleDuplicateSet(set.id!)}
+                        disabled={duplicatingSetId !== null}
+                        className="p-1.5 text-primary hover:text-primary-hover transition-colors disabled:opacity-50"
+                        title="Duplicate this set"
+                      >
+                        <Plus size={16} />
+                      </button>
                     )}
 
                     {/* Delete Button */}
-                    {sets.length > 1 && (
-                      <div className="flex-shrink-0">
+                    <div className="w-10 flex justify-end">
+                      {sets.length > 1 && (
                         <button
                           type="button"
                           onClick={() => handleDeleteSet(index)}
-                          className="p-2 text-error hover:text-error-hover hover:bg-error-muted border-2 border-transparent hover:border-error transition-colors"
+                          className="p-1.5 text-error/50 hover:text-error transition-colors"
                           title="Delete this set"
                         >
-                          <Trash size={20} />
+                          <Trash size={16} />
                         </button>
-                      </div>
-                    )}
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
 
-            {/* Add Set Button */}
-            <button
-              type="button"
-              onClick={handleAddSet}
-              className="w-full mt-3 px-6 py-3 bg-primary text-primary-foreground hover:bg-primary-hover transition-colors flex items-center justify-center gap-2 font-bold uppercase tracking-wider doom-button-3d"
-            >
-              <Plus size={18} />
-              Add Set (Clones Last)
-            </button>
-          </div>
+              {/* Add Set Button */}
+              <button
+                type="button"
+                onClick={handleAddSet}
+                className="w-full mt-2 py-2.5 border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary transition-colors flex items-center justify-center gap-2 text-base font-bold uppercase tracking-wider"
+              >
+                <Plus size={16} />
+                ADD SET (CLONES LAST)
+              </button>
+            </div>
 
           </div>
         ) : (
           /* Notes Tab */
           <div>
-            <label htmlFor="exercise-notes-config" className="block text-base font-bold text-foreground mb-2 tracking-wide uppercase">
-              Exercise Notes (Optional)
+            <label htmlFor="exercise-notes-config" className="block text-sm font-bold text-muted-foreground mb-1.5 uppercase tracking-wider">
+              EXERCISE NOTES
             </label>
             <textarea
               id="exercise-notes-config"
@@ -513,7 +509,7 @@ export function SetConfigurationInterface({
               onChange={(e) => setExerciseNotes(e.target.value)}
               placeholder="Add any notes for this exercise (e.g., form cues, modifications, etc.)"
               rows={10}
-              className="w-full px-3 py-2 border-2 border-input focus:outline-none focus:border-primary focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] text-sm bg-card text-foreground"
+              className="w-full px-3 py-2 border border-border focus:outline-none focus:border-primary text-base bg-card text-foreground"
             />
           </div>
         )}

--- a/components/ui/radix/wizard-dialog.tsx
+++ b/components/ui/radix/wizard-dialog.tsx
@@ -81,14 +81,14 @@ export function WizardDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showClose={false} fullScreenMobile={true} className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border-4 sm:border-4 border-border bg-card doom-card">
-        <DialogHeader className="border-b-2 border-border">
+      <DialogContent showClose={false} fullScreenMobile={true} className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card">
+        <DialogHeader className="border-b border-border bg-primary py-2">
           <div className="flex items-center justify-between">
             <div className="flex-1">
-              <DialogTitle className="text-xl font-bold text-foreground tracking-wide uppercase">{step.title}</DialogTitle>
-              {step.description && <DialogDescription className="font-bold text-muted-foreground mt-1 uppercase tracking-wide">{step.description}</DialogDescription>}
+              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">{step.title}</DialogTitle>
+              {step.description && <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">{step.description}</DialogDescription>}
             </div>
-            <div className="text-sm sm:text-base text-foreground font-bold tracking-wider ml-4 px-3 py-1 border-2 border-border bg-muted">
+            <div className="text-sm text-primary-foreground/80 font-bold tracking-wider ml-4 px-2.5 py-0.5 border border-primary-foreground/30">
               {currentStep + 1}/{steps.length}
             </div>
           </div>
@@ -96,7 +96,7 @@ export function WizardDialog({
 
         <DialogBody className="flex-1 min-h-0">{step.component}</DialogBody>
 
-        <DialogFooter className="border-t-2 border-border bg-muted/30">
+        <DialogFooter className="border-t border-border bg-card py-2">
           <div className="flex items-center justify-between w-full">
             <div>
               {showBackButton && (
@@ -107,7 +107,7 @@ export function WizardDialog({
               )}
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
               {!isLastStep && (
                 <Button variant="secondary" onClick={handleCancel} disabled={isProcessing} doom>
                   Cancel

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -73,21 +73,21 @@ export default function ExerciseActionsFooter({
   ]
 
   return (
-    <div className="border-t-2 border-border px-4 py-3 bg-muted flex-shrink-0">
-      <div className="grid grid-cols-[53%_34%_10%] sm:grid-cols-[55%_35%_10%] gap-3">
+    <div className="border-t border-border px-3 py-2 bg-card flex-shrink-0">
+      <div className="flex items-center gap-2">
         {/* Log Set Button */}
         <button type="button"
           onClick={onLogSet}
           disabled={!canLogSet || hasLoggedAllPrescribed}
-          className="py-3 bg-accent text-accent-foreground font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
+          className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
         >
-          Log Set {nextSetNumber}
+          LOG SET {nextSetNumber}
         </button>
 
         {/* Complete Workout Button */}
         <button type="button"
           disabled={isSubmitting || totalLoggedSets === 0}
-          className="py-3 bg-success text-success-foreground font-bold uppercase tracking-wider transition-all hover:bg-success/90 disabled:opacity-50 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
+          className="py-2.5 px-4 border border-success text-success text-sm font-bold uppercase tracking-wider transition-all hover:bg-success hover:text-success-foreground disabled:opacity-30 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
           onMouseDown={(e) => {
             if (isSubmitting || totalLoggedSets === 0) return;
             e.preventDefault();
@@ -101,7 +101,7 @@ export default function ExerciseActionsFooter({
         <ActionsMenu
           variant="default"
           size="md"
-          className="h-full aspect-square"
+          className="self-stretch w-10"
           actions={actions}
         />
       </div>

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -171,8 +171,8 @@ export default function ExerciseDisplayTabs({
 
           {exercise.exerciseDefinition?.instructions && (
             <div>
-              <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Instructions</h4>
-              <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed whitespace-pre-line">
+              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">INSTRUCTIONS</h4>
+              <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
                 {exercise.exerciseDefinition.instructions}
               </p>
             </div>
@@ -180,12 +180,12 @@ export default function ExerciseDisplayTabs({
 
           {exercise.exerciseDefinition?.primaryFAUs && exercise.exerciseDefinition.primaryFAUs.length > 0 && (
             <div>
-              <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Primary Muscles</h4>
-              <div className="flex flex-wrap gap-2">
+              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">PRIMARY MUSCLES</h4>
+              <div className="flex flex-wrap gap-1.5">
                 {exercise.exerciseDefinition.primaryFAUs.map((fau) => (
                   <span
                     key={fau}
-                    className="px-3 py-1.5 text-base sm:text-lg font-medium bg-primary/20 text-primary rounded-full"
+                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
                   >
                     {FAU_DISPLAY_NAMES[fau] || fau}
                   </span>
@@ -196,12 +196,12 @@ export default function ExerciseDisplayTabs({
 
           {exercise.exerciseDefinition?.secondaryFAUs && exercise.exerciseDefinition.secondaryFAUs.length > 0 && (
             <div>
-              <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Secondary Muscles</h4>
-              <div className="flex flex-wrap gap-2">
+              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">SECONDARY MUSCLES</h4>
+              <div className="flex flex-wrap gap-1.5">
                 {exercise.exerciseDefinition.secondaryFAUs.map((fau) => (
                   <span
                     key={fau}
-                    className="px-3 py-1.5 text-base sm:text-lg font-medium bg-muted text-foreground rounded-full"
+                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
                   >
                     {FAU_DISPLAY_NAMES[fau] || fau}
                   </span>
@@ -212,12 +212,12 @@ export default function ExerciseDisplayTabs({
 
           {exercise.exerciseDefinition?.equipment && exercise.exerciseDefinition.equipment.length > 0 && (
             <div>
-              <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Equipment</h4>
-              <div className="flex flex-wrap gap-2">
+              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">EQUIPMENT</h4>
+              <div className="flex flex-wrap gap-1.5">
                 {exercise.exerciseDefinition.equipment.map((item) => (
                   <span
                     key={item}
-                    className="px-3 py-1.5 text-base sm:text-lg font-medium bg-muted text-foreground rounded-full border border-border"
+                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
                   >
                     {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
                   </span>
@@ -259,31 +259,48 @@ export default function ExerciseDisplayTabs({
             <p className="text-base sm:text-lg text-error">Failed to load history</p>
           </div>
         ) : exerciseHistory ? (
-          <div className="space-y-6">
-            <div>
-              <h4 className="text-base sm:text-lg font-semibold text-foreground mb-2">Last Performed</h4>
-              <p className="text-base sm:text-lg text-muted-foreground">
-                {new Date(exerciseHistory.completedAt).toLocaleDateString()} -{' '}
-                {exerciseHistory.workoutName}
+          <div className="space-y-4">
+            {/* Last performed header */}
+            <div className="border border-border border-l-4 border-l-success bg-card doom-noise p-3">
+              <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-1">
+                LAST PERFORMED
               </p>
+              <p className="text-base font-bold text-foreground doom-heading">
+                {new Date(exerciseHistory.completedAt).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+              <p className="text-sm text-muted-foreground">{exerciseHistory.workoutName}</p>
             </div>
 
+            {/* Sets table */}
             <div>
-              <h4 className="text-base sm:text-lg font-semibold text-foreground mb-3">Sets Completed</h4>
-              <div className="space-y-1.5">
+              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">
+                SETS COMPLETED
+              </h4>
+              <div className="border border-border divide-y divide-border bg-card doom-noise">
+                {/* Header row */}
+                <div className="flex items-center px-3 py-1.5 text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                  <span className="w-10">#</span>
+                  <span className="flex-1">WEIGHT</span>
+                  <span className="w-16 text-right">REPS</span>
+                  <span className="w-16 text-right">
+                    {exerciseHistory.sets.some(s => s.rir !== null) ? 'RIR' : exerciseHistory.sets.some(s => s.rpe !== null) ? 'RPE' : ''}
+                  </span>
+                </div>
                 {exerciseHistory.sets.map((set) => (
                   <div
                     key={set.setNumber}
-                    className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg text-base sm:text-lg"
+                    className="flex items-center px-3 py-2.5 text-base"
                   >
-                    <span className="font-semibold text-muted-foreground">Set {set.setNumber}:</span>
-                    <span className="font-semibold text-foreground">{set.reps} reps @ {set.weight}{set.weightUnit}</span>
-                    {set.rpe !== null && (
-                      <span className="text-muted-foreground">• RPE {set.rpe}</span>
-                    )}
-                    {set.rir !== null && (
-                      <span className="text-muted-foreground">• RIR {set.rir}</span>
-                    )}
+                    <span className="w-10 font-bold text-muted-foreground">{set.setNumber}</span>
+                    <span className="flex-1 font-bold text-foreground">{set.weight}{set.weightUnit}</span>
+                    <span className="w-16 text-right font-semibold text-foreground">{set.reps}</span>
+                    <span className="w-16 text-right text-muted-foreground">
+                      {set.rir !== null ? set.rir : set.rpe !== null ? set.rpe : ''}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -19,25 +19,25 @@ export default function ExerciseLoggingHeader({
 }: ExerciseLoggingHeaderProps) {
   return (
     <div
-      className="bg-primary text-white px-4 py-3 border-b-2 border-primary-muted-dark flex-shrink-0"
-      style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.75rem)' }}
+      className="bg-primary text-white px-4 py-2 border-b border-primary-muted-dark flex-shrink-0"
+      style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.5rem)' }}
     >
       <div className="flex items-center justify-between gap-2">
-        <div className="text-base text-primary-foreground opacity-90 uppercase tracking-wider font-medium">
-          Exercise {currentExerciseIndex + 1} of {totalExercises}
+        <div className="text-sm text-primary-foreground/80 uppercase tracking-wider font-bold">
+          EXERCISE {currentExerciseIndex + 1} OF {totalExercises}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           {failedSetCount > 0 && (
-            <div className="flex items-center gap-1 text-warning text-sm">
-              <AlertCircle size={16} />
+            <div className="flex items-center gap-1 text-warning text-xs font-semibold">
+              <AlertCircle size={14} />
               <span>{failedSetCount} unsaved</span>
             </div>
           )}
           <button
             type="button"
             onClick={onMinimize}
-            className="min-h-9 min-w-9 flex items-center justify-center border-2 border-white/30 bg-white/15 hover:bg-white/25 transition-colors doom-focus-ring"
+            className="h-8 w-8 flex items-center justify-center text-white/70 hover:text-white hover:bg-white/15 transition-colors doom-focus-ring"
             aria-label="Minimize workout"
           >
             <ChevronDown className="h-4 w-4" />
@@ -45,7 +45,7 @@ export default function ExerciseLoggingHeader({
           <button
             type="button"
             onClick={onClose}
-            className="min-h-9 min-w-9 flex items-center justify-center border-2 border-white/30 bg-white/15 hover:bg-white/25 transition-colors doom-focus-ring"
+            className="h-8 w-8 flex items-center justify-center text-white/70 hover:text-white hover:bg-white/15 transition-colors doom-focus-ring"
             aria-label="Close workout"
           >
             <X className="h-4 w-4" />

--- a/components/workout-logging/ExerciseNavigation.tsx
+++ b/components/workout-logging/ExerciseNavigation.tsx
@@ -29,42 +29,40 @@ export default function ExerciseNavigation({
   const supersetLabel = currentExercise.exerciseGroup
 
   return (
-    <div className="border-b-2 border-border px-4 py-3 flex items-center justify-between bg-muted flex-shrink-0">
+    <div className="border-b border-border px-3 py-2 flex items-center justify-between bg-card flex-shrink-0">
       <button type="button"
         onClick={onPrevious}
         disabled={currentExerciseIndex === 0}
-        className={`p-3 transition-all doom-focus-ring ${
+        className={`p-2 transition-all doom-focus-ring ${
           currentExerciseIndex === 0
-            ? 'bg-muted opacity-30 cursor-not-allowed'
-            : 'bg-primary-muted hover:bg-primary hover:text-white border-2 border-transparent hover:border-primary'
+            ? 'opacity-20 cursor-not-allowed'
+            : 'text-muted-foreground hover:text-foreground'
         }`}
         aria-label="Previous exercise"
       >
-        <ChevronLeft size={24} strokeWidth={2.5} />
+        <ChevronLeft size={20} strokeWidth={2.5} />
       </button>
 
-      <div className="text-center flex-1 px-2">
-        <div className="flex items-center justify-center gap-2">
-          {isSuperset && (
-            <span className="px-3 py-1 bg-accent-muted text-accent-text text-sm font-bold uppercase tracking-wider border border-accent">
-              Superset {supersetLabel}
-            </span>
-          )}
-          <h3 className="text-xl sm:text-2xl font-bold text-foreground uppercase tracking-wide">{currentExercise.name}</h3>
-        </div>
+      <div className="text-center flex-1 min-w-0 px-2">
+        {isSuperset && (
+          <span className="inline-block px-2 py-0.5 text-xs font-bold uppercase tracking-wider text-accent border border-accent mb-0.5">
+            Superset {supersetLabel}
+          </span>
+        )}
+        <h3 className="text-lg font-bold text-foreground uppercase tracking-wide truncate doom-heading">{currentExercise.name}</h3>
       </div>
 
       <button type="button"
         onClick={onNext}
         disabled={currentExerciseIndex === totalExercises - 1}
-        className={`p-3 transition-all doom-focus-ring ${
+        className={`p-2 transition-all doom-focus-ring ${
           currentExerciseIndex === totalExercises - 1
-            ? 'bg-muted opacity-30 cursor-not-allowed'
-            : 'bg-primary-muted hover:bg-primary hover:text-white border-2 border-transparent hover:border-primary'
+            ? 'opacity-20 cursor-not-allowed'
+            : 'text-muted-foreground hover:text-foreground'
         }`}
         aria-label="Next exercise"
       >
-        <ChevronRight size={24} strokeWidth={2.5} />
+        <ChevronRight size={20} strokeWidth={2.5} />
       </button>
     </div>
   )

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -95,50 +95,66 @@ export default function SetList({
         </div>
       )}
 
-      {/* Logged sets — compact inline rows */}
-      {loggedSets.map((set) => {
-        const isFailed = set._syncStatus === 'error'
-        const isPending = set._syncStatus === 'pending'
-        return (
-          <div
-            key={`${set.exerciseId}-${set.setNumber}`}
-            className={`flex items-center justify-between px-2 py-1.5 text-sm ${
-              isFailed
-                ? 'text-warning'
-                : 'text-success-text opacity-70'
-            } ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
-          >
-            <span className="flex items-center gap-1.5">
-              {isFailed && <AlertCircle size={14} className="flex-shrink-0" />}
-              <span className="font-semibold">{set.setNumber}.</span>
-              {set.reps}×{set.weight}{set.weightUnit}
-              {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
-              {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
-            </span>
-            <button
-              type="button"
-              onClick={() => onDeleteSet(set.setNumber)}
-              className="text-error/50 hover:text-error p-0.5"
-            >
-              <Trash2 size={14} />
-            </button>
-          </div>
-        )
-      })}
-
-      {/* Remaining prescribed sets — muted, compact */}
-      {remainingSets.map((set) => (
-        <div
-          key={set.id}
-          className="flex items-center px-2 py-1.5 text-sm text-muted-foreground"
-        >
-          <span className="font-semibold">{set.setNumber}.</span>
-          <span className="ml-1.5">
-            {set.reps} reps @ {set.weight || '—'}
-            {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+      {/* Logged sets */}
+      {loggedSets.length > 0 && (
+        <div>
+          <span className="block text-xs font-bold text-success-text/60 uppercase tracking-wider px-1 mb-0.5">
+            LOGGED
           </span>
+          {loggedSets.map((set) => {
+            const isFailed = set._syncStatus === 'error'
+            const isPending = set._syncStatus === 'pending'
+            return (
+              <div
+                key={`${set.exerciseId}-${set.setNumber}`}
+                className={`flex items-center justify-between px-2 py-1.5 text-base ${
+                  isFailed
+                    ? 'text-warning'
+                    : 'text-success-text opacity-70'
+                } ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
+              >
+                <span className="flex items-center gap-1.5">
+                  {isFailed && <AlertCircle size={14} className="flex-shrink-0" />}
+                  <span className="font-bold">{set.setNumber}.</span>
+                  {set.reps}×{set.weight}{set.weightUnit}
+                  {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                  {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onDeleteSet(set.setNumber)}
+                  className="text-error/50 hover:text-error p-0.5"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            )
+          })}
         </div>
-      ))}
+      )}
+
+      {/* Remaining prescribed sets */}
+      {remainingSets.length > 0 && (
+        <div className="mt-1">
+          <span className="block text-xs font-bold text-muted-foreground uppercase tracking-wider px-1 mb-0.5">
+            PRESCRIBED
+          </span>
+          <div className="border border-border/50 divide-y divide-border/30">
+            {remainingSets.map((set) => (
+              <div
+                key={set.id}
+                className="flex items-center px-2 py-1.5 text-base text-muted-foreground/70"
+              >
+                <span className="font-bold w-6">{set.setNumber}.</span>
+                <span>
+                  {set.reps} reps @ {set.weight || '—'}
+                  {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -34,15 +34,15 @@ export function IntensitySelector({
   if (!isExpanded) {
     return (
       <div>
-        <span className="block text-xs text-muted-foreground mb-1 uppercase tracking-wider">
-          {label} (optional)
+        <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+          {label}
         </span>
         <button
           type="button"
           onClick={onExpand}
-          className="w-full h-14 px-4 flex items-center justify-center
-            bg-muted border-2 border-input border-b-4
-            hover:border-primary active:bg-secondary active:border-b-2 active:translate-y-[2px]
+          className="w-full h-12 px-4 flex items-center justify-center
+            bg-card border border-border
+            hover:border-primary
             transition-all duration-75"
         >
           <span className="text-2xl font-bold text-foreground tabular-nums">
@@ -56,11 +56,11 @@ export function IntensitySelector({
   // Expanded view with preset grid
   return (
     <div>
-      <span className="block text-xs text-muted-foreground mb-1 uppercase tracking-wider">
-        {label} (optional)
+      <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+        {label}
       </span>
 
-      <div className="space-y-1">
+      <div className="border border-border divide-y divide-border">
         {presets.map((preset) => {
           const isSelected = numericValue === preset.value
           return (
@@ -68,20 +68,20 @@ export function IntensitySelector({
               key={preset.value}
               type="button"
               onClick={() => handleSelect(preset)}
-              className={`w-full px-4 py-3 flex items-center gap-3
-                border-2 transition-colors text-left
-                active:bg-primary active:text-primary-foreground active:border-primary
+              className={`w-full px-3 py-2.5 flex items-center gap-3
+                transition-colors text-left
+                active:bg-primary active:text-primary-foreground
                 ${isSelected
-                  ? 'bg-primary/10 border-primary text-foreground shadow-[0_0_10px_rgba(var(--primary-rgb),0.2)]'
-                  : 'bg-muted border-input text-foreground hover:border-primary hover:bg-secondary'
+                  ? 'bg-primary/10 text-foreground'
+                  : 'bg-card text-foreground hover:bg-muted'
                 }`}
             >
-              <span className={`text-xl font-bold tabular-nums min-w-[40px] ${
+              <span className={`text-lg font-bold tabular-nums min-w-[36px] ${
                 isSelected ? 'text-primary' : ''
               }`}>
                 {preset.label}
               </span>
-              <span className="text-base text-muted-foreground font-medium">
+              <span className="text-sm text-muted-foreground">
                 {preset.description}
               </span>
             </button>
@@ -95,11 +95,11 @@ export function IntensitySelector({
             onChange('')
             onCollapse()
           }}
-          className="w-full px-4 py-3 bg-muted border-2 border-input
-            text-muted-foreground font-bold uppercase tracking-wider text-base
-            hover:border-primary hover:bg-secondary transition-colors"
+          className="w-full px-3 py-2.5 bg-card
+            text-muted-foreground font-bold uppercase tracking-wider text-sm
+            hover:bg-muted transition-colors"
         >
-          Skip {label}
+          SKIP {label}
         </button>
       </div>
     </div>

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -25,28 +25,28 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
 
   return (
     <div>
-      <span className="block text-xs text-muted-foreground mb-1 uppercase tracking-wider">
-        Reps
+      <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+        REPS
       </span>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center">
         <button
           type="button"
           onClick={handleDecrement}
           disabled={!hasValue || numericValue <= 0}
-          className="flex-shrink-0 w-14 h-14 flex items-center justify-center
-            bg-error/15 border-2 border-error/40 border-b-4
-            text-error hover:bg-error/25 hover:border-error
-            active:bg-error active:text-white active:border-b-2 active:translate-y-[2px]
-            disabled:opacity-30 disabled:hover:bg-error/15 disabled:hover:border-error/40
+          className="flex-shrink-0 w-12 h-12 flex items-center justify-center
+            border border-border text-muted-foreground
+            hover:text-error hover:border-error hover:bg-error/10
+            active:bg-error active:text-white
+            disabled:opacity-20 disabled:hover:text-muted-foreground disabled:hover:border-border disabled:hover:bg-transparent
             transition-all duration-75"
           aria-label="Decrease reps"
         >
-          <Minus size={24} strokeWidth={3} />
+          <Minus size={18} strokeWidth={2.5} />
         </button>
 
         <div
-          className="flex-1 h-14 flex items-center justify-center
-            bg-muted border-2 border-input
+          className="flex-1 h-12 flex items-center justify-center
+            bg-card border-y border-border
             text-2xl font-bold text-foreground tabular-nums min-w-[60px]"
         >
           {hasValue ? numericValue : (
@@ -59,14 +59,14 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
         <button
           type="button"
           onClick={handleIncrement}
-          className="flex-shrink-0 w-14 h-14 flex items-center justify-center
-            bg-success/15 border-2 border-success/40 border-b-4
-            text-success hover:bg-success/25 hover:border-success
-            active:bg-success active:text-white active:border-b-2 active:translate-y-[2px]
+          className="flex-shrink-0 w-12 h-12 flex items-center justify-center
+            border border-border text-muted-foreground
+            hover:text-success hover:border-success hover:bg-success/10
+            active:bg-success active:text-white
             transition-all duration-75"
           aria-label="Increase reps"
         >
-          <Plus size={24} strokeWidth={3} />
+          <Plus size={18} strokeWidth={2.5} />
         </button>
       </div>
     </div>

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -91,16 +91,16 @@ export function WeightKeypad({
   if (!isExpanded) {
     return (
       <div>
-        <span className="block text-xs text-muted-foreground mb-1 uppercase tracking-wider">
-          Weight ({weightUnit})
+        <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+          WEIGHT ({weightUnit.toUpperCase()})
         </span>
         <button
           type="button"
           onClick={handleExpand}
-          className="w-full h-14 px-4 flex items-center justify-center
-            bg-muted border-2 border-input border-b-4
+          className="w-full h-12 px-4 flex items-center justify-center
+            bg-card border border-border
             text-2xl font-bold text-foreground tabular-nums
-            hover:border-primary active:bg-secondary active:border-b-2 active:translate-y-[2px]
+            hover:border-primary
             transition-all duration-75"
         >
           {value || '0'}
@@ -115,16 +115,16 @@ export function WeightKeypad({
   // Expanded view with keypad - mt-auto pushes to bottom of flex container
   return (
     <div className="mt-auto">
-      <span className="block text-xs text-muted-foreground mb-1 uppercase tracking-wider">
-        Weight ({weightUnit})
+      <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+        WEIGHT ({weightUnit.toUpperCase()})
       </span>
 
       {/* Current value display */}
       <div
-        className="w-full h-14 px-4 flex items-center justify-center
+        className="w-full h-12 px-4 flex items-center justify-center
           bg-card border-2 border-primary
           text-2xl font-bold text-foreground tabular-nums
-          shadow-[0_0_10px_rgba(var(--primary-rgb),0.3)]"
+          shadow-[0_0_8px_rgba(var(--primary-rgb),0.2)]"
       >
         {value || '0'}
         <span className="text-sm font-semibold text-muted-foreground ml-2">
@@ -133,23 +133,23 @@ export function WeightKeypad({
       </div>
 
       {/* Number keypad grid */}
-      <div className="grid grid-cols-3 gap-1 mt-1">
+      <div className="grid grid-cols-3 gap-px mt-px bg-border">
         {KEYPAD_KEYS.map((key) => (
           <button
             key={key}
             type="button"
             onClick={() => handleKeyPress(key)}
-            className={`h-12 flex items-center justify-center
-              font-bold text-lg border-2 transition-colors
-              active:bg-primary active:text-primary-foreground active:border-primary
+            className={`h-11 flex items-center justify-center
+              font-bold text-lg transition-colors
+              active:bg-primary active:text-primary-foreground
               ${key === 'CLR'
-                ? 'bg-muted text-muted-foreground border-input hover:border-primary text-sm uppercase tracking-wider'
+                ? 'bg-muted text-muted-foreground hover:bg-secondary text-sm uppercase tracking-wider'
                 : key === 'DEL'
-                  ? 'bg-muted text-muted-foreground border-input hover:border-primary'
-                  : 'bg-muted text-foreground border-input hover:border-primary hover:bg-secondary'
+                  ? 'bg-muted text-muted-foreground hover:bg-secondary'
+                  : 'bg-card text-foreground hover:bg-secondary'
               }`}
           >
-            {key === 'DEL' ? <Delete size={20} /> : key}
+            {key === 'DEL' ? <Delete size={18} /> : key}
           </button>
         ))}
       </div>
@@ -158,12 +158,12 @@ export function WeightKeypad({
       <button
         type="button"
         onClick={handleDone}
-        className="w-full mt-1 h-12 bg-primary text-primary-foreground
-          font-bold uppercase tracking-wider text-base
+        className="w-full mt-px h-11 bg-primary text-primary-foreground
+          font-bold uppercase tracking-wider text-sm
           hover:bg-primary/90 active:bg-primary/80
-          transition-colors doom-button-3d"
+          transition-colors"
       >
-        Done
+        DONE
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- **Workout logger polish**: Slimmer header/nav, refined reps stepper and weight keypad (clean borders, no chunky 3D blocks), lighter footer with doom-button-3d, DOOM-styled History tab with table layout, sharp-edged muscle/equipment tags in Info tab
- **Set list improvements**: LOGGED/PRESCRIBED section labels, green power-up flash animation on newly logged sets, bigger text for readability
- **Exercise editor modernization**: Table layout for sets instead of individual bordered cards, underline tabs, dashed Add Set button, primary-colored wizard header, bumped font sizes throughout

## Test plan
- [ ] Logger: reps +/- buttons look clean, color on hover/active only
- [ ] Logger: weight keypad compact and expanded states look polished
- [ ] Logger: intensity selector compact and expanded match new style
- [ ] Logger: footer buttons have doom-button-3d accent line, heights match
- [ ] Logger: LOGGED/PRESCRIBED labels appear above respective set sections
- [ ] Logger: History tab shows table layout with green-bordered date card
- [ ] Logger: Info tab shows sharp-edged tags for muscles/equipment
- [ ] Editor: sets display as table rows with header, not individual boxes
- [ ] Editor: tabs use underline style, not folder-style borders
- [ ] Editor: Add Set button shows "(CLONES LAST)" helper text
- [ ] Editor: all text is readable (bumped font sizes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)