### PR TITLE
Fix: Add editor auth checks to feedback endpoints

### DIFF
--- a/app/api/feedback/[feedbackId]/route.ts
+++ b/app/api/feedback/[feedbackId]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { getCurrentUser } from '@/lib/auth/server'
+import { requireEditor } from '@/lib/admin/auth'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import type { FeedbackStatus } from '@/types/feedback'
@@ -10,10 +10,8 @@ export async function PATCH(
   { params }: { params: Promise<{ feedbackId: string }> }
 ) {
   try {
-    const { user, error } = await getCurrentUser()
-    if (error || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+    const { response } = await requireEditor()
+    if (response) return response
 
     const { feedbackId } = await params
 

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { sendDiscordNotification } from '@/lib/discord'
@@ -98,10 +99,8 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const { user, error } = await getCurrentUser()
-    if (error || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+    const { response } = await requireEditor()
+    if (response) return response
 
     const { searchParams } = new URL(request.url)
     const status = searchParams.get('status')


### PR DESCRIPTION
## Summary
- Added `requireEditor()` authorization checks to `GET /api/feedback` and `PATCH /api/feedback/[feedbackId]`
- Previously any authenticated user could list all feedback and modify status/adminNote fields
- Now only users with editor or admin role can access these endpoints, matching the pattern used by all other admin routes

## Test plan
- [ ] Verify `GET /api/feedback` returns 403 for non-editor users
- [ ] Verify `PATCH /api/feedback/{id}` returns 403 for non-editor users
- [ ] Verify both endpoints still work for editor/admin users
- [ ] Verify `POST /api/feedback` still works for any authenticated user (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)