### PR TITLE
fix: add edit button for active program

### DIFF
--- a/components/programs/ActiveProgramStrip.tsx
+++ b/components/programs/ActiveProgramStrip.tsx
@@ -1,49 +1,91 @@
 'use client'
 
-import { ChevronRight, Pencil, Star } from 'lucide-react'
+import { ChevronDown, ChevronRight, Dumbbell, Pencil, Star } from 'lucide-react'
 import Link from 'next/link'
+import { useState } from 'react'
 
 type Props = {
   programId: string
   programName: string
+  description: string | null
   currentWeek: number | null
   totalWeeks: number | null
+  weekCount: number
+  targetDaysPerWeek: number | null
 }
 
-export default function ActiveProgramStrip({ programId, programName, currentWeek, totalWeeks }: Props) {
+export default function ActiveProgramStrip({
+  programId,
+  programName,
+  description,
+  currentWeek,
+  totalWeeks,
+  weekCount,
+  targetDaysPerWeek,
+}: Props) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
   return (
-    <div className="border border-border border-l-4 border-l-success bg-card doom-noise p-3 sm:p-4">
-      <div className="flex items-center gap-3">
+    <div className="border border-border bg-card doom-noise">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full text-left px-4 py-3 flex items-center gap-3 transition-colors hover:bg-muted/50 active:bg-muted/70"
+      >
         <Star size={18} className="text-success shrink-0" fill="currentColor" />
         <div className="flex-1 min-w-0">
           <h3 className="text-base font-bold text-foreground doom-heading uppercase truncate">
             {programName}
           </h3>
-          {currentWeek && totalWeeks && (
-            <p className="text-sm text-muted-foreground">
-              Week {currentWeek} of {totalWeeks}
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            {currentWeek && totalWeeks && (
+              <span>Week {currentWeek} of {totalWeeks}</span>
+            )}
+            {currentWeek && totalWeeks && targetDaysPerWeek && (
+              <span aria-hidden="true">&middot;</span>
+            )}
+            {!currentWeek && weekCount > 0 && (
+              <span>{weekCount}wk</span>
+            )}
+            {!currentWeek && weekCount > 0 && targetDaysPerWeek && (
+              <span aria-hidden="true">&middot;</span>
+            )}
+            {targetDaysPerWeek && (
+              <span>{targetDaysPerWeek}x/wk</span>
+            )}
+          </div>
+        </div>
+        {isExpanded
+          ? <ChevronDown size={18} className="text-muted-foreground shrink-0" />
+          : <ChevronRight size={18} className="text-muted-foreground shrink-0" />
+        }
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 pb-4 bg-muted/20">
+          {description && (
+            <p className="text-sm text-muted-foreground py-3 leading-relaxed">
+              {description}
             </p>
           )}
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Link
+              href="/training"
+              className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-button-3d doom-focus-ring"
+            >
+              <Dumbbell size={14} />
+              TRAIN
+            </Link>
+            <Link
+              href={`/programs/${programId}/edit`}
+              className="flex items-center gap-1.5 px-3 py-2 border border-border text-foreground text-sm font-semibold uppercase tracking-wider hover:bg-muted transition-colors doom-focus-ring"
+            >
+              <Pencil size={14} />
+              EDIT
+            </Link>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <Link
-            href={`/programs/${programId}/edit`}
-            className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
-            aria-label="Edit program"
-          >
-            <Pencil size={16} />
-            <span className="text-xs font-semibold uppercase tracking-wider hidden sm:inline">EDIT</span>
-          </Link>
-          <Link
-            href="/training"
-            className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
-            aria-label="Go to training"
-          >
-            <span className="text-xs font-semibold uppercase tracking-wider hidden sm:inline">TRAIN</span>
-            <ChevronRight size={18} className="shrink-0" />
-          </Link>
-        </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/components/programs/ActiveProgramStrip.tsx
+++ b/components/programs/ActiveProgramStrip.tsx
@@ -1,20 +1,18 @@
 'use client'
 
-import { ChevronRight, Star } from 'lucide-react'
+import { ChevronRight, Pencil, Star } from 'lucide-react'
 import Link from 'next/link'
 
 type Props = {
+  programId: string
   programName: string
   currentWeek: number | null
   totalWeeks: number | null
 }
 
-export default function ActiveProgramStrip({ programName, currentWeek, totalWeeks }: Props) {
+export default function ActiveProgramStrip({ programId, programName, currentWeek, totalWeeks }: Props) {
   return (
-    <Link
-      href="/training"
-      className="block border border-border border-l-4 border-l-success bg-card doom-noise p-3 sm:p-4 transition-all hover:bg-muted/50 active:bg-muted/70 doom-focus-ring"
-    >
+    <div className="border border-border border-l-4 border-l-success bg-card doom-noise p-3 sm:p-4">
       <div className="flex items-center gap-3">
         <Star size={18} className="text-success shrink-0" fill="currentColor" />
         <div className="flex-1 min-w-0">
@@ -27,11 +25,25 @@ export default function ActiveProgramStrip({ programName, currentWeek, totalWeek
             </p>
           )}
         </div>
-        <span className="text-xs text-muted-foreground uppercase tracking-wider font-semibold hidden sm:block">
-          GO TO TRAINING
-        </span>
-        <ChevronRight size={18} className="text-muted-foreground shrink-0" />
+        <div className="flex items-center gap-1">
+          <Link
+            href={`/programs/${programId}/edit`}
+            className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+            aria-label="Edit program"
+          >
+            <Pencil size={16} />
+            <span className="text-xs font-semibold uppercase tracking-wider hidden sm:inline">EDIT</span>
+          </Link>
+          <Link
+            href="/training"
+            className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+            aria-label="Go to training"
+          >
+            <span className="text-xs font-semibold uppercase tracking-wider hidden sm:inline">TRAIN</span>
+            <ChevronRight size={18} className="shrink-0" />
+          </Link>
+        </div>
       </div>
-    </Link>
+    </div>
   )
 }

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -230,8 +230,11 @@ export default function ConsolidatedProgramsView({
             <ActiveProgramStrip
               programId={activeProgram.id}
               programName={activeProgram.name}
+              description={activeProgram.description}
               currentWeek={activeWeekInfo?.weekNumber ?? null}
               totalWeeks={activeWeekInfo?.totalWeeks ?? null}
+              weekCount={activeProgram._count.weeks}
+              targetDaysPerWeek={activeProgram.targetDaysPerWeek}
             />
           ) : (
             <div className="border border-border border-l-4 border-l-muted-foreground bg-card doom-noise p-3 sm:p-4">

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -228,6 +228,7 @@ export default function ConsolidatedProgramsView({
         <div className="px-4 sm:px-0 mb-4">
           {activeProgram ? (
             <ActiveProgramStrip
+              programId={activeProgram.id}
               programName={activeProgram.name}
               currentWeek={activeWeekInfo?.weekNumber ?? null}
               totalWeeks={activeWeekInfo?.totalWeeks ?? null}


### PR DESCRIPTION
## Summary
- The active program strip on the Programs page only had a "Go to Training" link, with no way to edit the active program
- Added an edit button (pencil icon + "EDIT" label on desktop) alongside the training link in the `ActiveProgramStrip` component
- Passed `programId` through from `ConsolidatedProgramsView` to enable the edit link

## Root cause
When the Programs page was redesigned as a unified hub (#336), the active program was filtered out of `MyProgramsList` (which has edit buttons) and shown only in `ActiveProgramStrip` (which only linked to `/training`). This left no UI path to edit the active program.

Fixes #337

## Test plan
- [ ] Navigate to Programs page with an active program
- [ ] Verify the edit button (pencil icon) appears on the active program strip
- [ ] Click edit — should navigate to `/programs/[id]/edit`
- [ ] Verify the training link still works
- [ ] Test on mobile (iPhone Safari) — edit should show pencil icon only, training shows chevron

🤖 Generated with [Claude Code](https://claude.com/claude-code)