### PR TITLE
Fix eslint react-hooks/exhaustive-deps warnings

### DIFF
--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Check, CheckCheck, ExternalLink, MessageSquarePlus, Tag } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 import type { FeedbackStatus } from '@/types/feedback'
 
@@ -75,7 +75,7 @@ export default function AdminFeedbackPage() {
       .catch(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [activeStatus])
+  }, [activeStatus, searchParams])
 
   const updateFeedback = async (id: string, status: FeedbackStatus, note?: string) => {
     setUpdating(id)

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AlertTriangle } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTour } from '@/components/tour'
 import { LoadingFrog } from '@/components/ui/loading-frog'
@@ -134,9 +134,13 @@ export default function ExerciseLoggingModal({
     setTourPaused(expandedInput !== null)
   }, [expandedInput, setTourPaused])
 
-  const currentPrescribedSets = currentExercise?.prescribedSets || []
-  const currentExerciseLoggedSets = loggedSets.filter(
-    (s) => s.exerciseId === currentExercise?.id
+  const currentPrescribedSets = useMemo(
+    () => currentExercise?.prescribedSets || [],
+    [currentExercise?.prescribedSets]
+  )
+  const currentExerciseLoggedSets = useMemo(
+    () => loggedSets.filter((s) => s.exerciseId === currentExercise?.id),
+    [loggedSets, currentExercise?.id]
   )
   const nextSetNumber = currentExerciseLoggedSets.length + 1
   const prescribedSet = currentPrescribedSets.find(

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -76,7 +76,7 @@ export default function SetList({
       return () => clearTimeout(timer)
     }
     prevCountRef.current = count
-  }, [loggedSets.length, exerciseId])
+  }, [loggedSets, exerciseId])
 
   return (
     <div className="space-y-1">


### PR DESCRIPTION
## Summary
- Add missing `searchParams` dependency in feedback admin page useEffect
- Wrap `currentPrescribedSets` and `currentExerciseLoggedSets` in `useMemo` to stabilize references used as effect dependencies in ExerciseLoggingModal
- Add missing `loggedSets` dependency in SetList useEffect (existing ref guard prevents unnecessary work)

## Test plan
- [ ] Verify `npm run lint` no longer shows exhaustive-deps warnings for these three files
- [ ] Verify feedback admin page still loads and filters correctly
- [ ] Verify workout logging modal prefill and set logging still works
- [ ] Verify set flash animation still triggers on new logged sets

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)