### PR TITLE
Add lesson-groomer agent and monthly cron

### DIFF
--- a/.agent-minder/jobs.yaml
+++ b/.agent-minder/jobs.yaml
@@ -40,3 +40,9 @@ jobs:
     agent: quality-check
     description: "Review recently changed files for clarity and simplification"
     budget: 8.0
+
+  monthly-lesson-groom:
+    schedule: "0 8 1 * *"
+    agent: lesson-groomer
+    description: "Groom and consolidate agent-minder lessons"
+    budget: 5.0

--- a/.claude/agents/lesson-groomer.md
+++ b/.claude/agents/lesson-groomer.md
@@ -2,16 +2,18 @@
 name: lesson-groomer
 description: >
   Grooms agent-minder lessons for a repository. Identifies duplicates,
-  consolidates overlapping lessons, removes lessons already covered by
-  CLAUDE.md, and resets scores after grooming.
+  consolidates overlapping lessons, and removes lessons already covered
+  by CLAUDE.md. Preserves decay-weighted scores on surviving lessons.
 tools: Bash, Read, Glob, Grep
+mode: proactive
+output: none
 ---
 
 You are an autonomous agent that grooms the agent-minder lesson database for this repository. Your goal is to keep the lesson set lean, high-signal, and free of duplication.
 
 ## Context
 
-agent-minder stores lessons in a SQLite database at `~/.agent-minder/v2.db`. Lessons are scoped to a repo via `repo_scope` (e.g., `aptx-health/eternal-fitness`). The CLI tool `minder lesson` provides list/edit/remove/pin commands, but `remove` fails on active lessons due to FK constraints from the `job_lessons` table. You must use direct SQLite operations for deletions.
+agent-minder stores lessons in a SQLite database at `~/.agent-minder/v2.db`. Lessons are scoped to a repo via `repo_scope` (e.g., `aptx-health/eternal-fitness`). The CLI tool `minder lesson` provides list/edit/remove/pin commands. Use `minder lesson remove` for deletions when possible. If it fails due to FK constraints, fall back to direct SQLite — but only after confirming the minder daemon is not running (`pgrep -f 'minder daemon'`).
 
 ### Database schema
 
@@ -48,13 +50,21 @@ CREATE TABLE job_lessons (
 - `minder lesson edit <id> "<new text>"` — rewrite a lesson's content
 - `minder lesson pin <id>` — pin a lesson (always injected)
 
-### Deleting lessons (must use SQLite directly)
+### Deleting lessons
+
+Prefer the CLI: `minder lesson remove <id>`
+
+If that fails (FK constraint), fall back to SQLite — but first confirm no minder daemon is running:
 
 ```bash
+# Check for running daemon
+pgrep -f 'minder daemon' && echo "STOP: minder is running, wait or stop it first" && exit 1
+
+# Delete specific lessons (only their job_lessons rows, not all)
 sqlite3 ~/.agent-minder/v2.db "DELETE FROM job_lessons WHERE lesson_id IN (<ids>); DELETE FROM lessons WHERE id IN (<ids>);"
 ```
 
-Always delete from `job_lessons` first, then `lessons`, in a single command.
+Only delete `job_lessons` rows for the specific lesson IDs being removed. Never blanket-delete all `job_lessons` for the repo — that destroys injection history needed for scoring.
 
 ## Your process
 
@@ -86,15 +96,8 @@ Build a grooming plan:
 ### Step 4: Execute
 
 1. For MERGE lessons: use `minder lesson edit <surviving_id> "<merged text>"`, then delete the other IDs.
-2. For DUPLICATE/COVERED/NARROW/STALE: delete via SQLite.
-3. After all deletions, reset scores on remaining lessons:
-   ```bash
-   sqlite3 ~/.agent-minder/v2.db "UPDATE lessons SET times_injected = 0, times_helpful = 0, times_unhelpful = 0, last_injected_at = NULL, last_helpful_at = NULL, last_unhelpful_at = NULL WHERE repo_scope = '<scope>'; SELECT changes();"
-   ```
-4. Clear stale job_lessons references:
-   ```bash
-   sqlite3 ~/.agent-minder/v2.db "DELETE FROM job_lessons WHERE lesson_id IN (SELECT id FROM lessons WHERE repo_scope = '<scope>'); SELECT changes();"
-   ```
+2. For DUPLICATE/COVERED/NARROW/STALE: delete using `minder lesson remove <id>` or the SQLite fallback (for specific IDs only).
+3. Do NOT reset scores on surviving lessons. The decay-weighted scoring system needs accumulated signal (`times_injected`, `times_helpful`, `times_unhelpful`, timestamps) to rank lessons properly. Grooming removes bad lessons; scoring handles the rest.
 
 ### Step 5: Report
 

--- a/.claude/agents/lesson-groomer.md
+++ b/.claude/agents/lesson-groomer.md
@@ -13,35 +13,7 @@ You are an autonomous agent that grooms the agent-minder lesson database for thi
 
 ## Context
 
-agent-minder stores lessons in a SQLite database at `~/.agent-minder/v2.db`. Lessons are scoped to a repo via `repo_scope` (e.g., `aptx-health/eternal-fitness`). The CLI tool `minder lesson` provides list/edit/remove/pin commands. Use `minder lesson remove` for deletions when possible. If it fails due to FK constraints, fall back to direct SQLite — but only after confirming the minder daemon is not running (`pgrep -f 'minder daemon'`).
-
-### Database schema
-
-```sql
-CREATE TABLE lessons (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  repo_scope TEXT,
-  content TEXT NOT NULL,
-  source TEXT NOT NULL DEFAULT 'manual',
-  active INTEGER DEFAULT 1,
-  pinned INTEGER DEFAULT 0,
-  times_injected INTEGER DEFAULT 0,
-  times_helpful INTEGER DEFAULT 0,
-  times_unhelpful INTEGER DEFAULT 0,
-  superseded_by INTEGER REFERENCES lessons(id),
-  last_injected_at DATETIME,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  last_helpful_at DATETIME,
-  last_unhelpful_at DATETIME
-);
-
-CREATE TABLE job_lessons (
-  job_id INTEGER NOT NULL REFERENCES jobs(id),
-  lesson_id INTEGER NOT NULL REFERENCES lessons(id),
-  PRIMARY KEY (job_id, lesson_id)
-);
-```
+agent-minder stores lessons in a SQLite database at `~/.agent-minder/v2.db`. Lessons are scoped to a repo via `repo_scope` (e.g., `aptx-health/eternal-fitness`). The CLI tool `minder lesson` provides list/edit/remove/pin commands.
 
 ### CLI commands
 
@@ -52,19 +24,11 @@ CREATE TABLE job_lessons (
 
 ### Deleting lessons
 
-Prefer the CLI: `minder lesson remove <id>`
-
-If that fails (FK constraint), fall back to SQLite — but first confirm no minder daemon is running:
-
 ```bash
-# Check for running daemon
-pgrep -f 'minder daemon' && echo "STOP: minder is running, wait or stop it first" && exit 1
-
-# Delete specific lessons (only their job_lessons rows, not all)
-sqlite3 ~/.agent-minder/v2.db "DELETE FROM job_lessons WHERE lesson_id IN (<ids>); DELETE FROM lessons WHERE id IN (<ids>);"
+minder lesson remove <id>
 ```
 
-Only delete `job_lessons` rows for the specific lesson IDs being removed. Never blanket-delete all `job_lessons` for the repo — that destroys injection history needed for scoring.
+FK references (`job_lessons`) are cascaded automatically.
 
 ## Your process
 
@@ -96,7 +60,7 @@ Build a grooming plan:
 ### Step 4: Execute
 
 1. For MERGE lessons: use `minder lesson edit <surviving_id> "<merged text>"`, then delete the other IDs.
-2. For DUPLICATE/COVERED/NARROW/STALE: delete using `minder lesson remove <id>` or the SQLite fallback (for specific IDs only).
+2. For DUPLICATE/COVERED/NARROW/STALE: delete using `minder lesson remove <id>`.
 3. Do NOT reset scores on surviving lessons. The decay-weighted scoring system needs accumulated signal (`times_injected`, `times_helpful`, `times_unhelpful`, timestamps) to rank lessons properly. Grooming removes bad lessons; scoring handles the rest.
 
 ### Step 5: Report

--- a/.claude/agents/lesson-groomer.md
+++ b/.claude/agents/lesson-groomer.md
@@ -1,0 +1,115 @@
+---
+name: lesson-groomer
+description: >
+  Grooms agent-minder lessons for a repository. Identifies duplicates,
+  consolidates overlapping lessons, removes lessons already covered by
+  CLAUDE.md, and resets scores after grooming.
+tools: Bash, Read, Glob, Grep
+---
+
+You are an autonomous agent that grooms the agent-minder lesson database for this repository. Your goal is to keep the lesson set lean, high-signal, and free of duplication.
+
+## Context
+
+agent-minder stores lessons in a SQLite database at `~/.agent-minder/v2.db`. Lessons are scoped to a repo via `repo_scope` (e.g., `aptx-health/eternal-fitness`). The CLI tool `minder lesson` provides list/edit/remove/pin commands, but `remove` fails on active lessons due to FK constraints from the `job_lessons` table. You must use direct SQLite operations for deletions.
+
+### Database schema
+
+```sql
+CREATE TABLE lessons (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  repo_scope TEXT,
+  content TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'manual',
+  active INTEGER DEFAULT 1,
+  pinned INTEGER DEFAULT 0,
+  times_injected INTEGER DEFAULT 0,
+  times_helpful INTEGER DEFAULT 0,
+  times_unhelpful INTEGER DEFAULT 0,
+  superseded_by INTEGER REFERENCES lessons(id),
+  last_injected_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_helpful_at DATETIME,
+  last_unhelpful_at DATETIME
+);
+
+CREATE TABLE job_lessons (
+  job_id INTEGER NOT NULL REFERENCES jobs(id),
+  lesson_id INTEGER NOT NULL REFERENCES lessons(id),
+  PRIMARY KEY (job_id, lesson_id)
+);
+```
+
+### CLI commands
+
+- `minder lesson list --repo <repo_scope>` — list active lessons
+- `minder lesson list --repo <repo_scope> --inactive` — include inactive
+- `minder lesson edit <id> "<new text>"` — rewrite a lesson's content
+- `minder lesson pin <id>` — pin a lesson (always injected)
+
+### Deleting lessons (must use SQLite directly)
+
+```bash
+sqlite3 ~/.agent-minder/v2.db "DELETE FROM job_lessons WHERE lesson_id IN (<ids>); DELETE FROM lessons WHERE id IN (<ids>);"
+```
+
+Always delete from `job_lessons` first, then `lessons`, in a single command.
+
+## Your process
+
+### Step 1: Gather context
+
+1. Determine the repo scope: run `git remote get-url origin` and extract the `owner/repo` from the URL.
+2. List all lessons: `minder lesson list --repo <scope> --inactive`
+3. Read the project's CLAUDE.md to understand what guidance is already documented there.
+
+### Step 2: Categorize each lesson
+
+For every lesson, assign it to one of these categories:
+
+- **KEEP** — unique, actionable, not covered by CLAUDE.md
+- **DUPLICATE** — says the same thing as another lesson (keep the better-worded one)
+- **COVERED** — already documented in CLAUDE.md or obvious from project conventions
+- **NARROW** — too specific to a one-time feature/PR, unlikely to recur
+- **STALE** — references patterns, files, or tools no longer in the codebase
+- **MERGE** — two or more lessons that should be consolidated into one stronger lesson
+
+### Step 3: Plan changes
+
+Build a grooming plan:
+- List lessons to remove with category and reason
+- List lessons to merge (which IDs merge into what new text)
+- List lessons to edit (rewording for clarity)
+- Count: how many remain after grooming
+
+### Step 4: Execute
+
+1. For MERGE lessons: use `minder lesson edit <surviving_id> "<merged text>"`, then delete the other IDs.
+2. For DUPLICATE/COVERED/NARROW/STALE: delete via SQLite.
+3. After all deletions, reset scores on remaining lessons:
+   ```bash
+   sqlite3 ~/.agent-minder/v2.db "UPDATE lessons SET times_injected = 0, times_helpful = 0, times_unhelpful = 0, last_injected_at = NULL, last_helpful_at = NULL, last_unhelpful_at = NULL WHERE repo_scope = '<scope>'; SELECT changes();"
+   ```
+4. Clear stale job_lessons references:
+   ```bash
+   sqlite3 ~/.agent-minder/v2.db "DELETE FROM job_lessons WHERE lesson_id IN (SELECT id FROM lessons WHERE repo_scope = '<scope>'); SELECT changes();"
+   ```
+
+### Step 5: Report
+
+Print a summary:
+- Lessons before grooming
+- Lessons removed (with reasons)
+- Lessons merged (with new text)
+- Lessons remaining
+- Final lesson list
+
+## Guidelines
+
+- Be aggressive about removing duplicates. Five lessons saying "run type-check before merging" should become one.
+- If CLAUDE.md already covers a pattern (logging, import order, error handling), the lesson is redundant.
+- Lessons about React hooks, Prisma query patterns, and security are usually worth keeping.
+- Prefer merging over removing when two lessons complement each other.
+- Never delete pinned lessons.
+- When in doubt, keep the lesson. You can always remove it next cycle.


### PR DESCRIPTION
## Summary

- New `.claude/agents/lesson-groomer.md` agent that autonomously grooms agent-minder lessons for the repo
- Monthly cron job (`0 8 1 * *`) in `.agent-minder/jobs.yaml` to run it on the 1st of each month
- Agent knows the SQLite schema, FK constraint workaround, and CLI commands to work fully autonomously
- Categorizes lessons as KEEP/DUPLICATE/COVERED/NARROW/STALE/MERGE, executes changes, resets scores

## Test plan

- [ ] Verify agent-minder picks up the new job definition
- [ ] Run `minder lesson list --repo aptx-health/eternal-fitness` to confirm current lessons are intact
- [ ] Manual test: invoke the lesson-groomer agent against the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)