### PR TITLE
feat(rate-limit): expand coverage across writes, admin, auth, feedback (#42)

### DIFF
--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -1,0 +1,146 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  checkRateLimit,
+  checkRateLimitWithHeaders,
+  getClientIp,
+  withRateLimitHeaders,
+} from '@/lib/rate-limit'
+import { NextResponse } from 'next/server'
+
+/**
+ * Tests for lib/rate-limit.
+ *
+ * By default NODE_ENV=test short-circuits checkRateLimit to allow all
+ * requests (so API integration tests aren't rate-limited). To actually
+ * exercise the limiter behavior we temporarily flip NODE_ENV inside each
+ * test that needs it.
+ */
+
+function makeLimiter(points: number, duration = 60) {
+  const instance = new RateLimiterMemory({ points, duration })
+  return () => instance
+}
+
+describe('rate-limit', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    // @ts-expect-error — test env override
+    process.env.NODE_ENV = originalEnv
+  })
+
+  describe('test env bypass', () => {
+    it('returns no-op result when NODE_ENV=test regardless of limiter state', async () => {
+      // @ts-expect-error — test env override
+      process.env.NODE_ENV = 'test'
+      const limiter = makeLimiter(1)
+      // Consume the single point first
+      await limiter().consume('user-1')
+      // Still allowed because we short-circuit in test
+      const result = await checkRateLimitWithHeaders(limiter, 'user-1')
+      expect(result.response).toBeNull()
+      expect(result.headers).toEqual({})
+    })
+  })
+
+  describe('checkRateLimitWithHeaders', () => {
+    beforeEach(() => {
+      // @ts-expect-error — deliberately flip out of test mode to exercise logic
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('allows requests under the limit and emits X-RateLimit headers', async () => {
+      const limiter = makeLimiter(3)
+      const res = await checkRateLimitWithHeaders(limiter, 'user-1')
+      expect(res.response).toBeNull()
+      expect(res.headers['X-RateLimit-Limit']).toBe('3')
+      expect(res.headers['X-RateLimit-Remaining']).toBe('2')
+      expect(res.headers['X-RateLimit-Reset']).toMatch(/^\d+$/)
+    })
+
+    it('returns 429 with Retry-After when the limit is exceeded', async () => {
+      const limiter = makeLimiter(2)
+      await checkRateLimitWithHeaders(limiter, 'user-1')
+      await checkRateLimitWithHeaders(limiter, 'user-1')
+      const res = await checkRateLimitWithHeaders(limiter, 'user-1')
+      expect(res.response).not.toBeNull()
+      expect(res.response?.status).toBe(429)
+      expect(res.headers['Retry-After']).toMatch(/^\d+$/)
+      expect(res.headers['X-RateLimit-Remaining']).toBe('0')
+    })
+
+    it('keys are isolated — user-1 exhaustion does not affect user-2', async () => {
+      const limiter = makeLimiter(1)
+      const first = await checkRateLimitWithHeaders(limiter, 'user-1')
+      const secondSameUser = await checkRateLimitWithHeaders(limiter, 'user-1')
+      const otherUser = await checkRateLimitWithHeaders(limiter, 'user-2')
+      expect(first.response).toBeNull()
+      expect(secondSameUser.response?.status).toBe(429)
+      expect(otherUser.response).toBeNull()
+    })
+
+    it('fails open on empty key rather than rate-limiting globally', async () => {
+      const limiter = makeLimiter(1)
+      const res = await checkRateLimitWithHeaders(limiter, '')
+      expect(res.response).toBeNull()
+      expect(res.headers).toEqual({})
+    })
+  })
+
+  describe('checkRateLimit (backwards-compatible wrapper)', () => {
+    beforeEach(() => {
+      // @ts-expect-error
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('returns null when allowed', async () => {
+      const limiter = makeLimiter(1)
+      expect(await checkRateLimit(limiter, 'user-1')).toBeNull()
+    })
+
+    it('returns a 429 NextResponse when exceeded', async () => {
+      const limiter = makeLimiter(1)
+      await checkRateLimit(limiter, 'user-1')
+      const res = await checkRateLimit(limiter, 'user-1')
+      expect(res?.status).toBe(429)
+    })
+  })
+
+  describe('withRateLimitHeaders', () => {
+    it('merges rate-limit headers onto a NextResponse', () => {
+      const response = NextResponse.json({ ok: true })
+      const merged = withRateLimitHeaders(response, {
+        response: null,
+        headers: { 'X-RateLimit-Limit': '10', 'X-RateLimit-Remaining': '7' },
+      })
+      expect(merged.headers.get('X-RateLimit-Limit')).toBe('10')
+      expect(merged.headers.get('X-RateLimit-Remaining')).toBe('7')
+    })
+
+    it('is a no-op when the result has no headers', () => {
+      const response = NextResponse.json({ ok: true })
+      const merged = withRateLimitHeaders(response, { response: null, headers: {} })
+      expect(merged.headers.get('X-RateLimit-Limit')).toBeNull()
+    })
+  })
+
+  describe('getClientIp', () => {
+    it('reads the first entry from x-forwarded-for', () => {
+      const req = new Request('http://x', {
+        headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+      })
+      expect(getClientIp(req)).toBe('1.2.3.4')
+    })
+
+    it('falls back to x-real-ip', () => {
+      const req = new Request('http://x', { headers: { 'x-real-ip': '9.9.9.9' } })
+      expect(getClientIp(req)).toBe('9.9.9.9')
+    })
+
+    it('returns "unknown" when no IP headers are present', () => {
+      const req = new Request('http://x')
+      expect(getClientIp(req)).toBe('unknown')
+    })
+  })
+})

--- a/app/api/admin/articles/[id]/route.ts
+++ b/app/api/admin/articles/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params
@@ -57,7 +57,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params
@@ -149,7 +149,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/articles/route.ts
+++ b/app/api/admin/articles/route.ts
@@ -10,7 +10,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const body = await request.json()

--- a/app/api/admin/collections/[id]/route.ts
+++ b/app/api/admin/collections/[id]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params
@@ -59,7 +59,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params
@@ -135,7 +135,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET() {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const collections = await prisma.collection.findMany({
@@ -43,7 +43,7 @@ export async function GET() {
  */
 export async function POST(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const body = await request.json()

--- a/app/api/admin/exercise-definitions/[id]/route.ts
+++ b/app/api/admin/exercise-definitions/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
     const user = auth.user
 
@@ -88,7 +88,7 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
     const user = auth.user
 
@@ -218,7 +218,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
     const user = auth.user
 

--- a/app/api/admin/exercise-definitions/route.ts
+++ b/app/api/admin/exercise-definitions/route.ts
@@ -23,7 +23,7 @@ import {
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)
@@ -181,7 +181,7 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
     const user = auth.user
 

--- a/app/api/admin/feedback/create-issue/route.ts
+++ b/app/api/admin/feedback/create-issue/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { adminLimiter, checkRateLimit } from '@/lib/rate-limit'
 
 const GITHUB_REPO = 'aptx-health/ripit-fitness'
 
@@ -18,6 +19,9 @@ export async function POST(request: NextRequest) {
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(adminLimiter, user.id)
+    if (limited) return limited
 
     const token = process.env.GH_ISSUE_TOKEN
     if (!token) {

--- a/app/api/admin/media/route.ts
+++ b/app/api/admin/media/route.ts
@@ -12,7 +12,7 @@ import { logger } from '@/lib/logger'
  */
 export async function POST(request: Request) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const formData = await request.formData()

--- a/app/api/admin/tags/[id]/route.ts
+++ b/app/api/admin/tags/[id]/route.ts
@@ -12,7 +12,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params
@@ -60,7 +60,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/tags/route.ts
+++ b/app/api/admin/tags/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET() {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const tags = await prisma.tag.findMany({
@@ -55,7 +55,7 @@ export async function GET() {
  */
 export async function POST(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const body = await request.json()

--- a/app/api/auth/complete-profile/route.ts
+++ b/app/api/auth/complete-profile/route.ts
@@ -2,6 +2,11 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { Pool } from 'pg'
 import { getCurrentUser } from '@/lib/auth/server'
 import { logger } from '@/lib/logger'
+import {
+  authSensitiveLimiter,
+  checkRateLimit,
+  getClientIp,
+} from '@/lib/rate-limit'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 
@@ -12,6 +17,11 @@ export async function POST(request: NextRequest) {
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    // IP-keyed rate limit. Account linking is a credential-stuffing target
+    // and bypasses BetterAuth's own limiter. 5 req / 60s per IP.
+    const limited = await checkRateLimit(authSensitiveLimiter, getClientIp(request))
+    if (limited) return limited
 
     const { email, password } = await request.json()
 

--- a/app/api/community/[communityProgramId]/add/route.ts
+++ b/app/api/community/[communityProgramId]/add/route.ts
@@ -3,6 +3,11 @@ import { getCurrentUser } from '@/lib/auth/server';
 import { cloneCommunityProgram } from '@/lib/community/cloning';
 import { prisma } from '@/lib/db';
 import { logger } from '@/lib/logger';
+import {
+  checkRateLimitWithHeaders,
+  communityCloneLimiter,
+  withRateLimitHeaders,
+} from '@/lib/rate-limit';
 
 export async function POST(
   _request: NextRequest,
@@ -18,6 +23,13 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    // Protect the BullMQ queue — community clones enqueue a multi-week
+    // background job, so we cap to 3 per 60s per user.
+    const rl = await checkRateLimitWithHeaders(communityCloneLimiter, user.id, {
+      endpoint: 'POST /api/community/[id]/add',
+    });
+    if (rl.response) return rl.response;
+
     // Clone the community program to user's collection
     // This returns immediately with a shell program (copyStatus='cloning')
     // The actual cloning happens in the background
@@ -30,11 +42,14 @@ export async function POST(
       );
     }
 
-    return NextResponse.json({
-      success: true,
-      programId: result.programId,
-      status: 'cloning', // Indicates background cloning is in progress
-    });
+    return withRateLimitHeaders(
+      NextResponse.json({
+        success: true,
+        programId: result.programId,
+        status: 'cloning', // Indicates background cloning is in progress
+      }),
+      rl
+    );
   } catch (error) {
     logger.error({ error, context: 'community-program-add' }, 'Failed to add community program');
     return NextResponse.json(

--- a/app/api/exercises/[exerciseId]/delete/route.ts
+++ b/app/api/exercises/[exerciseId]/delete/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, destructiveOpLimiter } from '@/lib/rate-limit'
 
 type DeleteExerciseRequest = {
   applyToFuture: boolean
@@ -20,6 +21,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(destructiveOpLimiter, user.id)
+    if (limited) return limited
 
     // Parse request body
     const body = await request.json() as DeleteExerciseRequest

--- a/app/api/exercises/[exerciseId]/replace/route.ts
+++ b/app/api/exercises/[exerciseId]/replace/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, destructiveOpLimiter } from '@/lib/rate-limit'
 
 type ReplaceExerciseRequest = {
   newExerciseDefinitionId: string
@@ -29,6 +30,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(destructiveOpLimiter, user.id)
+    if (limited) return limited
 
     // Parse request body
     const body = await request.json() as ReplaceExerciseRequest

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -3,11 +3,11 @@ import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { sendDiscordNotification } from '@/lib/discord'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, feedbackSubmissionLimiter } from '@/lib/rate-limit'
 import type { FeedbackCategory } from '@/types/feedback'
 import { VALID_CATEGORIES } from '@/types/feedback'
 
 const MAX_MESSAGE_LENGTH = 2000
-const RATE_LIMIT_PER_HOUR = 5
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,6 +15,11 @@ export async function POST(request: NextRequest) {
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    // Rate limit: 5 submissions / hour / user. Replaces a prior DB-count
+    // check that hit Postgres on every POST.
+    const limited = await checkRateLimit(feedbackSubmissionLimiter, user.id)
+    if (limited) return limited
 
     const body = await request.json()
     const { category, message, pageUrl, userAgent } = body as {
@@ -46,22 +51,6 @@ export async function POST(request: NextRequest) {
     // Validate pageUrl
     if (!pageUrl || pageUrl.trim().length === 0) {
       return NextResponse.json({ error: 'Page URL is required' }, { status: 400 })
-    }
-
-    // Rate limit: max submissions per hour
-    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
-    const recentCount = await prisma.feedback.count({
-      where: {
-        userId: user.id,
-        createdAt: { gt: oneHourAgo },
-      },
-    })
-
-    if (recentCount >= RATE_LIMIT_PER_HOUR) {
-      return NextResponse.json(
-        { error: 'Too many submissions. Please try again later.' },
-        { status: 429 }
-      )
     }
 
     const feedback = await prisma.feedback.create({

--- a/app/api/programs/[programId]/activate/route.ts
+++ b/app/api/programs/[programId]/activate/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
 
 export async function POST(
   _request: NextRequest,
@@ -16,6 +17,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(programManagementLimiter, user.id)
+    if (limited) return limited
 
     // Verify program exists and user owns it
     const program = await prisma.program.findUnique({

--- a/app/api/programs/[programId]/archive/route.ts
+++ b/app/api/programs/[programId]/archive/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, destructiveOpLimiter } from '@/lib/rate-limit'
 
 export async function POST(
   _request: NextRequest,
@@ -16,6 +17,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(destructiveOpLimiter, user.id)
+    if (limited) return limited
 
     // Verify program exists and user owns it
     const program = await prisma.program.findUnique({

--- a/app/api/programs/[programId]/delete/route.ts
+++ b/app/api/programs/[programId]/delete/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, destructiveOpLimiter } from '@/lib/rate-limit'
 
 export async function DELETE(
   _request: NextRequest,
@@ -16,6 +17,9 @@ export async function DELETE(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(destructiveOpLimiter, user.id)
+    if (limited) return limited
 
     // Verify program exists and user owns it
     const program = await prisma.program.findUnique({

--- a/app/api/programs/[programId]/duplicate/route.ts
+++ b/app/api/programs/[programId]/duplicate/route.ts
@@ -4,6 +4,7 @@ import { generateCopyName } from '@/lib/copy-name'
 import { prisma } from '@/lib/db'
 import { batchInsertWeek } from '@/lib/db/batch-insert'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
 
 export async function POST(
   _request: NextRequest,
@@ -18,6 +19,9 @@ export async function POST(
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(programManagementLimiter, user.id)
+    if (limited) return limited
 
     // Fetch the complete program with all nested relations
     const originalProgram = await prisma.program.findUnique({

--- a/app/api/programs/[programId]/restart/route.ts
+++ b/app/api/programs/[programId]/restart/route.ts
@@ -3,6 +3,7 @@ import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { restartProgram } from '@/lib/db/program-restart'
 import { logger } from '@/lib/logger'
+import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
 
 /**
  * POST /api/programs/[programId]/restart
@@ -24,6 +25,9 @@ export async function POST(
       logger.debug('Unauthorized - no user found')
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const limited = await checkRateLimit(programManagementLimiter, user.id)
+    if (limited) return limited
 
     logger.debug({ userId: user.id, programId }, 'User authenticated')
 

--- a/app/api/programs/route.ts
+++ b/app/api/programs/route.ts
@@ -2,6 +2,11 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import {
+  checkRateLimitWithHeaders,
+  programManagementLimiter,
+  withRateLimitHeaders,
+} from '@/lib/rate-limit'
 
 type CreateProgramRequest = {
   name: string
@@ -17,6 +22,11 @@ export async function POST(request: NextRequest) {
     if (error || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const rl = await checkRateLimitWithHeaders(programManagementLimiter, user.id, {
+      endpoint: 'POST /api/programs',
+    })
+    if (rl.response) return rl.response
 
     // Parse request body
     const body = await request.json() as CreateProgramRequest
@@ -54,10 +64,13 @@ export async function POST(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({
-      success: true,
-      program
-    })
+    return withRateLimitHeaders(
+      NextResponse.json({
+        success: true,
+        program,
+      }),
+      rl
+    )
   } catch (error) {
     logger.error({ error, context: 'program-create' }, 'Failed to create program')
     return NextResponse.json(

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -1,0 +1,121 @@
+# Rate Limiting
+
+Rate limiting is enforced at the API-route layer using [`rate-limiter-flexible`](https://github.com/animir/node-rate-limiter-flexible) backed by Redis (with in-memory fallback). Limits are **tiered by blast radius**, not applied uniformly — a hot-path workout logging endpoint has a very different budget than a community-program clone that enqueues a multi-week background job.
+
+## Tiers
+
+| Tier | Limiter | Budget | Key | Purpose |
+|---|---|---|---|---|
+| T0 — queue protection | `communityCloneLimiter` | 3 / 60s | userId | Protects the BullMQ clone worker from being flooded with multi-week jobs |
+| T1 — program mgmt | `programManagementLimiter` | 20 / 60s | userId | Program CRUD (create, duplicate, activate, restart) — the expensive ones enqueue or transact across many rows |
+| T2 — destructive ops | `destructiveOpLimiter` | 10 / 60s | userId | Delete/archive program, bulk `applyToFuture` exercise replace/delete |
+| T3 — admin | `adminLimiter` | 30 / 60s | userId | All `/api/admin/*` endpoints (reads + writes). Defense in depth behind editor/admin role |
+| T4 — workout writes | `workoutActionLimiter` | 10 / 10s | userId | Complete, skip, clear a workout |
+| T4 — set logging | `setLoggingLimiter` | 60 / 10s | userId | Draft sync, per-set upsert, per-set delete — intentionally generous for live logging |
+| T5 — auth sensitive | `authSensitiveLimiter` | 5 / 60s | **IP** | `/api/auth/complete-profile` (bypasses BetterAuth's own limiter) |
+| T6 — feedback | `feedbackSubmissionLimiter` | 5 / 3600s | userId | Replaces a prior DB-count check — submissions per hour |
+
+BetterAuth handles its own rate limiting on everything under `/api/auth/[...all]` (sign-in, sign-up, password reset, etc.). The `RELAXED_RATE_LIMITS` env var should be unset (or `false`) in production — it's only enabled in staging for load testing. This is **not** a place to add `lib/rate-limit.ts` limiters; don't double-wrap.
+
+## What is NOT rate-limited (and why)
+
+- **Read endpoints** (GETs). Cheap, cached, low abuse value. Add coverage case-by-case if a specific read becomes a problem.
+- **Health endpoints** (`/api/health/*`). Probed by k8s — must never 429.
+- **Signout**. Idempotent, harmless.
+- **Week/workout parent CRUD**. Not attack vectors; set logging (the child) is what matters and is already covered.
+- **Auth catch-all** (`/api/auth/[...all]`). BetterAuth handles it.
+
+## How to add coverage to a new route
+
+The simpler pattern (no headers-on-success):
+
+```ts
+import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
+
+export async function POST(request: NextRequest) {
+  const { user, error } = await getCurrentUser()
+  if (error || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const limited = await checkRateLimit(programManagementLimiter, user.id)
+  if (limited) return limited
+
+  // ... rest of handler
+}
+```
+
+If you want `X-RateLimit-*` headers on successful responses (so clients can self-throttle), use the richer helper:
+
+```ts
+import {
+  checkRateLimitWithHeaders,
+  communityCloneLimiter,
+  withRateLimitHeaders,
+} from '@/lib/rate-limit'
+
+const rl = await checkRateLimitWithHeaders(communityCloneLimiter, user.id, {
+  endpoint: 'POST /api/community/[id]/add',
+})
+if (rl.response) return rl.response
+
+// ... do work ...
+
+return withRateLimitHeaders(NextResponse.json({ ok: true }), rl)
+```
+
+For **admin** routes, prefer the `requireEditor({ rateLimit: true })` helper — it combines editor role check and rate limiting in one call:
+
+```ts
+const auth = await requireEditor({ rateLimit: true })
+if (auth.response) return auth.response
+```
+
+For **pre-auth** or **auth-sensitive** routes, key by IP rather than user id:
+
+```ts
+import { authSensitiveLimiter, checkRateLimit, getClientIp } from '@/lib/rate-limit'
+
+const limited = await checkRateLimit(authSensitiveLimiter, getClientIp(request))
+if (limited) return limited
+```
+
+## Response contract
+
+### On success
+If you used `checkRateLimitWithHeaders` + `withRateLimitHeaders`, the response carries:
+
+- `X-RateLimit-Limit` — the limiter's point budget
+- `X-RateLimit-Remaining` — points left in the current window
+- `X-RateLimit-Reset` — Unix epoch (seconds) when the window resets
+
+### On 429
+Always includes:
+
+- `Retry-After` — seconds until next attempt should succeed
+- `X-RateLimit-Limit`, `X-RateLimit-Remaining` (`0`), `X-RateLimit-Reset`
+
+Body: `{ "error": "Too many requests" }`.
+
+## Fail-open behavior
+
+If Redis is unreachable and the in-memory fallback fails for any reason, `checkRateLimit` **allows the request through** rather than blocking legitimate users. We log the error at `error` level for alerting but do not 503. A best-effort rate limiter is better than an outage.
+
+## Test bypass
+
+`checkRateLimit` short-circuits when `NODE_ENV=test`, so integration tests against real limiters don't flake or require time-travel. To exercise the limiter logic from a unit test, temporarily flip `process.env.NODE_ENV` to `'development'` (see `__tests__/lib/rate-limit.test.ts` for the pattern).
+
+## Observability
+
+Hitting a rate limit logs at `info` (not `warn`) because it's expected and useful telemetry for tuning, not an alertable event:
+
+```json
+{ "level": "info", "msg": "rate limit hit", "key": "...", "endpoint": "POST /api/community/[id]/add", "retryAfter": 45, "limit": 3 }
+```
+
+Aggregate these in Grafana / Loki to see which endpoints are running hot. If an endpoint is hitting limits for legitimate users repeatedly, loosen it; if nothing is ever hit, tighten it.
+
+## Tuning guidance
+
+- **Start conservative, observe, then loosen.** Tightening after launch is harder (users complain); loosening is easy.
+- **Check the log aggregation** for `rate limit hit` events before shipping a tightening.
+- **If a single user keeps hitting a limit**, check their client — it's often a retry storm or a buggy polling loop, not actual abuse.
+- **Redis pool pressure**: the limiter uses its own Redis connection (separate from BullMQ and app sessions). Not a factor in the Postgres connection math.

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from 'next/server'
 import { type AuthUser, getCurrentUser, type UserRole } from '@/lib/auth/server'
 import { logger } from '@/lib/logger'
+import { adminLimiter, checkRateLimit } from '@/lib/rate-limit'
+
+export interface RequireOptions {
+  /** Apply the admin rate limiter (30 req / 60s per user). Use on write handlers. */
+  rateLimit?: boolean
+}
 
 const ADMIN_ROLES: UserRole[] = ['admin']
 const EDITOR_ROLES: UserRole[] = ['admin', 'editor']
@@ -21,7 +27,7 @@ export type AdminAuth = AdminAuthResult | AdminAuthError
  * Require admin role for an API route.
  * Returns { user } on success, or { response } with the appropriate error.
  */
-export async function requireAdmin(): Promise<AdminAuth> {
+export async function requireAdmin(opts: RequireOptions = {}): Promise<AdminAuth> {
   const { user, error } = await getCurrentUser()
 
   if (error || !user) {
@@ -34,6 +40,11 @@ export async function requireAdmin(): Promise<AdminAuth> {
     return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
   }
 
+  if (opts.rateLimit) {
+    const limited = await checkRateLimit(adminLimiter, user.id)
+    if (limited) return { response: limited }
+  }
+
   return { user }
 }
 
@@ -41,7 +52,7 @@ export async function requireAdmin(): Promise<AdminAuth> {
  * Require editor or admin role for an API route.
  * Returns { user } on success, or { response } with the appropriate error.
  */
-export async function requireEditor(): Promise<AdminAuth> {
+export async function requireEditor(opts: RequireOptions = {}): Promise<AdminAuth> {
   const { user, error } = await getCurrentUser()
 
   if (error || !user) {
@@ -52,6 +63,11 @@ export async function requireEditor(): Promise<AdminAuth> {
   if (!EDITOR_ROLES.includes(user.role)) {
     logger.warn({ userId: user.id, role: user.role }, 'Editor auth: forbidden (editor required)')
     return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  if (opts.rateLimit) {
+    const limited = await checkRateLimit(adminLimiter, user.id)
+    if (limited) return { response: limited }
   }
 
   return { user }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -115,43 +115,169 @@ export const communityCloneLimiter = lazyLimiter({ keyPrefix: 'clone', points: 3
  */
 export const adminLimiter = lazyLimiter({ keyPrefix: 'admin', points: 30, duration: 60 })
 
+/**
+ * Sensitive auth endpoints that bypass BetterAuth's built-in limiter
+ * (e.g. /api/auth/complete-profile). IP-keyed to protect against
+ * credential-stuffing-style abuse on account linking.
+ * Tight budget: 5 req / 60s per IP.
+ */
+export const authSensitiveLimiter = lazyLimiter({
+  keyPrefix: 'auth-sensitive',
+  points: 5,
+  duration: 60,
+})
+
+/**
+ * Feedback submissions.
+ * Replaces a DB-count-based check that hit Postgres on every POST.
+ * 5 req / 3600s (hour) per user — matches the prior limit.
+ */
+export const feedbackSubmissionLimiter = lazyLimiter({
+  keyPrefix: 'feedback',
+  points: 5,
+  duration: 3600,
+})
+
 export type LimiterGetter = () => RateLimiterRedis | RateLimiterMemory
 
 /**
- * Check rate limit for a given limiter and key.
- * Returns a 429 NextResponse if rate limited, or null if allowed.
+ * Parse a limiter's config out of its instance. Used to expose
+ * X-RateLimit-Limit without duplicating config in call sites.
  */
-export async function checkRateLimit(
+function getLimiterPoints(limiter: RateLimiterRedis | RateLimiterMemory): number {
+  // Both classes expose `points` on the instance.
+  return (limiter as { points: number }).points
+}
+
+function buildRateLimitHeaders(
+  limit: number,
+  remaining: number,
+  msBeforeNext: number
+): Record<string, string> {
+  const resetEpoch = Math.ceil((Date.now() + msBeforeNext) / 1000)
+  return {
+    'X-RateLimit-Limit': String(limit),
+    'X-RateLimit-Remaining': String(Math.max(0, remaining)),
+    'X-RateLimit-Reset': String(resetEpoch),
+  }
+}
+
+export interface RateLimitResult {
+  /** A 429 response to return to the client, or null if the request may proceed. */
+  response: NextResponse | null
+  /** Headers to attach to the final response (whether 200 or 429). */
+  headers: Record<string, string>
+}
+
+/**
+ * Check rate limit for a given limiter and key.
+ *
+ * Preferred modern shape — returns both the (possibly null) 429 response
+ * AND a header map that the caller should merge onto their successful
+ * response so clients can self-throttle.
+ *
+ * Short-circuits in NODE_ENV=test so integration tests don't flake.
+ */
+export async function checkRateLimitWithHeaders(
   getLimiter: LimiterGetter,
-  key: string
-): Promise<NextResponse | null> {
-  // Guard against empty key — would otherwise rate-limit globally
-  if (!key) {
-    logger.error('checkRateLimit called with empty key, allowing request')
-    return null
+  key: string,
+  ctx: { endpoint?: string } = {}
+): Promise<RateLimitResult> {
+  // Test bypass — tests run against testcontainers and shouldn't be subject
+  // to rate limits. Explicit bypass is cleaner than relying on Redis being
+  // absent.
+  if (process.env.NODE_ENV === 'test') {
+    return { response: null, headers: {} }
   }
 
+  // Guard against empty key — would otherwise rate-limit globally
+  if (!key) {
+    logger.error({ endpoint: ctx.endpoint }, 'checkRateLimit called with empty key, allowing request')
+    return { response: null, headers: {} }
+  }
+
+  const limiter = getLimiter()
+  const limit = getLimiterPoints(limiter)
+
   try {
-    await getLimiter().consume(key)
-    return null
+    const res = await limiter.consume(key)
+    return {
+      response: null,
+      headers: buildRateLimitHeaders(limit, res.remainingPoints, res.msBeforeNext),
+    }
   } catch (rlRes: unknown) {
     // RateLimiterRes is thrown when rate limit is exceeded
     if (rlRes instanceof Error === false && rlRes && typeof rlRes === 'object' && 'msBeforeNext' in rlRes) {
       const res = rlRes as RateLimiterRes
       const retryAfter = Math.ceil(res.msBeforeNext / 1000)
-      logger.warn({ key, retryAfter }, 'Rate limit exceeded')
-      return NextResponse.json(
-        { error: 'Too many requests' },
-        {
-          status: 429,
-          headers: { 'Retry-After': String(retryAfter) },
-        }
+      const headers = {
+        ...buildRateLimitHeaders(limit, 0, res.msBeforeNext),
+        'Retry-After': String(retryAfter),
+      }
+      // Info level (not warn) — hitting a rate limit is expected and is
+      // useful telemetry for tuning, not an alertable event.
+      logger.info(
+        { key, retryAfter, endpoint: ctx.endpoint, limit },
+        'rate limit hit'
       )
+      return {
+        response: NextResponse.json({ error: 'Too many requests' }, { status: 429, headers }),
+        headers,
+      }
     }
 
-    // Unexpected error from rate limiter — allow the request through
-    // rather than blocking legitimate users
-    logger.error({ error: rlRes, key }, 'Rate limiter error, allowing request')
-    return null
+    // Unexpected error from rate limiter — fail open rather than blocking
+    // legitimate users.
+    logger.error({ error: rlRes, key, endpoint: ctx.endpoint }, 'Rate limiter error, allowing request')
+    return { response: null, headers: {} }
   }
+}
+
+/**
+ * Backwards-compatible wrapper returning just the 429 response (if any).
+ * Existing call sites can continue to use this; new call sites should
+ * prefer `checkRateLimitWithHeaders` so clients get X-RateLimit-* headers
+ * on successful responses.
+ */
+export async function checkRateLimit(
+  getLimiter: LimiterGetter,
+  key: string
+): Promise<NextResponse | null> {
+  const { response } = await checkRateLimitWithHeaders(getLimiter, key)
+  return response
+}
+
+/**
+ * Merges X-RateLimit-* headers from a RateLimitResult onto a successful
+ * NextResponse. No-op if the result has no headers (test bypass, fail-open).
+ *
+ * Usage:
+ * ```ts
+ * const rl = await checkRateLimitWithHeaders(limiter, user.id, { endpoint: '...' })
+ * if (rl.response) return rl.response
+ * // ... do work ...
+ * return withRateLimitHeaders(NextResponse.json(data), rl)
+ * ```
+ */
+export function withRateLimitHeaders(
+  response: NextResponse,
+  rl: RateLimitResult
+): NextResponse {
+  for (const [k, v] of Object.entries(rl.headers)) {
+    response.headers.set(k, v)
+  }
+  return response
+}
+
+/**
+ * Extracts a stable IP address from a NextRequest for IP-keyed rate limits.
+ * Falls back to a synthetic key so we never rate-limit globally on empty.
+ */
+export function getClientIp(request: Request): string {
+  const headers = request.headers
+  const forwardedFor = headers.get('x-forwarded-for')
+  if (forwardedFor) return forwardedFor.split(',')[0].trim()
+  const realIp = headers.get('x-real-ip')
+  if (realIp) return realIp.trim()
+  return 'unknown'
 }


### PR DESCRIPTION
Closes #42.

## Summary

Rate limiting now covers all high-value write paths and administrative endpoints, not just workout logging. Tiered by blast radius (queue-protection > bulk mutation > program writes > admin > hot-path writes), so `setLoggingLimiter` stays generous while `communityCloneLimiter` (which enqueues multi-week BullMQ jobs) stays tight at 3/60s.

Builds on the existing \`rate-limiter-flexible\` infrastructure rather than swapping to \`@upstash/ratelimit\` — the existing tiered scheme is richer than a uniform 10/10s.

## Coverage added

| Tier | Limiter | Budget | Endpoints |
|---|---|---|---|
| T0 queue | \`communityCloneLimiter\` | 3 / 60s | \`POST /api/community/[id]/add\` |
| T1 program mgmt | \`programManagementLimiter\` | 20 / 60s | \`POST /programs\`, \`/programs/[id]/{duplicate,activate,restart}\` |
| T2 destructive | \`destructiveOpLimiter\` | 10 / 60s | \`/programs/[id]/{delete,archive}\`, \`/exercises/[id]/{replace,delete}\` |
| T3 admin | \`adminLimiter\` | 30 / 60s | All \`/api/admin/*\` (via \`requireEditor({ rateLimit: true })\`) |
| T5 auth sensitive | \`authSensitiveLimiter\` (new) | 5 / 60s, **IP-keyed** | \`/api/auth/complete-profile\` |
| T6 feedback | \`feedbackSubmissionLimiter\` (new) | 5 / 3600s | \`/api/feedback\` (replaces a per-POST DB count query) |

## Infra improvements to \`checkRateLimit\`

- **\`NODE_ENV=test\` bypass** so integration tests don't flake
- **New \`checkRateLimitWithHeaders\`** returns \`{ response, headers }\` and emits \`X-RateLimit-{Limit,Remaining,Reset}\` on success so clients can self-throttle. 429 responses carry the same headers plus \`Retry-After\`.
- **\`withRateLimitHeaders(response, rl)\`** merges headers onto a successful \`NextResponse\`
- **\`getClientIp(request)\`** for pre-auth / IP-keyed limits (\`x-forwarded-for\` → \`x-real-ip\` → \`'unknown'\` fallback)
- **Log level dropped** from \`warn\` to \`info\` — rate limit hits are expected telemetry, not alertable
- Legacy \`checkRateLimit\` wrapper preserved for existing call sites (draft/complete/skip routes unchanged)

## \`requireEditor\` helper extension

Admin routes now opt into rate limiting via a single-word change:

\`\`\`ts
- const auth = await requireEditor()
+ const auth = await requireEditor({ rateLimit: true })
\`\`\`

Applied to **all** admin handlers including GETs — \`adminLimiter\` (30/60s) is generous enough for editor dashboards and uniform protection simplifies the code.

## Feedback endpoint

Dropped the per-POST \`prisma.feedback.count()\` query that hit Postgres on every submission. Same 5/hour budget, now served from Redis.

## What is NOT rate-limited (intentional)

- **Read endpoints (GETs)** — cheap, low-abuse. Add case-by-case if a specific read becomes a problem.
- **Auth catch-all \`/api/auth/[...all]\`** — BetterAuth handles its own limiting. Confirmed \`RELAXED_RATE_LIMITS\` is unset (→ false) in prod Doppler.
- **\`/api/health/*\`** — probed by k8s, must never 429.
- **Week/workout parent CRUD** — not attack vectors; the set-logging child is what matters and is already covered.

## Tests

- \`__tests__/lib/rate-limit.test.ts\` — **12 new unit tests** covering: test bypass, happy path, 429 path, key isolation, empty-key fail-open, the legacy wrapper, \`withRateLimitHeaders\`, \`getClientIp\`. Tests flip \`NODE_ENV\` to \`'development'\` to exercise the limiter logic that's normally bypassed.
- Full suite: **209 passed, 3 skipped, 0 failed**. Typecheck clean.

## Docs

New \`docs/RATE_LIMITING.md\` covers: tier table, coverage rationale, how to add coverage to a new route (three patterns — simple, with headers, admin), response contract, fail-open behavior, test bypass, observability, tuning guidance.

## Test plan

- [ ] CI green
- [ ] After merge, hit \`POST /api/community/[id]/add\` 4 times rapidly on staging → expect the 4th to return 429 with \`Retry-After\`
- [ ] Check staging logs for \`"rate limit hit"\` \`info\` events during load test
- [ ] Verify \`X-RateLimit-Remaining\` header drops on successful \`POST /api/community/[id]/add\` and \`POST /api/programs\` responses
- [ ] Run infra's \`quick-hey-tests.sh staging\` and confirm no legitimate-user 429s

## Out of scope (follow-ups if needed)

- Read-endpoint limits
- Switching to \`@upstash/ratelimit\`
- Per-IP global DDoS protection (belongs at ingress, not app)
- Rate limiting for week/workout parent CRUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)