### PR TITLE
fix(docker): precompile sync-exercise-data to drop tsx runtime dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,16 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
+# Pre-compile the exercise data sync script to plain JS so the runner
+# stage doesn't need tsx (and its fragile transitive dep tree) at runtime.
+RUN ./node_modules/.bin/esbuild scripts/sync-exercise-data.ts \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --target=node20 \
+      --external:@prisma/client \
+      --outfile=scripts-dist/sync-exercise-data.cjs
+
 # --- Stage 3: runner ---
 FROM node:20-alpine AS runner
 WORKDIR /app
@@ -45,13 +55,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Prisma migrations + exercise data sync (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
-RUN npm install prisma@6.19.0 tsx@4.19.4 get-tsconfig@4.13.0 esbuild@0.25.10 typescript@5.8.3 @types/node@22.15.3 --save-exact --no-audit --no-fund --ignore-scripts
+RUN npm install prisma@6.19.0 --save-exact --no-audit --no-fund --ignore-scripts
 # Copy Prisma engines from deps stage and fix ownership
 # npm install above creates @prisma/ owned by root; engines need to be writable by nextjs at runtime
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 RUN chown -R nextjs:nodejs ./node_modules/@prisma ./node_modules/prisma
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
-COPY scripts/sync-exercise-data.ts ./scripts/sync-exercise-data.ts
+COPY --from=builder /app/scripts-dist/sync-exercise-data.cjs ./scripts/sync-exercise-data.cjs
 COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json
 COPY scripts/validated-exercise-ids.json ./scripts/validated-exercise-ids.json
 RUN chmod +x ./scripts/prisma-migrate.sh

--- a/scripts/prisma-migrate.sh
+++ b/scripts/prisma-migrate.sh
@@ -24,6 +24,6 @@ echo ""
 echo "=== Exercise Data Sync ==="
 echo "Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 echo "==="
-./node_modules/.bin/tsx scripts/sync-exercise-data.ts
+node scripts/sync-exercise-data.cjs
 
 echo "Data sync completed successfully."


### PR DESCRIPTION
## Summary
Follow-up to #415. The layered \`npm install\` over \`.next/standalone\`'s pruned node_modules kept losing tsx transitive deps (\`get-tsconfig\`, then \`resolve-pkg-maps\`, ...). Whack-a-mole.

Real fix: bundle \`scripts/sync-exercise-data.ts\` to a self-contained \`.cjs\` in the builder stage via esbuild (only \`@prisma/client\` external), then run it with plain \`node\` in the runner. Drops tsx, get-tsconfig, esbuild, typescript, and @types/node from the runtime image entirely.

Closes #416.

## Test plan
- [x] esbuild bundle compiles cleanly (13.6kb)
- [x] \`node --check\` on bundled output
- [x] Local docker build + run sync against staging DB
- [ ] Staging deploy succeeds