### PR TITLE
feat: program activation redirect and continue/reset flow

### DIFF
--- a/__tests__/api/workout-history.test.ts
+++ b/__tests__/api/workout-history.test.ts
@@ -1,0 +1,159 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import {
+  createMultiWeekProgram,
+  createTestUser,
+  createTestWorkoutCompletion,
+} from '@/lib/test/factories'
+
+/**
+ * Simulates GET /api/programs/[programId]/workout-history
+ * Checks for non-archived WorkoutCompletion records on a program
+ */
+async function simulateWorkoutHistoryCheck(
+  prisma: PrismaClient,
+  programId: string,
+  userId: string
+): Promise<{ hasHistory: boolean; completionCount: number }> {
+  const completionCount = await prisma.workoutCompletion.count({
+    where: {
+      workout: {
+        week: {
+          programId,
+        },
+      },
+      userId,
+      isArchived: false,
+    },
+  })
+
+  return {
+    hasHistory: completionCount > 0,
+    completionCount,
+  }
+}
+
+describe('Workout History Check', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('should return no history for a fresh program', async () => {
+    const { program } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 2,
+      workoutsPerWeek: 3,
+    })
+
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, userId)
+
+    expect(result.hasHistory).toBe(false)
+    expect(result.completionCount).toBe(0)
+  })
+
+  it('should return history when program has completed workouts', async () => {
+    const { program, workouts } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 1,
+      workoutsPerWeek: 3,
+    })
+
+    await createTestWorkoutCompletion(prisma, workouts[0].id, userId, 'completed')
+    await createTestWorkoutCompletion(prisma, workouts[1].id, userId, 'completed')
+
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, userId)
+
+    expect(result.hasHistory).toBe(true)
+    expect(result.completionCount).toBe(2)
+  })
+
+  it('should not count archived completions', async () => {
+    const { program, workouts } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 1,
+      workoutsPerWeek: 3,
+    })
+
+    // Create a completion and then archive it (simulating a restart)
+    const completion = await createTestWorkoutCompletion(
+      prisma,
+      workouts[0].id,
+      userId,
+      'completed'
+    )
+    await prisma.workoutCompletion.update({
+      where: { id: completion.id },
+      data: { isArchived: true },
+    })
+
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, userId)
+
+    expect(result.hasHistory).toBe(false)
+    expect(result.completionCount).toBe(0)
+  })
+
+  it('should count non-archived completions even when archived ones exist', async () => {
+    const { program, workouts } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 1,
+      workoutsPerWeek: 3,
+    })
+
+    // Create an archived completion (from a previous cycle)
+    const archivedCompletion = await createTestWorkoutCompletion(
+      prisma,
+      workouts[0].id,
+      userId,
+      'completed'
+    )
+    await prisma.workoutCompletion.update({
+      where: { id: archivedCompletion.id },
+      data: { isArchived: true },
+    })
+
+    // Create a current (non-archived) completion
+    await createTestWorkoutCompletion(prisma, workouts[1].id, userId, 'completed')
+
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, userId)
+
+    expect(result.hasHistory).toBe(true)
+    expect(result.completionCount).toBe(1)
+  })
+
+  it('should not count completions from other users', async () => {
+    const { program, workouts } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 1,
+      workoutsPerWeek: 3,
+    })
+
+    // Create a completion for our user
+    await createTestWorkoutCompletion(prisma, workouts[0].id, userId, 'completed')
+
+    // Query as a different user — should see nothing
+    const otherUserId = 'other-user-id'
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, otherUserId)
+
+    expect(result.hasHistory).toBe(false)
+    expect(result.completionCount).toBe(0)
+  })
+
+  it('should count draft completions as history', async () => {
+    const { program, workouts } = await createMultiWeekProgram(prisma, userId, {
+      weekCount: 1,
+      workoutsPerWeek: 2,
+    })
+
+    // A draft completion means the user started but didn't finish
+    await createTestWorkoutCompletion(prisma, workouts[0].id, userId, 'draft')
+
+    const result = await simulateWorkoutHistoryCheck(prisma, program.id, userId)
+
+    expect(result.hasHistory).toBe(true)
+    expect(result.completionCount).toBe(1)
+  })
+})

--- a/app/api/programs/[programId]/workout-history/route.ts
+++ b/app/api/programs/[programId]/workout-history/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+/**
+ * GET /api/programs/[programId]/workout-history
+ * Check if a program has non-archived workout completion records
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ programId: string }> }
+) {
+  try {
+    const { programId } = await params
+
+    const { user, error: authError } = await getCurrentUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const program = await prisma.program.findFirst({
+      where: {
+        id: programId,
+        userId: user.id,
+      },
+      select: { id: true },
+    })
+
+    if (!program) {
+      return NextResponse.json({ error: 'Program not found' }, { status: 404 })
+    }
+
+    const completionCount = await prisma.workoutCompletion.count({
+      where: {
+        workout: {
+          week: {
+            programId,
+          },
+        },
+        userId: user.id,
+        isArchived: false,
+      },
+    })
+
+    logger.debug({ programId, completionCount }, 'Workout history check')
+
+    return NextResponse.json({
+      hasHistory: completionCount > 0,
+      completionCount,
+    })
+  } catch (error) {
+    logger.error({ error }, 'Error checking workout history')
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 
 type ActivationConfirmModalProps = {
@@ -61,15 +61,7 @@ export default function ActivationConfirmModal({
     return () => controller.abort()
   }, [programId])
 
-  // Auto-activate if no history (just show the replace-active warning if needed)
-  useEffect(() => {
-    if (historyState.status === 'no_history' && !existingActiveProgram) {
-      activateAndRedirect()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyState.status])
-
-  const activateAndRedirect = async () => {
+  const activateAndRedirect = useCallback(async () => {
     setActivating(true)
     setError(null)
 
@@ -91,7 +83,14 @@ export default function ActivationConfirmModal({
       setError(err instanceof Error ? err.message : 'Failed to activate program')
       setActivating(false)
     }
-  }
+  }, [programId, router, onClose])
+
+  // Auto-activate if no history (just show the replace-active warning if needed)
+  useEffect(() => {
+    if (historyState.status === 'no_history' && !existingActiveProgram) {
+      activateAndRedirect()
+    }
+  }, [historyState.status, existingActiveProgram, activateAndRedirect])
 
   const handleResetAndActivate = async () => {
     setActivating(true)

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -85,7 +85,7 @@ export default function ActivationConfirmModal({
     }
   }, [programId, router, onClose])
 
-  // Auto-activate if no history (just show the replace-active warning if needed)
+  // Auto-activate if no history and no active program conflict
   useEffect(() => {
     if (historyState.status === 'no_history' && !existingActiveProgram) {
       activateAndRedirect()
@@ -97,7 +97,6 @@ export default function ActivationConfirmModal({
     setError(null)
 
     try {
-      // Reset first
       const restartResponse = await fetch(`/api/programs/${programId}/restart`, {
         method: 'POST',
       })
@@ -109,7 +108,6 @@ export default function ActivationConfirmModal({
       const restartData = await restartResponse.json()
       clientLogger.info(`Archived ${restartData.archivedCompletions} completions before activation`)
 
-      // Then activate
       await activateAndRedirect()
     } catch (err) {
       clientLogger.error('Error resetting and activating program:', err)
@@ -121,10 +119,7 @@ export default function ActivationConfirmModal({
   // Loading state
   if (historyState.status === 'loading') {
     return (
-      <div
-        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      >
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
         <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
           <div className="flex justify-center py-4">
             <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
@@ -137,10 +132,7 @@ export default function ActivationConfirmModal({
   // Auto-activating (no history, no active program conflict)
   if (historyState.status === 'no_history' && !existingActiveProgram) {
     return (
-      <div
-        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      >
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
         <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
           {error ? (
             <>
@@ -150,7 +142,7 @@ export default function ActivationConfirmModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 CLOSE
               </button>
@@ -165,13 +157,10 @@ export default function ActivationConfirmModal({
     )
   }
 
-  // Error checking history — show it but let user proceed
+  // Error checking history -- let user proceed anyway
   if (historyState.status === 'error') {
     return (
-      <div
-        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      >
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
         <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
           <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
             ACTIVATE PROGRAM?
@@ -224,10 +213,7 @@ export default function ActivationConfirmModal({
   const hasHistory = historyState.status === 'has_history'
 
   return (
-    <div
-      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-      className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-    >
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
         <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
           ACTIVATE PROGRAM?
@@ -246,7 +232,7 @@ export default function ActivationConfirmModal({
         )}
 
         {hasHistory && (
-          <div className="bg-accent-muted border border-accent p-3 mb-4">
+          <div className="bg-muted border border-border p-3 mb-4">
             <p className="text-sm text-foreground">
               This program has <span className="font-bold">{historyState.completionCount}</span> completed workout{historyState.completionCount !== 1 ? 's' : ''}. Would you like to continue where you left off or start fresh?
             </p>
@@ -274,13 +260,21 @@ export default function ActivationConfirmModal({
                 type="button"
                 onClick={handleResetAndActivate}
                 disabled={activating}
-                className="w-full px-4 py-3 bg-secondary text-secondary-foreground border-2 border-secondary hover:bg-secondary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 {activating ? 'RESETTING...' : 'START FRESH'}
               </button>
               <p className="text-xs text-muted-foreground text-center">
                 Starting fresh archives your progress but keeps your logged sets for history
               </p>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={activating}
+                className="w-full px-4 py-2 text-muted-foreground hover:text-foreground text-sm font-medium uppercase tracking-wider"
+              >
+                CANCEL
+              </button>
             </>
           ) : (
             <div className="flex gap-3">
@@ -301,17 +295,6 @@ export default function ActivationConfirmModal({
                 {activating ? 'ACTIVATING...' : 'YES, ACTIVATE'}
               </button>
             </div>
-          )}
-
-          {hasHistory && (
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={activating}
-              className="w-full px-4 py-2 text-muted-foreground hover:text-foreground text-sm font-medium uppercase tracking-wider"
-            >
-              CANCEL
-            </button>
           )}
         </div>
       </div>

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -120,7 +120,7 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'loading') {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
+        <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
           <div className="flex justify-center py-4">
             <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
           </div>
@@ -133,7 +133,7 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'no_history' && !existingActiveProgram) {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
+        <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
           {error ? (
             <>
               <div className="bg-error-muted border border-error-border p-3 mb-4">
@@ -161,19 +161,19 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'error') {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-          <h3 className="text-2xl font-bold text-foreground doom-heading mb-3">
+        <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
+          <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
             ACTIVATE {programName.toUpperCase()}
           </h3>
 
           {existingActiveProgram && (
-            <p className="text-sm text-warning-text mb-3">
+            <p className="text-sm text-warning-text mb-4">
               Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
             </p>
           )}
 
           {error && (
-            <div className="bg-error-muted border border-error-border p-3 mb-4">
+            <div className="bg-error-muted border border-error-border p-3 mb-6">
               <p className="text-sm text-error">{error}</p>
             </div>
           )}
@@ -206,28 +206,25 @@ export default function ActivationConfirmModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-        <h3 className="text-xl font-bold text-foreground doom-heading mb-1">
-          ACTIVATE
+      <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
+        <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
+          ACTIVATE {programName.toUpperCase()}
         </h3>
-        <p className="text-lg font-semibold text-foreground mb-3">
-          {programName}
-        </p>
 
         {existingActiveProgram && (
-          <p className="text-sm text-warning-text mb-3">
+          <p className="text-sm text-warning-text mb-4">
             Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
           </p>
         )}
 
         {hasHistory && (
-          <p className="text-sm text-muted-foreground mb-4">
+          <p className="text-sm text-muted-foreground mb-6">
             {historyState.completionCount} workout{historyState.completionCount !== 1 ? 's' : ''} logged — continue or start fresh?
           </p>
         )}
 
         {error && (
-          <div className="bg-error-muted border border-error-border p-3 mb-4">
+          <div className="bg-error-muted border border-error-border p-3 mb-6">
             <p className="text-sm text-error">{error}</p>
           </div>
         )}

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -162,22 +162,14 @@ export default function ActivationConfirmModal({
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
         <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-          <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
-            ACTIVATE PROGRAM?
+          <h3 className="text-2xl font-bold text-foreground doom-heading mb-3">
+            ACTIVATE {programName.toUpperCase()}
           </h3>
 
-          <div className="bg-warning-muted border border-warning-border p-3 mb-4">
-            <p className="text-sm text-warning-text">
-              Could not check workout history. You can still activate.
-            </p>
-          </div>
-
           {existingActiveProgram && (
-            <div className="bg-warning-muted border border-warning-border p-3 mb-4">
-              <p className="text-sm text-warning-text">
-                <span className="font-semibold">Warning:</span> This will replace your current active program: <span className="font-bold">{existingActiveProgram.name}</span>
-              </p>
-            </div>
+            <p className="text-sm text-warning-text mb-3">
+              Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
+            </p>
           )}
 
           {error && (
@@ -215,28 +207,20 @@ export default function ActivationConfirmModal({
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-        <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
-          ACTIVATE PROGRAM?
+        <h3 className="text-2xl font-bold text-foreground doom-heading mb-3">
+          ACTIVATE {programName.toUpperCase()}
         </h3>
 
-        <p className="text-muted-foreground mb-4">
-          Activate <span className="font-bold text-foreground">{programName}</span>
-        </p>
-
         {existingActiveProgram && (
-          <div className="bg-warning-muted border border-warning-border p-3 mb-4">
-            <p className="text-sm text-warning-text">
-              <span className="font-semibold">Warning:</span> This will replace your current active program: <span className="font-bold">{existingActiveProgram.name}</span>
-            </p>
-          </div>
+          <p className="text-sm text-warning-text mb-3">
+            Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
+          </p>
         )}
 
         {hasHistory && (
-          <div className="bg-muted border border-border p-3 mb-4">
-            <p className="text-sm text-foreground">
-              This program has <span className="font-bold">{historyState.completionCount}</span> completed workout{historyState.completionCount !== 1 ? 's' : ''}. Would you like to continue where you left off or start fresh?
-            </p>
-          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            {historyState.completionCount} workout{historyState.completionCount !== 1 ? 's' : ''} logged — continue or start fresh?
+          </p>
         )}
 
         {error && (
@@ -254,7 +238,7 @@ export default function ActivationConfirmModal({
                 disabled={activating}
                 className="w-full px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
-                {activating ? 'ACTIVATING...' : 'CONTINUE WHERE I LEFT OFF'}
+                {activating ? 'ACTIVATING...' : 'CONTINUE'}
               </button>
               <button
                 type="button"
@@ -268,7 +252,7 @@ export default function ActivationConfirmModal({
                 type="button"
                 onClick={onClose}
                 disabled={activating}
-                className="w-full px-4 py-3 border-2 border-border text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 font-semibold uppercase tracking-wider"
               >
                 CANCEL
               </button>

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -1,0 +1,321 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { clientLogger } from '@/lib/client-logger'
+
+type ActivationConfirmModalProps = {
+  programId: string
+  programName: string
+  existingActiveProgram?: { id: string; name: string } | null
+  onClose: () => void
+}
+
+type HistoryState =
+  | { status: 'loading' }
+  | { status: 'no_history' }
+  | { status: 'has_history'; completionCount: number }
+  | { status: 'error'; message: string }
+
+export default function ActivationConfirmModal({
+  programId,
+  programName,
+  existingActiveProgram,
+  onClose,
+}: ActivationConfirmModalProps) {
+  const router = useRouter()
+  const [historyState, setHistoryState] = useState<HistoryState>({ status: 'loading' })
+  const [activating, setActivating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Check workout history on mount
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const checkHistory = async () => {
+      try {
+        const response = await fetch(`/api/programs/${programId}/workout-history`, {
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to check workout history')
+        }
+
+        const data = await response.json()
+
+        if (data.hasHistory) {
+          setHistoryState({ status: 'has_history', completionCount: data.completionCount })
+        } else {
+          setHistoryState({ status: 'no_history' })
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        clientLogger.error('Error checking workout history:', err)
+        setHistoryState({ status: 'error', message: 'Failed to check workout history' })
+      }
+    }
+
+    checkHistory()
+
+    return () => controller.abort()
+  }, [programId])
+
+  // Auto-activate if no history (just show the replace-active warning if needed)
+  useEffect(() => {
+    if (historyState.status === 'no_history' && !existingActiveProgram) {
+      activateAndRedirect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [historyState.status])
+
+  const activateAndRedirect = async () => {
+    setActivating(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/programs/${programId}/activate`, {
+        method: 'POST',
+      })
+
+      const data = await response.json()
+      if (!data.success) {
+        throw new Error(data.error || 'Failed to activate program')
+      }
+
+      router.push('/training')
+      router.refresh()
+      onClose()
+    } catch (err) {
+      clientLogger.error('Error activating program:', err)
+      setError(err instanceof Error ? err.message : 'Failed to activate program')
+      setActivating(false)
+    }
+  }
+
+  const handleResetAndActivate = async () => {
+    setActivating(true)
+    setError(null)
+
+    try {
+      // Reset first
+      const restartResponse = await fetch(`/api/programs/${programId}/restart`, {
+        method: 'POST',
+      })
+
+      if (!restartResponse.ok) {
+        throw new Error('Failed to reset program')
+      }
+
+      const restartData = await restartResponse.json()
+      clientLogger.info(`Archived ${restartData.archivedCompletions} completions before activation`)
+
+      // Then activate
+      await activateAndRedirect()
+    } catch (err) {
+      clientLogger.error('Error resetting and activating program:', err)
+      setError(err instanceof Error ? err.message : 'Failed to reset program')
+      setActivating(false)
+    }
+  }
+
+  // Loading state
+  if (historyState.status === 'loading') {
+    return (
+      <div
+        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      >
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+          <div className="flex justify-center py-4">
+            <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Auto-activating (no history, no active program conflict)
+  if (historyState.status === 'no_history' && !existingActiveProgram) {
+    return (
+      <div
+        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      >
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+          {error ? (
+            <>
+              <div className="bg-error-muted border border-error-border p-3 mb-4">
+                <p className="text-sm text-error">{error}</p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                CLOSE
+              </button>
+            </>
+          ) : (
+            <div className="flex justify-center py-4">
+              <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // Error checking history — show it but let user proceed
+  if (historyState.status === 'error') {
+    return (
+      <div
+        style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+        className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      >
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+          <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
+            ACTIVATE PROGRAM?
+          </h3>
+
+          <div className="bg-warning-muted border border-warning-border p-3 mb-4">
+            <p className="text-sm text-warning-text">
+              Could not check workout history. You can still activate.
+            </p>
+          </div>
+
+          {existingActiveProgram && (
+            <div className="bg-warning-muted border border-warning-border p-3 mb-4">
+              <p className="text-sm text-warning-text">
+                <span className="font-semibold">Warning:</span> This will replace your current active program: <span className="font-bold">{existingActiveProgram.name}</span>
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-error-muted border border-error-border p-3 mb-4">
+              <p className="text-sm text-error">{error}</p>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={activating}
+              className="flex-1 px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+            >
+              CANCEL
+            </button>
+            <button
+              type="button"
+              onClick={activateAndRedirect}
+              disabled={activating}
+              className="flex-1 px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+            >
+              {activating ? 'ACTIVATING...' : 'ACTIVATE'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Main modal: has history OR needs to confirm replacing active program
+  const hasHistory = historyState.status === 'has_history'
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+      className="bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+    >
+      <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+        <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
+          ACTIVATE PROGRAM?
+        </h3>
+
+        <p className="text-muted-foreground mb-4">
+          Activate <span className="font-bold text-foreground">{programName}</span>
+        </p>
+
+        {existingActiveProgram && (
+          <div className="bg-warning-muted border border-warning-border p-3 mb-4">
+            <p className="text-sm text-warning-text">
+              <span className="font-semibold">Warning:</span> This will replace your current active program: <span className="font-bold">{existingActiveProgram.name}</span>
+            </p>
+          </div>
+        )}
+
+        {hasHistory && (
+          <div className="bg-accent-muted border border-accent p-3 mb-4">
+            <p className="text-sm text-foreground">
+              This program has <span className="font-bold">{historyState.completionCount}</span> completed workout{historyState.completionCount !== 1 ? 's' : ''}. Would you like to continue where you left off or start fresh?
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-error-muted border border-error-border p-3 mb-4">
+            <p className="text-sm text-error">{error}</p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3">
+          {hasHistory ? (
+            <>
+              <button
+                type="button"
+                onClick={activateAndRedirect}
+                disabled={activating}
+                className="w-full px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                {activating ? 'ACTIVATING...' : 'CONTINUE WHERE I LEFT OFF'}
+              </button>
+              <button
+                type="button"
+                onClick={handleResetAndActivate}
+                disabled={activating}
+                className="w-full px-4 py-3 bg-secondary text-secondary-foreground border-2 border-secondary hover:bg-secondary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                {activating ? 'RESETTING...' : 'START FRESH'}
+              </button>
+              <p className="text-xs text-muted-foreground text-center">
+                Starting fresh archives your progress but keeps your logged sets for history
+              </p>
+            </>
+          ) : (
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={activating}
+                className="flex-1 px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                CANCEL
+              </button>
+              <button
+                type="button"
+                onClick={activateAndRedirect}
+                disabled={activating}
+                className="flex-1 px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              >
+                {activating ? 'ACTIVATING...' : 'YES, ACTIVATE'}
+              </button>
+            </div>
+          )}
+
+          {hasHistory && (
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={activating}
+              className="w-full px-4 py-2 text-muted-foreground hover:text-foreground text-sm font-medium uppercase tracking-wider"
+            >
+              CANCEL
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -258,24 +258,24 @@ export default function ActivationConfirmModal({
               </button>
             </>
           ) : (
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={activating}
-                className="flex-1 px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
-              >
-                CANCEL
-              </button>
+            <>
               <button
                 type="button"
                 onClick={activateAndRedirect}
                 disabled={activating}
-                className="flex-1 px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 {activating ? 'ACTIVATING...' : 'YES, ACTIVATE'}
               </button>
-            </div>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={activating}
+                className="w-full py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 font-semibold uppercase tracking-wider"
+              >
+                CANCEL
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -207,9 +207,12 @@ export default function ActivationConfirmModal({
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-        <h3 className="text-2xl font-bold text-foreground doom-heading mb-3">
-          ACTIVATE {programName.toUpperCase()}
+        <h3 className="text-xl font-bold text-foreground doom-heading mb-1">
+          ACTIVATE
         </h3>
+        <p className="text-lg font-semibold text-foreground mb-3">
+          {programName}
+        </p>
 
         {existingActiveProgram && (
           <p className="text-sm text-warning-text mb-3">

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -27,6 +27,7 @@ export default function ActivationConfirmModal({
   const [historyState, setHistoryState] = useState<HistoryState>({ status: 'loading' })
   const [activating, setActivating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [confirmingReset, setConfirmingReset] = useState(false)
 
   // Check workout history on mount
   useEffect(() => {
@@ -204,6 +205,48 @@ export default function ActivationConfirmModal({
   // Main modal: has history OR needs to confirm replacing active program
   const hasHistory = historyState.status === 'has_history'
 
+  // Reset confirmation view
+  if (confirmingReset) {
+    return (
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+        <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
+          <h3 className="text-xl font-bold text-foreground doom-heading mb-4">
+            START FRESH?
+          </h3>
+
+          <p className="text-base text-warning-text mb-6">
+            Workout completion progress will be reset. Your logged sets are kept for history.
+          </p>
+
+          {error && (
+            <div className="bg-error-muted border border-error-border p-3 mb-6">
+              <p className="text-sm text-error">{error}</p>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={handleResetAndActivate}
+              disabled={activating}
+              className="w-full px-4 py-2.5 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+            >
+              {activating ? 'RESETTING...' : 'YES, START FRESH'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingReset(false)}
+              disabled={activating}
+              className="w-full py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 font-semibold uppercase tracking-wider"
+            >
+              GO BACK
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
@@ -242,11 +285,11 @@ export default function ActivationConfirmModal({
               </button>
               <button
                 type="button"
-                onClick={handleResetAndActivate}
+                onClick={() => setConfirmingReset(true)}
                 disabled={activating}
                 className="w-full px-4 py-2.5 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
-                {activating ? 'RESETTING...' : 'START FRESH'}
+                START FRESH
               </button>
               <button
                 type="button"

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -142,7 +142,7 @@ export default function ActivationConfirmModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-2.5 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 CLOSE
               </button>
@@ -162,12 +162,12 @@ export default function ActivationConfirmModal({
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
         <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-          <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
+          <h3 className="text-xl font-bold text-foreground doom-heading mb-4">
             ACTIVATE {programName.toUpperCase()}
           </h3>
 
           {existingActiveProgram && (
-            <p className="text-sm text-warning-text mb-4">
+            <p className="text-base text-warning-text mb-4">
               Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
             </p>
           )}
@@ -183,7 +183,7 @@ export default function ActivationConfirmModal({
               type="button"
               onClick={onClose}
               disabled={activating}
-              className="flex-1 px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              className="flex-1 px-4 py-2.5 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
             >
               CANCEL
             </button>
@@ -191,7 +191,7 @@ export default function ActivationConfirmModal({
               type="button"
               onClick={activateAndRedirect}
               disabled={activating}
-              className="flex-1 px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+              className="flex-1 px-4 py-2.5 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
             >
               {activating ? 'ACTIVATING...' : 'ACTIVATE'}
             </button>
@@ -207,18 +207,18 @@ export default function ActivationConfirmModal({
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border-2 border-primary p-8 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
-        <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
+        <h3 className="text-xl font-bold text-foreground doom-heading mb-4">
           ACTIVATE {programName.toUpperCase()}
         </h3>
 
         {existingActiveProgram && (
-          <p className="text-sm text-warning-text mb-4">
+          <p className="text-base text-warning-text mb-4">
             Replaces <span className="font-bold">{existingActiveProgram.name}</span> as active program
           </p>
         )}
 
         {hasHistory && (
-          <p className="text-sm text-muted-foreground mb-6">
+          <p className="text-base text-muted-foreground mb-6">
             {historyState.completionCount} workout{historyState.completionCount !== 1 ? 's' : ''} logged — continue or start fresh?
           </p>
         )}
@@ -236,7 +236,7 @@ export default function ActivationConfirmModal({
                 type="button"
                 onClick={activateAndRedirect}
                 disabled={activating}
-                className="w-full px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-2.5 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 {activating ? 'ACTIVATING...' : 'CONTINUE'}
               </button>
@@ -244,7 +244,7 @@ export default function ActivationConfirmModal({
                 type="button"
                 onClick={handleResetAndActivate}
                 disabled={activating}
-                className="w-full px-4 py-3 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-2.5 border-2 border-border text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 {activating ? 'RESETTING...' : 'START FRESH'}
               </button>
@@ -263,7 +263,7 @@ export default function ActivationConfirmModal({
                 type="button"
                 onClick={activateAndRedirect}
                 disabled={activating}
-                className="w-full px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
+                className="w-full px-4 py-2.5 bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 {activating ? 'ACTIVATING...' : 'YES, ACTIVATE'}
               </button>

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -120,7 +120,7 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'loading') {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
           <div className="flex justify-center py-4">
             <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
           </div>
@@ -133,7 +133,7 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'no_history' && !existingActiveProgram) {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
           {error ? (
             <>
               <div className="bg-error-muted border border-error-border p-3 mb-4">
@@ -161,7 +161,7 @@ export default function ActivationConfirmModal({
   if (historyState.status === 'error') {
     return (
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+        <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
           <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
             ACTIVATE PROGRAM?
           </h3>
@@ -214,7 +214,7 @@ export default function ActivationConfirmModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card shadow-2xl">
+      <div className="bg-card border-2 border-primary p-6 max-w-md w-full doom-noise doom-card doom-corners shadow-2xl">
         <h3 className="text-2xl font-bold text-foreground doom-heading mb-4">
           ACTIVATE PROGRAM?
         </h3>
@@ -264,14 +264,11 @@ export default function ActivationConfirmModal({
               >
                 {activating ? 'RESETTING...' : 'START FRESH'}
               </button>
-              <p className="text-xs text-muted-foreground text-center">
-                Starting fresh archives your progress but keeps your logged sets for history
-              </p>
               <button
                 type="button"
                 onClick={onClose}
                 disabled={activating}
-                className="w-full px-4 py-2 text-muted-foreground hover:text-foreground text-sm font-medium uppercase tracking-wider"
+                className="w-full px-4 py-3 border-2 border-border text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 doom-button-3d doom-focus-ring font-semibold uppercase tracking-wider"
               >
                 CANCEL
               </button>

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -283,6 +283,7 @@ export default function ConsolidatedProgramsView({
                 localCopyStatuses={localCopyStatuses}
                 deletedPrograms={deletedPrograms}
                 hasActiveProgram={!!activeProgram}
+                activeProgram={activeProgram ? { id: activeProgram.id, name: activeProgram.name } : null}
               />
 
               {archivedStrengthCount > 0 && (

--- a/components/programs/MyProgramsList.tsx
+++ b/components/programs/MyProgramsList.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useToast } from '@/components/ToastProvider'
 import { clientLogger } from '@/lib/client-logger'
+import ActivationConfirmModal from './ActivationConfirmModal'
 
 type Program = {
   id: string
@@ -24,6 +25,7 @@ type Props = {
   localCopyStatuses: Record<string, string>
   deletedPrograms: Set<string>
   hasActiveProgram: boolean
+  activeProgram?: { id: string; name: string } | null
 }
 
 const INITIAL_SHOW = 5
@@ -34,14 +36,15 @@ export default function MyProgramsList({
   localCopyStatuses,
   deletedPrograms,
   hasActiveProgram,
+  activeProgram,
 }: Props) {
   const router = useRouter()
   const toast = useToast()
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [showAll, setShowAll] = useState(false)
-  const [activating, setActivating] = useState<string | null>(null)
   const [archiving, setArchiving] = useState<string | null>(null)
   const [duplicating, setDuplicating] = useState<string | null>(null)
+  const [activationTarget, setActivationTarget] = useState<{ id: string; name: string } | null>(null)
 
   // Filter out active program (shown in strip) and deleted programs
   const inactivePrograms = programs
@@ -51,24 +54,8 @@ export default function MyProgramsList({
   const displayedPrograms = showAll ? inactivePrograms : inactivePrograms.slice(0, INITIAL_SHOW)
   const hasMore = inactivePrograms.length > INITIAL_SHOW
 
-  const handleActivate = async (programId: string, programName: string) => {
-    if (hasActiveProgram) {
-      if (!confirm(`This will replace your current active program. Activate "${programName}"?`)) return
-    }
-    setActivating(programId)
-    try {
-      const response = await fetch(`/api/programs/${programId}/activate`, { method: 'POST' })
-      if (response.ok) {
-        router.refresh()
-      } else {
-        toast.error('Failed to activate program')
-      }
-    } catch (error) {
-      clientLogger.error('Error activating program:', error)
-      toast.error('Failed to activate program')
-    } finally {
-      setActivating(null)
-    }
+  const handleActivate = (programId: string, programName: string) => {
+    setActivationTarget({ id: programId, name: programName })
   }
 
   const handleArchive = async (programId: string, programName: string) => {
@@ -134,7 +121,7 @@ export default function MyProgramsList({
           const isCloning = copyStatus === 'cloning' || copyStatus?.startsWith('cloning_week_')
           const progress = cloningProgress[program.id]
           const isExpanded = expandedId === program.id
-          const isLoading = activating === program.id || archiving === program.id || duplicating === program.id
+          const isLoading = archiving === program.id || duplicating === program.id
 
           return (
             <div key={program.id}>
@@ -191,11 +178,7 @@ export default function MyProgramsList({
                       disabled={isLoading}
                       className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-button-3d doom-focus-ring disabled:opacity-50"
                     >
-                      {activating === program.id ? (
-                        <div className="w-4 h-4 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" />
-                      ) : (
-                        <Star size={14} />
-                      )}
+                      <Star size={14} />
                       ACTIVATE
                     </button>
                     <Link
@@ -251,6 +234,15 @@ export default function MyProgramsList({
       )}
 
       <CreateProgramRow />
+
+      {activationTarget && (
+        <ActivationConfirmModal
+          programId={activationTarget.id}
+          programName={activationTarget.name}
+          existingActiveProgram={activeProgram}
+          onClose={() => setActivationTarget(null)}
+        />
+      )}
     </div>
   )
 }

--- a/components/programs/StrengthActions.tsx
+++ b/components/programs/StrengthActions.tsx
@@ -4,11 +4,13 @@ import { Archive, Copy, Star } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import ActivationConfirmModal from './ActivationConfirmModal'
 
 type StrengthActionsProps = {
   programId: string
   programName: string
   isActive: boolean
+  existingActiveProgram?: { id: string; name: string } | null
 }
 
 export function StrengthPrimaryActions({
@@ -55,12 +57,13 @@ export function StrengthUtilityActions({
   programId,
   programName,
   isActive,
+  existingActiveProgram,
   isMobile = false,
 }: StrengthActionsProps & { isMobile?: boolean }) {
   const router = useRouter()
   const [duplicating, setDuplicating] = useState(false)
-  const [activating, setActivating] = useState(false)
   const [archiving, setArchiving] = useState(false)
+  const [showActivationModal, setShowActivationModal] = useState(false)
 
   const handleDuplicate = async () => {
     if (
@@ -87,26 +90,6 @@ export function StrengthUtilityActions({
       alert('Failed to duplicate program. Please try again.')
     } finally {
       setDuplicating(false)
-    }
-  }
-
-  const handleSetActive = async () => {
-    setActivating(true)
-    try {
-      const response = await fetch(`/api/programs/${programId}/activate`, {
-        method: 'POST',
-      })
-
-      if (!response.ok) {
-        throw new Error('Failed to activate program')
-      }
-
-      router.refresh()
-    } catch (error) {
-      console.error('Error activating program:', error)
-      alert('Failed to activate program. Please try again.')
-    } finally {
-      setActivating(false)
     }
   }
 
@@ -145,8 +128,7 @@ export function StrengthUtilityActions({
               <Copy className="w-5 h-5" />
             </button>
             <button type="button"
-              onClick={handleSetActive}
-              disabled={activating}
+              onClick={() => setShowActivationModal(true)}
               className="p-2 text-muted-foreground hover:text-accent hover:bg-muted rounded transition-colors disabled:opacity-50"
               title="Set Active"
               aria-label="Set as active program"
@@ -164,6 +146,14 @@ export function StrengthUtilityActions({
         >
           <Archive className="w-5 h-5" />
         </button>
+        {showActivationModal && (
+          <ActivationConfirmModal
+            programId={programId}
+            programName={programName}
+            existingActiveProgram={existingActiveProgram}
+            onClose={() => setShowActivationModal(false)}
+          />
+        )}
       </>
     )
   }
@@ -180,11 +170,10 @@ export function StrengthUtilityActions({
             {duplicating ? 'Duplicating...' : 'Duplicate'}
           </button>
           <button type="button"
-            onClick={handleSetActive}
-            disabled={activating}
-            className="px-3 py-1.5 text-sm text-muted-foreground hover:text-accent hover:bg-muted transition-colors font-medium disabled:opacity-50"
+            onClick={() => setShowActivationModal(true)}
+            className="px-3 py-1.5 text-sm text-muted-foreground hover:text-accent hover:bg-muted transition-colors font-medium"
           >
-            {activating ? 'Activating...' : 'Set Active'}
+            Set Active
           </button>
         </>
       )}
@@ -195,6 +184,14 @@ export function StrengthUtilityActions({
       >
         {archiving ? 'Archiving...' : 'Archive'}
       </button>
+      {showActivationModal && (
+        <ActivationConfirmModal
+          programId={programId}
+          programName={programName}
+          existingActiveProgram={existingActiveProgram}
+          onClose={() => setShowActivationModal(false)}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary

- Activating a program now redirects to `/training` instead of just refreshing `/programs`
- When activating a program with existing workout history, shows a modal with **Continue** vs **Start Fresh** options
- "Start Fresh" has a confirmation step warning that completion progress resets (logged sets preserved)
- Replaces `window.confirm()` with proper themed modal matching existing UI patterns

## Changes

- **New**: `GET /api/programs/[programId]/workout-history` — checks for non-archived completions
- **New**: `ActivationConfirmModal` — handles history check, continue/reset/confirm flows
- **Updated**: `StrengthActions`, `MyProgramsList`, `ConsolidatedProgramsView` — wired up modal
- **New**: Integration tests for workout history endpoint (6 tests)

## Test plan

- [ ] Activate a program with no workout history — should activate and redirect to /training
- [ ] Activate a program with workout history — should show continue/start fresh modal
- [ ] Click "Continue" — activates as-is, redirects to /training
- [ ] Click "Start Fresh" — shows confirmation, then resets and activates
- [ ] Activate when another program is active — shows "Replaces X" warning
- [ ] Cancel at any step — returns to programs page without changes

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)