### PR TITLE
feat: dark mode detection for auth pages

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -14,11 +14,14 @@ export default function AuthLayout({
               var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
               root.dataset.mode = isDark ? 'dark' : 'light';
               if (isDark) { root.classList.add('dark'); } else { root.classList.remove('dark'); }
-              var mql = window.matchMedia('(prefers-color-scheme: dark)');
-              mql.addEventListener('change', function(e) {
-                root.dataset.mode = e.matches ? 'dark' : 'light';
-                if (e.matches) { root.classList.add('dark'); } else { root.classList.remove('dark'); }
-              });
+              if (!window.__authThemeListenerAttached) {
+                var mql = window.matchMedia('(prefers-color-scheme: dark)');
+                mql.addEventListener('change', function(e) {
+                  root.dataset.mode = e.matches ? 'dark' : 'light';
+                  if (e.matches) { root.classList.add('dark'); } else { root.classList.remove('dark'); }
+                });
+                window.__authThemeListenerAttached = true;
+              }
             })();
           `,
         }}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -3,5 +3,27 @@ export default function AuthLayout({
 }: {
   children: React.ReactNode
 }) {
-  return <>{children}</>
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function() {
+              var root = document.documentElement;
+              root.dataset.theme = 'ripit';
+              var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              root.dataset.mode = isDark ? 'dark' : 'light';
+              if (isDark) { root.classList.add('dark'); } else { root.classList.remove('dark'); }
+              var mql = window.matchMedia('(prefers-color-scheme: dark)');
+              mql.addEventListener('change', function(e) {
+                root.dataset.mode = e.matches ? 'dark' : 'light';
+                if (e.matches) { root.classList.add('dark'); } else { root.classList.remove('dark'); }
+              });
+            })();
+          `,
+        }}
+      />
+      {children}
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- Auth pages (login, signup, forgot-password, reset-password, complete-profile) now detect the device's preferred color scheme (light/dark) and apply the RIPIT theme accordingly
- An inline script in the auth layout overrides the root `data-theme` and `data-mode` attributes before paint, ensuring no flash of wrong theme
- A `prefers-color-scheme` media query listener updates the mode dynamically if the user toggles system dark/light mode while on an auth page
- When navigating to the main app after login (full page load), the stored user theme preference is restored by the root layout script

## Test plan
- [ ] Visit /login with system in dark mode -- should show RIPIT dark theme
- [ ] Visit /login with system in light mode -- should show RIPIT light theme
- [ ] Visit /signup with system in dark mode -- should show RIPIT dark theme
- [ ] Toggle system dark/light mode while on /login -- page should update immediately
- [ ] Login with a non-RIPIT theme stored (e.g. DOOM) -- main app should restore stored theme after redirect
- [ ] Visit /forgot-password and /reset-password -- should also respect system preference

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)