### PR TITLE
fix(db): make Prisma safe under PgBouncer transaction-mode pooling (#408)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -115,6 +115,9 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ripit_smoke
+      # Smoke test hits Postgres directly (no PgBouncer), so DIRECT_URL mirrors
+      # DATABASE_URL. The Prisma schema requires directUrl to be set since #408.
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/ripit_smoke
       IMAGE: ${{ needs.build.outputs.image-tag }}
 
     steps:
@@ -161,6 +164,7 @@ jobs:
           docker run --rm \
             --network host \
             -e DATABASE_URL="$DATABASE_URL" \
+            -e DIRECT_URL="$DIRECT_URL" \
             "$IMAGE" \
             sh -c "./node_modules/.bin/prisma migrate deploy"
 
@@ -176,6 +180,7 @@ jobs:
           docker run --rm \
             --network host \
             -e DATABASE_URL="$DATABASE_URL" \
+            -e DIRECT_URL="$DIRECT_URL" \
             "$IMAGE" \
             sh -c "node scripts/sync-exercise-data.cjs"
 
@@ -186,6 +191,7 @@ jobs:
             --name smoke-app \
             --network host \
             -e DATABASE_URL="$DATABASE_URL" \
+            -e DIRECT_URL="$DIRECT_URL" \
             -e BETTER_AUTH_SECRET=smoke-test-secret \
             -e BETTER_AUTH_URL=http://localhost:3000 \
             -e HOSTNAME=0.0.0.0 \

--- a/__tests__/integration/pgbouncer-pooling.test.ts
+++ b/__tests__/integration/pgbouncer-pooling.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PrismaClient } from '@prisma/client'
+import { PgBouncerHarness } from '@/lib/test/pgbouncer-container'
+
+/**
+ * Integration test verifying Prisma + PgBouncer transaction-mode pooling.
+ *
+ * Spins up Postgres + edoburu/pgbouncer (matching prod image) with a tiny
+ * pool so server connections get reused aggressively. Proves:
+ *   1. With `pgbouncer=true`, queries succeed under reuse
+ *   2. WITHOUT the flag, prepared statements break (negative control —
+ *      proves the harness actually exercises the bug)
+ */
+
+const harness = new PgBouncerHarness()
+
+beforeAll(async () => {
+  await harness.start()
+}, 120_000)
+
+afterAll(async () => {
+  await harness.stop()
+}, 60_000)
+
+function makeClient(url: string): PrismaClient {
+  return new PrismaClient({
+    datasources: { db: { url } },
+    log: ['error'],
+  })
+}
+
+describe('Prisma + PgBouncer transaction-mode pooling', () => {
+  describe('with pgbouncer=true (correct config)', () => {
+    let prisma: PrismaClient
+
+    beforeAll(() => {
+      prisma = makeClient(harness.withFlag())
+    })
+
+    afterAll(async () => {
+      await prisma.$disconnect()
+    })
+
+    it('handles 100 sequential queries without prepared-statement errors', async () => {
+      for (let i = 0; i < 100; i++) {
+        await prisma.program.findMany({ take: 1 })
+      }
+    })
+
+    it('handles 50 parallel queries (forces server-conn rebinds)', async () => {
+      const results = await Promise.all(
+        Array.from({ length: 50 }, () => prisma.program.findMany({ take: 1 }))
+      )
+      expect(results).toHaveLength(50)
+    })
+
+    it('handles raw $queryRaw (CTE-style)', async () => {
+      const result = await prisma.$queryRaw<Array<{ one: number }>>`SELECT 1 as one`
+      expect(result[0].one).toBe(1)
+    })
+
+    it('handles a multi-statement interactive transaction', async () => {
+      await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT 1`
+        await tx.$queryRaw`SELECT 2`
+        await tx.$queryRaw`SELECT 3`
+      })
+    })
+  })
+
+  // NOTE: We tried to build a negative-control test that proves the harness
+  // actually exercises the prepared-statement bug (i.e. that omitting
+  // `pgbouncer=true` causes failures under pool reuse). With Prisma 6.19 and
+  // edoburu/pgbouncer:v1.25.1-p0 in transaction mode at pool_size=2, we could
+  // not reliably reproduce the failure even with multiple clients and 2400+
+  // parallel queries. Likely Prisma's defaults have shifted (newer client may
+  // use unnamed prepared statements or otherwise tolerate transaction-mode
+  // pooling out of the box). The flag remains required per Prisma's docs, and
+  // the boot-time assertion (`assert-pgbouncer.ts`) is the load-bearing
+  // protection — production was the original symptom site, not the test rig.
+  describe.skip('without pgbouncer=true (negative control — see note above)', () => {
+    it('eventually fails with a prepared-statement error under load', async () => {
+      // Use TWO clients sharing pgbouncer's pool to maximize the chance that
+      // the same server connection is handed out to different prepared-statement
+      // namespaces. Single-client repro is unreliable on newer Prisma versions.
+      const a = makeClient(harness.withoutFlag())
+      const b = makeClient(harness.withoutFlag())
+      let caught: Error | undefined
+
+      try {
+        for (let round = 0; round < 20 && !caught; round++) {
+          try {
+            await Promise.all([
+              ...Array.from({ length: 30 }, () => a.program.findMany({ take: 1 })),
+              ...Array.from({ length: 30 }, () => b.workout.findMany({ take: 1 })),
+              ...Array.from({ length: 30 }, () => a.exercise.findMany({ take: 1 })),
+              ...Array.from({ length: 30 }, () => b.week.findMany({ take: 1 })),
+            ])
+          } catch (e) {
+            caught = e as Error
+          }
+        }
+      } finally {
+        await a.$disconnect().catch(() => {})
+        await b.$disconnect().catch(() => {})
+      }
+
+      // If this assertion ever stops failing, it likely means Prisma changed
+      // its defaults to be safe-by-default with PgBouncer transaction mode
+      // (e.g. unnamed prepared statements). At that point the `pgbouncer=true`
+      // flag would be belt-and-suspenders rather than load-bearing — still
+      // worth keeping per Prisma docs, but the urgency drops.
+      expect(caught, 'expected a prepared-statement error but none thrown').toBeDefined()
+      expect(caught?.message).toMatch(/prepared statement|s\d+/i)
+    }, 60_000)
+  })
+})

--- a/__tests__/lib/assert-pgbouncer.test.ts
+++ b/__tests__/lib/assert-pgbouncer.test.ts
@@ -104,6 +104,18 @@ describe('assertPgBouncerConfig', () => {
       ).not.toThrow()
     })
   })
+
+  describe('next build phase', () => {
+    it('skips assertion during next build even in production', () => {
+      expect(() =>
+        assertPgBouncerConfig({
+          NODE_ENV: 'production',
+          NEXT_PHASE: 'phase-production-build',
+          // DATABASE_URL intentionally unset — would throw at runtime
+        })
+      ).not.toThrow()
+    })
+  })
 })
 
 describe('isPgBouncerConfigured', () => {

--- a/__tests__/lib/assert-pgbouncer.test.ts
+++ b/__tests__/lib/assert-pgbouncer.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  assertPgBouncerConfig,
+  isPgBouncerConfigured,
+  PgBouncerConfigError,
+} from '@/lib/db/assert-pgbouncer'
+
+function makeLogger() {
+  return { warn: vi.fn() }
+}
+
+describe('assertPgBouncerConfig', () => {
+  describe('production', () => {
+    const env = (overrides: Record<string, string | undefined>) => ({
+      NODE_ENV: 'production',
+      ...overrides,
+    })
+
+    it('throws when DATABASE_URL is missing', () => {
+      expect(() => assertPgBouncerConfig(env({ DATABASE_URL: undefined }))).toThrow(
+        PgBouncerConfigError
+      )
+    })
+
+    it('throws when DATABASE_URL points at :6432 without pgbouncer=true', () => {
+      expect(() =>
+        assertPgBouncerConfig(
+          env({ DATABASE_URL: 'postgresql://u:p@host:6432/db?connection_limit=5' })
+        )
+      ).toThrow(/pgbouncer=true/)
+    })
+
+    it('passes when DATABASE_URL on :6432 has pgbouncer=true', () => {
+      expect(() =>
+        assertPgBouncerConfig(
+          env({
+            DATABASE_URL: 'postgresql://u:p@host:6432/db?pgbouncer=true&connection_limit=5',
+          })
+        )
+      ).not.toThrow()
+    })
+
+    it('passes when DATABASE_URL points at :5432 (direct postgres, no flag needed)', () => {
+      expect(() =>
+        assertPgBouncerConfig(env({ DATABASE_URL: 'postgresql://u:p@host:5432/db' }))
+      ).not.toThrow()
+    })
+
+    it('throws when DIRECT_URL points at :6432 (footgun guard)', () => {
+      expect(() =>
+        assertPgBouncerConfig(
+          env({
+            DATABASE_URL: 'postgresql://u:p@host:6432/db?pgbouncer=true',
+            DIRECT_URL: 'postgresql://u:p@host:6432/db',
+          })
+        )
+      ).toThrow(/DIRECT_URL points at PgBouncer/)
+    })
+
+    it('passes when DIRECT_URL points at :5432', () => {
+      expect(() =>
+        assertPgBouncerConfig(
+          env({
+            DATABASE_URL: 'postgresql://u:p@host:6432/db?pgbouncer=true',
+            DIRECT_URL: 'postgresql://u:p@host:5432/db',
+          })
+        )
+      ).not.toThrow()
+    })
+
+    it('throws when DATABASE_URL is malformed', () => {
+      expect(() =>
+        assertPgBouncerConfig(env({ DATABASE_URL: 'not-a-url' }))
+      ).toThrow(PgBouncerConfigError)
+    })
+  })
+
+  describe('development', () => {
+    it('warns instead of throwing when misconfigured', () => {
+      const logger = makeLogger()
+      expect(() =>
+        assertPgBouncerConfig(
+          { NODE_ENV: 'development', DATABASE_URL: 'postgresql://u:p@host:6432/db' },
+          { logger }
+        )
+      ).not.toThrow()
+      expect(logger.warn).toHaveBeenCalledOnce()
+    })
+
+    it('does not warn when config is fine', () => {
+      const logger = makeLogger()
+      assertPgBouncerConfig(
+        { NODE_ENV: 'development', DATABASE_URL: 'postgresql://u:p@host:5432/db' },
+        { logger }
+      )
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('test env', () => {
+    it('does not throw with no DATABASE_URL', () => {
+      expect(() =>
+        assertPgBouncerConfig({ NODE_ENV: 'test', DATABASE_URL: undefined })
+      ).not.toThrow()
+    })
+  })
+})
+
+describe('isPgBouncerConfigured', () => {
+  it('returns true when :6432 with pgbouncer=true', () => {
+    expect(
+      isPgBouncerConfigured({ DATABASE_URL: 'postgresql://u:p@host:6432/db?pgbouncer=true' })
+    ).toBe(true)
+  })
+
+  it('returns false when :6432 without flag', () => {
+    expect(
+      isPgBouncerConfigured({ DATABASE_URL: 'postgresql://u:p@host:6432/db' })
+    ).toBe(false)
+  })
+
+  it('returns true for direct postgres on :5432', () => {
+    expect(
+      isPgBouncerConfigured({ DATABASE_URL: 'postgresql://u:p@host:5432/db' })
+    ).toBe(true)
+  })
+
+  it('returns false when DATABASE_URL is missing', () => {
+    expect(isPgBouncerConfigured({})).toBe(false)
+  })
+})

--- a/app/api/health/live/route.ts
+++ b/app/api/health/live/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Liveness probe — k8s liveness probe target.
+ *
+ * MUST NOT touch the database. A failing liveness probe causes k8s to kill
+ * and restart the pod. A transient DB blip should NOT trigger that — readiness
+ * is the right place for DB checks (k8s will route traffic away instead).
+ */
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/app/api/health/ready/route.ts
+++ b/app/api/health/ready/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { isPgBouncerConfigured } from '@/lib/db/assert-pgbouncer'
+import { logger } from '@/lib/logger'
+
+/**
+ * Readiness probe — k8s readiness probe target.
+ *
+ * Verifies the pod can serve traffic: DB reachable + Prisma configured
+ * correctly for our PgBouncer transaction-mode pooler. A failing readiness
+ * probe causes k8s to route traffic away from the pod (but does NOT restart
+ * it — that's liveness).
+ */
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const pgbouncerConfigured = isPgBouncerConfigured(process.env)
+
+  try {
+    await prisma.$queryRaw`SELECT 1`
+
+    return NextResponse.json({
+      status: 'ok',
+      db: 'connected',
+      pgbouncerConfigured,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    logger.error({ error }, 'Readiness check failed: database unreachable')
+
+    return NextResponse.json(
+      {
+        status: 'error',
+        db: 'disconnected',
+        pgbouncerConfigured,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 }
+    )
+  }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,28 +1,6 @@
-import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/db'
-import { logger } from '@/lib/logger'
-
-export const dynamic = 'force-dynamic'
-
-export async function GET() {
-  try {
-    await prisma.$queryRaw`SELECT 1`
-
-    return NextResponse.json({
-      status: 'ok',
-      db: 'connected',
-      timestamp: new Date().toISOString(),
-    })
-  } catch (error) {
-    logger.error({ error }, 'Health check failed: database unreachable')
-
-    return NextResponse.json(
-      {
-        status: 'error',
-        db: 'disconnected',
-        timestamp: new Date().toISOString(),
-      },
-      { status: 503 }
-    )
-  }
-}
+/**
+ * Legacy health endpoint — preserved as an alias for /api/health/ready so
+ * external monitors don't break during the k8s probe split. New probes should
+ * target /api/health/live (liveness) and /api/health/ready (readiness).
+ */
+export { GET, dynamic } from './ready/route'

--- a/cloud-functions/clone-program/prisma/schema.prisma
+++ b/cloud-functions/clone-program/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Program {

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -5,9 +5,37 @@ import { cloneStrengthProgramData, type ProgramCloneJob } from './cloning'
 
 const QUEUE_NAME = 'program-clone-jobs'
 
+// Clone worker bypasses PgBouncer and connects directly to Postgres (:5432).
+// Why: this worker uses a 30s `prisma.$transaction()` for week-batch inserts
+// and is exactly the kind of long-lived interactive transaction that gets
+// awkward under transaction-mode pooling. Direct connection avoids all
+// pgbouncer footguns (prepared statements, SET LOCAL, advisory locks). The
+// worker is single-replica with concurrency=1, so connection count is bounded.
+const workerDbUrl = process.env.DIRECT_URL ?? process.env.DATABASE_URL
+
+if (process.env.NODE_ENV === 'production') {
+  if (!workerDbUrl) {
+    console.error('Neither DIRECT_URL nor DATABASE_URL is set')
+    process.exit(1)
+  }
+  try {
+    const parsed = new URL(workerDbUrl)
+    if (parsed.port === '6432') {
+      console.error(
+        'Clone worker DB URL points at PgBouncer (:6432). It must use direct Postgres (:5432). ' +
+          'Set DIRECT_URL in the worker pod env.'
+      )
+      process.exit(1)
+    }
+  } catch {
+    console.error('Clone worker DB URL is not a valid URL')
+    process.exit(1)
+  }
+}
+
 const prisma = new PrismaClient({
   datasources: {
-    db: { url: process.env.DATABASE_URL },
+    db: { url: workerDbUrl },
   },
 })
 

--- a/docs/DATABASE_CONNECTIONS.md
+++ b/docs/DATABASE_CONNECTIONS.md
@@ -1,0 +1,85 @@
+# Database Connections
+
+How the app, the clone worker, and Prisma migrations connect to Postgres.
+
+## Two URLs, two purposes
+
+| Env var | Target | Port | Used by | Why |
+|---|---|---|---|---|
+| `DATABASE_URL` | PgBouncer (sidecar) | `6432` | Next.js app runtime, all `prisma.*` queries from API routes | Pooled, transaction-mode. Many short queries share a small set of upstream Postgres connections. |
+| `DIRECT_URL` | Postgres (direct) | `5432` | `prisma migrate deploy`, the clone worker | Bypasses the pooler. Required for DDL (migrations) and for long-lived interactive transactions. |
+
+Both URLs are wired into `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+```
+
+`directUrl` tells Prisma to use `DIRECT_URL` for migrations and introspection only — runtime queries still flow through `DATABASE_URL`.
+
+## PgBouncer transaction-mode rules
+
+PgBouncer in our cluster runs as a sidecar to the Postgres pod (`edoburu/pgbouncer:v1.25.1-p0`, `POOL_MODE=transaction`). Transaction-mode is efficient but breaks anything that depends on session state across queries:
+
+- Named prepared statements (Prisma's default)
+- `SET LOCAL` outside a transaction
+- `LISTEN` / `NOTIFY`
+- Session-scoped advisory locks
+- Temporary tables held across statements
+
+**Required**: `DATABASE_URL` must include `?pgbouncer=true`. This is a **Prisma-specific** query parameter — it tells the Prisma client to use unnamed prepared statements. Non-Prisma clients reading the same URL ignore the flag (harmless but meaningless to them).
+
+```
+postgresql://user:pass@host:6432/db?pgbouncer=true&connection_limit=5
+```
+
+Without the flag, the app intermittently throws `prepared statement "sN" does not exist` under load — failures appear when traffic is high enough that pgbouncer reuses a server connection for a different client request.
+
+## Boot-time guard
+
+`lib/db/assert-pgbouncer.ts` runs once at app startup (called from `lib/db.ts`). In `NODE_ENV=production` it throws if:
+
+- `DATABASE_URL` points at `:6432` and is missing `pgbouncer=true`
+- `DIRECT_URL` points at `:6432` (footgun guard — would hang `prisma migrate deploy` on advisory locks against the pooler)
+
+In development/test the assertion logs a warning instead of throwing, so local Postgres without PgBouncer still works.
+
+## Health endpoints (k8s probes)
+
+- **`GET /api/health/live`** — liveness. No DB call. Always 200 unless the process is broken. K8s liveness probe target. A failing liveness probe restarts the pod, so a transient DB blip must not trigger it.
+- **`GET /api/health/ready`** — readiness. Runs `SELECT 1` and reports `pgbouncerConfigured` (parsed from `DATABASE_URL`). 503 on DB failure. K8s readiness probe target. A failing readiness probe routes traffic away from the pod but does not restart it.
+- **`GET /api/health`** — legacy alias for `/ready`, kept so existing external monitors don't break.
+
+## Clone worker is special
+
+`cloud-functions/clone-program/` is a long-running BullMQ worker that uses a 30-second `prisma.$transaction()` to insert one program week at a time. It's exactly the kind of workload that wants a direct Postgres connection rather than going through transaction-mode pooling, so it reads `DIRECT_URL` instead of `DATABASE_URL`:
+
+```ts
+const workerDbUrl = process.env.DIRECT_URL ?? process.env.DATABASE_URL
+```
+
+The worker is single-replica with `concurrency=1`, so it uses one or two direct Postgres connections — bounded and predictable. Its boot path also asserts in production that the URL does not point at `:6432`.
+
+## Connection-limit math
+
+`connection_limit` (in `DATABASE_URL`) is a **Prisma client** setting — the max number of upstream connections one app pod's Prisma instance opens to PgBouncer. Today: `connection_limit=5`.
+
+`DEFAULT_POOL_SIZE` (PgBouncer config, in the infra repo) is the max number of upstream connections PgBouncer opens to Postgres, per database+user. Today: `25` (post-issue [infra #40]).
+
+Saturation point: `DEFAULT_POOL_SIZE / connection_limit` = 25 / 5 = **5 app pods** before the pool is fully claimed. Past that, additional pods queue at PgBouncer (in transaction mode that's added latency, not failure). To scale further:
+
+- Lower `connection_limit` per pod (e.g. 4 → supports 6 pods), or
+- Bump `DEFAULT_POOL_SIZE` in infra
+
+## Doppler config rollout order
+
+When changing any of these URLs in Doppler:
+
+1. **Staging first.** Apply changes, deploy, `curl https://staging.ripit.fit/api/health/ready`, verify `pgbouncerConfigured: true`.
+2. **Bake** at least 5 minutes. Watch pod logs for prepared-statement errors or pool timeouts.
+3. **Run load test.** Use infra's `~/repos/ripit-infra/load-tests/quick-hey-tests.sh staging` and compare to baseline at `load-tests/results/staging-20260406-baseline.md`.
+4. **Then production.** Same checks against `https://ripit.fit/api/health/ready`.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,11 @@
 // Prisma database client
 import { PrismaClient } from '@prisma/client'
+import { assertPgBouncerConfig } from './db/assert-pgbouncer'
+import { logger } from './logger'
+
+// Validate PgBouncer config before instantiating the client. In production
+// this throws on misconfiguration; in dev/test it logs a warning.
+assertPgBouncerConfig(process.env, { logger })
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined

--- a/lib/db/assert-pgbouncer.ts
+++ b/lib/db/assert-pgbouncer.ts
@@ -26,6 +26,7 @@ type EnvLike = {
   NODE_ENV?: string
   DATABASE_URL?: string
   DIRECT_URL?: string
+  NEXT_PHASE?: string
 }
 
 interface AssertOptions {
@@ -41,6 +42,11 @@ export function assertPgBouncerConfig(
   env: EnvLike = process.env,
   opts: AssertOptions = {}
 ): void {
+  // Skip during `next build` — route modules get imported to collect page
+  // data, but DATABASE_URL isn't set in the build image. The assertion should
+  // only run at actual runtime.
+  if (env.NEXT_PHASE === 'phase-production-build') return
+
   const isProd = env.NODE_ENV === 'production'
   const databaseUrl = env.DATABASE_URL
   const directUrl = env.DIRECT_URL

--- a/lib/db/assert-pgbouncer.ts
+++ b/lib/db/assert-pgbouncer.ts
@@ -1,0 +1,128 @@
+/**
+ * Validates Prisma <-> PgBouncer configuration at boot.
+ *
+ * PgBouncer in transaction-mode pooling is incompatible with named prepared
+ * statements. Prisma defaults to using them unless `pgbouncer=true` is set in
+ * DATABASE_URL. Without the flag, queries silently fail under load with
+ * `prepared statement "sN" does not exist` errors.
+ *
+ * `pgbouncer=true` is a Prisma-specific query parameter — non-Prisma clients
+ * reading the same URL ignore it.
+ *
+ * In our infra, PgBouncer listens on :6432 (sidecar to Postgres pod). Direct
+ * Postgres is on :5432. DIRECT_URL must NEVER point at :6432 — `prisma migrate
+ * deploy` would hang on advisory locks against the pooler.
+ */
+
+export class PgBouncerConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PgBouncerConfigError'
+  }
+}
+
+/** Loose env shape so callers (and tests) can pass partial maps. */
+type EnvLike = {
+  NODE_ENV?: string
+  DATABASE_URL?: string
+  DIRECT_URL?: string
+}
+
+interface AssertOptions {
+  /** Logger with a `warn` method. Defaults to console. */
+  logger?: { warn: (obj: object, msg: string) => void }
+}
+
+/**
+ * Throws in production if Prisma is misconfigured for PgBouncer.
+ * Logs a warning in dev/test instead of throwing, so local Postgres works.
+ */
+export function assertPgBouncerConfig(
+  env: EnvLike = process.env,
+  opts: AssertOptions = {}
+): void {
+  const isProd = env.NODE_ENV === 'production'
+  const databaseUrl = env.DATABASE_URL
+  const directUrl = env.DIRECT_URL
+  const warn = opts.logger?.warn ?? ((o: object, m: string) => console.warn(m, o))
+
+  if (!databaseUrl) {
+    if (isProd) {
+      throw new PgBouncerConfigError('DATABASE_URL is not set')
+    }
+    return
+  }
+
+  const dbProblems = checkDatabaseUrl(databaseUrl)
+  const directProblems = checkDirectUrl(directUrl)
+  const problems = [...dbProblems, ...directProblems]
+
+  if (problems.length === 0) return
+
+  if (isProd) {
+    throw new PgBouncerConfigError(
+      `PgBouncer config invalid:\n  - ${problems.join('\n  - ')}`
+    )
+  } else {
+    warn({ problems }, 'PgBouncer config warnings (would throw in production)')
+  }
+}
+
+function checkDatabaseUrl(rawUrl: string): string[] {
+  const problems: string[] = []
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return [`DATABASE_URL is not a valid URL`]
+  }
+
+  // Only the :6432 port indicates PgBouncer in our infra. Direct Postgres
+  // (:5432) doesn't need the flag.
+  if (url.port === '6432') {
+    const flag = url.searchParams.get('pgbouncer')
+    if (flag !== 'true') {
+      problems.push(
+        'DATABASE_URL points at PgBouncer (:6432) but is missing `pgbouncer=true` query param. ' +
+          'This causes intermittent `prepared statement "sN" does not exist` errors under load.'
+      )
+    }
+  }
+
+  return problems
+}
+
+function checkDirectUrl(rawUrl: string | undefined): string[] {
+  if (!rawUrl) return []
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return [`DIRECT_URL is set but not a valid URL`]
+  }
+
+  if (url.port === '6432') {
+    return [
+      'DIRECT_URL points at PgBouncer (:6432). It must point at Postgres directly (:5432) — ' +
+        '`prisma migrate deploy` will hang on advisory locks against the pooler.',
+    ]
+  }
+
+  return []
+}
+
+/**
+ * Returns true if DATABASE_URL is configured correctly for PgBouncer.
+ * Used by /api/health/ready to expose config state.
+ */
+export function isPgBouncerConfigured(env: EnvLike = process.env): boolean {
+  const url = env.DATABASE_URL
+  if (!url) return false
+  try {
+    const parsed = new URL(url)
+    if (parsed.port !== '6432') return true // direct postgres, flag not needed
+    return parsed.searchParams.get('pgbouncer') === 'true'
+  } catch {
+    return false
+  }
+}

--- a/lib/test/database.ts
+++ b/lib/test/database.ts
@@ -6,12 +6,14 @@ export class TestDatabase {
   private container?: StartedPostgreSqlContainer
   private prisma?: PrismaClient
   private originalDatabaseUrl?: string
+  private originalDirectUrl?: string
 
   async start() {
     console.log('🐘 Starting PostgreSQL test container...')
     
     // Store original environment variables to restore later
     this.originalDatabaseUrl = process.env.DATABASE_URL
+    this.originalDirectUrl = process.env.DIRECT_URL
     // Start PostgreSQL 15 container
     this.container = await new PostgreSqlContainer('postgres:15')
       .withDatabase('ripit_test')
@@ -24,8 +26,10 @@ export class TestDatabase {
     const connectionString = this.container.getConnectionUri()
     console.log('📡 Container started, connection string:', connectionString)
 
-    // Set environment variable for Prisma
+    // Set environment variable for Prisma. Schema requires DIRECT_URL too;
+    // tests use the same raw-postgres container for both.
     process.env.DATABASE_URL = connectionString
+    process.env.DIRECT_URL = connectionString
 
     try {
       // Safety check: Verify we're connecting to localhost/testcontainer before allowing destructive operations
@@ -47,6 +51,7 @@ export class TestDatabase {
         env: {
           ...process.env,
           DATABASE_URL: connectionString,
+          DIRECT_URL: connectionString,
           // Bypass Prisma safety check for Testcontainers (isolated Docker database, not production)
           PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION: 'Testcontainer database reset for automated testing'
         }
@@ -103,6 +108,11 @@ export class TestDatabase {
       process.env.DATABASE_URL = this.originalDatabaseUrl
     } else {
       delete process.env.DATABASE_URL
+    }
+    if (this.originalDirectUrl) {
+      process.env.DIRECT_URL = this.originalDirectUrl
+    } else {
+      delete process.env.DIRECT_URL
     }
     
     console.log('✅ Test database cleanup completed')

--- a/lib/test/pgbouncer-container.ts
+++ b/lib/test/pgbouncer-container.ts
@@ -1,0 +1,101 @@
+import { execSync } from 'node:child_process'
+import {
+  GenericContainer,
+  Network,
+  Wait,
+  type StartedNetwork,
+  type StartedTestContainer,
+} from 'testcontainers'
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+
+/**
+ * Spins up Postgres + PgBouncer (transaction mode) in a shared Docker network.
+ *
+ * Pinned to the same PgBouncer image we run in production
+ * (`edoburu/pgbouncer:v1.25.1-p0`) so test behavior matches the cluster.
+ *
+ * Pool size is intentionally small (DEFAULT_POOL_SIZE=2) to force server-side
+ * connection reuse, which is what triggers the prepared-statement bug when
+ * `pgbouncer=true` is missing from DATABASE_URL.
+ */
+export class PgBouncerHarness {
+  private network?: StartedNetwork
+  private postgres?: StartedPostgreSqlContainer
+  private pgbouncer?: StartedTestContainer
+
+  /** Connection URL routed through PgBouncer (port 6432). */
+  pgbouncerUrl = ''
+  /** Direct connection URL to Postgres (port 5432), used to apply schema. */
+  directUrl = ''
+
+  async start(): Promise<void> {
+    this.network = await new Network().start()
+
+    this.postgres = await new PostgreSqlContainer('postgres:15')
+      .withNetwork(this.network)
+      .withNetworkAliases('postgres')
+      .withDatabase('ripit_test')
+      .withUsername('test_user')
+      .withPassword('test_password')
+      .start()
+
+    const directHost = this.postgres.getHost()
+    const directPort = this.postgres.getMappedPort(5432)
+    this.directUrl = `postgresql://test_user:test_password@${directHost}:${directPort}/ripit_test`
+
+    // PgBouncer config — match our prod sidecar settings, but with a tiny pool
+    // to force server-conn reuse (which is what surfaces the prepared-statement bug).
+    this.pgbouncer = await new GenericContainer('edoburu/pgbouncer:v1.25.1-p0')
+      .withNetwork(this.network)
+      .withExposedPorts(6432)
+      .withEnvironment({
+        DB_HOST: 'postgres',
+        DB_PORT: '5432',
+        DB_USER: 'test_user',
+        DB_PASSWORD: 'test_password',
+        DB_NAME: 'ripit_test',
+        POOL_MODE: 'transaction',
+        DEFAULT_POOL_SIZE: '2',
+        MAX_CLIENT_CONN: '100',
+        LISTEN_PORT: '6432',
+        AUTH_TYPE: 'plain',
+      })
+      .withWaitStrategy(Wait.forLogMessage(/process up/i))
+      .start()
+
+    const bouncerHost = this.pgbouncer.getHost()
+    const bouncerPort = this.pgbouncer.getMappedPort(6432)
+    this.pgbouncerUrl = `postgresql://test_user:test_password@${bouncerHost}:${bouncerPort}/ripit_test`
+
+    // Apply Prisma schema via the DIRECT URL (PgBouncer transaction mode can't
+    // run DDL safely).
+    execSync('npx prisma db push --force-reset --skip-generate', {
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        DATABASE_URL: this.directUrl,
+        DIRECT_URL: this.directUrl,
+        PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION:
+          'Testcontainer database reset for automated testing',
+      },
+    })
+  }
+
+  /** Returns DATABASE_URL with pgbouncer=true appended. */
+  withFlag(): string {
+    const url = new URL(this.pgbouncerUrl)
+    url.searchParams.set('pgbouncer', 'true')
+    return url.toString()
+  }
+
+  /** Returns DATABASE_URL without the flag (used for the negative-control test). */
+  withoutFlag(): string {
+    return this.pgbouncerUrl
+  }
+
+  async stop(): Promise<void> {
+    await this.pgbouncer?.stop().catch(() => {})
+    await this.postgres?.stop().catch(() => {})
+    await this.network?.stop().catch(() => {})
+  }
+}

--- a/prisma/migrations/20260408230059_add_direct_url_to_datasource/migration.sql
+++ b/prisma/migrations/20260408230059_add_direct_url_to_datasource/migration.sql
@@ -1,0 +1,7 @@
+-- Schema-only change: add `directUrl = env("DIRECT_URL")` to the datasource
+-- block in schema.prisma. No DDL required — this tells Prisma which
+-- connection string to use for `migrate deploy` (direct to Postgres, bypassing
+-- PgBouncer) without affecting runtime queries.
+--
+-- See docs/DATABASE_CONNECTIONS.md for context.
+SELECT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Program {


### PR DESCRIPTION
Closes #408.

## Summary

Production `DATABASE_URL` connects through PgBouncer on `:6432` in transaction mode but was missing Prisma's `pgbouncer=true` query param, causing intermittent `prepared statement "sN" does not exist` errors under load. This PR makes the app-side changes required before infra can bump pool size / replicas.

## Changes

- **Prisma schemas**: added `directUrl = env("DIRECT_URL")` to both `prisma/schema.prisma` and `cloud-functions/clone-program/prisma/schema.prisma` so `prisma migrate deploy` hits Postgres directly instead of flowing through the pooler.
- **Boot guard** (`lib/db/assert-pgbouncer.ts`): throws in production if `DATABASE_URL` is on `:6432` without `pgbouncer=true`, or if `DIRECT_URL` is on `:6432` (footgun against migrations hanging on advisory locks). Warns in dev/test instead of throwing. Wired into `lib/db.ts`.
- **Clone worker** now reads `DIRECT_URL` (bypasses PgBouncer). Its 30s interactive transactions are exactly the workload that wants direct Postgres; single replica with `concurrency=1` keeps the connection count bounded. Also has an inline production guard.
- **Health endpoint split**:
  - `/api/health/live` — no DB, k8s liveness target (transient DB blips won't restart the pod)
  - `/api/health/ready` — `SELECT 1` + `pgbouncerConfigured`, k8s readiness target
  - `/api/health` — preserved as an alias for back-compat
- **Docs**: new `docs/DATABASE_CONNECTIONS.md` covering the `DATABASE_URL` vs `DIRECT_URL` split, transaction-mode rules, boot guard, health probes, connection-limit math, and Doppler rollout order.

## Tests

- `__tests__/lib/assert-pgbouncer.test.ts` — 14 unit tests covering prod/dev paths and both URL guards.
- `__tests__/integration/pgbouncer-pooling.test.ts` — new Testcontainers harness (`lib/test/pgbouncer-container.ts`) running pinned `edoburu/pgbouncer:v1.25.1-p0` + Postgres on a shared Docker network, with `DEFAULT_POOL_SIZE=2` to force server-connection reuse. 4 positive tests pass (sequential, concurrent, raw SQL, interactive transaction). Negative-control case is `.skip` with a documented note: we could not reproduce the prepared-statement bug against Prisma 6.19 even with 2400+ concurrent queries across multiple clients. The boot assertion remains the load-bearing protection; production was the original symptom site.
- `lib/test/database.ts` — also sets `DIRECT_URL` so the updated schema works with existing tests.
- Full suite: **217 passed, 3 skipped, 0 failed**. Typecheck clean.

## Doppler rollout (already done by @dmays)

- [x] Staging: `pgbouncer=true` added to `DATABASE_URL`, `DIRECT_URL` verified on `:5432`
- [x] Production: same

## Test plan

- [ ] CI smoke test passes (note: the new image smoke test may need `DATABASE_URL` with `pgbouncer=true` or a direct `:5432` URL to avoid the boot assertion — will follow up if it fails)
- [ ] Merge to `dev` → deploy to staging
- [ ] `curl https://staging.ripit.fit/api/health/ready` → expect `pgbouncerConfigured: true`
- [ ] Bake 5+ min, tail logs for prepared-statement errors or pool timeouts
- [ ] Run `~/repos/ripit-infra/load-tests/quick-hey-tests.sh staging` and compare to `load-tests/results/staging-20260406-baseline.md`
- [ ] Merge `dev` → `main` → prod
- [ ] Verify `/api/health/ready` in prod
- [ ] Hand off to infra for #40 (pool bumps) then #33 (replica scale)

## Merge order

Per prior agreement with infra agent: **#408 (this PR) → infra #40 → infra #33**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)