### PR TITLE
fix: resolve lint warnings across 13 files

### DIFF
--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import type { ArticleLevel, Prisma, TagCategory } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'

--- a/app/api/programs/[programId]/route.ts
+++ b/app/api/programs/[programId]/route.ts
@@ -21,7 +21,7 @@ export async function PATCH(
     const { name, description } = body
 
     // Validate required fields
-    if (!name || !name.trim()) {
+    if (!name?.trim()) {
       return NextResponse.json(
         { error: 'Program name is required' },
         { status: 400 }

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import type { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 

--- a/app/api/workouts/[workoutId]/route.ts
+++ b/app/api/workouts/[workoutId]/route.ts
@@ -161,7 +161,7 @@ export async function PATCH(
     const { name } = body
 
     // Validate required fields
-    if (!name || !name.trim()) {
+    if (!name?.trim()) {
       return NextResponse.json(
         { error: 'Workout name is required' },
         { status: 400 }

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -62,7 +62,7 @@ async function processCloneJob(job: Job<ProgramCloneJob>): Promise<void> {
     select: { programData: true },
   })
 
-  if (!communityProgram || !communityProgram.programData) {
+  if (!communityProgram?.programData) {
     throw new Error(`Community program not found or has no data: ${communityProgramId}`)
   }
 

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -367,7 +367,7 @@ export default function ExerciseLoggingModal({
     }
 
     performDeleteSet(exerciseId, setNumber)
-  }, [currentExercise?.id, loggedSets, currentExercise, performDeleteSet])
+  }, [currentExercise, loggedSets, performDeleteSet])
 
   const handleConfirmDelete = useCallback(() => {
     if (showDeleteConfirm.exerciseId && showDeleteConfirm.setNumber) {

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -334,7 +334,7 @@ export default function StrengthWeekView({
 
   // Opens logging modal with progressive loading (fast!)
   // Intercepts with primer (first ever) then warm-up (sessions 1-3)
-  const handleOpenLogging = async (workoutId: string) => {
+  const handleOpenLogging = useCallback(async (workoutId: string) => {
     // Prevent opening a different workout while a draft exists
     if (activeDraft && activeDraft.workoutId !== workoutId) {
       alert(
@@ -362,7 +362,7 @@ export default function StrengthWeekView({
     }
 
     await proceedToLogging(workoutId)
-  }
+  }, [activeDraft, showPrimer, primerOpen, showWarmup, warmupOpen, proceedToLogging])
 
   const handleWarmupCancel = () => {
     setWarmupOpen(false)

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -42,6 +42,7 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
       onKeyDown={e => { if (e.key === 'Escape') onCancel() }}
       aria-label="Close dialog"
     >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: presentation wrapper stops click propagation */}
       <div
         role="presentation"
         style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -192,6 +192,7 @@ export default function ConsolidatedProgramsView({
   }
 
   // Resume polling for cloning programs on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only effect
   useEffect(() => {
     const cloningPrograms = strengthPrograms.filter(p =>
       p.copyStatus === 'cloning' || p.copyStatus?.startsWith('cloning_week_')
@@ -207,6 +208,7 @@ export default function ConsolidatedProgramsView({
   }, [])
 
   // Poll for cloning status from URL param (after adding from community)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps intentionally limited to searchParams and cloningProgramId
   useEffect(() => {
     const cloningId = searchParams.get('cloning')
     if (cloningId && completedClones.has(cloningId)) return

--- a/components/ui/SwipeableCard.tsx
+++ b/components/ui/SwipeableCard.tsx
@@ -85,7 +85,7 @@ export default function SwipeableCard({
   }, [revealWidth])
 
   const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (!touchRef.current || !touchRef.current.directionLocked) {
+    if (!touchRef.current?.directionLocked) {
       touchRef.current = null
       setIsDragging(false)
       return

--- a/lib/community/cloning.ts
+++ b/lib/community/cloning.ts
@@ -81,7 +81,7 @@ export async function cloneCommunityProgram(
 
     const programData = communityProgram.programData as Record<string, unknown>;
 
-    if (!programData || !programData.weeks) {
+    if (!programData?.weeks) {
       return {
         success: false,
         error: 'Invalid program data',

--- a/lib/community/publishing.ts
+++ b/lib/community/publishing.ts
@@ -20,7 +20,7 @@ export async function getUserDisplayName(
   });
 
   // If no settings or displayName is null/empty, return fallback
-  if (!userSettings || !userSettings.displayName || userSettings.displayName.trim() === '') {
+  if (!userSettings?.displayName || userSettings.displayName.trim() === '') {
     return 'Anonymous User';
   }
 

--- a/lib/community/validation.ts
+++ b/lib/community/validation.ts
@@ -159,8 +159,7 @@ export async function isProgramPublished(
  * This should only be called when actually publishing, not during initial validation
  */
 // biome-ignore lint/suspicious/noExplicitAny: dynamic program metadata fields
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function validateProgramMetadata(program: Record<string, any>): ValidationResult {
+export function validateProgramMetadata(program: Record<string, any>): ValidationResult { // eslint-disable-line @typescript-eslint/no-explicit-any
   const errors: string[] = [];
 
   if (!program.level || program.level.trim() === '') {


### PR DESCRIPTION
## Summary

- Fix import ordering (biome organizeImports) in 2 API routes
- Replace verbose null checks with optional chaining in 5 files (API routes, SwipeableCard, community libs, clone worker)
- Wrap `handleOpenLogging` in `useCallback` to stabilize useEffect dependency in StrengthWeekView
- Remove redundant `currentExercise.id` from useCallback deps in ExerciseLoggingModal (already covered by `currentExercise`)
- Fix stale biome-ignore directive in validation.ts (reorder so it targets the code line, not another comment)
- Add biome-ignore for intentionally scoped mount-only effects in ConsolidatedProgramsView
- Add biome-ignore for presentation wrapper click handler in WarmupInterstitial

## Test plan

- [ ] Type-check passes (verified locally)
- [ ] Biome check passes on all non-test/script source files (verified locally)
- [ ] ESLint passes with 0 errors (verified locally, 1 pre-existing warning in MediaUploader)
- [ ] All changes are mechanical (no behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)