### PR TITLE
Combined: lint and code quality fixes (#351-#355)

### DIFF
--- a/__tests__/api/warmup-flag.test.ts
+++ b/__tests__/api/warmup-flag.test.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { recordStrengthPerformance } from '@/lib/stats/exercise-performance'
 import { getTestDatabase } from '@/lib/test/database'
 import {
   createCompleteTestScenario,
@@ -8,7 +9,6 @@ import {
   createTestUser,
   createTestWorkoutCompletion,
 } from '@/lib/test/factories'
-import { recordStrengthPerformance } from '@/lib/stats/exercise-performance'
 import {
   simulateDraftLoad,
   simulateDraftSave,

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -75,7 +75,7 @@ export default function AdminFeedbackPage() {
       .catch(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [activeStatus])
+  }, [activeStatus, searchParams.get])
 
   const updateFeedback = async (id: string, status: FeedbackStatus, note?: string) => {
     setUpdating(id)
@@ -222,7 +222,7 @@ export default function AdminFeedbackPage() {
                   <div className="min-w-0 flex-1">
                     <p className="text-sm text-foreground whitespace-pre-wrap break-words">
                       {item.message.length > 150
-                        ? item.message.substring(0, 150) + '...'
+                        ? `${item.message.substring(0, 150)}...`
                         : item.message}
                     </p>
                     <div className="flex flex-wrap gap-2 mt-2">

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Check, CheckCheck, ExternalLink, MessageSquarePlus, Tag } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 import type { FeedbackStatus } from '@/types/feedback'
 
@@ -75,7 +75,7 @@ export default function AdminFeedbackPage() {
       .catch(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [activeStatus])
+  }, [activeStatus, searchParams])
 
   const updateFeedback = async (id: string, status: FeedbackStatus, note?: string) => {
     setUpdating(id)

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Check, CheckCheck, ExternalLink, MessageSquarePlus, Tag } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 import type { FeedbackStatus } from '@/types/feedback'
 

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -75,7 +75,7 @@ export default function AdminFeedbackPage() {
       .catch(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [activeStatus, searchParams.get])
+  }, [activeStatus])
 
   const updateFeedback = async (id: string, status: FeedbackStatus, note?: string) => {
     setUpdating(id)

--- a/app/(app)/dev/mobile-spike/components.tsx
+++ b/app/(app)/dev/mobile-spike/components.tsx
@@ -129,7 +129,7 @@ function LearnContent() {
       </p>
       <h2 className="text-base font-bold">Understanding Sets and Reps</h2>
       <p className="text-sm leading-relaxed">
-        A rep (repetition) is one complete movement of an exercise. A set is a group of consecutive reps. When you see "3x5 @ 135 lbs" it means 3 sets of 5 reps at 135 pounds. Rest periods between sets typically range from 2-5 minutes for heavy compound movements and 1-2 minutes for lighter accessory work.
+        A rep (repetition) is one complete movement of an exercise. A set is a group of consecutive reps. When you see &ldquo;3x5 @ 135 lbs&rdquo; it means 3 sets of 5 reps at 135 pounds. Rest periods between sets typically range from 2-5 minutes for heavy compound movements and 1-2 minutes for lighter accessory work.
       </p>
       <h2 className="text-base font-bold">RPE and Autoregulation</h2>
       <p className="text-sm leading-relaxed">
@@ -237,6 +237,7 @@ export function FullScreenModal({
   onMinimize: () => void
 }) {
   const [sets, setSets] = useState<string[]>([])
+  const [now] = useState(() => Date.now())
 
   return (
     <div
@@ -342,7 +343,7 @@ export function FullScreenModal({
               className="p-2 rounded border border-border text-xs text-muted-foreground"
             >
               {new Date(
-                Date.now() - (i + 1) * 7 * 24 * 60 * 60 * 1000
+                now - (i + 1) * 7 * 24 * 60 * 60 * 1000
               ).toLocaleDateString()}
               : 5x5 @ {175 + i * 2.5} lbs
             </div>

--- a/app/(app)/dev/mobile-spike/page.tsx
+++ b/app/(app)/dev/mobile-spike/page.tsx
@@ -2,6 +2,7 @@
 
 import { Activity, BookOpen, Dumbbell, LayoutGrid, Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
 import {
   DebugOverlay,
@@ -36,7 +37,7 @@ export default function MobileSpikePage() {
   const [hasDraft, setHasDraft] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [showDebug, setShowDebug] = useState(true)
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null)
+  const mounted = useMounted()
 
   const scrollPositions = useRef<Record<Tab, number>>({
     training: 0,
@@ -45,10 +46,6 @@ export default function MobileSpikePage() {
     settings: 0,
   })
   const contentRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setPortalTarget(document.body)
-  }, [])
 
   useEffect(() => {
     if (contentRef.current) {
@@ -160,7 +157,7 @@ export default function MobileSpikePage() {
 
       {/* Full-screen workout logging modal — via portal */}
       {modalOpen &&
-        portalTarget &&
+        mounted &&
         createPortal(
           <FullScreenModal
             onClose={() => setModalOpen(false)}
@@ -169,7 +166,7 @@ export default function MobileSpikePage() {
               setHasDraft(true)
             }}
           />,
-          portalTarget
+          document.body
         )}
 
       {/* Toggle debug button — bottom right, above nav */}

--- a/app/(app)/dev/mobile-spike/page.tsx
+++ b/app/(app)/dev/mobile-spike/page.tsx
@@ -2,8 +2,8 @@
 
 import { Activity, BookOpen, Dumbbell, LayoutGrid, Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
+import { useMounted } from '@/hooks/useMounted'
 import {
   DebugOverlay,
   FullScreenModal,

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import type { ArticleLevel, Prisma, TagCategory } from '@prisma/client'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
@@ -19,9 +20,7 @@ export async function GET(request: NextRequest) {
     const contexts = searchParams.getAll('context')
 
     // Build where clause for published articles only
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // biome-ignore lint/suspicious/noExplicitAny: Prisma where clause built dynamically
-    const where: any = {
+    const where: Prisma.ArticleWhereInput = {
       status: 'published',
     }
 
@@ -43,16 +42,16 @@ export async function GET(request: NextRequest) {
 
     // Level filter (multi-select, OR within category)
     if (levels.length > 0) {
-      where.level = { in: levels }
+      where.level = { in: levels as ArticleLevel[] }
     }
 
     // Tag filters (AND across categories, OR within each category)
-    const tagFilters = []
+    const tagFilters: Prisma.ArticleWhereInput[] = []
     if (topics.length > 0) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'topic', name: { in: topics } },
+            tag: { category: 'topic' as TagCategory, name: { in: topics } },
           },
         },
       })
@@ -61,7 +60,7 @@ export async function GET(request: NextRequest) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'body_area', name: { in: bodyAreas } },
+            tag: { category: 'body_area' as TagCategory, name: { in: bodyAreas } },
           },
         },
       })
@@ -70,7 +69,7 @@ export async function GET(request: NextRequest) {
       tagFilters.push({
         tags: {
           some: {
-            tag: { category: 'context', name: { in: contexts } },
+            tag: { category: 'context' as TagCategory, name: { in: contexts } },
           },
         },
       })

--- a/app/api/feedback/[feedbackId]/route.ts
+++ b/app/api/feedback/[feedbackId]/route.ts
@@ -2,8 +2,8 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
-import { VALID_STATUSES } from '@/types/feedback'
 import type { FeedbackStatus } from '@/types/feedback'
+import { VALID_STATUSES } from '@/types/feedback'
 
 export async function PATCH(
   request: NextRequest,

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -3,8 +3,8 @@ import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { sendDiscordNotification } from '@/lib/discord'
 import { logger } from '@/lib/logger'
-import { VALID_CATEGORIES } from '@/types/feedback'
 import type { FeedbackCategory } from '@/types/feedback'
+import { VALID_CATEGORIES } from '@/types/feedback'
 
 const MAX_MESSAGE_LENGTH = 2000
 const RATE_LIMIT_PER_HOUR = 5

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 
@@ -90,9 +91,27 @@ export async function POST(
     // Calculate next order number for current workout
     const maxOrder = Math.max(0, ...workout.exercises.map(e => e.order))
     const nextOrder = maxOrder + 1
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // biome-ignore lint/suspicious/noExplicitAny: complex Prisma return type varies by branch
-    let addedExercise: any
+    const exerciseInclude = {
+      prescribedSets: {
+        orderBy: { setNumber: 'asc' as const },
+      },
+      exerciseDefinition: {
+        select: {
+          id: true,
+          name: true,
+          primaryFAUs: true,
+          secondaryFAUs: true,
+          equipment: true,
+          instructions: true,
+        },
+      },
+    } satisfies Prisma.ExerciseInclude
+
+    type ExerciseWithDetails = Prisma.ExerciseGetPayload<{
+      include: typeof exerciseInclude
+    }>
+
+    let addedExercise: ExerciseWithDetails | null = null
     let addedToCount = 0
 
     if (!applyToFuture) {
@@ -166,21 +185,7 @@ export async function POST(
         // Return exercise with all relations
         return await tx.exercise.findUnique({
           where: { id: exercise.id },
-          include: {
-            prescribedSets: {
-              orderBy: { setNumber: 'asc' }
-            },
-            exerciseDefinition: {
-              select: {
-                id: true,
-                name: true,
-                primaryFAUs: true,
-                secondaryFAUs: true,
-                equipment: true,
-                instructions: true
-              }
-            }
-          }
+          include: exerciseInclude,
         })
       })
 
@@ -251,21 +256,7 @@ export async function POST(
           if (targetWorkout.id === workoutId) {
             addedExercise = await tx.exercise.findUnique({
               where: { id: exercise.id },
-              include: {
-                prescribedSets: {
-                  orderBy: { setNumber: 'asc' }
-                },
-                exerciseDefinition: {
-                  select: {
-                    id: true,
-                    name: true,
-                    primaryFAUs: true,
-                    secondaryFAUs: true,
-                    equipment: true,
-                    instructions: true
-                  }
-                }
-              }
+              include: exerciseInclude,
             })
           }
         }

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AlertTriangle } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTour } from '@/components/tour'
 import { LoadingFrog } from '@/components/ui/loading-frog'
@@ -134,9 +134,13 @@ export default function ExerciseLoggingModal({
     setTourPaused(expandedInput !== null)
   }, [expandedInput, setTourPaused])
 
-  const currentPrescribedSets = currentExercise?.prescribedSets || []
-  const currentExerciseLoggedSets = loggedSets.filter(
-    (s) => s.exerciseId === currentExercise?.id
+  const currentPrescribedSets = useMemo(
+    () => currentExercise?.prescribedSets || [],
+    [currentExercise?.prescribedSets]
+  )
+  const currentExerciseLoggedSets = useMemo(
+    () => loggedSets.filter((s) => s.exerciseId === currentExercise?.id),
+    [loggedSets, currentExercise?.id]
   )
   const nextSetNumber = currentExerciseLoggedSets.length + 1
   const prescribedSet = currentPrescribedSets.find(

--- a/components/features/FeedbackModal.tsx
+++ b/components/features/FeedbackModal.tsx
@@ -7,8 +7,8 @@ import { useState } from 'react'
 
 import { useToast } from '@/components/ToastProvider'
 import { clientLogger } from '@/lib/client-logger'
-import { FEEDBACK_CATEGORIES } from '@/types/feedback'
 import type { FeedbackCategory } from '@/types/feedback'
+import { FEEDBACK_CATEGORIES } from '@/types/feedback'
 
 type FeedbackModalProps = {
   open: boolean

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -181,7 +181,7 @@ export default function ConsolidatedProgramsView({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [cloningProgramId, completedClones.has, startPolling, strengthPrograms.filter])
 
   // Poll for cloning status from URL param (after adding from community)
   useEffect(() => {
@@ -201,7 +201,7 @@ export default function ConsolidatedProgramsView({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, cloningProgramId])
+  }, [searchParams, cloningProgramId, completedClones.has, startPolling])
 
   const handleTabChange = (tab: 'my' | 'browse') => {
     setActiveTab(tab)

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -181,7 +181,7 @@ export default function ConsolidatedProgramsView({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cloningProgramId, completedClones.has, startPolling, strengthPrograms.filter])
+  }, [])
 
   // Poll for cloning status from URL param (after adding from community)
   useEffect(() => {
@@ -201,7 +201,7 @@ export default function ConsolidatedProgramsView({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, cloningProgramId, completedClones.has, startPolling])
+  }, [searchParams, cloningProgramId])
 
   const handleTabChange = (tab: 'my' | 'browse') => {
     setActiveTab(tab)

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
+import { useMounted } from '@/hooks/useMounted'
 
 interface TourOverlayProps {
   targetSelector: string | null

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useMounted } from '@/hooks/useMounted'
 import { createPortal } from 'react-dom'
 
 interface TourOverlayProps {
@@ -24,16 +25,13 @@ function getClipPath(rect: DOMRect, padding: number = 6): string {
 
 export function TourOverlay({ targetSelector, visible, onClickOverlay }: TourOverlayProps) {
   const [clipPath, setClipPath] = useState<string | null>(null)
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const mounted = useMounted()
 
   useEffect(() => {
     if (!targetSelector || !visible) {
-      setClipPath(null)
-      return
+      // Defer the reset to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setClipPath(null))
+      return () => cancelAnimationFrame(frame)
     }
 
     const updateClip = () => {

--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -66,6 +66,7 @@ export function TourTooltip({
 
   return createPortal(
     <div
+      // eslint-disable-next-line react-hooks/refs -- refs.setFloating is a Floating UI callback ref, not a .current access
       ref={refs.setFloating}
       style={{
         ...floatingStyles,

--- a/components/ui/radix/accordion.tsx
+++ b/components/ui/radix/accordion.tsx
@@ -50,4 +50,4 @@ const AccordionContent = React.forwardRef<
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger }

--- a/components/ui/radix/alert-dialog.tsx
+++ b/components/ui/radix/alert-dialog.tsx
@@ -106,12 +106,12 @@ AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
 
 export {
   AlertDialog,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 }

--- a/components/ui/radix/dialog.tsx
+++ b/components/ui/radix/dialog.tsx
@@ -115,12 +115,12 @@ DialogBody.displayName = 'DialogBody'
 
 export {
   Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
   DialogBody,
   DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 }

--- a/components/ui/radix/popover.tsx
+++ b/components/ui/radix/popover.tsx
@@ -23,4 +23,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent }
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger }

--- a/components/ui/radix/select.tsx
+++ b/components/ui/radix/select.tsx
@@ -130,13 +130,13 @@ SelectSeparator.displayName = SelectPrimitive.Separator.displayName
 
 export {
   Select,
-  SelectGroup,
-  SelectValue,
-  SelectTrigger,
   SelectContent,
-  SelectLabel,
+  SelectGroup,
   SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
+  SelectLabel,
   SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
 }

--- a/components/ui/radix/tabs.tsx
+++ b/components/ui/radix/tabs.tsx
@@ -41,4 +41,4 @@ const TabsContent = React.forwardRef<
 ))
 TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/components/ui/radix/toast.tsx
+++ b/components/ui/radix/toast.tsx
@@ -96,13 +96,13 @@ type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
 type ToastActionElement = React.ReactElement<typeof ToastAction>
 
 export {
-  type ToastProps,
-  type ToastActionElement,
-  ToastProvider,
-  ToastViewport,
   Toast,
-  ToastTitle,
-  ToastDescription,
-  ToastClose,
   ToastAction,
+  type ToastActionElement,
+  ToastClose,
+  ToastDescription,
+  type ToastProps,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
 }

--- a/components/ui/radix/tooltip.tsx
+++ b/components/ui/radix/tooltip.tsx
@@ -22,4 +22,4 @@ const TooltipContent = React.forwardRef<
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -76,7 +76,7 @@ export default function SetList({
       return () => clearTimeout(timer)
     }
     prevCountRef.current = count
-  }, [loggedSets.length, exerciseId])
+  }, [loggedSets, exerciseId])
 
   return (
     <div className="space-y-1">

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -71,14 +71,14 @@ export default function SetList({
 
     if (count > prevCountRef.current) {
       const newest = loggedSets[count - 1]
-      // Defer to avoid synchronous setState in useEffect; setTimeout
-      // also handles the flash-off after 650ms
-      const flashTimer = setTimeout(() => {
-        setFlashSetNumber(newest.setNumber)
-        setTimeout(() => setFlashSetNumber(null), 650)
-      }, 0)
+      // Defer to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setFlashSetNumber(newest.setNumber))
+      const flashOffTimer = setTimeout(() => setFlashSetNumber(null), 650)
       prevCountRef.current = count
-      return () => clearTimeout(flashTimer)
+      return () => {
+        cancelAnimationFrame(frame)
+        clearTimeout(flashOffTimer)
+      }
     }
     prevCountRef.current = count
   }, [loggedSets.length, exerciseId])

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -64,16 +64,21 @@ export default function SetList({
     if (exerciseId !== prevExerciseRef.current) {
       prevExerciseRef.current = exerciseId
       prevCountRef.current = count
-      setFlashSetNumber(null)
-      return
+      // Defer reset to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => setFlashSetNumber(null))
+      return () => cancelAnimationFrame(frame)
     }
 
     if (count > prevCountRef.current) {
       const newest = loggedSets[count - 1]
-      setFlashSetNumber(newest.setNumber)
-      const timer = setTimeout(() => setFlashSetNumber(null), 650)
+      // Defer to avoid synchronous setState in useEffect; setTimeout
+      // also handles the flash-off after 650ms
+      const flashTimer = setTimeout(() => {
+        setFlashSetNumber(newest.setNumber)
+        setTimeout(() => setFlashSetNumber(null), 650)
+      }, 0)
       prevCountRef.current = count
-      return () => clearTimeout(timer)
+      return () => clearTimeout(flashTimer)
     }
     prevCountRef.current = count
   }, [loggedSets.length, exerciseId])

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -76,7 +76,7 @@ export default function SetList({
       return () => clearTimeout(timer)
     }
     prevCountRef.current = count
-  }, [loggedSets.length, exerciseId, loggedSets])
+  }, [loggedSets.length, exerciseId])
 
   return (
     <div className="space-y-1">

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -76,7 +76,7 @@ export default function SetList({
       return () => clearTimeout(timer)
     }
     prevCountRef.current = count
-  }, [loggedSets.length, exerciseId])
+  }, [loggedSets.length, exerciseId, loggedSets])
 
   return (
     <div className="space-y-1">

--- a/hooks/useMounted.ts
+++ b/hooks/useMounted.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from 'react'
+
+const emptySubscribe = () => () => {}
+
+/**
+ * SSR-safe hook that returns true after hydration (client-side only).
+ * Uses useSyncExternalStore to avoid setState-in-useEffect lint warnings.
+ */
+export function useMounted(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  )
+}

--- a/lib/admin/minio.ts
+++ b/lib/admin/minio.ts
@@ -66,4 +66,4 @@ export async function uploadMedia(
   return { url, objectName }
 }
 
-export { MAX_FILE_SIZE, ALLOWED_TYPES }
+export { ALLOWED_TYPES, MAX_FILE_SIZE }

--- a/prisma/seeds/curated/exercise-defs.ts
+++ b/prisma/seeds/curated/exercise-defs.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
 
 /**
  * Exercise definitions needed by curated workouts that don't exist

--- a/prisma/seeds/curated/helpers.ts
+++ b/prisma/seeds/curated/helpers.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
 
 export type SetSpec = {
   setNumber: number

--- a/prisma/seeds/curated/index.ts
+++ b/prisma/seeds/curated/index.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client'
-import { createProgramFromSpec } from './helpers'
 import { seedCuratedExerciseDefinitions } from './exercise-defs'
+import { createProgramFromSpec } from './helpers'
 import { machineStarter } from './programs/01-machine-starter'
 import { confidenceBuilder } from './programs/02-confidence-builder'
 import { fullBodyStrength } from './programs/03-full-body-strength'

--- a/prisma/seeds/curated/programs/01-machine-starter.ts
+++ b/prisma/seeds/curated/programs/01-machine-starter.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const machineStarter: ProgramSpec = {
   name: 'Machine Starter',

--- a/prisma/seeds/curated/programs/02-confidence-builder.ts
+++ b/prisma/seeds/curated/programs/02-confidence-builder.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const confidenceBuilder: ProgramSpec = {
   name: 'Confidence Builder',

--- a/prisma/seeds/curated/programs/03-full-body-strength.ts
+++ b/prisma/seeds/curated/programs/03-full-body-strength.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const fullBodyStrength: ProgramSpec = {
   name: 'Full Body Strength',

--- a/prisma/seeds/curated/programs/04-push-pull-legs.ts
+++ b/prisma/seeds/curated/programs/04-push-pull-legs.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const pushPullLegs: ProgramSpec = {
   name: 'Push / Pull / Legs',

--- a/prisma/seeds/curated/programs/05-nothing-but-cables.ts
+++ b/prisma/seeds/curated/programs/05-nothing-but-cables.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const nothingButCables: ProgramSpec = {
   name: 'Nothing But Cables',

--- a/prisma/seeds/curated/programs/06-barbell-basics.ts
+++ b/prisma/seeds/curated/programs/06-barbell-basics.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSetsRpe } from '../helpers'
+import { makeSetsRpe, type ProgramSpec } from '../helpers'
 
 export const barbellBasics: ProgramSpec = {
   name: 'Barbell Basics 5x5',

--- a/prisma/seeds/curated/programs/07-heavy-upper-lower.ts
+++ b/prisma/seeds/curated/programs/07-heavy-upper-lower.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSetsRpe } from '../helpers'
+import { makeSetsRpe, type ProgramSpec } from '../helpers'
 
 export const heavyUpperLower: ProgramSpec = {
   name: '3-Day Powerbuilder - Strength and Mass',

--- a/prisma/seeds/curated/programs/08-home-training.ts
+++ b/prisma/seeds/curated/programs/08-home-training.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const homeTraining: ProgramSpec = {
   name: 'Home Training',

--- a/prisma/seeds/curated/programs/09-modern-bodybuild.ts
+++ b/prisma/seeds/curated/programs/09-modern-bodybuild.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const modernBodybuild: ProgramSpec = {
   name: 'Modern Bodybuild',

--- a/prisma/seeds/curated/programs/10-modern-bodybuild-female.ts
+++ b/prisma/seeds/curated/programs/10-modern-bodybuild-female.ts
@@ -1,4 +1,4 @@
-import { ProgramSpec, makeSets } from '../helpers'
+import { makeSets, type ProgramSpec } from '../helpers'
 
 export const modernBodybuildFemale: ProgramSpec = {
   name: 'Modern Bodybuild -- Female Physique',

--- a/prisma/seeds/curated/seed-community-programs.ts
+++ b/prisma/seeds/curated/seed-community-programs.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { type Prisma, PrismaClient } from '@prisma/client'
-import { readFileSync } from 'fs'
-import { join } from 'path'
 
 const prisma = new PrismaClient()
 

--- a/prisma/seeds/seed-dev-content.ts
+++ b/prisma/seeds/seed-dev-content.ts
@@ -235,7 +235,7 @@ async function seedWorkoutHistory() {
 
         for (const ps of exercise.prescribedSets) {
           // Simulate realistic logged data: slight variation from prescribed
-          const prescribedReps = parseInt(ps.reps) || 8
+          const prescribedReps = parseInt(ps.reps, 10) || 8
           const repsVariation = Math.random() > 0.3 ? 0 : -1
           const loggedReps = Math.max(1, prescribedReps + repsVariation)
 

--- a/scripts/build-exercise-mapping.ts
+++ b/scripts/build-exercise-mapping.ts
@@ -19,17 +19,17 @@ const fs = require('fs') as typeof import('fs')
 const path = require('path') as typeof import('path')
 
 import type {
+  MappingOutput,
+  Match,
   OurExercise,
   TheirExercise,
-  Match,
   UnmatchedExercise,
-  MappingOutput,
 } from './exercise-matching-utils'
 
 import {
-  normalize,
   deepNormalize,
   findBestMatch,
+  normalize,
 } from './exercise-matching-utils'
 
 // ---------------------------------------------------------------------------

--- a/scripts/build-exercise-mapping.ts
+++ b/scripts/build-exercise-mapping.ts
@@ -15,8 +15,8 @@
  */
 
 /* eslint-disable @typescript-eslint/no-require-imports */
-const fs = require('fs') as typeof import('fs')
-const path = require('path') as typeof import('path')
+const fs = require('node:fs') as typeof import('fs')
+const path = require('node:path') as typeof import('path')
 
 import type {
   MappingOutput,
@@ -333,7 +333,7 @@ async function main() {
   }
 
   // 7. Write output
-  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2) + '\n')
+  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`)
 
   // 8. Print summary
   console.log('\n=== Results ===')

--- a/scripts/copy-curated-image-urls.js
+++ b/scripts/copy-curated-image-urls.js
@@ -13,8 +13,8 @@
  * Usage: node scripts/copy-curated-image-urls.js
  */
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const mapping = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'exercise-mapping.json'), 'utf8')

--- a/scripts/enrich-exercises.js
+++ b/scripts/enrich-exercises.js
@@ -20,8 +20,8 @@
  * Usage: node scripts/enrich-exercises.js
  */
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const EXERCISE_DB_URL =
   'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json'

--- a/scripts/export-exercise-data.ts
+++ b/scripts/export-exercise-data.ts
@@ -10,9 +10,9 @@
  * Writes: prisma/seeds/exercise-definitions.json
  */
 
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { PrismaClient } from '@prisma/client'
-import { writeFileSync } from 'fs'
-import { join } from 'path'
 
 const prisma = new PrismaClient()
 
@@ -37,7 +37,7 @@ async function main() {
   })
 
   const outPath = join(__dirname, '..', 'prisma', 'seeds', 'exercise-definitions.json')
-  writeFileSync(outPath, JSON.stringify(exercises, null, 2) + '\n')
+  writeFileSync(outPath, `${JSON.stringify(exercises, null, 2)}\n`)
 
   console.log(`Exported ${exercises.length} exercise definitions to prisma/seeds/exercise-definitions.json`)
 }

--- a/scripts/generate-curated-seed.js
+++ b/scripts/generate-curated-seed.js
@@ -15,8 +15,8 @@
  * Usage: node scripts/generate-curated-seed.js
  */
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const EXERCISE_DB_URL =
   'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json'

--- a/scripts/generate-update-metadata.js
+++ b/scripts/generate-update-metadata.js
@@ -16,8 +16,8 @@
  * Usage: node scripts/generate-update-metadata.js
  */
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const EXERCISE_DB_URL =
   'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json'

--- a/scripts/review-matches-2.html
+++ b/scripts/review-matches-2.html
@@ -405,7 +405,7 @@ function render() {
   container.innerHTML = html;
 }
 
-function _select(i, theirId) {
+function select(i, theirId) {
   const ex = exercises[i];
   if (selections[ex.our_id] === theirId) {
     delete selections[ex.our_id]; // toggle off
@@ -416,7 +416,7 @@ function _select(i, theirId) {
   updateCounts();
 }
 
-function _autoSelectPicks() {
+function autoSelectPicks() {
   for (let i = 0; i < exercises.length; i++) {
     const ex = exercises[i];
     if (selections[ex.our_id] === undefined) {
@@ -437,7 +437,7 @@ function updateCounts() {
   document.getElementById('remaining-count').textContent = exercises.length - resolved;
 }
 
-function _exportResults() {
+function exportResults() {
   const results = {
     reviewed_at: new Date().toISOString(),
     new_matches: [],

--- a/scripts/review-matches-2.html
+++ b/scripts/review-matches-2.html
@@ -405,7 +405,7 @@ function render() {
   container.innerHTML = html;
 }
 
-function select(i, theirId) {
+function _select(i, theirId) {
   const ex = exercises[i];
   if (selections[ex.our_id] === theirId) {
     delete selections[ex.our_id]; // toggle off
@@ -416,7 +416,7 @@ function select(i, theirId) {
   updateCounts();
 }
 
-function autoSelectPicks() {
+function _autoSelectPicks() {
   for (let i = 0; i < exercises.length; i++) {
     const ex = exercises[i];
     if (selections[ex.our_id] === undefined) {
@@ -437,7 +437,7 @@ function updateCounts() {
   document.getElementById('remaining-count').textContent = exercises.length - resolved;
 }
 
-function exportResults() {
+function _exportResults() {
   const results = {
     reviewed_at: new Date().toISOString(),
     new_matches: [],

--- a/scripts/review-matches.html
+++ b/scripts/review-matches.html
@@ -202,7 +202,7 @@ function render() {
 
   let html = '';
   for (const sec of sections) {
-    const _items = matches.filter(m => m.verdict === sec.verdict);
+    const items = matches.filter(m => m.verdict === sec.verdict);
     html += `<div class="section">`;
     html += `<div class="section-header ${sec.cls}">${sec.label}</div>`;
     for (let i = 0; i < matches.length; i++) {
@@ -226,7 +226,7 @@ function render() {
   container.innerHTML = html;
 }
 
-function _toggleRow(i) {
+function toggleRow(i) {
   const cb = document.getElementById(`cb-${i}`);
   const row = document.getElementById(`row-${i}`);
   row.classList.toggle('checked', cb.checked);
@@ -240,7 +240,7 @@ function updateCounts() {
   document.getElementById('remaining-count').textContent = total - checked;
 }
 
-function _checkAllInSection(verdict) {
+function checkAllInSection(verdict) {
   for (let i = 0; i < matches.length; i++) {
     if (matches[i].verdict === verdict) {
       const cb = document.getElementById(`cb-${i}`);
@@ -251,7 +251,7 @@ function _checkAllInSection(verdict) {
   updateCounts();
 }
 
-function _exportResults() {
+function exportResults() {
   const results = {
     reviewed_at: new Date().toISOString(),
     validate: [],   // GOOD/OK that user agreed with -> set validated:true

--- a/scripts/review-matches.html
+++ b/scripts/review-matches.html
@@ -202,7 +202,7 @@ function render() {
 
   let html = '';
   for (const sec of sections) {
-    const items = matches.filter(m => m.verdict === sec.verdict);
+    const _items = matches.filter(m => m.verdict === sec.verdict);
     html += `<div class="section">`;
     html += `<div class="section-header ${sec.cls}">${sec.label}</div>`;
     for (let i = 0; i < matches.length; i++) {
@@ -226,7 +226,7 @@ function render() {
   container.innerHTML = html;
 }
 
-function toggleRow(i) {
+function _toggleRow(i) {
   const cb = document.getElementById(`cb-${i}`);
   const row = document.getElementById(`row-${i}`);
   row.classList.toggle('checked', cb.checked);
@@ -240,7 +240,7 @@ function updateCounts() {
   document.getElementById('remaining-count').textContent = total - checked;
 }
 
-function checkAllInSection(verdict) {
+function _checkAllInSection(verdict) {
   for (let i = 0; i < matches.length; i++) {
     if (matches[i].verdict === verdict) {
       const cb = document.getElementById(`cb-${i}`);
@@ -251,7 +251,7 @@ function checkAllInSection(verdict) {
   updateCounts();
 }
 
-function exportResults() {
+function _exportResults() {
   const results = {
     reviewed_at: new Date().toISOString(),
     validate: [],   // GOOD/OK that user agreed with -> set validated:true

--- a/scripts/sync-exercise-data.ts
+++ b/scripts/sync-exercise-data.ts
@@ -17,7 +17,7 @@
  */
 
 import { type Prisma, PrismaClient } from '@prisma/client'
-import { readFileSync, readdirSync } from 'fs'
+import { readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
 
 const prisma = new PrismaClient()

--- a/scripts/sync-exercise-data.ts
+++ b/scripts/sync-exercise-data.ts
@@ -16,9 +16,9 @@
  *   doppler run --config preview -- npx tsx scripts/sync-exercise-data.ts
  */
 
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { type Prisma, PrismaClient } from '@prisma/client'
-import { readdirSync, readFileSync } from 'fs'
-import { join } from 'path'
 
 const prisma = new PrismaClient()
 

--- a/scripts/sync-exercise-images.ts
+++ b/scripts/sync-exercise-images.ts
@@ -5,9 +5,9 @@
  */
 
 /* eslint-disable @typescript-eslint/no-require-imports */
-const https = require('https') as typeof import('https')
-const fs = require('fs') as typeof import('fs')
-const path = require('path') as typeof import('path')
+const https = require('node:https') as typeof import('https')
+const fs = require('node:fs') as typeof import('fs')
+const path = require('node:path') as typeof import('path')
 
 // Types
 

--- a/scripts/sync-exercise-images.ts
+++ b/scripts/sync-exercise-images.ts
@@ -157,7 +157,7 @@ function downloadBuffer(
         // Server errors - retry
         if (!res.statusCode || res.statusCode >= 500) {
           if (attempt < MAX_RETRIES) {
-            const delay = BASE_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+            const delay = BASE_RETRY_DELAY_MS * 2 ** (attempt - 1)
             setTimeout(
               () => resolve(downloadBuffer(url, attempt + 1)),
               delay
@@ -180,7 +180,7 @@ function downloadBuffer(
       })
       .on('error', (err) => {
         if (attempt < MAX_RETRIES) {
-          const delay = BASE_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+          const delay = BASE_RETRY_DELAY_MS * 2 ** (attempt - 1)
           setTimeout(
             () => resolve(downloadBuffer(url, attempt + 1)),
             delay


### PR DESCRIPTION
## Summary

Combines 5 agent-generated lint/code quality PRs into a single merge to avoid triggering 5 separate CI builds.

### Included PRs
- **#356** (issue #353): Fix react-hooks/exhaustive-deps warnings — useMemo wrappers, missing deps
- **#358** (issue #354): Fix mobile-spike/tour eslint errors — entity escaping, Date.now purity, Floating UI ref suppress
- **#359** (issue #355): Fix no-explicit-any in API routes — proper Prisma types replacing any
- **#360** (issue #351): Biome auto-fix — import sorting, template literals, node: protocol across 37 files
- **#361** (issue #352): Fix set-state-in-effect — useMounted hook via useSyncExternalStore, rAF deferral

### NOT included
- **#357** (dep updates): Has a pre-existing test failure in clone-worker, will be handled separately

## Test plan
- [ ] CI passes (type-check + tests)
- [ ] Close individual PRs #356, #358, #359, #360, #361 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)