### PR TITLE
fix: workout card stuck loading after discard

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -161,7 +161,7 @@ export default function StrengthWeekView({
 }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { activeDraft, refreshDraft } = useDraftWorkout()
+  const { activeDraft, refreshDraft, clearDraft } = useDraftWorkout()
   const { settings, isLoading: settingsLoading, refetch: refetchSettings } = useUserSettings()
   const [isPending, startTransition] = useTransition()
   const [updatingWorkoutId, setUpdatingWorkoutId] = useState<string | null>(null)
@@ -230,6 +230,15 @@ export default function StrengthWeekView({
       setUpdatingWorkoutId(null)
     }
   }, [isPending, updatingWorkoutId])
+
+  // Safety timeout: clear loading state if transition stalls (e.g. router.refresh() hangs)
+  useEffect(() => {
+    if (!updatingWorkoutId) return
+    const timeout = setTimeout(() => {
+      setUpdatingWorkoutId(null)
+    }, 5000)
+    return () => clearTimeout(timeout)
+  }, [updatingWorkoutId])
 
   const handleProgramRestart = useCallback(() => {
     // Set restarting flag to prevent completion checks
@@ -390,7 +399,9 @@ export default function StrengthWeekView({
     setWorkoutData(null)
     setWorkoutMetadata(null)
 
-    // Refresh draft context so floating button reflects current state
+    // Optimistically clear draft context so UI unblocks immediately,
+    // then refresh from server for authoritative state
+    clearDraft()
     refreshDraft()
 
     if (workoutUpdated && workoutId) {


### PR DESCRIPTION
## Summary
- After discarding a workout draft, the workout card on the training page could show a loading spinner for 10+ seconds and become unclickable, requiring a page refresh to recover
- Root cause: `router.refresh()` inside `startTransition` can stall in Next.js 15, leaving `isPending` true indefinitely, which keeps `isLoading` on the WorkoutCard true and blocks `handleCardTap`
- Added a 5-second safety timeout to clear the `updatingWorkoutId` loading state if the transition never resolves
- Optimistically clear draft context via `clearDraft()` before the async `refreshDraft()` call, so the UI unblocks without waiting for a server round-trip

## Test plan
- [ ] Open a workout and log one set
- [ ] Exit the workout and choose "Discard All"
- [ ] Verify the workout card on the training page does NOT show a persistent loading spinner
- [ ] Verify you can immediately tap the workout card to restart logging
- [ ] Complete a workout normally and verify the completion flow still works (loading spinner clears promptly)

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)