### PR TITLE
fix: include week description in clone worker

### DIFF
--- a/cloud-functions/clone-program/src/batch-insert.ts
+++ b/cloud-functions/clone-program/src/batch-insert.ts
@@ -3,6 +3,7 @@ import { Prisma, type PrismaClient } from '@prisma/client'
 
 interface WeekData {
   weekNumber: number
+  description?: string | null
   workouts?: WorkoutData[]
 }
 
@@ -83,8 +84,8 @@ export async function batchInsertStrengthWeek(
 
   // 1. INSERT Week (single row)
   await tx.$executeRaw(Prisma.sql`
-    INSERT INTO "Week" (id, "weekNumber", "programId", "userId")
-    VALUES (${weekId}, ${weekData.weekNumber}, ${programId}, ${userId})
+    INSERT INTO "Week" (id, "weekNumber", description, "programId", "userId")
+    VALUES (${weekId}, ${weekData.weekNumber}, ${weekData.description || null}, ${programId}, ${userId})
   `)
 
   // 2. Batch INSERT Workouts


### PR DESCRIPTION
## Summary
- Clone worker was not copying `description` when inserting Week rows, so all cloned curated programs had empty week descriptions
- Added `description` to the `WeekData` interface and the Week INSERT SQL in `cloud-functions/clone-program/src/batch-insert.ts`

Closes #341

## Test plan
- [x] Verified locally: seeded community programs, created a test clone with empty descriptions, confirmed descriptions are present in snapshot `programData`
- [ ] After deploy, reclone curated programs to pick up week descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)