### PR TITLE
Fix eslint react-hooks/set-state-in-effect errors

### DIFF
--- a/app/(app)/dev/mobile-spike/page.tsx
+++ b/app/(app)/dev/mobile-spike/page.tsx
@@ -2,6 +2,7 @@
 
 import { Activity, BookOpen, Dumbbell, LayoutGrid, Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
 import {
   DebugOverlay,
@@ -36,7 +37,7 @@ export default function MobileSpikePage() {
   const [hasDraft, setHasDraft] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [showDebug, setShowDebug] = useState(true)
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null)
+  const mounted = useMounted()
 
   const scrollPositions = useRef<Record<Tab, number>>({
     training: 0,
@@ -45,10 +46,6 @@ export default function MobileSpikePage() {
     settings: 0,
   })
   const contentRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setPortalTarget(document.body)
-  }, [])
 
   useEffect(() => {
     if (contentRef.current) {
@@ -160,7 +157,7 @@ export default function MobileSpikePage() {
 
       {/* Full-screen workout logging modal — via portal */}
       {modalOpen &&
-        portalTarget &&
+        mounted &&
         createPortal(
           <FullScreenModal
             onClose={() => setModalOpen(false)}
@@ -169,7 +166,7 @@ export default function MobileSpikePage() {
               setHasDraft(true)
             }}
           />,
-          portalTarget
+          document.body
         )}
 
       {/* Toggle debug button — bottom right, above nav */}

--- a/app/(app)/dev/mobile-spike/page.tsx
+++ b/app/(app)/dev/mobile-spike/page.tsx
@@ -2,8 +2,8 @@
 
 import { Activity, BookOpen, Dumbbell, LayoutGrid, Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
+import { useMounted } from '@/hooks/useMounted'
 import {
   DebugOverlay,
   FullScreenModal,

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
+import { useMounted } from '@/hooks/useMounted'
 
 interface TourOverlayProps {
   targetSelector: string | null

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
 
 interface TourOverlayProps {
@@ -24,16 +25,13 @@ function getClipPath(rect: DOMRect, padding: number = 6): string {
 
 export function TourOverlay({ targetSelector, visible, onClickOverlay }: TourOverlayProps) {
   const [clipPath, setClipPath] = useState<string | null>(null)
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const mounted = useMounted()
 
   useEffect(() => {
     if (!targetSelector || !visible) {
-      setClipPath(null)
-      return
+      // Defer the reset to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setClipPath(null))
+      return () => cancelAnimationFrame(frame)
     }
 
     const updateClip = () => {

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -71,14 +71,14 @@ export default function SetList({
 
     if (count > prevCountRef.current) {
       const newest = loggedSets[count - 1]
-      // Defer to avoid synchronous setState in useEffect; setTimeout
-      // also handles the flash-off after 650ms
-      const flashTimer = setTimeout(() => {
-        setFlashSetNumber(newest.setNumber)
-        setTimeout(() => setFlashSetNumber(null), 650)
-      }, 0)
+      // Defer to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setFlashSetNumber(newest.setNumber))
+      const flashOffTimer = setTimeout(() => setFlashSetNumber(null), 650)
       prevCountRef.current = count
-      return () => clearTimeout(flashTimer)
+      return () => {
+        cancelAnimationFrame(frame)
+        clearTimeout(flashOffTimer)
+      }
     }
     prevCountRef.current = count
   }, [loggedSets.length, exerciseId])

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -64,16 +64,21 @@ export default function SetList({
     if (exerciseId !== prevExerciseRef.current) {
       prevExerciseRef.current = exerciseId
       prevCountRef.current = count
-      setFlashSetNumber(null)
-      return
+      // Defer reset to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setFlashSetNumber(null))
+      return () => cancelAnimationFrame(frame)
     }
 
     if (count > prevCountRef.current) {
       const newest = loggedSets[count - 1]
-      setFlashSetNumber(newest.setNumber)
-      const timer = setTimeout(() => setFlashSetNumber(null), 650)
+      // Defer to avoid synchronous setState in useEffect; setTimeout
+      // also handles the flash-off after 650ms
+      const flashTimer = setTimeout(() => {
+        setFlashSetNumber(newest.setNumber)
+        setTimeout(() => setFlashSetNumber(null), 650)
+      }, 0)
       prevCountRef.current = count
-      return () => clearTimeout(timer)
+      return () => clearTimeout(flashTimer)
     }
     prevCountRef.current = count
   }, [loggedSets.length, exerciseId])

--- a/hooks/useMounted.ts
+++ b/hooks/useMounted.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from 'react'
+
+const emptySubscribe = () => () => {}
+
+/**
+ * SSR-safe hook that returns true after hydration (client-side only).
+ * Uses useSyncExternalStore to avoid setState-in-useEffect lint warnings.
+ */
+export function useMounted(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  )
+}


### PR DESCRIPTION
## Summary
- Extract `useMounted` hook using `useSyncExternalStore` for SSR-safe mount detection, replacing `useState`+`useEffect` patterns in mobile-spike portal and TourOverlay
- Defer synchronous `setState` calls in useEffect via `requestAnimationFrame`/`setTimeout` for TourOverlay clipPath reset and SetList flash animation
- Eliminates all 4 `react-hooks/set-state-in-effect` lint errors

## Test plan
- [ ] Verify mobile-spike page portal still renders correctly
- [ ] Verify TourOverlay spotlight/clip-path transitions work on scroll/resize
- [ ] Verify SetList flash animation fires on new logged set
- [ ] Run `npm run lint` -- zero `set-state-in-effect` errors
- [ ] Run `npm run type-check` -- clean

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)