### PR TITLE
fix: add cancel button to warmup interstitial popup

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -350,6 +350,11 @@ export default function StrengthWeekView({
     await proceedToLogging(workoutId)
   }
 
+  const handleWarmupCancel = () => {
+    setWarmupOpen(false)
+    setPendingLoggingWorkoutId(null)
+  }
+
   const handleWarmupContinue = () => {
     setWarmupOpen(false)
     if (pendingLoggingWorkoutId) {
@@ -602,6 +607,7 @@ export default function StrengthWeekView({
       <WarmupInterstitial
         open={warmupOpen}
         onContinue={handleWarmupContinue}
+        onCancel={handleWarmupCancel}
         onDismissPermanently={handleWarmupDismissPermanently}
       />
 

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -36,10 +36,12 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
     <div
       style={{ position: 'fixed', inset: 0, zIndex: 50 }}
       className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
+      onClick={onCancel}
     >
       <div
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
         className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
+        onClick={e => e.stopPropagation()}
       >
         {/* Header */}
         <div className="p-4 border-b border-border flex items-center justify-between">

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -34,10 +34,15 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
 
   return (
     <div
+      role="button"
+      tabIndex={-1}
       style={{ position: 'fixed', inset: 0, zIndex: 50 }}
       className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
       onClick={onCancel}
+      onKeyDown={e => { if (e.key === 'Escape') onCancel() }}
+      aria-label="Close dialog"
     >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
       <div
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
         className="relative w-full max-w-md bg-card border-2 border-border doom-noise"

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -42,11 +42,12 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
       onKeyDown={e => { if (e.key === 'Escape') onCancel() }}
       aria-label="Close dialog"
     >
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
       <div
+        role="presentation"
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
         className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
       >
         {/* Header */}
         <div className="p-4 border-b border-border flex items-center justify-between">

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -1,15 +1,17 @@
 'use client'
 
+import { X } from 'lucide-react'
 import { useState } from 'react'
 import { useUserSettings } from '@/hooks/useUserSettings'
 
 interface WarmupInterstitialProps {
   open: boolean
   onContinue: () => void
+  onCancel: () => void
   onDismissPermanently: () => void
 }
 
-export function WarmupInterstitial({ open, onContinue, onDismissPermanently }: WarmupInterstitialProps) {
+export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPermanently }: WarmupInterstitialProps) {
   const { updateSettings } = useUserSettings()
   const [dontShowAgain, setDontShowAgain] = useState(false)
   const [dismissing, setDismissing] = useState(false)
@@ -40,10 +42,18 @@ export function WarmupInterstitial({ open, onContinue, onDismissPermanently }: W
         className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
       >
         {/* Header */}
-        <div className="p-4 border-b border-border">
+        <div className="p-4 border-b border-border flex items-center justify-between">
           <h2 className="text-lg font-bold text-foreground doom-heading uppercase tracking-wider">
             Warm Up First
           </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
         </div>
 
         {/* Body */}


### PR DESCRIPTION
## Summary
- Added an X (close) button to the warmup interstitial popup header, allowing users to dismiss the popup without being forced to start the workout
- Wired up a cancel handler in `StrengthWeekView` that closes the popup and clears the pending workout state

## Context
Users reported that the warmup context popup had no way to cancel/dismiss it — the only option was "Start Workout", forcing them to proceed into the exercise even when they wanted to back out.

The fix follows the same pattern used by the `BeginnerPrimerWizard` component, which already has an X close button.

## Changes
- `components/features/training/WarmupInterstitial.tsx` — Added `onCancel` prop and X close button in header
- `components/StrengthWeekView.tsx` — Added `handleWarmupCancel` handler, passed to `WarmupInterstitial`

## Test plan
- [ ] Open a workout (with < 4 completed workouts so warmup shows)
- [ ] Verify warmup popup appears with X button in top-right corner
- [ ] Click X — popup dismisses, returns to week view without opening workout
- [ ] Click "Start Workout" — still works as before, opens the workout
- [ ] Check "Don't show again" + "Start Workout" — still persists dismissal

Fixes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)