### PR TITLE
Add Next.js security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,8 +9,65 @@ const withSerwist = withSerwistInit({
   cacheOnNavigation: true,
 });
 
+// Security headers applied to all routes
+const securityHeaders = [
+  {
+    // Prevent clickjacking by disallowing framing
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    // Prevent MIME type sniffing
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    // Control referrer information sent with requests
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    // Enforce HTTPS (1 year, include subdomains)
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains',
+  },
+  {
+    // Restrict browser feature access
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+  },
+  {
+    // Content Security Policy
+    // 'unsafe-inline' required for theme initialization scripts and Next.js inline styles
+    // 'unsafe-eval' required for Next.js development mode hot reload
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''}`,
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' https://cdn.ripit.fit data: blob:",
+      "font-src 'self'",
+      "connect-src 'self'",
+      "worker-src 'self'",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+    ].join('; '),
+  },
+];
+
 const nextConfig: NextConfig = {
   output: 'standalone',
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- Adds comprehensive security headers to `next.config.ts` via the `headers()` configuration
- Headers: CSP, X-Frame-Options (DENY), X-Content-Type-Options (nosniff), HSTS, Referrer-Policy, Permissions-Policy
- CSP allows `unsafe-inline` for theme initialization inline scripts and Next.js inline styles
- `unsafe-eval` only enabled in development mode for hot reload

## Headers added
| Header | Value |
|--------|-------|
| X-Frame-Options | DENY |
| X-Content-Type-Options | nosniff |
| Referrer-Policy | strict-origin-when-cross-origin |
| Strict-Transport-Security | max-age=31536000; includeSubDomains |
| Permissions-Policy | camera=(), microphone=(), geolocation=(), browsing-topics=() |
| Content-Security-Policy | default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' https://cdn.ripit.fit data: blob:; ... |

## Test plan
- [ ] Verify app loads correctly in development (no CSP violations in console)
- [ ] Verify staging deployment serves correct response headers (curl -I)
- [ ] Confirm theme toggle still works (inline script not blocked)
- [ ] Confirm service worker registration works (worker-src 'self')
- [ ] Confirm images from cdn.ripit.fit still load

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)