### PR TITLE
Expand reviewer agent fix protocol with three-tier system

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -46,13 +46,39 @@ For each changed file, evaluate:
 
 ## Fix protocol
 
-If you find issues that are clearly fixable (typos, missing error handling, wrong import order):
-1. Fix them directly in the code
-2. Run type-check and lint to verify
-3. Commit with a clear message referencing the PR
-4. Push to the PR branch
+### Always fix (don't just comment)
 
-For issues requiring discussion or design decisions, post a review comment instead of fixing.
+These are mechanical, unambiguous issues. Fix them directly every time you encounter them in changed files — including pre-existing problems in files the PR touches:
+
+- **Import order**: Reorder to match project convention (external deps, types, internal utils, components)
+- **`console.log` / `console.error`**: Replace with `logger.error`/`logger.info` (server) or `clientLogger` (client). Add the import if missing.
+- **Stale lint/biome disable directives**: Remove `eslint-disable`, `biome-ignore`, or `@ts-ignore` comments that no longer suppress anything
+- **Resource leaks**: Fix missing cleanup in `useEffect` (timers, subscriptions, abort controllers) when the correct cleanup is obvious
+- **Missing accessibility attributes**: Add `aria-label`, `role`, etc. when the intent is clear from context
+- **Typos**: In variable names, comments, user-facing strings
+
+### Fix with care
+
+These require judgment — fix them if the correct change is unambiguous, otherwise comment:
+
+- **Missing error handling**: Add `try/catch` with `logger.error()` to API routes that lack it
+- **Missing auth checks**: Add `getCurrentUser()` guard to unprotected API routes
+- **N+1 queries**: Refactor to use `include`/`select` when the fix is straightforward
+
+### Never fix (comment only)
+
+These involve design decisions or user-facing behavior changes — always post a review comment:
+
+- UX changes (adding dismiss behaviors, changing navigation flow)
+- Architecture or data model changes
+- Performance optimizations that change query structure significantly
+- Anything that changes the public API contract
+
+### After fixing
+
+1. Make fixes as **separate commits** with clear messages (e.g., `fix: replace console.error with logger in [file]`)
+2. Run type-check and lint to verify — do NOT run `biome check --fix` or `eslint --fix` auto-fixers, as they have caused issues. Make targeted manual edits instead.
+3. Push to the PR branch
 
 ## Structured assessment
 
@@ -66,7 +92,10 @@ After reviewing, post a PR comment with this structure:
 ### What looks good
 - (list strengths)
 
-### Issues found
+### Issues fixed
+- **[severity]**: description (file:line) — fixed in [commit sha]
+
+### Issues requiring discussion
 - **[severity]**: description (file:line)
 
 ### Suggestions (optional)


### PR DESCRIPTION
## Summary
- Replaced the vague "fix clearly fixable issues" guidance with a three-tier protocol: **always fix**, **fix with care**, **never fix (comment only)**
- Based on analysis of PRs #379, #374, #361, #359 where the reviewer was inconsistent about fixing vs commenting on mechanical issues
- Explicitly bans `biome check --fix` and `eslint --fix` auto-fixers — manual edits only
- Splits review template into "issues fixed" (with commit sha) and "issues requiring discussion"

## Test plan
- [ ] Run reviewer agent on next PR and verify it follows the tiered fix protocol
- [ ] Confirm it makes manual fixes for "always fix" items instead of just commenting
- [ ] Confirm it does not run auto-fixers

🤖 Generated with [Claude Code](https://claude.com/claude-code)