### PR TITLE
Contextual content surfacing: primer, warm-up, habit nudge

### DIFF
--- a/app/(app)/training/page.tsx
+++ b/app/(app)/training/page.tsx
@@ -11,11 +11,11 @@ import { getStrengthWeekByNumber } from '@/lib/db/week-navigation'
 export const revalidate = 30
 
 type Props = {
-  searchParams: Promise<{ week?: string }>
+  searchParams: Promise<{ week?: string; debugHistoryCount?: string }>
 }
 
 export default async function TrainingPage({ searchParams }: Props) {
-  const { week: weekParam } = await searchParams
+  const { week: weekParam, debugHistoryCount } = await searchParams
   const { user, error } = await getCurrentUser()
 
   if (error || !user) {
@@ -25,7 +25,7 @@ export default async function TrainingPage({ searchParams }: Props) {
   const requestedWeek = weekParam ? parseInt(weekParam, 10) : null
   const validWeekParam = requestedWeek && !Number.isNaN(requestedWeek) && requestedWeek > 0
 
-  const [weekData, workoutHistoryCount] = await Promise.all([
+  const [weekData, rawHistoryCount] = await Promise.all([
     validWeekParam
       ? getStrengthWeekByNumber(user.id, requestedWeek)
       : getCurrentStrengthWeek(user.id),
@@ -36,6 +36,14 @@ export default async function TrainingPage({ searchParams }: Props) {
       }
     })
   ])
+
+  // Dev-only override for testing contextual content triggers
+  const debugOverride = process.env.NODE_ENV !== 'production' && debugHistoryCount
+    ? parseInt(debugHistoryCount, 10)
+    : undefined
+  const workoutHistoryCount = debugOverride !== undefined && !Number.isNaN(debugOverride)
+    ? debugOverride
+    : rawHistoryCount
 
   return (
     <div className="min-h-screen bg-background sm:px-6 py-4">

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -6,6 +6,9 @@ type UpdateSettingsRequest = {
   displayName?: string
   defaultWeightUnit?: 'lbs' | 'kg'
   defaultIntensityRating?: 'rpe' | 'rir'
+  dismissedPrimer?: boolean
+  dismissedWarmup?: boolean
+  dismissedStickNudge?: boolean
 }
 
 export async function GET(_request: NextRequest) {
@@ -61,7 +64,7 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json() as UpdateSettingsRequest
-    const { displayName, defaultWeightUnit, defaultIntensityRating } = body
+    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge } = body
 
     // Validate weight unit
     if (defaultWeightUnit && !['lbs', 'kg'].includes(defaultWeightUnit)) {
@@ -86,6 +89,9 @@ export async function PUT(request: NextRequest) {
         ...(displayName !== undefined && { displayName: displayName?.trim() || null }),
         ...(defaultWeightUnit && { defaultWeightUnit }),
         ...(defaultIntensityRating && { defaultIntensityRating }),
+        ...(dismissedPrimer !== undefined && { dismissedPrimer }),
+        ...(dismissedWarmup !== undefined && { dismissedWarmup }),
+        ...(dismissedStickNudge !== undefined && { dismissedStickNudge }),
         updatedAt: new Date()
       },
       create: {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2039,6 +2039,41 @@ body {
   animation: shimmer 2s infinite;
 }
 
+@keyframes accent-sweep {
+  0% {
+    transform: translateX(-100%);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(100%);
+    opacity: 1;
+  }
+}
+
+.animate-accent-sweep {
+  overflow: hidden;
+}
+
+.animate-accent-sweep::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--primary) 15%, transparent) 40%,
+    color-mix(in srgb, var(--primary) 15%, transparent) 60%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: accent-sweep 0.8s ease-out 0.3s 1;
+  pointer-events: none;
+  z-index: 1;
+}
+
 /* Prose styles for Learn article markdown content */
 .prose-learn {
   color: var(--foreground);

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -4,11 +4,15 @@ import { CheckCircle } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState, useTransition } from 'react'
 import ExerciseLoggingModal from '@/components/ExerciseLoggingModal'
+import { BeginnerPrimerWizard } from '@/components/features/training/BeginnerPrimerWizard'
+import { StickNudgeBanner } from '@/components/features/training/StickNudgeBanner'
+import { WarmupInterstitial } from '@/components/features/training/WarmupInterstitial'
 import { ProgramCompletionModal } from '@/components/ProgramCompletionModal'
 import WeekNavigator from '@/components/ui/WeekNavigator'
 import WorkoutHistoryList from '@/components/WorkoutHistoryList'
 import WorkoutPreviewModal from '@/components/WorkoutPreviewModal'
 import WorkoutCard from '@/components/workout/WorkoutCard'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
 
@@ -156,6 +160,7 @@ export default function StrengthWeekView({
   const router = useRouter()
   const searchParams = useSearchParams()
   const { activeDraft, refreshDraft } = useDraftWorkout()
+  const { settings, isLoading: settingsLoading, refetch: refetchSettings } = useUserSettings()
   const [isPending, startTransition] = useTransition()
   const [updatingWorkoutId, setUpdatingWorkoutId] = useState<string | null>(null)
   const [skippingWorkout, setSkippingWorkout] = useState<string | null>(null)
@@ -172,6 +177,11 @@ export default function StrengthWeekView({
   const [isProgramComplete, setIsProgramComplete] = useState(false)
 
   const resumeWorkoutId = searchParams.get('resume')
+
+  // Contextual content triggers
+  const showPrimer = historyCount === 0 && !settings?.dismissedPrimer && !settingsLoading
+  const showWarmup = historyCount < 4 && !settings?.dismissedWarmup
+  const showStickNudge = historyCount >= 3 && historyCount <= 8 && !settings?.dismissedStickNudge && !settingsLoading
 
   const checkProgramCompletion = useCallback(async (openModal = false) => {
     // Skip check if we're currently restarting
@@ -262,16 +272,12 @@ export default function StrengthWeekView({
     if (data) setModalMode('preview')
   }
 
-  // Opens logging modal with progressive loading (fast!)
-  const handleOpenLogging = async (workoutId: string) => {
-    // Prevent opening a different workout while a draft exists
-    if (activeDraft && activeDraft.workoutId !== workoutId) {
-      alert(
-        `You have an in-progress workout ("${activeDraft.workoutName}"). Resume or discard it first.`
-      )
-      return
-    }
+  // Warm-up interception state
+  const [warmupOpen, setWarmupOpen] = useState(false)
+  const [pendingLoggingWorkoutId, setPendingLoggingWorkoutId] = useState<string | null>(null)
 
+  // Core logging flow — fetches metadata and opens the logging modal
+  const proceedToLogging = useCallback(async (workoutId: string) => {
     setSelectedWorkoutId(workoutId)
     const metadata = await fetchWorkoutMetadata(workoutId)
     if (!metadata) return
@@ -285,6 +291,43 @@ export default function StrengthWeekView({
     }
 
     setModalMode('logging')
+  }, [fetchWorkoutMetadata, fetchWorkoutData])
+
+  // Opens logging modal with progressive loading (fast!)
+  // Intercepts with warm-up interstitial for early sessions
+  const handleOpenLogging = async (workoutId: string) => {
+    // Prevent opening a different workout while a draft exists
+    if (activeDraft && activeDraft.workoutId !== workoutId) {
+      alert(
+        `You have an in-progress workout ("${activeDraft.workoutName}"). Resume or discard it first.`
+      )
+      return
+    }
+
+    // Warm-up interception for early sessions
+    if (showWarmup && !warmupOpen) {
+      setPendingLoggingWorkoutId(workoutId)
+      setWarmupOpen(true)
+      return
+    }
+
+    await proceedToLogging(workoutId)
+  }
+
+  const handleWarmupContinue = () => {
+    setWarmupOpen(false)
+    if (pendingLoggingWorkoutId) {
+      proceedToLogging(pendingLoggingWorkoutId)
+      setPendingLoggingWorkoutId(null)
+    }
+  }
+
+  const handleWarmupDismissPermanently = () => {
+    setWarmupOpen(false)
+    if (pendingLoggingWorkoutId) {
+      proceedToLogging(pendingLoggingWorkoutId)
+      setPendingLoggingWorkoutId(null)
+    }
   }
 
   // Auto-resume draft workout when navigated with ?resume= param
@@ -432,6 +475,12 @@ export default function StrengthWeekView({
         )}
       </div>
 
+      {showStickNudge && (
+        <div className="mb-4">
+          <StickNudgeBanner onDismiss={refetchSettings} />
+        </div>
+      )}
+
       <div className="space-y-3">
         {week.workouts.map(workout => (
           <WorkoutCard
@@ -501,6 +550,18 @@ export default function StrengthWeekView({
           onComplete={handleCompleteWorkout}
           onRefresh={handleRefreshMetadata}
         />
+      )}
+
+      {/* Warm-up Interstitial — shown between Log tap and logging modal */}
+      <WarmupInterstitial
+        open={warmupOpen}
+        onContinue={handleWarmupContinue}
+        onDismissPermanently={handleWarmupDismissPermanently}
+      />
+
+      {/* Beginner Primer Wizard */}
+      {showPrimer && (
+        <BeginnerPrimerWizard open onDismiss={refetchSettings} />
       )}
 
       {/* Program Completion Modal */}

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -272,7 +272,8 @@ export default function StrengthWeekView({
     if (data) setModalMode('preview')
   }
 
-  // Warm-up interception state
+  // Interception state — primer and warm-up gate before logging modal
+  const [primerOpen, setPrimerOpen] = useState(false)
   const [warmupOpen, setWarmupOpen] = useState(false)
   const [pendingLoggingWorkoutId, setPendingLoggingWorkoutId] = useState<string | null>(null)
 
@@ -293,14 +294,32 @@ export default function StrengthWeekView({
     setModalMode('logging')
   }, [fetchWorkoutMetadata, fetchWorkoutData])
 
+  // After primer completes, check if warm-up is also needed before proceeding
+  const proceedAfterPrimer = () => {
+    setPrimerOpen(false)
+    if (showWarmup && pendingLoggingWorkoutId) {
+      setWarmupOpen(true)
+    } else if (pendingLoggingWorkoutId) {
+      proceedToLogging(pendingLoggingWorkoutId)
+      setPendingLoggingWorkoutId(null)
+    }
+  }
+
   // Opens logging modal with progressive loading (fast!)
-  // Intercepts with warm-up interstitial for early sessions
+  // Intercepts with primer (first ever) then warm-up (sessions 1-3)
   const handleOpenLogging = async (workoutId: string) => {
     // Prevent opening a different workout while a draft exists
     if (activeDraft && activeDraft.workoutId !== workoutId) {
       alert(
         `You have an in-progress workout ("${activeDraft.workoutName}"). Resume or discard it first.`
       )
+      return
+    }
+
+    // Primer interception — first ever workout
+    if (showPrimer && !primerOpen) {
+      setPendingLoggingWorkoutId(workoutId)
+      setPrimerOpen(true)
       return
     }
 
@@ -324,6 +343,7 @@ export default function StrengthWeekView({
 
   const handleWarmupDismissPermanently = () => {
     setWarmupOpen(false)
+    refetchSettings()
     if (pendingLoggingWorkoutId) {
       proceedToLogging(pendingLoggingWorkoutId)
       setPendingLoggingWorkoutId(null)
@@ -552,17 +572,21 @@ export default function StrengthWeekView({
         />
       )}
 
+      {/* Beginner Primer — shown on first-ever Log tap, before warm-up */}
+      <BeginnerPrimerWizard
+        open={primerOpen}
+        onDismiss={() => {
+          refetchSettings()
+          proceedAfterPrimer()
+        }}
+      />
+
       {/* Warm-up Interstitial — shown between Log tap and logging modal */}
       <WarmupInterstitial
         open={warmupOpen}
         onContinue={handleWarmupContinue}
         onDismissPermanently={handleWarmupDismissPermanently}
       />
-
-      {/* Beginner Primer Wizard */}
-      {showPrimer && (
-        <BeginnerPrimerWizard open onDismiss={refetchSettings} />
-      )}
 
       {/* Program Completion Modal */}
       <ProgramCompletionModal

--- a/components/features/training/BeginnerPrimerWizard.tsx
+++ b/components/features/training/BeginnerPrimerWizard.tsx
@@ -111,7 +111,7 @@ export function BeginnerPrimerWizard({ open, onDismiss }: BeginnerPrimerWizardPr
   return (
     <div
       style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-      className="flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+      className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
     >
       <div
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}

--- a/components/features/training/BeginnerPrimerWizard.tsx
+++ b/components/features/training/BeginnerPrimerWizard.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+import { useUserSettings } from '@/hooks/useUserSettings'
+
+interface BeginnerPrimerWizardProps {
+  open: boolean
+  onDismiss: () => void
+}
+
+const PAGES = [
+  {
+    title: 'THE APP DOES THE THINKING',
+    content: (
+      <>
+        <p className="text-muted-foreground mb-3">
+          Your program tells you exactly what to do each day: which exercises, how many sets, how many reps.
+        </p>
+        <p className="text-muted-foreground mb-3">
+          Just follow along and log what you did. No planning required.
+        </p>
+        <p className="text-muted-foreground">
+          Everything in your program uses equipment at this gym — no guesswork.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: 'GO LIGHTER THAN YOU THINK',
+    content: (
+      <>
+        <p className="text-muted-foreground mb-3">
+          Controlled reps at moderate effort beat heavy weight with sloppy form. Your first week, pick weights that feel almost too easy — you&apos;ll dial it in.
+        </p>
+        <p className="text-muted-foreground mb-4">
+          The app tracks something called RIR (reps in reserve). It just means &ldquo;how many more could you have done?&rdquo; You&apos;ll get a feel for it.
+        </p>
+        <Link href="/learn/choosing-the-right-weight" className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider">
+          Read more: Choosing the Right Weight
+        </Link>
+      </>
+    ),
+  },
+  {
+    title: 'YOU BELONG HERE',
+    content: (
+      <>
+        <p className="text-muted-foreground mb-3">
+          Everyone in the gym started somewhere. Nobody is watching you as closely as you think.
+        </p>
+        <p className="text-muted-foreground mb-3">
+          Wipe down equipment when you&apos;re done, rerack your weights, and don&apos;t camp on a machine while scrolling — that&apos;s really it.
+        </p>
+        <p className="text-muted-foreground mb-4">
+          If you&apos;re unsure how a machine works, ask someone. Gym regulars genuinely like helping.
+        </p>
+        <Link href="/learn/gym-etiquette" className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider">
+          Read more: Gym Etiquette
+        </Link>
+      </>
+    ),
+  },
+  {
+    title: 'YOUR BODY WILL TALK TO YOU',
+    content: (
+      <>
+        <p className="text-muted-foreground mb-3">
+          Feeling sore a day or two after your first workout is completely normal — especially the first week.
+        </p>
+        <p className="text-muted-foreground mb-3">
+          Sharp pain during a lift is not. Stop, lower the weight, or skip that exercise.
+        </p>
+        <p className="text-muted-foreground mb-4">
+          Rest 2-3 minutes between the big lifts. There&apos;s no rush.
+        </p>
+        <div className="flex flex-col gap-1">
+          <Link href="/learn/your-first-week" className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider">
+            Read more: Your First Week
+          </Link>
+          <Link href="/learn/staying-safe" className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider">
+            Read more: Staying Safe
+          </Link>
+        </div>
+      </>
+    ),
+  },
+]
+
+export function BeginnerPrimerWizard({ open, onDismiss }: BeginnerPrimerWizardProps) {
+  const { updateSettings } = useUserSettings()
+  const [currentPage, setCurrentPage] = useState(0)
+  const [dismissing, setDismissing] = useState(false)
+
+  if (!open) return null
+
+  const isLastPage = currentPage === PAGES.length - 1
+  const page = PAGES[currentPage]
+
+  const handleDismiss = async () => {
+    setDismissing(true)
+    try {
+      await updateSettings({ dismissedPrimer: true })
+      onDismiss()
+    } catch {
+      setDismissing(false)
+    }
+  }
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+      className="flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+    >
+      <div
+        style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
+        className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 className="text-lg font-bold text-foreground doom-heading uppercase tracking-wider">
+            Getting Started
+          </h2>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            disabled={dismissing}
+            className="p-1 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+            aria-label="Skip primer"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          <h3 className="text-base font-bold text-foreground uppercase tracking-wider mb-4">
+            {page.title}
+          </h3>
+          {page.content}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between p-4 border-t border-border">
+          {/* Page dots */}
+          <div className="flex gap-2">
+            {PAGES.map((_, i) => (
+              <div
+                key={i}
+                className={`w-2 h-2 rounded-full transition-colors ${
+                  i === currentPage ? 'bg-primary' : 'bg-muted-foreground/30'
+                }`}
+              />
+            ))}
+          </div>
+
+          {/* Navigation */}
+          <div className="flex gap-2">
+            {currentPage > 0 && (
+              <button
+                type="button"
+                onClick={() => setCurrentPage(p => p - 1)}
+                className="flex items-center gap-1 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                <ChevronLeft size={16} />
+                Back
+              </button>
+            )}
+            {isLastPage ? (
+              <button
+                type="button"
+                onClick={handleDismiss}
+                disabled={dismissing}
+                className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 doom-button-3d doom-focus-ring font-semibold text-sm uppercase tracking-wider disabled:opacity-50"
+              >
+                {dismissing ? 'Loading...' : "Let's Go"}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setCurrentPage(p => p + 1)}
+                className="flex items-center gap-1 px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 doom-button-3d doom-focus-ring font-semibold text-sm uppercase tracking-wider"
+              >
+                Next
+                <ChevronRight size={16} />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/training/StickNudgeBanner.tsx
+++ b/components/features/training/StickNudgeBanner.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { BookOpen, X } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+import { useUserSettings } from '@/hooks/useUserSettings'
+
+interface StickNudgeBannerProps {
+  onDismiss: () => void
+}
+
+export function StickNudgeBanner({ onDismiss }: StickNudgeBannerProps) {
+  const { updateSettings } = useUserSettings()
+  const [dismissing, setDismissing] = useState(false)
+
+  const handleDismiss = async () => {
+    setDismissing(true)
+    try {
+      await updateSettings({ dismissedStickNudge: true })
+      onDismiss()
+    } catch {
+      setDismissing(false)
+    }
+  }
+
+  return (
+    <div className="relative border-2 border-primary bg-card doom-noise p-4 mb-4">
+      <button
+        type="button"
+        onClick={handleDismiss}
+        disabled={dismissing}
+        className="absolute top-3 right-3 p-1 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+        aria-label="Dismiss"
+      >
+        <X size={16} />
+      </button>
+
+      <div className="flex items-start gap-3 pr-6">
+        <div className="shrink-0 mt-0.5">
+          <BookOpen size={20} className="text-primary" />
+        </div>
+        <div>
+          <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-1">
+            Making It Stick
+          </h3>
+          <p className="text-sm text-muted-foreground mb-2">
+            You&apos;ve got a few workouts under your belt. Want to make the habit easier to keep?
+          </p>
+          <Link
+            href="/learn"
+            className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider doom-focus-ring"
+          >
+            Read in the Learn tab
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/training/StickNudgeBanner.tsx
+++ b/components/features/training/StickNudgeBanner.tsx
@@ -24,36 +24,32 @@ export function StickNudgeBanner({ onDismiss }: StickNudgeBannerProps) {
   }
 
   return (
-    <div className="relative border-2 border-primary bg-card doom-noise p-4 mb-4">
-      <button
-        type="button"
-        onClick={handleDismiss}
-        disabled={dismissing}
-        className="absolute top-3 right-3 p-1 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
-        aria-label="Dismiss"
-      >
-        <X size={16} />
-      </button>
-
-      <div className="flex items-start gap-3 pr-6">
-        <div className="shrink-0 mt-0.5">
-          <BookOpen size={20} className="text-primary" />
-        </div>
-        <div>
-          <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-1">
-            Making It Stick
-          </h3>
-          <p className="text-sm text-muted-foreground mb-2">
-            You&apos;ve got a few workouts under your belt. Want to make the habit easier to keep?
-          </p>
-          <Link
-            href="/learn"
-            className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider doom-focus-ring"
-          >
-            Read in the Learn tab
-          </Link>
-        </div>
+    <div className="relative border border-border border-t-[3px] border-t-primary bg-card doom-noise p-4 mb-4 animate-accent-sweep">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <p className="text-base font-bold text-foreground doom-heading uppercase tracking-wider">
+          You&apos;re off to a great start
+        </p>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          disabled={dismissing}
+          className="shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+          aria-label="Dismiss"
+        >
+          <X size={16} />
+        </button>
       </div>
+      <p className="text-sm text-muted-foreground mb-3">
+        You&apos;ve got a few workouts under your belt. Want to make the habit easier to keep?
+      </p>
+      <Link
+        href="/learn/making-the-gym-easy"
+        onClick={handleDismiss}
+        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 font-semibold doom-focus-ring"
+      >
+        <BookOpen size={14} />
+        Read &ldquo;Making It Stick&rdquo;
+      </Link>
     </div>
   )
 }

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { useUserSettings } from '@/hooks/useUserSettings'
+
+interface WarmupInterstitialProps {
+  open: boolean
+  onContinue: () => void
+  onDismissPermanently: () => void
+}
+
+export function WarmupInterstitial({ open, onContinue, onDismissPermanently }: WarmupInterstitialProps) {
+  const { updateSettings } = useUserSettings()
+  const [dontShowAgain, setDontShowAgain] = useState(false)
+  const [dismissing, setDismissing] = useState(false)
+
+  if (!open) return null
+
+  const handleStart = async () => {
+    if (dontShowAgain) {
+      setDismissing(true)
+      try {
+        await updateSettings({ dismissedWarmup: true })
+        onDismissPermanently()
+      } catch {
+        setDismissing(false)
+      }
+    } else {
+      onContinue()
+    }
+  }
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+      className="flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+    >
+      <div
+        style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
+        className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-border">
+          <h2 className="text-lg font-bold text-foreground doom-heading uppercase tracking-wider">
+            Warm Up First
+          </h2>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          <div className="mb-4">
+            <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-2">
+              Get your body ready (5 min)
+            </h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              Walk on the treadmill at an incline, jump rope, or ride the bike until you break a light sweat.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Roll your shoulders, swing your arms, twist your torso, bend down and touch your toes. Loosen up whatever you&apos;re about to train.
+            </p>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-2">
+              Your first sets are warm-ups
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Each exercise starts with warm-up sets — use a weight that feels easy. Focus on the movement, not the load. More complex lifts have more warm-up sets built in.
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-border">
+          <label className="flex items-center gap-2 mb-4 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={e => setDontShowAgain(e.target.checked)}
+              className="w-4 h-4 rounded border-border bg-muted text-primary focus:ring-primary"
+            />
+            <span className="text-sm text-muted-foreground">
+              Don&apos;t show warm-up information again
+            </span>
+          </label>
+
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={dismissing}
+            className="w-full py-3 bg-primary text-primary-foreground hover:bg-primary/90 doom-button-3d doom-focus-ring font-semibold text-sm uppercase tracking-wider disabled:opacity-50"
+          >
+            {dismissing ? 'Loading...' : 'Start Workout'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -33,7 +33,7 @@ export function WarmupInterstitial({ open, onContinue, onDismissPermanently }: W
   return (
     <div
       style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-      className="flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+      className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
     >
       <div
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -4,6 +4,9 @@ export type UserSettings = {
   displayName: string | null
   defaultWeightUnit: 'lbs' | 'kg'
   defaultIntensityRating: 'rpe' | 'rir'
+  dismissedPrimer: boolean
+  dismissedWarmup: boolean
+  dismissedStickNudge: boolean
 }
 
 type UseUserSettingsReturn = {

--- a/prisma/migrations/20260402002150_add_content_dismissals/migration.sql
+++ b/prisma/migrations/20260402002150_add_content_dismissals/migration.sql
@@ -1,0 +1,4 @@
+-- Add dismissal tracking for contextual content surfacing
+ALTER TABLE "UserSettings" ADD COLUMN "dismissedPrimer" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "UserSettings" ADD COLUMN "dismissedWarmup" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "UserSettings" ADD COLUMN "dismissedStickNudge" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -289,6 +289,9 @@ model UserSettings {
   displayName            String?
   defaultWeightUnit      String   @default("lbs")
   defaultIntensityRating String   @default("rir")
+  dismissedPrimer        Boolean  @default(false)
+  dismissedWarmup        Boolean  @default(false)
+  dismissedStickNudge    Boolean  @default(false)
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

- **BeginnerPrimerWizard**: 4-screen wizard shown on first-ever Log tap (historyCount=0). Covers "app does the thinking", weight selection, gym etiquette, body signals. Links to Learn articles. Chains to warm-up after completion.
- **WarmupInterstitial**: Single-page warm-up checklist shown before logging for sessions 1-3. Checkbox to permanently dismiss. Auto-hides after session 4.
- **StickNudgeBanner**: Inline banner on training page after 3-4 completions linking to "Making It Stick" article. Top accent stripe, theme-aware sweep animation, dismisses on X or article click.
- Schema adds `dismissedPrimer`/`dismissedWarmup`/`dismissedStickNudge` booleans to UserSettings
- Dev testing via `?debugHistoryCount=N` query param

### Interception flow on Log tap

```
historyCount=0, primer not dismissed -> Primer wizard
  -> on complete/skip -> Warm-up interstitial
    -> on continue -> Logging modal

historyCount 1-3, warmup not dismissed -> Warm-up interstitial
  -> on continue -> Logging modal

historyCount 4+ -> Logging modal directly
```

Refs #300, #223, #224

## Test plan

- [x] `?debugHistoryCount=0`: tap Log, step through 4 primer screens, verify warm-up follows, then logging opens
- [x] `?debugHistoryCount=0`: tap Log, X out of primer on screen 2, verify warm-up still shows
- [x] `?debugHistoryCount=2`: tap Log, only warm-up shows (no primer)
- [x] `?debugHistoryCount=5`: tap Log, straight to logging
- [x] `?debugHistoryCount=3`: stick nudge banner visible, tap article link, banner gone on return
- [x] `?debugHistoryCount=9`: no stick nudge
- [x] Warm-up: leave checkbox unchecked, tap Start Workout, tap Log again — warm-up reappears
- [x] Warm-up: check checkbox, tap Start Workout, tap Log again — warm-up gone
- [x] Reset dismissals in DB, verify all three resurface

🤖 Generated with [Claude Code](https://claude.com/claude-code)