### PR TITLE
feat: guided tour for Programs Browse tab on first login

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, RotateCcw, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
 import { useThemePreference } from '@/hooks/useThemePreference'
@@ -16,6 +17,7 @@ type ConnectedAccounts = {
 }
 
 export default function SettingsPage() {
+  const router = useRouter()
   const { data: session } = useSession()
   const { settings, isLoading, updateSettings } = useUserSettings()
   const { preference, updateTheme } = useThemePreference()
@@ -459,6 +461,7 @@ export default function SettingsPage() {
                   onClick={async () => {
                     await updateSettings({ completedTours: '[]' })
                     setSaved(false)
+                    router.refresh()
                   }}
                   className="px-4 py-2 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center gap-2"
                 >

--- a/components/community/CommunityProgramCard.tsx
+++ b/components/community/CommunityProgramCard.tsx
@@ -28,11 +28,13 @@ type CommunityProgram = {
 type CommunityProgramCardProps = {
   program: CommunityProgram
   currentUserId: string
+  'data-tour'?: string
 }
 
 export default function CommunityProgramCard({
   program,
   currentUserId,
+  'data-tour': dataTour,
 }: CommunityProgramCardProps) {
   const router = useRouter()
   const [isAdding, setIsAdding] = useState(false)
@@ -83,7 +85,7 @@ export default function CommunityProgramCard({
 
   return (
     <>
-      <div className="p-4 sm:p-6 bg-card border-2 border-border hover:border-primary transition-colors doom-corners doom-noise">
+      <div data-tour={dataTour} className="p-4 sm:p-6 bg-card border-2 border-border hover:border-primary transition-colors doom-corners doom-noise">
         {/* Header */}
         <div className="flex justify-between items-start gap-3 mb-3">
           <div className="flex-1 min-w-0">

--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -219,12 +219,12 @@ export default function CommunityProgramsView({
             {/* Program Cards */}
             <div className="grid grid-cols-1 gap-4 mb-8">
               {paginatedPrograms.map((program, index) => (
-                <div key={program.id} {...(index === 0 ? { 'data-tour': 'program-card' } : {})}>
-                  <CommunityProgramCard
-                    program={program}
-                    currentUserId={currentUserId}
-                  />
-                </div>
+                <CommunityProgramCard
+                  key={program.id}
+                  program={program}
+                  currentUserId={currentUserId}
+                  {...(index === 0 ? { 'data-tour': 'program-card' } : {})}
+                />
               ))}
             </div>
 

--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -127,7 +127,7 @@ export default function CommunityProgramsView({
             {/* Level Filter Popover */}
             <Popover>
               <PopoverTrigger asChild>
-                <button type="button" className="px-4 py-2 border-2 border-border text-foreground hover:border-primary transition-colors uppercase tracking-wider font-semibold doom-focus-ring flex items-center gap-2 text-sm">
+                <button type="button" data-tour="level-filter" className="px-4 py-2 border-2 border-border text-foreground hover:border-primary transition-colors uppercase tracking-wider font-semibold doom-focus-ring flex items-center gap-2 text-sm">
                   Level: {selectedLevel ? LEVEL_LABELS[selectedLevel] : 'All'}
                   <ChevronDown size={16} />
                 </button>
@@ -158,7 +158,7 @@ export default function CommunityProgramsView({
             {/* Goals Filter Popover */}
             <Popover>
               <PopoverTrigger asChild>
-                <button type="button" className="px-4 py-2 border-2 border-border text-foreground hover:border-primary transition-colors uppercase tracking-wider font-semibold doom-focus-ring flex items-center gap-2 text-sm">
+                <button type="button" data-tour="goals-filter" className="px-4 py-2 border-2 border-border text-foreground hover:border-primary transition-colors uppercase tracking-wider font-semibold doom-focus-ring flex items-center gap-2 text-sm">
                   Goals: {selectedGoals.length > 0 ? `${selectedGoals.length} selected` : 'Any'}
                   <ChevronDown size={16} />
                 </button>
@@ -218,12 +218,13 @@ export default function CommunityProgramsView({
           <>
             {/* Program Cards */}
             <div className="grid grid-cols-1 gap-4 mb-8">
-              {paginatedPrograms.map((program) => (
-                <CommunityProgramCard
-                  key={program.id}
-                  program={program}
-                  currentUserId={currentUserId}
-                />
+              {paginatedPrograms.map((program, index) => (
+                <div key={program.id} {...(index === 0 ? { 'data-tour': 'program-card' } : {})}>
+                  <CommunityProgramCard
+                    program={program}
+                    currentUserId={currentUserId}
+                  />
+                </div>
               ))}
             </div>
 

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -4,7 +4,10 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import CommunityProgramsView from '@/components/community/CommunityProgramsView'
 import { useToast } from '@/components/ToastProvider'
+import { useTour } from '@/components/tour/TourProvider'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
+import { PROGRAMS_PAGE_STEPS, PROGRAMS_PAGE_TOUR_ID } from '@/lib/tour/steps/programs-page'
 import StrengthActivationModal from '../StrengthActivationModal'
 import ActiveProgramStrip from './ActiveProgramStrip'
 import ArchivedProgramsSection from './ArchivedProgramsSection'
@@ -58,10 +61,30 @@ export default function ConsolidatedProgramsView({
   const searchParams = useSearchParams()
   const router = useRouter()
   const toast = useToast()
+  const { settings, isLoading: settingsLoading } = useUserSettings()
+  const { startTour, isActive: tourActive } = useTour()
 
-  // Tab state
+  // Default to Browse tab for first-time users (no programs yet) or when URL param says so
   const tabParam = searchParams.get('tab')
-  const [activeTab, setActiveTab] = useState<'my' | 'browse'>(tabParam === 'browse' ? 'browse' : 'my')
+  const isNewUser = strengthPrograms.length === 0
+  const [activeTab, setActiveTab] = useState<'my' | 'browse'>(
+    tabParam === 'browse' || isNewUser ? 'browse' : 'my'
+  )
+
+  // Programs page guided tour - triggers on Browse tab for first-time users
+  useEffect(() => {
+    if (settingsLoading || !settings || tourActive) return
+    if (activeTab !== 'browse') return
+    try {
+      const completed: string[] = JSON.parse(settings.completedTours || '[]')
+      if (!completed.includes(PROGRAMS_PAGE_TOUR_ID)) {
+        const timer = setTimeout(() => {
+          startTour(PROGRAMS_PAGE_TOUR_ID, PROGRAMS_PAGE_STEPS)
+        }, 300)
+        return () => clearTimeout(timer)
+      }
+    } catch { /* invalid JSON, skip */ }
+  }, [settingsLoading, settings, tourActive, activeTab, startTour])
 
   // Cloning state
   const [cloningProgramId, setCloningProgramId] = useState<string | null>(null)
@@ -261,6 +284,7 @@ export default function ConsolidatedProgramsView({
             </button>
             <button
               type="button"
+              data-tour="browse-tab"
               onClick={() => handleTabChange('browse')}
               className={`flex-1 py-2.5 text-sm font-bold uppercase tracking-wider transition-colors doom-focus-ring ${
                 activeTab === 'browse'

--- a/lib/tour/steps/programs-page.ts
+++ b/lib/tour/steps/programs-page.ts
@@ -4,18 +4,32 @@ export const PROGRAMS_PAGE_TOUR_ID = 'programs-page'
 
 export const PROGRAMS_PAGE_STEPS: TourStep[] = [
   {
-    id: 'program-card',
-    targetSelector: '[data-tour="program-card"]',
-    title: 'YOUR PROGRAMS',
-    body: 'Browse available programs. Each one is tailored to this gym\'s equipment.',
+    id: 'browse-tab',
+    targetSelector: '[data-tour="browse-tab"]',
+    title: 'BROWSE PROGRAMS',
+    body: 'Find a training program that fits your goals. All programs are designed for real gym equipment.',
     placement: 'bottom',
   },
   {
-    id: 'activate-btn',
-    targetSelector: '[data-tour="activate-btn"]',
-    title: 'START A PROGRAM',
-    body: 'Tap to activate a program. It shows up on your Training page.',
-    placement: 'top',
+    id: 'level-filter',
+    targetSelector: '[data-tour="level-filter"]',
+    title: 'FILTER BY LEVEL',
+    body: 'Pick your experience level to narrow down programs. Beginner programs start lighter with more guidance.',
+    placement: 'bottom',
+  },
+  {
+    id: 'goals-filter',
+    targetSelector: '[data-tour="goals-filter"]',
+    title: 'FILTER BY GOALS',
+    body: 'Select one or more training goals like strength, hypertrophy, or general fitness to find the right fit.',
+    placement: 'bottom',
+  },
+  {
+    id: 'program-card',
+    targetSelector: '[data-tour="program-card"]',
+    title: 'PICK A PROGRAM',
+    body: 'Tap any program card to see the full details and add it to your collection.',
+    placement: 'bottom',
     optional: true,
   },
 ]


### PR DESCRIPTION
## Summary
- New users (no programs) now land on the **Browse** tab by default instead of the empty My Programs tab
- A 4-step guided tour highlights the Browse tab, Level filter, Goals filter, and first program card
- Uses the existing tour system (`TourProvider`/`TourOverlay`/`TourTooltip`) and `UserSettings.completedTours` tracking — tour only shows once

## Test plan
- [ ] Log in as a new user with no programs — verify Browse tab is selected by default
- [ ] Verify the 4-step guided tour appears highlighting: Browse tab, Level filter, Goals filter, first program card
- [ ] Complete or skip the tour, navigate away and return — verify tour does not re-appear
- [ ] Log in as an existing user with programs — verify My Programs tab is still the default
- [ ] Verify tour doesn't interfere with other existing tours (Training page, Workout logger)

Fixes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)