### PR TITLE
Fix @typescript-eslint/no-explicit-any in API routes

### DIFF
--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import type { ArticleLevel, Prisma, TagCategory } from '@prisma/client'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
@@ -19,9 +20,7 @@ export async function GET(request: NextRequest) {
     const contexts = searchParams.getAll('context')
 
     // Build where clause for published articles only
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // biome-ignore lint/suspicious/noExplicitAny: Prisma where clause built dynamically
-    const where: any = {
+    const where: Prisma.ArticleWhereInput = {
       status: 'published',
     }
 
@@ -43,16 +42,16 @@ export async function GET(request: NextRequest) {
 
     // Level filter (multi-select, OR within category)
     if (levels.length > 0) {
-      where.level = { in: levels }
+      where.level = { in: levels as ArticleLevel[] }
     }
 
     // Tag filters (AND across categories, OR within each category)
-    const tagFilters = []
+    const tagFilters: Prisma.ArticleWhereInput[] = []
     if (topics.length > 0) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'topic', name: { in: topics } },
+            tag: { category: 'topic' as TagCategory, name: { in: topics } },
           },
         },
       })
@@ -61,7 +60,7 @@ export async function GET(request: NextRequest) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'body_area', name: { in: bodyAreas } },
+            tag: { category: 'body_area' as TagCategory, name: { in: bodyAreas } },
           },
         },
       })
@@ -70,7 +69,7 @@ export async function GET(request: NextRequest) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'context', name: { in: contexts } },
+            tag: { category: 'context' as TagCategory, name: { in: contexts } },
           },
         },
       })

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 
@@ -90,9 +91,27 @@ export async function POST(
     // Calculate next order number for current workout
     const maxOrder = Math.max(0, ...workout.exercises.map(e => e.order))
     const nextOrder = maxOrder + 1
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // biome-ignore lint/suspicious/noExplicitAny: complex Prisma return type varies by branch
-    let addedExercise: any
+    const exerciseInclude = {
+      prescribedSets: {
+        orderBy: { setNumber: 'asc' as const },
+      },
+      exerciseDefinition: {
+        select: {
+          id: true,
+          name: true,
+          primaryFAUs: true,
+          secondaryFAUs: true,
+          equipment: true,
+          instructions: true,
+        },
+      },
+    } satisfies Prisma.ExerciseInclude
+
+    type ExerciseWithDetails = Prisma.ExerciseGetPayload<{
+      include: typeof exerciseInclude
+    }>
+
+    let addedExercise: ExerciseWithDetails | null = null
     let addedToCount = 0
 
     if (!applyToFuture) {
@@ -166,21 +185,7 @@ export async function POST(
         // Return exercise with all relations
         return await tx.exercise.findUnique({
           where: { id: exercise.id },
-          include: {
-            prescribedSets: {
-              orderBy: { setNumber: 'asc' }
-            },
-            exerciseDefinition: {
-              select: {
-                id: true,
-                name: true,
-                primaryFAUs: true,
-                secondaryFAUs: true,
-                equipment: true,
-                instructions: true
-              }
-            }
-          }
+          include: exerciseInclude,
         })
       })
 
@@ -251,21 +256,7 @@ export async function POST(
           if (targetWorkout.id === workoutId) {
             addedExercise = await tx.exercise.findUnique({
               where: { id: exercise.id },
-              include: {
-                prescribedSets: {
-                  orderBy: { setNumber: 'asc' }
-                },
-                exerciseDefinition: {
-                  select: {
-                    id: true,
-                    name: true,
-                    primaryFAUs: true,
-                    secondaryFAUs: true,
-                    equipment: true,
-                    instructions: true
-                  }
-                }
-              }
+              include: exerciseInclude,
             })
           }
         }


### PR DESCRIPTION
## Summary
- Replace `any` with `Prisma.ArticleWhereInput` in articles API route, with proper enum casts for `ArticleLevel` and `TagCategory`
- Replace `any` with derived `ExerciseWithDetails` type in add-during-logging route, extracting shared include config
- Remove stale `eslint-disable` and `biome-ignore` directives from both files

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm run lint` shows no errors in modified files
- [x] Pre-commit hooks pass

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)