### PR TITLE
fix: skip warmup popup when resuming draft workout

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -333,15 +333,19 @@ export default function StrengthWeekView({
       return
     }
 
+    // Skip primer/warmup interception when resuming an existing draft —
+    // the user already started this workout and saw these screens
+    const isResumingDraft = activeDraft && activeDraft.workoutId === workoutId
+
     // Primer interception — first ever workout
-    if (showPrimer && !primerOpen) {
+    if (showPrimer && !primerOpen && !isResumingDraft) {
       setPendingLoggingWorkoutId(workoutId)
       setPrimerOpen(true)
       return
     }
 
     // Warm-up interception for early sessions
-    if (showWarmup && !warmupOpen) {
+    if (showWarmup && !warmupOpen && !isResumingDraft) {
       setPendingLoggingWorkoutId(workoutId)
       setWarmupOpen(true)
       return


### PR DESCRIPTION
## Summary
- When resuming a minimized/draft workout, the warmup interstitial and beginner primer popups were incorrectly shown again
- Added an `isResumingDraft` check to `handleOpenLogging` that skips primer/warmup interception when the workout already has an active draft
- This covers both the FloatingDraftButton resume flow (`?resume=` param) and directly clicking a workout card with an existing draft

## Root cause
`handleOpenLogging()` always checked `showWarmup`/`showPrimer` before opening the logging modal, with no distinction between starting a new workout vs resuming one already in progress.

## Test plan
- [ ] Start a workout on a new account (< 4 sessions) — warmup popup should appear
- [ ] Minimize that workout, then resume via the floating button — warmup popup should NOT appear
- [ ] Click the workout card directly while a draft exists — warmup popup should NOT appear
- [ ] All 168 existing tests pass with no regressions

Fixes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)