### PR TITLE
fix: weekly quality cleanup - logging, imports, a11y

### DIFF
--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import type { ArticleLevel, Prisma, TagCategory } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
 
 type UpdateSettingsRequest = {
   displayName?: string
@@ -48,7 +49,7 @@ export async function GET(_request: NextRequest) {
       settings
     })
   } catch (error) {
-    console.error('Error fetching user settings:', error)
+    logger.error({ error, context: 'settings-get' }, 'Failed to fetch user settings')
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }
@@ -109,7 +110,7 @@ export async function PUT(request: NextRequest) {
       settings
     })
   } catch (error) {
-    console.error('Error updating user settings:', error)
+    logger.error({ error, context: 'settings-put' }, 'Failed to update user settings')
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import type { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
 
 type AddDuringLoggingRequest = {
   exerciseDefinitionId: string
@@ -271,7 +272,7 @@ export async function POST(
       addedToCount
     })
   } catch (error) {
-    console.error('Error adding exercise during logging:', error)
+    logger.error({ error, context: 'add-during-logging' }, 'Error adding exercise during logging')
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -43,7 +43,8 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
       aria-label="Close dialog"
     >
       <div
-        role="presentation"
+        role="dialog"
+        aria-label="Warm up information"
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
         className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
         onClick={e => e.stopPropagation()}


### PR DESCRIPTION
## Summary

- **settings/route.ts**: Replace `console.error` with structured `logger.error` in GET and PUT handlers
- **add-during-logging/route.ts**: Replace `console.error` with structured `logger.error`, fix biome import ordering (type imports before value imports)
- **articles/route.ts**: Fix biome import ordering (type imports before value imports)
- **WarmupInterstitial.tsx**: Fix biome `noStaticElementInteractions` by changing `role="presentation"` to `role="dialog"` with `aria-label`

## Files reviewed (no issues)

- `app/api/feedback/route.ts` - Clean
- `app/api/feedback/[feedbackId]/route.ts` - Clean
- `app/api/admin/feedback/create-issue/route.ts` - Clean
- `components/workout/WorkoutCard.tsx` - Clean
- `components/workout-logging/RestStopwatch.tsx` - Clean
- `components/features/FeedbackModal.tsx` - Clean
- `components/tour/TourProvider.tsx` - Clean
- `components/StrengthWeekView.tsx` - Pre-existing exhaustive-deps warning on handleOpenLogging (not addressed; requires complex useCallback refactor with risk of regressions, and existing guard logic prevents loops per lesson 46)
- `hooks/useRestTimer.ts` - Clean

## Test plan

- [ ] Type-check passes with no errors
- [ ] Biome check passes on all 4 edited files
- [ ] No behavioral changes: import reordering, logger swap, and role attribute change are purely cosmetic/structural

🤖 Generated with [Claude Code](https://claude.com/claude-code)