### PR TITLE
Fix collection nav bar: Next button cut off on mobile

### DIFF
--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -293,30 +293,25 @@ export default function ArticleDetail({
       {/* Mobile fixed bottom nav — collection prev/next */}
       {collectionContext && (
         <div className="fixed bottom-16 left-0 right-0 sm:hidden bg-card border-t-2 border-border z-40">
-          <div className="flex items-stretch">
+          <div className="grid grid-cols-3 items-stretch">
             {prevArticle ? (
               <Link
                 href={`/learn/${prevArticle.slug}?collection=${collectionContext.id}`}
-                className="flex-1 flex items-center gap-2 px-4 py-3 border-r border-border
+                className="flex items-center gap-1.5 px-4 py-3 border-r border-border
                   active:bg-muted transition-colors"
               >
                 <ChevronLeft className="h-4 w-4 flex-shrink-0 text-primary" />
-                <div className="min-w-0">
-                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
-                    Prev
-                  </span>
-                  <span className="text-xs text-foreground truncate block">
-                    {prevArticle.title}
-                  </span>
-                </div>
+                <span className="text-xs text-foreground font-semibold uppercase tracking-wider">
+                  Previous
+                </span>
               </Link>
             ) : (
-              <div className="flex-1 px-4 py-3 border-r border-border" />
+              <div className="px-4 py-3 border-r border-border" />
             )}
 
             {/* Position indicator */}
-            <div className="flex items-center px-3">
-              <span className="text-[10px] text-muted-foreground font-bold uppercase tracking-wider whitespace-nowrap">
+            <div className="flex items-center justify-center px-2">
+              <span className="text-xs text-muted-foreground font-bold tracking-wider whitespace-nowrap">
                 {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
               </span>
             </div>
@@ -324,23 +319,18 @@ export default function ArticleDetail({
             {nextArticle ? (
               <Link
                 href={`/learn/${nextArticle.slug}?collection=${collectionContext.id}`}
-                className="flex-1 flex items-center justify-end gap-2 px-4 py-3 border-l border-border
+                className="flex items-center justify-end gap-1.5 px-4 py-3 border-l border-border
                   active:bg-muted transition-colors"
               >
-                <div className="min-w-0 text-right">
-                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold block">
-                    Next
-                  </span>
-                  <span className="text-xs text-foreground truncate block">
-                    {nextArticle.title}
-                  </span>
-                </div>
+                <span className="text-xs text-foreground font-semibold uppercase tracking-wider">
+                  Next
+                </span>
                 <ChevronRight className="h-4 w-4 flex-shrink-0 text-primary" />
               </Link>
             ) : (
               <Link
                 href={`/learn/collections/${collectionContext.id}`}
-                className="flex-1 flex items-center justify-end gap-2 px-4 py-3 border-l border-border
+                className="flex items-center justify-end gap-1.5 px-4 py-3 border-l border-border
                   active:bg-muted transition-colors"
               >
                 <span className="text-xs text-green-400 font-semibold uppercase tracking-wider">

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -95,7 +95,7 @@ export default function ArticleDetail({
         {collectionContext ? (
           <Link
             href={backHref}
-            className="sm:hidden fixed left-3 flex items-center gap-2 px-3 py-2
+            className="sm:hidden fixed left-3 flex items-center gap-2 px-3.5 py-2.5
               bg-card border-2 border-border text-foreground
               shadow-[2px_2px_0_rgba(0,0,0,0.3)]"
             style={{
@@ -104,11 +104,11 @@ export default function ArticleDetail({
             }}
             aria-label={`Back to ${collectionContext.name}`}
           >
-            <BookOpen className="h-4 w-4 text-primary flex-shrink-0" />
-            <span className="text-[10px] font-bold uppercase tracking-wider max-w-[120px] truncate">
+            <BookOpen className="h-5 w-5 text-primary flex-shrink-0" />
+            <span className="text-xs font-bold uppercase tracking-wider max-w-[140px] truncate">
               {collectionContext.name}
             </span>
-            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+            <span className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
               {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
             </span>
           </Link>
@@ -300,21 +300,21 @@ export default function ArticleDetail({
             {prevArticle ? (
               <Link
                 href={`/learn/${prevArticle.slug}?collection=${collectionContext.id}`}
-                className="flex items-center gap-1.5 px-4 py-3 border-r border-border
+                className="flex items-center gap-2 px-4 py-4 border-r border-border
                   active:bg-muted transition-colors"
               >
-                <ChevronLeft className="h-4 w-4 flex-shrink-0 text-primary" />
-                <span className="text-xs text-foreground font-semibold uppercase tracking-wider">
+                <ChevronLeft className="h-5 w-5 flex-shrink-0 text-primary" />
+                <span className="text-sm text-foreground font-semibold uppercase tracking-wider">
                   Previous
                 </span>
               </Link>
             ) : (
-              <div className="px-4 py-3 border-r border-border" />
+              <div className="px-4 py-4 border-r border-border" />
             )}
 
             {/* Position indicator */}
             <div className="flex items-center justify-center px-2">
-              <span className="text-xs text-muted-foreground font-bold tracking-wider whitespace-nowrap">
+              <span className="text-sm text-muted-foreground font-bold tracking-wider whitespace-nowrap">
                 {collectionContext.currentIndex + 1}/{collectionContext.articles.length}
               </span>
             </div>
@@ -322,24 +322,24 @@ export default function ArticleDetail({
             {nextArticle ? (
               <Link
                 href={`/learn/${nextArticle.slug}?collection=${collectionContext.id}`}
-                className="flex items-center justify-end gap-1.5 px-4 py-3 border-l border-border
+                className="flex items-center justify-end gap-2 px-4 py-4 border-l border-border
                   active:bg-muted transition-colors"
               >
-                <span className="text-xs text-foreground font-semibold uppercase tracking-wider">
+                <span className="text-sm text-foreground font-semibold uppercase tracking-wider">
                   Next
                 </span>
-                <ChevronRight className="h-4 w-4 flex-shrink-0 text-primary" />
+                <ChevronRight className="h-5 w-5 flex-shrink-0 text-primary" />
               </Link>
             ) : (
               <Link
                 href={`/learn/collections/${collectionContext.id}`}
-                className="flex items-center justify-end gap-1.5 px-4 py-3 border-l border-border
+                className="flex items-center justify-end gap-2 px-4 py-4 border-l border-border
                   active:bg-muted transition-colors"
               >
-                <span className="text-xs text-green-400 font-semibold uppercase tracking-wider">
+                <span className="text-sm text-green-400 font-semibold uppercase tracking-wider">
                   Done
                 </span>
-                <ChevronRight className="h-4 w-4 flex-shrink-0 text-green-400" />
+                <ChevronRight className="h-5 w-5 flex-shrink-0 text-green-400" />
               </Link>
             )}
           </div>

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -292,7 +292,10 @@ export default function ArticleDetail({
 
       {/* Mobile fixed bottom nav — collection prev/next */}
       {collectionContext && (
-        <div className="fixed bottom-16 left-0 right-0 sm:hidden bg-card border-t-2 border-border z-40">
+        <div
+          className="fixed left-0 right-0 sm:hidden bg-card border-t-2 border-border z-40"
+          style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom, 0px))' }}
+        >
           <div className="grid grid-cols-3 items-stretch">
             {prevArticle ? (
               <Link


### PR DESCRIPTION
## Summary
- Replaced article titles in mobile collection nav with simple "Previous"/"Next" labels, per issue discussion
- Switched from `flex-1` to CSS `grid-cols-3` for a stable 3-column layout that prevents the Next button from overflowing
- Increased label text size from `text-[10px]` to `text-xs` for better readability

## Test plan
- [x] Open an article within a collection on mobile (or narrow viewport < 640px)
- [x] Verify "Previous" and "Next" buttons are fully visible and never clipped
- [x] Verify position indicator (e.g. "3/6") is centered
- [x] Verify "Done" button appears on last article in collection
- [x] Verify desktop collection nav (>640px) is unchanged
- [ ] Verify no gap between tab bar and collection nav bar

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)