### PR TITLE
feat: add rate limiting to hot-path workout endpoints

### DIFF
--- a/app/api/workouts/[workoutId]/clear/route.ts
+++ b/app/api/workouts/[workoutId]/clear/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 
 
 export async function POST(
@@ -17,6 +18,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
 
     // Verify workout exists and user owns it
     const workout = await prisma.workout.findUnique({

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 
 type LoggedSetInput = {
   exerciseId: string
@@ -25,6 +26,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
 
     // Parse optional fallback sets (used when some per-set writes failed)
     const body = await request.json()

--- a/app/api/workouts/[workoutId]/draft/route.ts
+++ b/app/api/workouts/[workoutId]/draft/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, setLoggingLimiter } from '@/lib/rate-limit'
 
 type LoggedSetInput = {
   exerciseId: string
@@ -27,6 +28,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(setLoggingLimiter, user.id)
+    if (limited) return limited
 
     // Parse request body
     const body = await request.json()

--- a/app/api/workouts/[workoutId]/draft/sets/[setId]/route.ts
+++ b/app/api/workouts/[workoutId]/draft/sets/[setId]/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, setLoggingLimiter } from '@/lib/rate-limit'
 
 export async function DELETE(
   _request: NextRequest,
@@ -14,6 +15,9 @@ export async function DELETE(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(setLoggingLimiter, user.id)
+    if (limited) return limited
 
     // Find the set and verify ownership through the completion -> workout -> program chain
     const loggedSet = await prisma.loggedSet.findUnique({

--- a/app/api/workouts/[workoutId]/draft/sets/route.ts
+++ b/app/api/workouts/[workoutId]/draft/sets/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, setLoggingLimiter } from '@/lib/rate-limit'
 
 type SetInput = {
   exerciseId: string
@@ -25,6 +26,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(setLoggingLimiter, user.id)
+    if (limited) return limited
 
     const body = await request.json()
     const set = body as SetInput

--- a/app/api/workouts/[workoutId]/skip/route.ts
+++ b/app/api/workouts/[workoutId]/skip/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 
 export async function POST(
   _request: NextRequest,
@@ -16,6 +17,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
 
     // Verify workout exists and user owns it
     const workout = await prisma.workout.findUnique({

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,138 @@
+import { RateLimiterRedis, RateLimiterMemory } from 'rate-limiter-flexible'
+import { NextResponse } from 'next/server'
+import Redis from 'ioredis'
+import { logger } from '@/lib/logger'
+
+// Lazy singleton Redis connection for rate limiting
+let redisClient: Redis | null = null
+
+function getRedisClient(): Redis | null {
+  if (redisClient) return redisClient
+
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl) {
+    logger.warn('REDIS_URL not set, falling back to in-memory rate limiting')
+    return null
+  }
+
+  try {
+    redisClient = new Redis(redisUrl, {
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 3000,
+      lazyConnect: true,
+    })
+
+    redisClient.on('error', (err) => {
+      logger.error({ error: err }, 'Rate limiter Redis connection error')
+    })
+
+    return redisClient
+  } catch {
+    logger.warn('Failed to create Redis client for rate limiting, using in-memory fallback')
+    return null
+  }
+}
+
+// --- Pre-configured limiters ---
+
+// In-memory fallback limiter factory (used when Redis is unavailable)
+function createMemoryLimiter(points: number, duration: number) {
+  return new RateLimiterMemory({ points, duration })
+}
+
+// Redis limiter factory with in-memory fallback
+function createLimiter(
+  keyPrefix: string,
+  points: number,
+  duration: number
+): RateLimiterRedis | RateLimiterMemory {
+  const redis = getRedisClient()
+  if (!redis) {
+    return createMemoryLimiter(points, duration)
+  }
+
+  return new RateLimiterRedis({
+    storeClient: redis,
+    keyPrefix: `rl:${keyPrefix}`,
+    points,
+    duration,
+    inMemoryBlockOnConsumed: points + 1,
+    inMemoryBlockDuration: duration,
+    insuranceLimiter: createMemoryLimiter(points, duration),
+  })
+}
+
+/**
+ * Set logging (draft sync, per-set upsert, set delete)
+ * High frequency during workouts: 60 req / 10s per user
+ */
+export const setLoggingLimiter = createLimiter('sets', 60, 10)
+
+/**
+ * Workout actions (complete, skip, clear)
+ * Lower frequency actions: 10 req / 10s per user
+ */
+export const workoutActionLimiter = createLimiter('workout-actions', 10, 10)
+
+/**
+ * Program management (create, duplicate, activate, archive, etc.)
+ * Moderate editing pace: 20 req / 60s per user
+ */
+export const programManagementLimiter = createLimiter('program-mgmt', 20, 60)
+
+/**
+ * Destructive operations (delete week/workout/exercise)
+ * Prevent accidental mass deletion: 10 req / 60s per user
+ */
+export const destructiveOpLimiter = createLimiter('destructive', 10, 60)
+
+/**
+ * Community clone (enqueues BullMQ jobs)
+ * Protect the queue: 3 req / 60s per user
+ */
+export const communityCloneLimiter = createLimiter('clone', 3, 60)
+
+/**
+ * Admin endpoints: 30 req / 60s per user
+ */
+export const adminLimiter = createLimiter('admin', 30, 60)
+
+/**
+ * Check rate limit for a given limiter and key.
+ * Returns a 429 NextResponse if rate limited, or null if allowed.
+ */
+export async function checkRateLimit(
+  limiter: RateLimiterRedis | RateLimiterMemory,
+  key: string
+): Promise<NextResponse | null> {
+  try {
+    await limiter.consume(key)
+    return null
+  } catch (rlRes: unknown) {
+    // RateLimiterRes is thrown when rate limit is exceeded
+    if (
+      rlRes &&
+      typeof rlRes === 'object' &&
+      'msBeforeNext' in rlRes &&
+      typeof (rlRes as { msBeforeNext: number }).msBeforeNext === 'number'
+    ) {
+      const retryAfter = Math.ceil(
+        (rlRes as { msBeforeNext: number }).msBeforeNext / 1000
+      )
+      logger.warn({ key, retryAfter }, 'Rate limit exceeded')
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfter) },
+        }
+      )
+    }
+
+    // Unexpected error from rate limiter — allow the request through
+    // rather than blocking legitimate users
+    logger.error({ error: rlRes, key }, 'Rate limiter error, allowing request')
+    return null
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,13 +1,19 @@
-import { RateLimiterRedis, RateLimiterMemory } from 'rate-limiter-flexible'
+import {
+  RateLimiterRedis,
+  RateLimiterMemory,
+  type RateLimiterRes,
+} from 'rate-limiter-flexible'
 import { NextResponse } from 'next/server'
 import Redis from 'ioredis'
 import { logger } from '@/lib/logger'
 
 // Lazy singleton Redis connection for rate limiting
 let redisClient: Redis | null = null
+let redisInitAttempted = false
 
 function getRedisClient(): Redis | null {
-  if (redisClient) return redisClient
+  if (redisInitAttempted) return redisClient
+  redisInitAttempted = true
 
   const redisUrl = process.env.REDIS_URL
   if (!redisUrl) {
@@ -41,85 +47,98 @@ function createMemoryLimiter(points: number, duration: number) {
   return new RateLimiterMemory({ points, duration })
 }
 
-// Redis limiter factory with in-memory fallback
-function createLimiter(
-  keyPrefix: string,
-  points: number,
-  duration: number
-): RateLimiterRedis | RateLimiterMemory {
-  const redis = getRedisClient()
-  if (!redis) {
-    return createMemoryLimiter(points, duration)
-  }
+type LimiterConfig = { keyPrefix: string; points: number; duration: number }
 
-  return new RateLimiterRedis({
-    storeClient: redis,
-    keyPrefix: `rl:${keyPrefix}`,
-    points,
-    duration,
-    inMemoryBlockOnConsumed: points + 1,
-    inMemoryBlockDuration: duration,
-    insuranceLimiter: createMemoryLimiter(points, duration),
-  })
+// Lazy limiter factory: defers Redis client construction until first use
+// so module import (during build, edge analysis, etc.) doesn't lock us
+// into the in-memory fallback before REDIS_URL is available at runtime.
+function lazyLimiter(
+  config: LimiterConfig
+): () => RateLimiterRedis | RateLimiterMemory {
+  let instance: RateLimiterRedis | RateLimiterMemory | null = null
+  return () => {
+    if (instance) return instance
+    const redis = getRedisClient()
+    if (!redis) {
+      logger.warn(
+        { keyPrefix: config.keyPrefix },
+        'Rate limiter using in-memory fallback (no Redis)'
+      )
+      instance = createMemoryLimiter(config.points, config.duration)
+      return instance
+    }
+    instance = new RateLimiterRedis({
+      storeClient: redis,
+      keyPrefix: `rl:${config.keyPrefix}`,
+      points: config.points,
+      duration: config.duration,
+      inMemoryBlockOnConsumed: config.points + 1,
+      inMemoryBlockDuration: config.duration,
+      insuranceLimiter: createMemoryLimiter(config.points, config.duration),
+    })
+    return instance
+  }
 }
 
 /**
  * Set logging (draft sync, per-set upsert, set delete)
  * High frequency during workouts: 60 req / 10s per user
  */
-export const setLoggingLimiter = createLimiter('sets', 60, 10)
+export const setLoggingLimiter = lazyLimiter({ keyPrefix: 'sets', points: 60, duration: 10 })
 
 /**
  * Workout actions (complete, skip, clear)
  * Lower frequency actions: 10 req / 10s per user
  */
-export const workoutActionLimiter = createLimiter('workout-actions', 10, 10)
+export const workoutActionLimiter = lazyLimiter({ keyPrefix: 'workout-actions', points: 10, duration: 10 })
 
 /**
  * Program management (create, duplicate, activate, archive, etc.)
  * Moderate editing pace: 20 req / 60s per user
  */
-export const programManagementLimiter = createLimiter('program-mgmt', 20, 60)
+export const programManagementLimiter = lazyLimiter({ keyPrefix: 'program-mgmt', points: 20, duration: 60 })
 
 /**
  * Destructive operations (delete week/workout/exercise)
  * Prevent accidental mass deletion: 10 req / 60s per user
  */
-export const destructiveOpLimiter = createLimiter('destructive', 10, 60)
+export const destructiveOpLimiter = lazyLimiter({ keyPrefix: 'destructive', points: 10, duration: 60 })
 
 /**
  * Community clone (enqueues BullMQ jobs)
  * Protect the queue: 3 req / 60s per user
  */
-export const communityCloneLimiter = createLimiter('clone', 3, 60)
+export const communityCloneLimiter = lazyLimiter({ keyPrefix: 'clone', points: 3, duration: 60 })
 
 /**
  * Admin endpoints: 30 req / 60s per user
  */
-export const adminLimiter = createLimiter('admin', 30, 60)
+export const adminLimiter = lazyLimiter({ keyPrefix: 'admin', points: 30, duration: 60 })
+
+export type LimiterGetter = () => RateLimiterRedis | RateLimiterMemory
 
 /**
  * Check rate limit for a given limiter and key.
  * Returns a 429 NextResponse if rate limited, or null if allowed.
  */
 export async function checkRateLimit(
-  limiter: RateLimiterRedis | RateLimiterMemory,
+  getLimiter: LimiterGetter,
   key: string
 ): Promise<NextResponse | null> {
+  // Guard against empty key — would otherwise rate-limit globally
+  if (!key) {
+    logger.error('checkRateLimit called with empty key, allowing request')
+    return null
+  }
+
   try {
-    await limiter.consume(key)
+    await getLimiter().consume(key)
     return null
   } catch (rlRes: unknown) {
     // RateLimiterRes is thrown when rate limit is exceeded
-    if (
-      rlRes &&
-      typeof rlRes === 'object' &&
-      'msBeforeNext' in rlRes &&
-      typeof (rlRes as { msBeforeNext: number }).msBeforeNext === 'number'
-    ) {
-      const retryAfter = Math.ceil(
-        (rlRes as { msBeforeNext: number }).msBeforeNext / 1000
-      )
+    if (rlRes instanceof Error === false && rlRes && typeof rlRes === 'object' && 'msBeforeNext' in rlRes) {
+      const res = rlRes as RateLimiterRes
+      const retryAfter = Math.ceil(res.msBeforeNext / 1000)
       logger.warn({ key, retryAfter }, 'Rate limit exceeded')
       return NextResponse.json(
         { error: 'Too many requests' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "next": "16.2.2",
         "pg": "^8.20.0",
         "pino": "^10.3.1",
+        "rate-limiter-flexible": "^11.0.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
@@ -13018,6 +13019,12 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-11.0.0.tgz",
+      "integrity": "sha512-UhN3xVeU6Az3y6hAuxMUwFsKcKD1HffhMGK0MknbSxH9vkwslS/p19ovCvJqIVT97pE778nKu2sUgYAcxj4dmQ==",
+      "license": "ISC"
     },
     "node_modules/rc9": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "next": "16.2.2",
     "pg": "^8.20.0",
     "pino": "^10.3.1",
+    "rate-limiter-flexible": "^11.0.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary

- Adds `rate-limiter-flexible` with Redis backend (reuses existing ioredis via BullMQ) to protect the highest-frequency write endpoints
- Rate limits set logging endpoints (draft sync, per-set upsert, set delete) at 60 req/10s per user
- Rate limits workout action endpoints (complete, skip, clear) at 10 req/10s per user
- Returns 429 with `Retry-After` header — client already handles this via `fetchWithRetry` with exponential backoff
- Includes in-memory fallback when Redis is unavailable, plus `insuranceLimiter` for Redis failures
- Pre-configured limiters exported for Phase 2: program management (20/60s), destructive ops (10/60s), community clone (3/60s), admin (30/60s)

## Implementation details

- `lib/rate-limit.ts`: Lazy singleton Redis connection, pre-configured limiters per endpoint class, `checkRateLimit()` wrapper
- Rate limit check runs after auth (`getCurrentUser()`) so we can use `userId` as the identifier
- `inMemoryBlockOnConsumed` optimization avoids Redis round-trips for already-blocked keys

## Test plan

- [x] Type-check passes
- [x] Lint passes
- [ ] Integration tests (require Docker/Testcontainers)
- [ ] Manual: rapid-fire set logging in browser dev console, verify 429 after 60 requests in 10s
- [ ] Manual: verify normal workout flow is unaffected by generous limits

Fixes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)