### PR TITLE
fix: prisma migrate permissions in Docker init container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # Prisma migrations + exercise data sync (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
 RUN npm install prisma@6.19.0 tsx@4.19.4 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund --ignore-scripts
-# Copy Prisma engines from deps stage (already downloaded via prisma generate in stage 1)
-# This avoids needing @prisma/client in the runner — only the CLI + engines are needed for migrations
+# Copy Prisma engines from deps stage and fix ownership
+# npm install above creates @prisma/ owned by root; engines need to be writable by nextjs at runtime
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
+RUN chown -R nextjs:nodejs ./node_modules/@prisma ./node_modules/prisma
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
 COPY scripts/sync-exercise-data.ts ./scripts/sync-exercise-data.ts
 COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json


### PR DESCRIPTION
## Summary

- Add `chown -R nextjs:nodejs` for `@prisma` and `prisma` dirs in the runner stage
- The `npm install prisma@6.19.0` step creates these dirs as root, but the init container runs as `nextjs` and `prisma migrate deploy` needs write access to the engines directory

Staging deploy is currently failing with:
```
Error: Can't write to /app/node_modules/@prisma/engines please make sure you install "prisma" with the right permissions.
```

## Test plan
- [ ] Staging deploy succeeds after merge