### PR TITLE
feat: add rest stopwatch watermark below prescribed sets

### DIFF
--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
 import type { LoggedSet } from '@/types/workout'
+import RestStopwatch from './RestStopwatch'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -131,13 +132,20 @@ export default function ExerciseDisplayTabs({
       <TabsContent value="log-sets" className="flex-1 overflow-y-auto px-4 flex flex-col gap-2">
         {loggingForm}
         {!isInputExpanded && (
-          <SetList
-            prescribedSets={prescribedSets}
-            loggedSets={loggedSets}
-            exerciseHistory={null}
-            onDeleteSet={onDeleteSet}
-            exerciseId={exercise.id}
-          />
+          <>
+            <SetList
+              prescribedSets={prescribedSets}
+              loggedSets={loggedSets}
+              exerciseHistory={null}
+              onDeleteSet={onDeleteSet}
+              exerciseId={exercise.id}
+            />
+            <RestStopwatch
+              loggedSetCount={loggedSets.length}
+              prescribedSetCount={prescribedSets.length}
+              exerciseId={exercise.id}
+            />
+          </>
         )}
       </TabsContent>
 

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useRestTimer } from '@/hooks/useRestTimer'
+
+interface RestStopwatchProps {
+  loggedSetCount: number
+  prescribedSetCount: number
+  exerciseId: string
+}
+
+/**
+ * Subtle watermark-style rest stopwatch displayed below the set list.
+ * Resets on each logged set. Hides when no sets are logged or all sets are complete.
+ */
+export default function RestStopwatch({
+  loggedSetCount,
+  prescribedSetCount,
+  exerciseId,
+}: RestStopwatchProps) {
+  const { formatted, isRunning } = useRestTimer(
+    loggedSetCount,
+    prescribedSetCount,
+    exerciseId
+  )
+
+  if (!isRunning) return null
+
+  return (
+    <div className="flex items-center justify-center py-4 select-none" aria-live="off">
+      <span
+        className="text-5xl font-bold tracking-wider text-muted-foreground/15 tabular-nums"
+        aria-label={`Rest timer: ${formatted}`}
+      >
+        {formatted}
+      </span>
+    </div>
+  )
+}

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -28,6 +28,7 @@ export default function RestStopwatch({
   return (
     <div className="flex items-center justify-center py-4 select-none" aria-live="off">
       <span
+        role="timer"
         className="text-5xl font-bold tracking-wider text-muted-foreground/15 tabular-nums"
         aria-label={`Rest timer: ${formatted}`}
       >

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -1,0 +1,112 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Timestamp-based rest timer that survives browser backgrounding and phone sleep.
+ *
+ * Uses Date.now() difference instead of counting intervals, so elapsed time
+ * is always accurate regardless of tab throttling or suspension.
+ *
+ * Resets when a non-final set is logged. Stops when all sets are complete.
+ */
+export function useRestTimer(
+  loggedSetCount: number,
+  prescribedSetCount: number,
+  exerciseId: string
+) {
+  const [elapsed, setElapsed] = useState(0)
+  const [isRunning, setIsRunning] = useState(false)
+  const startRef = useRef<number | null>(null)
+  const prevExerciseRef = useRef(exerciseId)
+  const prevCountRef = useRef(loggedSetCount)
+
+  // Determine if the timer should be running
+  const isComplete = loggedSetCount >= prescribedSetCount && prescribedSetCount > 0
+
+  // Reset when exercise changes or sets change
+  useEffect(() => {
+    // Exercise changed — reset tracking
+    if (exerciseId !== prevExerciseRef.current) {
+      prevExerciseRef.current = exerciseId
+      prevCountRef.current = loggedSetCount
+      startRef.current = null
+      // Defer setState to avoid synchronous setState in useEffect
+      const frame = requestAnimationFrame(() => {
+        setElapsed(0)
+        setIsRunning(false)
+      })
+      return () => cancelAnimationFrame(frame)
+    }
+
+    // New set logged (and not all sets complete) — reset the timer
+    if (loggedSetCount > prevCountRef.current && !isComplete) {
+      startRef.current = Date.now()
+      const frame = requestAnimationFrame(() => {
+        setElapsed(0)
+        setIsRunning(true)
+      })
+      prevCountRef.current = loggedSetCount
+      return () => cancelAnimationFrame(frame)
+    }
+
+    // Set deleted — if no logged sets remain, stop the timer
+    if (loggedSetCount === 0 && prevCountRef.current > 0) {
+      startRef.current = null
+      const frame = requestAnimationFrame(() => {
+        setElapsed(0)
+        setIsRunning(false)
+      })
+      prevCountRef.current = loggedSetCount
+      return () => cancelAnimationFrame(frame)
+    }
+
+    // All sets complete — stop the timer
+    if (isComplete && startRef.current !== null) {
+      startRef.current = null
+      const frame = requestAnimationFrame(() => setIsRunning(false))
+      prevCountRef.current = loggedSetCount
+      return () => cancelAnimationFrame(frame)
+    }
+
+    prevCountRef.current = loggedSetCount
+  }, [loggedSetCount, exerciseId, isComplete])
+
+  // Tick the display every second
+  useEffect(() => {
+    if (!isRunning) return
+
+    const tick = () => {
+      if (startRef.current !== null) {
+        setElapsed(Math.floor((Date.now() - startRef.current) / 1000))
+      }
+    }
+
+    tick() // Immediate update
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [isRunning])
+
+  // Recalculate immediately when tab becomes visible again
+  useEffect(() => {
+    const handler = () => {
+      if (!document.hidden && startRef.current !== null) {
+        setElapsed(Math.floor((Date.now() - startRef.current) / 1000))
+      }
+    }
+    document.addEventListener('visibilitychange', handler)
+    return () => document.removeEventListener('visibilitychange', handler)
+  }, [])
+
+  const formatTime = useCallback((totalSeconds: number): string => {
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${minutes}:${String(seconds).padStart(2, '0')}`
+  }, [])
+
+  return {
+    elapsed,
+    formatted: formatTime(elapsed),
+    isRunning,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a subtle, watermark-style rest stopwatch that appears below the set list during workout logging
- Uses timestamp-based timing (`Date.now()` diff) so elapsed time is accurate even after browser backgrounding or phone sleep
- Resets on each non-final logged set; hides when no sets are logged or all sets are complete
- Includes `visibilitychange` listener for instant recalculation when returning to the tab

## New files

- `hooks/useRestTimer.ts` — Timestamp-based hook with visibility change handling
- `components/workout-logging/RestStopwatch.tsx` — Watermark-style display component (large, low-opacity, centered)

## Test plan

- [ ] Log a set and verify the stopwatch appears below the set list
- [ ] Log another set and verify the stopwatch resets to 0:00
- [ ] Log the final prescribed set and verify the stopwatch disappears
- [ ] Switch exercises and verify the stopwatch resets/hides appropriately
- [ ] Background the browser/phone, return, and verify the elapsed time is correct
- [ ] Delete all logged sets and verify the stopwatch disappears
- [ ] Verify the stopwatch is not visible when the input form is expanded

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)