### PR TITLE
Enable lesson capture on quality-check review stage

### DIFF
--- a/.claude/agents/quality-check.md
+++ b/.claude/agents/quality-check.md
@@ -8,6 +8,7 @@ mode: proactive
 output: pr
 stages:
   - name: review
+    captures_lessons: true
   - name: verify
     agent: reviewer
     on_failure: skip


### PR DESCRIPTION
## Summary

- Adds `captures_lessons: true` to the quality-check agent's first stage so its findings are captured as lessons for future agent runs
- The reviewer stage (second stage) already captures lessons automatically

## Test plan

- [ ] Run quality-check agent and verify lessons are captured from its review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)