### PR TITLE
fix: add 2-minute timeout to agent test commands

### DIFF
--- a/.claude/agents/autopilot.md
+++ b/.claude/agents/autopilot.md
@@ -23,7 +23,7 @@ If `doppler run` fails with "You must specify a project", this is why.
 ## Project-specific guidance
 
 - **Build**: `doppler run -- npm run build`
-- **Test**: `doppler run -- npm test`
+- **Test**: `timeout 120 doppler run -- npm test` (2 min timeout -- if it hangs, move on)
 - **Lint**: `npm run lint` (no doppler needed)
 - **Type-check**: `npm run type-check` (no doppler needed)
 - **Prisma generate**: `doppler run -- npx prisma@6.19.0 generate`

--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -28,7 +28,7 @@ If `doppler run` fails with "You must specify a project", this is why.
 ## Project-specific guidance
 
 - **Build**: `doppler run -- npm run build`
-- **Test**: `doppler run -- npm test`
+- **Test**: `timeout 120 doppler run -- npm test` (2 min timeout -- if it hangs, move on)
 - **Lint**: `npm run lint` (no doppler needed)
 - **Type-check**: `npm run type-check` (no doppler needed)
 - **Prisma generate**: `doppler run -- npx prisma@6.19.0 generate`
@@ -79,7 +79,7 @@ Make the smallest code change that fixes the bug. Do not refactor, clean up, or 
 
 Run in this order:
 ```bash
-doppler run -- npm test           # New test passes, no regressions
+timeout 120 doppler run -- npm test  # New test passes, no regressions (2 min timeout)
 npm run type-check                # No type errors
 npm run lint                      # No lint errors
 ```

--- a/.claude/agents/dependency-updater.md
+++ b/.claude/agents/dependency-updater.md
@@ -76,7 +76,7 @@ Use `npx npm-check-updates --cooldown 3d` to avoid freshly-published packages th
 doppler run -- npx prisma@6.19.0 generate   # If Prisma packages changed
 npm run type-check                            # Type errors from breaking changes
 npm run lint                                  # Lint compliance
-doppler run -- npm test                       # Full test suite
+timeout 120 doppler run -- npm test            # Full test suite (2 min timeout)
 doppler run -- npm run build                  # Build succeeds
 ```
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -20,7 +20,7 @@ If `doppler run` fails with "You must specify a project", this is why.
 
 ## Project-specific guidance
 
-- **Test**: `doppler run -- npm test`
+- **Test**: `timeout 120 doppler run -- npm test` (2 min timeout -- if it hangs, move on)
 - **Lint**: `npm run lint` (no doppler needed)
 - **Type-check**: `npm run type-check` (no doppler needed)
 - After doppler setup, use `doppler run --` without `--config` — the setup binds the config.


### PR DESCRIPTION
## Summary

- Add `timeout 120` wrapper to test commands in autopilot, reviewer, bug-fixer, and dependency-updater agent definitions
- Prevents agents from hanging indefinitely when testcontainers startup stalls or test processes don't exit
- On timeout (exit 124), the agent regains control to retry or move on

## Test plan

- [x] Verified all 4 agent definitions updated consistently
- [ ] Observe next agent run to confirm timeout behavior works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)