### PR TITLE
Guided walkthrough with coach marks

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation'
 import BottomNav from '@/components/BottomNav'
 import FloatingDraftButton from '@/components/FloatingDraftButton'
-import Header from '@/components/Header'
 import FeedbackButton from '@/components/features/FeedbackButton'
+import Header from '@/components/Header'
+import { TourProvider } from '@/components/tour'
 import { getCurrentUser } from '@/lib/auth/server'
 import { DraftWorkoutProvider } from '@/lib/contexts/DraftWorkoutContext'
 
@@ -19,6 +20,7 @@ export default async function AppLayout({
 
   return (
     <DraftWorkoutProvider>
+      <TourProvider>
       <div className="min-h-screen">
         <Header userEmail={user.email || ''} />
         <FloatingDraftButton />
@@ -32,6 +34,7 @@ export default async function AppLayout({
         <BottomNav />
         <FeedbackButton />
       </div>
+    </TourProvider>
     </DraftWorkoutProvider>
   )
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, RotateCcw, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -443,6 +443,33 @@ export default function SettingsPage() {
               </div>
               <FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
             </div>
+
+            {/* Replay Tours */}
+            {settings && (() => {
+              let hasCompleted = false
+              try { hasCompleted = JSON.parse(settings.completedTours || '[]').length > 0 } catch {}
+              return hasCompleted
+            })() && (
+              <div className="pt-4 border-t border-border">
+                <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                  Guided Tours
+                </span>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await updateSettings({ completedTours: '[]' })
+                    setSaved(false)
+                  }}
+                  className="px-4 py-2 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center gap-2"
+                >
+                  <RotateCcw size={16} />
+                  Replay Tours
+                </button>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Re-enables guided hints on the training and workout screens.
+                </p>
+              </div>
+            )}
 
             {/* Sign Out */}
             <div className="pt-4 border-t border-border">

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -9,6 +9,7 @@ type UpdateSettingsRequest = {
   dismissedPrimer?: boolean
   dismissedWarmup?: boolean
   dismissedStickNudge?: boolean
+  completedTours?: string
 }
 
 export async function GET(_request: NextRequest) {
@@ -64,7 +65,7 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json() as UpdateSettingsRequest
-    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge } = body
+    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours } = body
 
     // Validate weight unit
     if (defaultWeightUnit && !['lbs', 'kg'].includes(defaultWeightUnit)) {
@@ -92,6 +93,7 @@ export async function PUT(request: NextRequest) {
         ...(dismissedPrimer !== undefined && { dismissedPrimer }),
         ...(dismissedWarmup !== undefined && { dismissedWarmup }),
         ...(dismissedStickNudge !== undefined && { dismissedStickNudge }),
+        ...(completedTours !== undefined && { completedTours }),
         updatedAt: new Date()
       },
       create: {

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -3,13 +3,16 @@
 import { AlertTriangle } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTour } from '@/components/tour'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { useImagePrefetch } from '@/hooks/useImagePrefetch'
 import { type Exercise, type ExerciseHistory, useProgressiveExercises } from '@/hooks/useProgressiveExercises'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import { useWorkoutDraft } from '@/hooks/useWorkoutDraft'
 import { completeDraft, discardDraft } from '@/lib/api/workout-sets'
 import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
+import { WORKOUT_LOGGER_STEPS, WORKOUT_LOGGER_TOUR_ID } from '@/lib/tour/steps/workout-logger'
 import type { LoggedSet } from '@/types/workout'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
 import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
@@ -69,6 +72,10 @@ export default function ExerciseLoggingModal({
   // Input expansion state (lifted from SetLoggingForm for SetList visibility)
   const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
 
+  // Guided tour
+  const { startTour, setTourPaused, isActive: tourActive } = useTour()
+  const { settings: userSettings } = useUserSettings()
+
   // Wizard state
   const [activeWizard, setActiveWizard] = useState<'add' | 'swap' | 'edit' | 'delete' | null>(null)
   const [navigateToLastExercise, setNavigateToLastExercise] = useState(false)
@@ -106,6 +113,26 @@ export default function ExerciseLoggingModal({
     flushFailedSets,
     clearCache,
   } = useWorkoutDraft(workoutId)
+
+  // Start logger tour for first-time users once the exercise loads
+  useEffect(() => {
+    if (!currentExercise || !userSettings || tourActive) return
+    try {
+      const completed: string[] = JSON.parse(userSettings.completedTours || '[]')
+      if (!completed.includes(WORKOUT_LOGGER_TOUR_ID)) {
+        // Small delay so the UI renders before the tour overlay appears
+        const timer = setTimeout(() => {
+          startTour(WORKOUT_LOGGER_TOUR_ID, WORKOUT_LOGGER_STEPS)
+        }, 500)
+        return () => clearTimeout(timer)
+      }
+    } catch { /* invalid JSON, skip */ }
+  }, [currentExercise, userSettings, tourActive, startTour])
+
+  // Pause tour when inputs expand (layout shifts)
+  useEffect(() => {
+    setTourPaused(expandedInput !== null)
+  }, [expandedInput, setTourPaused])
 
   const currentPrescribedSets = currentExercise?.prescribedSets || []
   const currentExerciseLoggedSets = loggedSets.filter(

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -8,6 +8,7 @@ import { BeginnerPrimerWizard } from '@/components/features/training/BeginnerPri
 import { StickNudgeBanner } from '@/components/features/training/StickNudgeBanner'
 import { WarmupInterstitial } from '@/components/features/training/WarmupInterstitial'
 import { ProgramCompletionModal } from '@/components/ProgramCompletionModal'
+import { useTour } from '@/components/tour'
 import WeekNavigator from '@/components/ui/WeekNavigator'
 import WorkoutHistoryList from '@/components/WorkoutHistoryList'
 import WorkoutPreviewModal from '@/components/WorkoutPreviewModal'
@@ -15,6 +16,7 @@ import WorkoutCard from '@/components/workout/WorkoutCard'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
+import { TRAINING_PAGE_STEPS, TRAINING_PAGE_TOUR_ID } from '@/lib/tour/steps/training-page'
 
 type Workout = {
   id: string
@@ -182,6 +184,21 @@ export default function StrengthWeekView({
   const showPrimer = historyCount === 0 && !settings?.dismissedPrimer && !settingsLoading
   const showWarmup = historyCount < 4 && !settings?.dismissedWarmup
   const showStickNudge = historyCount >= 3 && historyCount <= 8 && !settings?.dismissedStickNudge && !settingsLoading
+
+  // Training page guided tour
+  const { startTour: startPageTour, isActive: tourActive } = useTour()
+  useEffect(() => {
+    if (settingsLoading || !settings || tourActive) return
+    try {
+      const completed: string[] = JSON.parse(settings.completedTours || '[]')
+      if (!completed.includes(TRAINING_PAGE_TOUR_ID)) {
+        const timer = setTimeout(() => {
+          startPageTour(TRAINING_PAGE_TOUR_ID, TRAINING_PAGE_STEPS)
+        }, 300)
+        return () => clearTimeout(timer)
+      }
+    } catch { /* invalid JSON, skip */ }
+  }, [settingsLoading, settings, tourActive, startPageTour])
 
   const checkProgramCompletion = useCallback(async (openModal = false) => {
     // Skip check if we're currently restarting

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+interface TourOverlayProps {
+  targetSelector: string | null
+  visible: boolean
+  onClickOverlay?: () => void
+}
+
+function getClipPath(rect: DOMRect, padding: number = 6): string {
+  const top = rect.top - padding
+  const left = rect.left - padding
+  const bottom = rect.bottom + padding
+  const right = rect.right + padding
+
+  return `polygon(
+    0% 0%, 0% 100%, ${left}px 100%, ${left}px ${top}px,
+    ${right}px ${top}px, ${right}px ${bottom}px,
+    ${left}px ${bottom}px, ${left}px 100%, 100% 100%, 100% 0%
+  )`
+}
+
+export function TourOverlay({ targetSelector, visible, onClickOverlay }: TourOverlayProps) {
+  const [clipPath, setClipPath] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!targetSelector || !visible) {
+      setClipPath(null)
+      return
+    }
+
+    const updateClip = () => {
+      const el = document.querySelector(targetSelector) as HTMLElement | null
+      if (el) {
+        setClipPath(getClipPath(el.getBoundingClientRect()))
+      }
+    }
+
+    updateClip()
+
+    // Update on scroll/resize
+    window.addEventListener('scroll', updateClip, true)
+    window.addEventListener('resize', updateClip)
+
+    return () => {
+      window.removeEventListener('scroll', updateClip, true)
+      window.removeEventListener('resize', updateClip)
+    }
+  }, [targetSelector, visible])
+
+  if (!mounted || !visible) return null
+
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 55,
+        clipPath: clipPath || undefined,
+        transition: 'clip-path 300ms ease, opacity 200ms ease',
+        opacity: clipPath ? 1 : 0,
+        pointerEvents: 'auto',
+      }}
+      className="bg-black/40 backdrop-blur-[1px]"
+      onClick={onClickOverlay}
+      aria-hidden="true"
+    />,
+    document.body
+  )
+}

--- a/components/tour/TourProvider.tsx
+++ b/components/tour/TourProvider.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react'
+import { useUserSettings } from '@/hooks/useUserSettings'
+import { TourOverlay } from './TourOverlay'
+import { TourTooltip } from './TourTooltip'
+import type { TourContextValue, TourStep } from './tour-types'
+
+const TourContext = createContext<TourContextValue | null>(null)
+
+export function useTour(): TourContextValue {
+  const ctx = useContext(TourContext)
+  if (!ctx) {
+    throw new Error('useTour must be used within a TourProvider')
+  }
+  return ctx
+}
+
+export function TourProvider({ children }: { children: React.ReactNode }) {
+  const { settings, updateSettings } = useUserSettings()
+  const [tourId, setTourId] = useState<string | null>(null)
+  const [steps, setSteps] = useState<TourStep[]>([])
+  const [stepIndex, setStepIndex] = useState(0)
+  const [isPaused, setIsPaused] = useState(false)
+  // Track tours completed this session to prevent re-triggering before settings refetch
+  const justCompletedRef = useRef<Set<string>>(new Set())
+
+  const isActive = tourId !== null
+
+  const completeTour = useCallback(async (id: string) => {
+    setTourId(null)
+    setSteps([])
+    setStepIndex(0)
+    justCompletedRef.current.add(id)
+
+    if (settings) {
+      try {
+        const completed: string[] = JSON.parse(settings.completedTours || '[]')
+        if (!completed.includes(id)) {
+          completed.push(id)
+          await updateSettings({ completedTours: JSON.stringify(completed) })
+        }
+      } catch {
+        await updateSettings({ completedTours: JSON.stringify([id]) })
+      }
+    }
+  }, [settings, updateSettings])
+
+  const startTour = useCallback((id: string, tourSteps: TourStep[]) => {
+    // Don't restart a tour that was just completed this session
+    if (justCompletedRef.current.has(id)) return
+
+    // Filter out optional steps whose targets don't exist
+    const availableSteps = tourSteps.filter(step => {
+      if (!step.optional) return true
+      return document.querySelector(step.targetSelector) !== null
+    })
+
+    if (availableSteps.length === 0) return
+
+    setTourId(id)
+    setSteps(availableSteps)
+    setStepIndex(0)
+    setIsPaused(false)
+  }, [])
+
+  const nextStep = useCallback(() => {
+    if (stepIndex < steps.length - 1) {
+      // Skip steps whose targets aren't in the DOM
+      let next = stepIndex + 1
+      while (next < steps.length && !document.querySelector(steps[next].targetSelector)) {
+        next++
+      }
+      if (next < steps.length) {
+        setStepIndex(next)
+      } else if (tourId) {
+        completeTour(tourId)
+      }
+    } else if (tourId) {
+      completeTour(tourId)
+    }
+  }, [stepIndex, steps, tourId, completeTour])
+
+  const prevStep = useCallback(() => {
+    if (stepIndex > 0) {
+      setStepIndex(stepIndex - 1)
+    }
+  }, [stepIndex])
+
+  const skipTour = useCallback(() => {
+    if (tourId) {
+      completeTour(tourId)
+    }
+  }, [tourId, completeTour])
+
+  const setTourPaused = useCallback((paused: boolean) => {
+    setIsPaused(paused)
+  }, [])
+
+  const currentStep = isActive && steps[stepIndex] ? steps[stepIndex] : null
+  const visible = isActive && !isPaused && currentStep !== null
+
+  const value = useMemo<TourContextValue>(() => ({
+    isActive,
+    isPaused,
+    tourId,
+    currentStep,
+    stepIndex,
+    totalSteps: steps.length,
+    startTour,
+    nextStep,
+    prevStep,
+    skipTour,
+    setTourPaused,
+  }), [isActive, isPaused, tourId, currentStep, stepIndex, steps.length, startTour, nextStep, prevStep, skipTour, setTourPaused])
+
+  return (
+    <TourContext.Provider value={value}>
+      {children}
+      <TourOverlay
+        targetSelector={currentStep?.targetSelector || null}
+        visible={visible}
+        onClickOverlay={nextStep}
+      />
+      <TourTooltip
+        step={currentStep}
+        stepIndex={stepIndex}
+        totalSteps={steps.length}
+        visible={visible}
+        onNext={nextStep}
+        onPrev={prevStep}
+        onSkip={skipTour}
+      />
+    </TourContext.Provider>
+  )
+}

--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom'
+import { ChevronLeft, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { TourStep } from './tour-types'
+
+interface TourTooltipProps {
+  step: TourStep | null
+  stepIndex: number
+  totalSteps: number
+  visible: boolean
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+}
+
+export function TourTooltip({
+  step,
+  stepIndex,
+  totalSteps,
+  visible,
+  onNext,
+  onPrev,
+  onSkip,
+}: TourTooltipProps) {
+  const [mounted, setMounted] = useState(false)
+  const [targetEl, setTargetEl] = useState<HTMLElement | null>(null)
+
+  const { refs, floatingStyles } = useFloating({
+    placement: step?.placement || 'bottom',
+    middleware: [offset(12), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  })
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Find and track target element
+  useEffect(() => {
+    if (!step?.targetSelector || !visible) {
+      setTargetEl(null)
+      return
+    }
+
+    const findTarget = () => {
+      const el = document.querySelector(step.targetSelector) as HTMLElement | null
+      if (el) {
+        setTargetEl(el)
+        refs.setReference(el)
+      }
+    }
+
+    findTarget()
+
+    // Retry briefly in case element isn't rendered yet
+    const retryTimer = setTimeout(findTarget, 100)
+    return () => clearTimeout(retryTimer)
+  }, [step?.targetSelector, visible, refs])
+
+  const isLastStep = stepIndex === totalSteps - 1
+
+  if (!mounted || !visible || !step || !targetEl) return null
+
+  return createPortal(
+    <div
+      ref={refs.setFloating}
+      style={{
+        ...floatingStyles,
+        zIndex: 56,
+      }}
+      className="w-72 max-w-[calc(100vw-2rem)]"
+    >
+      <div className="bg-card border-2 border-primary doom-noise p-5 shadow-lg">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2 mb-3">
+          <h3 className="text-base font-bold text-foreground doom-heading uppercase tracking-wider">
+            {step.title}
+          </h3>
+          <button
+            type="button"
+            onClick={onSkip}
+            className="shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Skip tour"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <p className="text-base text-muted-foreground mb-5 leading-relaxed">
+          {step.body}
+        </p>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {stepIndex + 1} of {totalSteps}
+          </span>
+
+          <div className="flex items-center gap-1">
+            {stepIndex > 0 && (
+              <button
+                type="button"
+                onClick={onPrev}
+                className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Previous step"
+              >
+                <ChevronLeft size={18} />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onNext}
+              className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 text-sm font-semibold uppercase tracking-wider"
+            >
+              {isLastStep ? 'Done' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/tour/index.ts
+++ b/components/tour/index.ts
@@ -1,0 +1,2 @@
+export { TourProvider, useTour } from './TourProvider'
+export type { TourContextValue, TourStep } from './tour-types'

--- a/components/tour/tour-types.ts
+++ b/components/tour/tour-types.ts
@@ -1,0 +1,24 @@
+export interface TourStep {
+  id: string
+  /** CSS selector for the target element, e.g. '[data-tour="reps-stepper"]' */
+  targetSelector: string
+  title: string
+  body: string
+  placement: 'top' | 'bottom' | 'left' | 'right'
+  /** Skip this step if the target element isn't found in the DOM */
+  optional?: boolean
+}
+
+export interface TourContextValue {
+  isActive: boolean
+  isPaused: boolean
+  tourId: string | null
+  currentStep: TourStep | null
+  stepIndex: number
+  totalSteps: number
+  startTour: (tourId: string, steps: TourStep[]) => void
+  nextStep: () => void
+  prevStep: () => void
+  skipTour: () => void
+  setTourPaused: (paused: boolean) => void
+}

--- a/components/ui/WeekNavigator.tsx
+++ b/components/ui/WeekNavigator.tsx
@@ -19,7 +19,7 @@ export default function WeekNavigator({
   const hasNext = currentWeek < totalWeeks
 
   return (
-    <div className="flex items-center justify-between gap-2">
+    <div data-tour="week-nav" className="flex items-center justify-between gap-2">
       {/* Prev button */}
       <Link
         href={hasPrev ? `${baseUrl}?week=${currentWeek - 1}` : '#'}

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -77,6 +77,7 @@ export default function ExerciseActionsFooter({
       <div className="flex items-center gap-2">
         {/* Log Set Button */}
         <button type="button"
+          data-tour="log-set"
           onClick={onLogSet}
           disabled={!canLogSet || hasLoggedAllPrescribed}
           className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
@@ -86,6 +87,7 @@ export default function ExerciseActionsFooter({
 
         {/* Complete Workout Button */}
         <button type="button"
+          data-tour="complete"
           disabled={isSubmitting || totalLoggedSets === 0}
           className="py-2.5 px-4 border border-success text-success text-sm font-bold uppercase tracking-wider transition-all hover:bg-success hover:text-success-foreground disabled:opacity-30 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
           onMouseDown={(e) => {

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -111,7 +111,7 @@ export default function ExerciseDisplayTabs({
         <TabsTrigger value="log-sets">
           <span>Log Sets</span>
         </TabsTrigger>
-        <TabsTrigger value="info">
+        <TabsTrigger value="info" data-tour="info-tab">
           <span>Info</span>
         </TabsTrigger>
         {hasNotes && (

--- a/components/workout-logging/ExerciseNavigation.tsx
+++ b/components/workout-logging/ExerciseNavigation.tsx
@@ -29,7 +29,7 @@ export default function ExerciseNavigation({
   const supersetLabel = currentExercise.exerciseGroup
 
   return (
-    <div className="border-b border-border px-3 py-2 flex items-center justify-between bg-card flex-shrink-0">
+    <div data-tour="exercise-nav" className="border-b border-border px-3 py-2 flex items-center justify-between bg-card flex-shrink-0">
       <button type="button"
         onClick={onPrevious}
         disabled={currentExerciseIndex === 0}

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -33,7 +33,7 @@ export function IntensitySelector({
   // Compact view
   if (!isExpanded) {
     return (
-      <div>
+      <div data-tour="intensity-input">
         <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
           {label}
         </span>

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -24,7 +24,7 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
   }
 
   return (
-    <div>
+    <div data-tour="reps-stepper">
       <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
         REPS
       </span>

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -90,7 +90,7 @@ export function WeightKeypad({
   // Compact view
   if (!isExpanded) {
     return (
-      <div>
+      <div data-tour="weight-input">
         <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
           WEIGHT ({weightUnit.toUpperCase()})
         </span>

--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -111,6 +111,7 @@ export default function WorkoutCard({
     <SwipeableCard actions={swipeActions}>
       <button
         type="button"
+        data-tour="workout-card"
         onClick={handleCardTap}
         disabled={isLoading || isSkipping || isUnskipping}
         aria-label={`${actionLabel}: Day ${workout.dayNumber} ${workout.name}`}

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -7,6 +7,7 @@ export type UserSettings = {
   dismissedPrimer: boolean
   dismissedWarmup: boolean
   dismissedStickNudge: boolean
+  completedTours: string
 }
 
 type UseUserSettingsReturn = {

--- a/lib/tour/steps/programs-page.ts
+++ b/lib/tour/steps/programs-page.ts
@@ -1,0 +1,21 @@
+import type { TourStep } from '@/components/tour/tour-types'
+
+export const PROGRAMS_PAGE_TOUR_ID = 'programs-page'
+
+export const PROGRAMS_PAGE_STEPS: TourStep[] = [
+  {
+    id: 'program-card',
+    targetSelector: '[data-tour="program-card"]',
+    title: 'YOUR PROGRAMS',
+    body: 'Browse available programs. Each one is tailored to this gym\'s equipment.',
+    placement: 'bottom',
+  },
+  {
+    id: 'activate-btn',
+    targetSelector: '[data-tour="activate-btn"]',
+    title: 'START A PROGRAM',
+    body: 'Tap to activate a program. It shows up on your Training page.',
+    placement: 'top',
+    optional: true,
+  },
+]

--- a/lib/tour/steps/training-page.ts
+++ b/lib/tour/steps/training-page.ts
@@ -1,0 +1,27 @@
+import type { TourStep } from '@/components/tour/tour-types'
+
+export const TRAINING_PAGE_TOUR_ID = 'training-page'
+
+export const TRAINING_PAGE_STEPS: TourStep[] = [
+  {
+    id: 'week-nav',
+    targetSelector: '[data-tour="week-nav"]',
+    title: 'YOUR TRAINING WEEK',
+    body: 'Navigate between weeks of your program using the arrows.',
+    placement: 'bottom',
+  },
+  {
+    id: 'workout-card',
+    targetSelector: '[data-tour="workout-card"]',
+    title: 'YOUR WORKOUTS',
+    body: 'Each card is a training day. Tap one to start logging.',
+    placement: 'bottom',
+  },
+  {
+    id: 'workout-card-swipe',
+    targetSelector: '[data-tour="workout-card"]',
+    title: 'MORE OPTIONS',
+    body: 'Swipe a workout card left to preview or skip it.',
+    placement: 'bottom',
+  },
+]

--- a/lib/tour/steps/workout-logger.ts
+++ b/lib/tour/steps/workout-logger.ts
@@ -1,0 +1,56 @@
+import type { TourStep } from '@/components/tour/tour-types'
+
+export const WORKOUT_LOGGER_TOUR_ID = 'workout-logger'
+
+export const WORKOUT_LOGGER_STEPS: TourStep[] = [
+  {
+    id: 'exercise-nav',
+    targetSelector: '[data-tour="exercise-nav"]',
+    title: 'NAVIGATE EXERCISES',
+    body: 'Swipe left/right or use the arrows to move between exercises.',
+    placement: 'bottom',
+  },
+  {
+    id: 'reps-stepper',
+    targetSelector: '[data-tour="reps-stepper"]',
+    title: 'SET YOUR REPS',
+    body: 'How many repetitions you did in this set. Tap + or - to adjust. The number is pre-filled from your program.',
+    placement: 'bottom',
+  },
+  {
+    id: 'weight-input',
+    targetSelector: '[data-tour="weight-input"]',
+    title: 'ENTER WEIGHT',
+    body: 'Tap to open the keypad. Start lighter than you think.',
+    placement: 'top',
+  },
+  {
+    id: 'intensity-input',
+    targetSelector: '[data-tour="intensity-input"]',
+    title: 'RATE YOUR EFFORT (RIR)',
+    body: 'After your set, ask yourself: how many more reps could I have done? That number is your RIR. Leave blank if unsure.',
+    placement: 'top',
+    optional: true,
+  },
+  {
+    id: 'log-set',
+    targetSelector: '[data-tour="log-set"]',
+    title: 'LOG YOUR SET',
+    body: 'Tap after each set to save your reps, weight, and effort. Your program tells you how many sets to do.',
+    placement: 'top',
+  },
+  {
+    id: 'info-tab',
+    targetSelector: '[data-tour="info-tab"]',
+    title: 'NEED HELP WITH FORM?',
+    body: 'The Info tab shows how to do the exercise and which muscles it works.',
+    placement: 'bottom',
+  },
+  {
+    id: 'complete',
+    targetSelector: '[data-tour="complete"]',
+    title: 'FINISH YOUR WORKOUT',
+    body: 'When all exercises are done, tap Complete to save everything.',
+    placement: 'top',
+  },
+]

--- a/prisma/migrations/20260402193108_add_completed_tours/migration.sql
+++ b/prisma/migrations/20260402193108_add_completed_tours/migration.sql
@@ -1,0 +1,2 @@
+-- Track which guided tours the user has completed or skipped
+ALTER TABLE "UserSettings" ADD COLUMN "completedTours" TEXT NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -292,6 +292,7 @@ model UserSettings {
   dismissedPrimer        Boolean  @default(false)
   dismissedWarmup        Boolean  @default(false)
   dismissedStickNudge    Boolean  @default(false)
+  completedTours         String   @default("[]")
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

Custom guided tour system for first-time users, built on `@floating-ui/react-dom` (already a transitive dependency via Radix). Subtle dim overlay with clip-path cutout spotlighting the target element, floating tooltip with Next/Back/Skip.

- **Training page tour** (3 steps): week navigator, workout cards, swipe hint
- **Workout logger tour** (7 steps): exercise nav, reps, weight, RIR, log set, info tab, complete
- **Programs page steps** defined but not wired (placeholder for when needed)

### Architecture

- `components/tour/` — TourProvider (context), TourOverlay (clip-path cutout), TourTooltip (Floating UI)
- `lib/tour/steps/` — plain data arrays per tour. Adding/reordering steps = editing one file
- `data-tour` attributes on target elements — zero coupling, components don't know tours exist
- `completedTours` JSON string on UserSettings — one field scales to any number of tours
- Tour pauses when logger inputs expand (layout shift)
- "Replay Tours" button in settings page

### UX decisions

- Subtle overlay (bg-black/40 + backdrop-blur) — not intrusive
- Tours auto-trigger on first visit, persist dismissal to DB (works across devices)
- Logger tour starts with 500ms delay after exercise loads
- Swipe navigation mentioned in exercise nav hint

Refs #345

## Test plan

- [ ] New user: training page tour fires on first visit with active program
- [ ] New user: logger tour fires on first Log tap after exercise loads
- [ ] Step through all training page steps (3), verify they complete and don't restart
- [ ] Step through all logger steps (7), verify they complete and don't restart
- [ ] Skip Tour on step 2: tour ends, doesn't reappear
- [ ] Expand weight keypad mid-tour: overlay fades, resumes at same step on collapse
- [ ] Settings > Replay Tours: resets all, tours reappear
- [ ] Mobile: tooltips don't cover target elements, flip/shift works
- [ ] Hard refresh after completing tours: they stay dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)