### PR TITLE
feat: add unresolved filter to admin feedback page

### DIFF
--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -18,7 +18,7 @@ interface FeedbackItem {
   createdAt: string
 }
 
-const STATUS_TABS = ['all', 'new', 'reviewed', 'resolved'] as const
+const STATUS_TABS = ['unresolved', 'all', 'new', 'reviewed', 'resolved'] as const
 
 const CATEGORY_LABELS: Record<string, string> = {
   bug: 'bug',
@@ -31,7 +31,7 @@ export default function AdminFeedbackPage() {
   const [feedback, setFeedback] = useState<FeedbackItem[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
-  const [activeStatus, setActiveStatus] = useState<string>('new')
+  const [activeStatus, setActiveStatus] = useState<string>('unresolved')
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [adminNote, setAdminNote] = useState('')
   const [updating, setUpdating] = useState<string | null>(null)
@@ -54,6 +54,7 @@ export default function AdminFeedbackPage() {
 
     const params = new URLSearchParams()
     if (activeStatus !== 'all') params.set('status', activeStatus)
+    // 'unresolved' is passed to API which handles it as status IN ['new', 'reviewed']
     params.set('limit', '100')
 
     fetch(`/api/feedback?${params}`)

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -109,7 +109,9 @@ export async function GET(request: NextRequest) {
     const offset = parseInt(searchParams.get('offset') || '0', 10)
 
     const where: Record<string, unknown> = {}
-    if (status) {
+    if (status === 'unresolved') {
+      where.status = { in: ['new', 'reviewed'] }
+    } else if (status) {
       where.status = status
     }
 


### PR DESCRIPTION
## Summary
- Adds an "unresolved" tab to the admin feedback page that shows feedback with status "new" or "reviewed"
- Makes "unresolved" the default view so admins immediately see actionable items
- API handles `status=unresolved` by querying `status IN ['new', 'reviewed']`

## Test plan
- [ ] Navigate to /admin/feedback and verify "unresolved" tab is selected by default
- [ ] Verify "unresolved" tab shows both "new" and "reviewed" feedback items
- [ ] Verify "resolved" items do not appear under "unresolved" tab
- [ ] Verify all other tabs (all, new, reviewed, resolved) still work correctly
- [ ] Verify Discord deep-link (?expand=id) still switches to "all" tab correctly

Fixes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)