### PR TITLE
feat: Extra Sets / Next Exercise buttons after all prescribed sets logged

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -72,6 +72,9 @@ export default function ExerciseLoggingModal({
   // Input expansion state (lifted from SetLoggingForm for SetList visibility)
   const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
 
+  // Extra sets mode: allows logging beyond prescribed sets
+  const [extraSetsMode, setExtraSetsMode] = useState(false)
+
   // Guided tour
   const { startTour, setTourPaused, isActive: tourActive } = useTour()
   const { settings: userSettings } = useUserSettings()
@@ -218,6 +221,7 @@ export default function ExerciseLoggingModal({
 
   const handleNextExercise = () => {
     lastPrefillKey.current = ''
+    setExtraSetsMode(false)
     goToNext()
     setCurrentSet(prev => ({
       reps: '',
@@ -230,6 +234,7 @@ export default function ExerciseLoggingModal({
 
   const handlePreviousExercise = () => {
     lastPrefillKey.current = ''
+    setExtraSetsMode(false)
     goToPrevious()
     setCurrentSet(prev => ({
       reps: '',
@@ -480,12 +485,16 @@ export default function ExerciseLoggingModal({
                   <SetLoggingForm
                     prescribedSet={prescribedSet}
                     hasLoggedAllPrescribed={hasLoggedAllPrescribed}
+                    extraSetsMode={extraSetsMode}
                     hasRpe={hasRpe}
                     hasRir={hasRir}
                     currentSet={currentSet}
                     onSetChange={setCurrentSet}
                     expandedInput={expandedInput}
                     onExpandedInputChange={setExpandedInput}
+                    onExtraSets={() => setExtraSetsMode(true)}
+                    onNextExercise={handleNextExercise}
+                    isLastExercise={currentIndex >= totalExercises - 1}
                   />
                 }
               />
@@ -499,6 +508,7 @@ export default function ExerciseLoggingModal({
             totalLoggedSets={totalLoggedSets}
             canLogSet={!!canLogSet}
             hasLoggedAllPrescribed={hasLoggedAllPrescribed}
+            extraSetsMode={extraSetsMode}
             isSubmitting={isSubmitting}
             onLogSet={handleLogSet}
             onCompleteWorkout={() => setIsConfirming(true)}

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -9,6 +9,7 @@ interface ExerciseActionsFooterProps {
   totalLoggedSets: number
   canLogSet: boolean
   hasLoggedAllPrescribed: boolean
+  extraSetsMode: boolean
   isSubmitting: boolean
   onLogSet: () => void
   onCompleteWorkout: () => void
@@ -25,6 +26,7 @@ export default function ExerciseActionsFooter({
   totalLoggedSets,
   canLogSet,
   hasLoggedAllPrescribed,
+  extraSetsMode,
   isSubmitting,
   onLogSet,
   onCompleteWorkout,
@@ -79,7 +81,7 @@ export default function ExerciseActionsFooter({
         <button type="button"
           data-tour="log-set"
           onClick={onLogSet}
-          disabled={!canLogSet || hasLoggedAllPrescribed}
+          disabled={!canLogSet || (hasLoggedAllPrescribed && !extraSetsMode)}
           className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
         >
           LOG SET {nextSetNumber}

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -20,6 +20,7 @@ export type ExpandedInput = 'weight' | 'rpe' | 'rir' | null
 interface SetLoggingFormProps {
   prescribedSet: PrescribedSet | undefined
   hasLoggedAllPrescribed: boolean
+  extraSetsMode: boolean
   hasRpe: boolean
   hasRir: boolean
   currentSet: {
@@ -38,17 +39,24 @@ interface SetLoggingFormProps {
   }) => void
   expandedInput: ExpandedInput
   onExpandedInputChange: (input: ExpandedInput) => void
+  onExtraSets: () => void
+  onNextExercise: () => void
+  isLastExercise: boolean
 }
 
 export default function SetLoggingForm({
   prescribedSet,
   hasLoggedAllPrescribed,
+  extraSetsMode,
   hasRpe,
   hasRir,
   currentSet,
   onSetChange,
   expandedInput,
   onExpandedInputChange,
+  onExtraSets,
+  onNextExercise,
+  isLastExercise,
 }: SetLoggingFormProps) {
   const { settings } = useUserSettings()
 
@@ -62,15 +70,34 @@ export default function SetLoggingForm({
     }
   }, [settings?.defaultWeightUnit, currentSet, onSetChange])
 
-  if (hasLoggedAllPrescribed) {
+  if (hasLoggedAllPrescribed && !extraSetsMode) {
     return (
-      <div className="bg-success-muted border-2 border-success-border p-4 text-center flex-shrink-0">
-        <div className="text-success-text font-bold mb-2 uppercase tracking-wider">
+      <div className="bg-success-muted border-2 border-success-border p-4 flex-shrink-0">
+        <div className="text-success-text font-bold mb-3 uppercase tracking-wider text-center">
           All prescribed sets logged!
         </div>
-        <p className="text-sm text-success-text">
-          Continue to next exercise or complete workout
-        </p>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onExtraSets}
+            className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 doom-button-3d doom-focus-ring"
+          >
+            Extra Sets
+          </button>
+          {!isLastExercise ? (
+            <button
+              type="button"
+              onClick={onNextExercise}
+              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-button-3d doom-focus-ring"
+            >
+              Next Exercise
+            </button>
+          ) : (
+            <div className="flex-1 py-2.5 text-center text-sm text-success-text font-bold uppercase tracking-wider">
+              Last exercise
+            </div>
+          )}
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- Replaces the static "All prescribed sets logged!" banner with two action buttons: **Extra Sets** and **Next Exercise**
- "Extra Sets" enables continued logging beyond prescribed sets (re-shows the form and re-enables the LOG SET button)
- "Next Exercise" advances to the next exercise (shows "Last exercise" label when on the final exercise)
- Extra sets mode resets automatically when navigating between exercises

## Test plan

- [ ] Log all prescribed sets for an exercise and verify the two-button banner appears
- [ ] Tap "Extra Sets" and verify the logging form reappears with the LOG SET button enabled
- [ ] Tap "Next Exercise" and verify navigation to the next exercise
- [ ] On the last exercise, verify "Last exercise" label appears instead of Next Exercise button
- [ ] Navigate away and back to an exercise with all sets logged — verify banner shows (not extra sets mode)
- [ ] Verify mobile layout looks correct (iPhone-sized viewport)

Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)