### PR TITLE
feat: show prescribed rep range in workout logger

### DIFF
--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -96,6 +96,7 @@ export default function SetLoggingForm({
             value={currentSet.reps}
             onChange={(val) => onSetChange({ ...currentSet, reps: val })}
             placeholder={prescribedSet?.reps?.toString()}
+            prescribedReps={prescribedSet?.reps?.toString()}
           />
         )}
 

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -6,11 +6,15 @@ interface RepsStepperProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  prescribedReps?: string
 }
 
-export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) {
+export function RepsStepper({ value, onChange, placeholder, prescribedReps }: RepsStepperProps) {
   const numericValue = value ? parseInt(value, 10) : 0
   const hasValue = value !== ''
+
+  // Show prescribed range when it differs from the current value (e.g., "8-12" vs "12")
+  const showPrescribedRange = prescribedReps && hasValue && prescribedReps !== value
 
   const handleDecrement = () => {
     if (!hasValue) return
@@ -26,7 +30,9 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
   return (
     <div data-tour="reps-stepper">
       <span className="block text-xs text-muted-foreground mb-1 font-bold uppercase tracking-wider">
-        REPS
+        REPS{showPrescribedRange && (
+          <span className="text-primary/70 ml-1.5 normal-case font-medium">Rx: {prescribedReps}</span>
+        )}
       </span>
       <div className="flex items-center">
         <button


### PR DESCRIPTION
## Summary

- Shows the prescribed rep range (e.g., "Rx: 8-12") next to the REPS label in the reps stepper during workout logging
- Previously, users only saw the prefilled high-end value (e.g., "12") with no indication of the full prescribed range
- The range label appears only when the prescribed reps differ from the current value (e.g., ranges like "8-12" show the label, but single values like "10" do not)

**Note on weight progression guidance:** The existing "Progressive Overload: Adding Weight Over Time" article in the Learn tab already covers when to add weight based on hitting prescribed sets.

## Test plan

- [ ] Open a workout with exercises that have rep ranges (e.g., "8-12")
- [ ] Verify "Rx: 8-12" appears next to the REPS label in the stepper
- [ ] Verify the label disappears when prescribed reps is a single number matching the prefilled value
- [ ] Verify the label disappears after all prescribed sets are logged (form switches to "all prescribed sets logged" message)
- [ ] Verify stepper +/- buttons still work correctly

Fixes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)