### PR TITLE
Auto-navigate to first incomplete exercise on draft resume

### DIFF
--- a/app/api/workouts/[workoutId]/metadata/route.ts
+++ b/app/api/workouts/[workoutId]/metadata/route.ts
@@ -65,55 +65,93 @@ export async function GET(
       whereConditions.push({ workoutCompletionId: completionId, isOneOff: true })
     }
 
-    // Fetch first exercise with full data (same query we'd make separately)
-    const firstExercise = await prisma.exercise.findFirst({
-      where: { OR: whereConditions, userId: user.id },
-      orderBy: { order: 'asc' },
-      select: {
-        id: true,
-        name: true,
-        order: true,
-        exerciseGroup: true,
-        notes: true,
-        isOneOff: true,
-        exerciseDefinitionId: true,
-        exerciseDefinition: {
-          select: {
-            id: true,
-            name: true,
-            primaryFAUs: true,
-            secondaryFAUs: true,
-            equipment: true,
-            instructions: true,
-            imageUrls: true,
-            isSystem: true,
-            createdBy: true,
-          },
-        },
-        prescribedSets: {
-          orderBy: { setNumber: 'asc' },
-          select: {
-            id: true,
-            setNumber: true,
-            reps: true,
-            weight: true,
-            rpe: true,
-            rir: true,
-          },
+    const exerciseSelect = {
+      id: true,
+      name: true,
+      order: true,
+      exerciseGroup: true,
+      notes: true,
+      isOneOff: true,
+      exerciseDefinitionId: true,
+      exerciseDefinition: {
+        select: {
+          id: true,
+          name: true,
+          primaryFAUs: true,
+          secondaryFAUs: true,
+          equipment: true,
+          instructions: true,
+          imageUrls: true,
+          isSystem: true,
+          createdBy: true,
         },
       },
-    })
+      prescribedSets: {
+        orderBy: { setNumber: 'asc' as const },
+        select: {
+          id: true,
+          setNumber: true,
+          reps: true,
+          weight: true,
+          rpe: true,
+          rir: true,
+        },
+      },
+    }
 
     // Count total exercises (including one-offs)
     const exerciseCount = await prisma.exercise.count({
       where: { OR: whereConditions, userId: user.id },
     })
 
-    // Fetch history for first exercise in parallel with nothing (already done above)
-    let firstExerciseHistory = null
-    if (firstExercise) {
-      firstExerciseHistory = await getLastExercisePerformance(
-        firstExercise.exerciseDefinitionId,
+    // When resuming a draft, find the first exercise with incomplete sets
+    let resumeExerciseIndex = 0
+    if (completionId && completionStatus === 'draft') {
+      // Fetch all exercises (ordered) and logged set counts in parallel
+      const [allExercises, loggedSetCounts] = await Promise.all([
+        prisma.exercise.findMany({
+          where: { OR: whereConditions, userId: user.id },
+          orderBy: { order: 'asc' },
+          select: { id: true, _count: { select: { prescribedSets: true } } },
+        }),
+        prisma.loggedSet.groupBy({
+          by: ['exerciseId'],
+          where: { completionId },
+          _count: true,
+        }),
+      ])
+
+      const loggedCountMap = new Map(
+        loggedSetCounts.map((g) => [g.exerciseId, g._count])
+      )
+
+      for (let i = 0; i < allExercises.length; i++) {
+        const ex = allExercises[i]
+        const loggedCount = loggedCountMap.get(ex.id) ?? 0
+        if (loggedCount < ex._count.prescribedSets) {
+          resumeExerciseIndex = i
+          break
+        }
+        // If all exercises are complete, stay at last exercise
+        if (i === allExercises.length - 1) {
+          resumeExerciseIndex = i
+        }
+      }
+    }
+
+    // Fetch the target exercise (first incomplete for drafts, first overall otherwise)
+    const targetExercise = await prisma.exercise.findFirst({
+      where: { OR: whereConditions, userId: user.id },
+      orderBy: { order: 'asc' },
+      skip: resumeExerciseIndex,
+      select: exerciseSelect,
+    })
+
+    // Fetch history for the target exercise
+    let targetExerciseHistory = null
+    if (targetExercise) {
+      targetExerciseHistory = await getLastExercisePerformance(
+        targetExercise.exerciseDefinitionId,
         user.id,
         new Date()
       )
@@ -129,8 +167,9 @@ export async function GET(
       exerciseCount,
       completionId,
       completionStatus,
-      firstExercise,
-      firstExerciseHistory,
+      firstExercise: targetExercise,
+      firstExerciseHistory: targetExerciseHistory,
+      resumeExerciseIndex,
     })
   } catch (error) {
     logger.error({ error, context: 'workout-metadata' }, 'Error fetching workout metadata')

--- a/app/api/workouts/[workoutId]/metadata/route.ts
+++ b/app/api/workouts/[workoutId]/metadata/route.ts
@@ -99,13 +99,9 @@ export async function GET(
       },
     }
 
-    // Count total exercises (including one-offs)
-    const exerciseCount = await prisma.exercise.count({
-      where: { OR: whereConditions, userId: user.id },
-    })
-
     // When resuming a draft, find the first exercise with incomplete sets
     let resumeExerciseIndex = 0
+    let exerciseCount: number
     if (completionId && completionStatus === 'draft') {
       // Fetch all exercises (ordered) and logged set counts in parallel
       const [allExercises, loggedSetCounts] = await Promise.all([
@@ -120,6 +116,9 @@ export async function GET(
           _count: true,
         }),
       ])
+
+      // Use allExercises.length instead of a separate count query
+      exerciseCount = allExercises.length
 
       const loggedCountMap = new Map(
         loggedSetCounts.map((g) => [g.exerciseId, g._count])
@@ -137,6 +136,11 @@ export async function GET(
           resumeExerciseIndex = i
         }
       }
+    } else {
+      // Non-draft: just count exercises
+      exerciseCount = await prisma.exercise.count({
+        where: { OR: whereConditions, userId: user.id },
+      })
     }
 
     // Fetch the target exercise (first incomplete for drafts, first overall otherwise)

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -37,6 +37,7 @@ type Props = {
   workoutCompletionId?: string
   initialExercise?: Exercise | null
   initialHistory?: ExerciseHistory | null
+  initialExerciseIndex?: number
   onComplete: () => Promise<void>
   onRefresh?: () => Promise<void>
 }
@@ -49,6 +50,7 @@ export default function ExerciseLoggingModal({
   workoutCompletionId,
   initialExercise,
   initialHistory,
+  initialExerciseIndex = 0,
   onComplete,
   onRefresh,
 }: Props) {
@@ -98,6 +100,7 @@ export default function ExerciseLoggingModal({
   } = useProgressiveExercises(workoutId, exerciseCount, workoutCompletionId, {
     initialExercise: initialExercise ?? undefined,
     initialHistory: initialHistory ?? undefined,
+    initialIndex: initialExerciseIndex,
   })
 
   // Pre-fetch exercise images so Info tab loads instantly

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -150,6 +150,7 @@ type WorkoutMetadata = {
       rir: number | null
     }>
   } | null
+  resumeExerciseIndex?: number
 }
 
 export default function StrengthWeekView({
@@ -584,6 +585,7 @@ export default function StrengthWeekView({
           workoutCompletionId={workoutMetadata.completionId}
           initialExercise={workoutMetadata.firstExercise}
           initialHistory={workoutMetadata.firstExerciseHistory}
+          initialExerciseIndex={workoutMetadata.resumeExerciseIndex ?? 0}
           onComplete={handleCompleteWorkout}
           onRefresh={handleRefreshMetadata}
         />

--- a/hooks/useProgressiveExercises.ts
+++ b/hooks/useProgressiveExercises.ts
@@ -53,6 +53,7 @@ export type LoadState = 'pending' | 'loading' | 'loaded' | 'error'
 export interface UseProgressiveExercisesOptions {
   initialExercise?: Exercise | null
   initialHistory?: ExerciseHistory | null
+  initialIndex?: number
 }
 
 export interface UseProgressiveExercisesResult {
@@ -92,22 +93,22 @@ export function useProgressiveExercises(
   completionId?: string,
   options?: UseProgressiveExercisesOptions
 ): UseProgressiveExercisesResult {
-  const { initialExercise, initialHistory } = options || {}
+  const { initialExercise, initialHistory, initialIndex = 0 } = options || {}
 
   // Initialize state with initial data if provided
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [totalExercises, setTotalExercises] = useState(exerciseCount)
 
   const [loadedExercises, setLoadedExercises] = useState<Map<number, Exercise>>(() => {
     if (initialExercise) {
-      return new Map([[0, initialExercise]])
+      return new Map([[initialIndex, initialExercise]])
     }
     return new Map()
   })
 
   const [exerciseLoadStates, setExerciseLoadStates] = useState<Map<number, LoadState>>(() => {
     if (initialExercise) {
-      return new Map([[0, 'loaded']])
+      return new Map([[initialIndex, 'loaded']])
     }
     return new Map()
   })


### PR DESCRIPTION
## Summary
- When resuming a minimized or draft workout, the logging modal now opens directly to the first exercise with incomplete sets (where logged sets < prescribed sets)
- The metadata API endpoint calculates the resume index server-side by comparing logged vs prescribed set counts per exercise
- Falls back to the first exercise for new workouts (non-draft) or if all exercises are complete

## Changes
- **`app/api/workouts/[workoutId]/metadata/route.ts`** — Added draft resume logic: queries exercises and logged set counts in parallel, finds first incomplete exercise, returns it as the initial exercise along with `resumeExerciseIndex`
- **`hooks/useProgressiveExercises.ts`** — Added `initialIndex` option to start at a non-zero exercise position
- **`components/ExerciseLoggingModal.tsx`** — Added `initialExerciseIndex` prop, passes through to progressive exercises hook
- **`components/StrengthWeekView.tsx`** — Passes `resumeExerciseIndex` from metadata to the logging modal

## Test plan
- [ ] Start a workout, log sets for the first 2 exercises, minimize
- [ ] Resume the workout — should open at the 3rd exercise (first incomplete)
- [ ] Complete all sets for all exercises, minimize, resume — should open at the last exercise
- [ ] Start a fresh workout (no draft) — should still open at the first exercise

Fixes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)