### PR TITLE
ci: add OCI labels and ripit.* metadata for image traceability

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -70,6 +70,22 @@ jobs:
           build-args: |
             NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL || 'https://staging.ripit.fit' }}
             NEXT_PUBLIC_VENMO_HANDLE=${{ vars.NEXT_PUBLIC_VENMO_HANDLE }}
+          # OCI standard labels — GHCR reads these to populate the "Source" link
+          # on the package page, and `docker inspect` surfaces them for forensics
+          # on a running image. Plus custom ripit.* labels for workflow/PR traceback.
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.ref.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+            org.opencontainers.image.title=ripit-fitness
+            org.opencontainers.image.description=Ripit Fitness — strength training tracker
+            ripit.branch=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            ripit.actor=${{ github.actor }}
+            ripit.workflow.run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            ripit.pr.number=${{ github.event.pull_request.number || '' }}
+            ripit.pr.url=${{ github.event.pull_request.html_url || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -77,13 +93,16 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}" | sed 's/"/\\"/g')
           curl -s -H "Content-Type: application/json" -d "{
             \"embeds\": [{
               \"title\": \"Production image ready\",
               \"description\": \"Update infra repo with new image tag:\n\`\`\`\nsha-${{ github.sha }}\n\`\`\`\",
               \"color\": 5025616,
               \"fields\": [
-                {\"name\": \"Commit\", \"value\": \"[\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})\", \"inline\": true},
+                {\"name\": \"Commit\", \"value\": \"[\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) — ${COMMIT_MSG}\", \"inline\": false},
+                {\"name\": \"Workflow run\", \"value\": \"[#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": true},
+                {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
                 {\"name\": \"Image\", \"value\": \"\`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}\`\", \"inline\": false}
               ]
             }]

--- a/.github/workflows/deploy-clone-worker.yml
+++ b/.github/workflows/deploy-clone-worker.yml
@@ -48,12 +48,23 @@ jobs:
             exit 1
           fi
 
-      - name: Build Docker image
-        run: |
-          docker build \
-            -t "$IMAGE_NAME:${{ steps.tags.outputs.tag }}" \
-            ./cloud-functions/clone-program
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image to GHCR
-        run: |
-          docker push "$IMAGE_NAME:${{ steps.tags.outputs.tag }}"
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./cloud-functions/clone-program
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+            org.opencontainers.image.title=clone-program
+            org.opencontainers.image.description=Ripit clone worker (BullMQ)
+            ripit.branch=${{ github.ref_name }}
+            ripit.actor=${{ github.actor }}
+            ripit.workflow.run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/docs/IMAGE_TRACEABILITY.md
+++ b/docs/IMAGE_TRACEABILITY.md
@@ -1,0 +1,65 @@
+# Image Traceability
+
+Every image pushed to GHCR is tagged with OCI standard labels plus custom `ripit.*` labels so you can trace it back to the exact commit, PR, and workflow run that built it.
+
+## On GHCR (web UI)
+
+`org.opencontainers.image.source` makes the package page display a **"Source"** link that jumps straight to the commit on GitHub. Visit the package page for [ripit-fitness](https://github.com/aptx-health/ripit-fitness/pkgs/container/ripit-fitness) or [clone-program](https://github.com/aptx-health/ripit-fitness/pkgs/container/clone-program).
+
+## From a running image (or pulled tarball)
+
+```bash
+docker inspect ghcr.io/aptx-health/ripit-fitness:sha-<sha> \
+  | jq '.[0].Config.Labels'
+```
+
+You'll see something like:
+
+```json
+{
+  "org.opencontainers.image.source": "https://github.com/aptx-health/ripit-fitness",
+  "org.opencontainers.image.revision": "abc1234...",
+  "org.opencontainers.image.ref.name": "main",
+  "org.opencontainers.image.created": "2026-04-08T23:45:12Z",
+  "org.opencontainers.image.title": "ripit-fitness",
+  "ripit.branch": "main",
+  "ripit.actor": "dmays",
+  "ripit.workflow.run": "https://github.com/aptx-health/ripit-fitness/actions/runs/1234567890",
+  "ripit.pr.number": "429",
+  "ripit.pr.url": "https://github.com/aptx-health/ripit-fitness/pull/429"
+}
+```
+
+## From inside k8s
+
+```bash
+kubectl get pod <pod> -o jsonpath='{.spec.containers[0].image}'
+# then:
+docker pull <that-image>
+docker inspect <that-image> | jq '.[0].Config.Labels'
+```
+
+Or: `skopeo inspect docker://<image>` works without pulling.
+
+## Common operator questions
+
+| Question | How to answer |
+|---|---|
+| What commit is running in prod right now? | `kubectl exec <pod> -- env` won't tell you — `docker inspect` the image and read `org.opencontainers.image.revision` |
+| What PR introduced this bug? | `docker inspect` → `ripit.pr.url` (or `ripit.pr.number`) |
+| Who triggered this build? | `docker inspect` → `ripit.actor` |
+| Where are the build logs? | `docker inspect` → `ripit.workflow.run` (direct link to the GitHub Actions run) |
+| When was this built? | `docker inspect` → `org.opencontainers.image.created` |
+| What branch? | `docker inspect` → `org.opencontainers.image.ref.name` |
+
+## Tag conventions
+
+| Tag pattern | Built on | Mutable? |
+|---|---|---|
+| `ripit-fitness:staging` | merge to `dev` | **yes** (overwritten each merge) |
+| `ripit-fitness:sha-<full-sha>` | merge to `main` | no (pinned forever) |
+| `ripit-fitness:pr-<num>-sha-<short>` | PR to `dev` | no (one per commit) |
+| `clone-program:staging` | merge to `dev` (path-filtered) | yes |
+| `clone-program:<full-sha>` | merge to `main` (path-filtered) | no |
+
+Labels are always present regardless of tag mutability — even `:staging` can be traced back to the specific commit that produced it.


### PR DESCRIPTION
## Summary

Makes it possible to trace any image running in production (or failing to deploy) back to its exact commit, PR, branch, actor, and workflow run — without having to cross-reference tags against git history.

## What changes

- **App + clone worker images** now carry standard OCI labels (`org.opencontainers.image.source`, `.revision`, `.ref.name`, `.created`, `.title`, etc.) plus custom `ripit.*` labels (`ripit.branch`, `ripit.actor`, `ripit.workflow.run`, `ripit.pr.number`, `ripit.pr.url`).
- **GHCR package pages** will now render a clickable **"View source"** link jumping straight to the commit (GHCR reads `org.opencontainers.image.source`).
- **Clone worker workflow** converted from raw `docker build` / `docker push` to `docker/build-push-action@v6` so labels can be applied.
- **Discord prod-build notification** enriched with workflow run link, actor, and commit message subject.
- **New `docs/IMAGE_TRACEABILITY.md`** operator guide: how to pull labels off a running image via `docker inspect` / `skopeo inspect`, and a question→answer table for common ops scenarios.

## What does NOT change

- Tag patterns are identical (`:staging` mutable on dev merges, `:sha-<sha>` pinned on main merges, `:pr-<num>-sha-<short>` for PRs).
- Build args, caching, smoke test, and deploy flow are unchanged.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, pull the new `:staging` image and run `docker inspect ghcr.io/aptx-health/ripit-fitness:staging | jq '.[0].Config.Labels'` — confirm all `org.opencontainers.image.*` and `ripit.*` labels are populated
- [ ] Visit https://github.com/aptx-health/ripit-fitness/pkgs/container/ripit-fitness and verify the "Source" link now renders on the latest version
- [ ] Next production build: confirm Discord notification includes workflow run link + commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)