### PR TITLE
feat: contextual post-workout feedback prompt

### DIFF
--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -13,6 +13,7 @@ interface FeedbackItem {
   message: string
   pageUrl: string
   userAgent: string | null
+  properties: string | null
   status: string
   adminNote: string | null
   githubIssueUrl: string | null
@@ -26,6 +27,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   feature: 'enhancement',
   confusion: 'ux',
   general: 'feedback',
+  post_session: 'post-session',
 }
 
 export default function AdminFeedbackPage() {
@@ -160,6 +162,7 @@ export default function AdminFeedbackPage() {
       case 'bug': return 'text-red-800 bg-red-100 border-red-300 dark:text-red-400 dark:bg-red-900/30 dark:border-red-700'
       case 'feature': return 'text-blue-800 bg-blue-100 border-blue-300 dark:text-blue-400 dark:bg-blue-900/30 dark:border-blue-700'
       case 'confusion': return 'text-yellow-800 bg-yellow-100 border-yellow-300 dark:text-yellow-400 dark:bg-yellow-900/30 dark:border-yellow-700'
+      case 'post_session': return 'text-purple-800 bg-purple-100 border-purple-300 dark:text-purple-400 dark:bg-purple-900/30 dark:border-purple-700'
       default: return 'text-zinc-700 bg-zinc-100 border-zinc-300 dark:text-zinc-400 dark:bg-zinc-800 dark:border-zinc-600'
     }
   }
@@ -264,6 +267,23 @@ export default function AdminFeedbackPage() {
               {/* Expanded detail */}
               {expandedId === item.id && (
                 <div className="px-4 pb-4 border-t border-border pt-3 space-y-3">
+                  {/* Question prompt (post_session) */}
+                  {item.category === 'post_session' && item.properties && (() => {
+                    try {
+                      const props = JSON.parse(item.properties)
+                      return props.question ? (
+                        <div>
+                          <span className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+                            Question Asked
+                          </span>
+                          <p className="text-sm text-foreground italic bg-muted p-3 border border-border">
+                            {props.question}
+                          </p>
+                        </div>
+                      ) : null
+                    } catch { return null }
+                  })()}
+
                   {/* Full message */}
                   <div>
                     <span className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -23,11 +23,12 @@ export async function POST(request: NextRequest) {
     if (limited) return limited
 
     const body = await request.json()
-    const { category, message, pageUrl, userAgent } = body as {
+    const { category, message, pageUrl, userAgent, properties } = body as {
       category: string
       message: string
       pageUrl: string
       userAgent?: string
+      properties?: Record<string, string>
     }
 
     // Validate category
@@ -54,6 +55,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Page URL is required' }, { status: 400 })
     }
 
+    // Validate properties if provided (must be a flat string-keyed object)
+    let propertiesJson: string | null = null
+    if (properties && typeof properties === 'object') {
+      propertiesJson = JSON.stringify(properties)
+      if (propertiesJson.length > 2000) {
+        return NextResponse.json(
+          { error: 'Properties too large' },
+          { status: 400 }
+        )
+      }
+    }
+
     const feedback = await prisma.feedback.create({
       data: {
         userId: user.id,
@@ -61,6 +74,7 @@ export async function POST(request: NextRequest) {
         message: message.trim(),
         pageUrl,
         userAgent: userAgent || null,
+        properties: propertiesJson,
       },
     })
 
@@ -68,15 +82,19 @@ export async function POST(request: NextRequest) {
 
     // Discord notification (fire and forget)
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://ripit.fit'
+    const discordFields = [
+      { name: 'Page', value: pageUrl, inline: true },
+      { name: 'User', value: user.email || user.id, inline: true },
+    ]
+    if (category === 'post_session' && properties?.question) {
+      discordFields.unshift({ name: 'Question', value: properties.question, inline: false })
+    }
     sendDiscordNotification({
-      title: `Feedback: ${category.charAt(0).toUpperCase() + category.slice(1)}`,
+      title: `Feedback: ${category === 'post_session' ? 'Post-Session' : category.charAt(0).toUpperCase() + category.slice(1)}`,
       description: message.trim().substring(0, 200) + (message.trim().length > 200 ? '...' : ''),
-      color: 0xEA580C,
+      color: category === 'post_session' ? 0x8B5CF6 : 0xEA580C,
       url: `${appUrl}/admin/feedback?expand=${feedback.id}`,
-      fields: [
-        { name: 'Page', value: pageUrl, inline: true },
-        { name: 'User', value: user.email || user.id, inline: true },
-      ],
+      fields: discordFields,
     })
 
     return NextResponse.json({ success: true, id: feedback.id })
@@ -93,6 +111,7 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url)
     const status = searchParams.get('status')
+    const categoryFilter = searchParams.get('category')
     const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100)
     const offset = parseInt(searchParams.get('offset') || '0', 10)
 
@@ -101,6 +120,9 @@ export async function GET(request: NextRequest) {
       where.status = { in: ['new', 'reviewed'] }
     } else if (status) {
       where.status = status
+    }
+    if (categoryFilter) {
+      where.category = categoryFilter
     }
 
     const [feedback, total] = await Promise.all([

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -11,6 +11,8 @@ type UpdateSettingsRequest = {
   dismissedWarmup?: boolean
   dismissedStickNudge?: boolean
   completedTours?: string
+  postSessionPromptCount?: number
+  lastPostSessionPromptAt?: string
 }
 
 export async function GET(_request: NextRequest) {
@@ -66,7 +68,7 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json() as UpdateSettingsRequest
-    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours } = body
+    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours, postSessionPromptCount, lastPostSessionPromptAt } = body
 
     // Validate weight unit
     if (defaultWeightUnit && !['lbs', 'kg'].includes(defaultWeightUnit)) {
@@ -95,6 +97,8 @@ export async function PUT(request: NextRequest) {
         ...(dismissedWarmup !== undefined && { dismissedWarmup }),
         ...(dismissedStickNudge !== undefined && { dismissedStickNudge }),
         ...(completedTours !== undefined && { completedTours }),
+        ...(postSessionPromptCount !== undefined && { postSessionPromptCount }),
+        ...(lastPostSessionPromptAt !== undefined && { lastPostSessionPromptAt: new Date(lastPostSessionPromptAt) }),
         updatedAt: new Date()
       },
       create: {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -86,6 +86,14 @@ export async function PUT(request: NextRequest) {
       )
     }
 
+    // Validate postSessionPromptCount
+    if (postSessionPromptCount !== undefined && (typeof postSessionPromptCount !== 'number' || postSessionPromptCount < 0 || !Number.isInteger(postSessionPromptCount))) {
+      return NextResponse.json(
+        { error: 'Invalid postSessionPromptCount. Must be a non-negative integer' },
+        { status: 400 }
+      )
+    }
+
     // Update or create settings
     const settings = await prisma.userSettings.upsert({
       where: { userId: user.id },

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState, useTransition } from 'react'
 import ExerciseLoggingModal from '@/components/ExerciseLoggingModal'
 import { BeginnerPrimerWizard } from '@/components/features/training/BeginnerPrimerWizard'
+import { PostSessionFeedback, pickPostSessionQuestion } from '@/components/features/training/PostSessionFeedback'
 import { StickNudgeBanner } from '@/components/features/training/StickNudgeBanner'
 import { WarmupInterstitial } from '@/components/features/training/WarmupInterstitial'
 import { ProgramCompletionModal } from '@/components/ProgramCompletionModal'
@@ -17,6 +18,7 @@ import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
 import { TRAINING_PAGE_STEPS, TRAINING_PAGE_TOUR_ID } from '@/lib/tour/steps/training-page'
+import { POST_SESSION_COOLDOWN } from '@/types/feedback'
 
 type Workout = {
   id: string
@@ -163,7 +165,7 @@ export default function StrengthWeekView({
   const router = useRouter()
   const searchParams = useSearchParams()
   const { activeDraft, refreshDraft, clearDraft } = useDraftWorkout()
-  const { settings, isLoading: settingsLoading, refetch: refetchSettings } = useUserSettings()
+  const { settings, isLoading: settingsLoading, refetch: refetchSettings, updateSettings } = useUserSettings()
   const [isPending, startTransition] = useTransition()
   const [updatingWorkoutId, setUpdatingWorkoutId] = useState<string | null>(null)
   const [skippingWorkout, setSkippingWorkout] = useState<string | null>(null)
@@ -178,6 +180,8 @@ export default function StrengthWeekView({
   const [showCompletionModal, setShowCompletionModal] = useState(false)
   const [isRestarting, setIsRestarting] = useState(false)
   const [isProgramComplete, setIsProgramComplete] = useState(false)
+  const [postSessionQuestion, setPostSessionQuestion] = useState<string | null>(null)
+  const [pendingProgramCompletionCheck, setPendingProgramCompletionCheck] = useState(false)
 
   const resumeWorkoutId = searchParams.get('resume')
 
@@ -439,7 +443,35 @@ export default function StrengthWeekView({
   // Completion is handled inside ExerciseLoggingModal now (per-set writes + status flip)
   const handleCompleteWorkout = async () => {
     handleCloseModal(true)
-    await checkProgramCompletion(true)
+
+    // Check if we should show the post-session feedback prompt
+    const shouldPrompt = settings
+      && (settings.postSessionPromptCount % POST_SESSION_COOLDOWN === 0)
+    if (shouldPrompt) {
+      setPostSessionQuestion(pickPostSessionQuestion())
+      setPendingProgramCompletionCheck(true)
+      // Bump the prompt counter immediately so skip/send both count
+      updateSettings({
+        postSessionPromptCount: (settings.postSessionPromptCount ?? 0) + 1,
+        lastPostSessionPromptAt: new Date().toISOString(),
+      }).then(() => refetchSettings()).catch(() => {})
+    } else {
+      // Increment counter even when not showing to keep cadence
+      if (settings) {
+        updateSettings({
+          postSessionPromptCount: (settings.postSessionPromptCount ?? 0) + 1,
+        }).then(() => refetchSettings()).catch(() => {})
+      }
+      await checkProgramCompletion(true)
+    }
+  }
+
+  const handlePostSessionClose = async () => {
+    setPostSessionQuestion(null)
+    if (pendingProgramCompletionCheck) {
+      setPendingProgramCompletionCheck(false)
+      await checkProgramCompletion(true)
+    }
   }
 
   const _handleClearWorkout = async () => {
@@ -627,6 +659,13 @@ export default function StrengthWeekView({
         onContinue={handleWarmupContinue}
         onCancel={handleWarmupCancel}
         onDismissPermanently={handleWarmupDismissPermanently}
+      />
+
+      {/* Post-Session Feedback */}
+      <PostSessionFeedback
+        open={!!postSessionQuestion}
+        question={postSessionQuestion || ''}
+        onClose={handlePostSessionClose}
       />
 
       {/* Program Completion Modal */}

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -663,6 +663,7 @@ export default function StrengthWeekView({
 
       {/* Post-Session Feedback */}
       <PostSessionFeedback
+        key={postSessionQuestion}
         open={!!postSessionQuestion}
         question={postSessionQuestion || ''}
         onClose={handlePostSessionClose}

--- a/components/features/FeedbackModal.tsx
+++ b/components/features/FeedbackModal.tsx
@@ -120,7 +120,7 @@ export default function FeedbackModal({ open, onOpenChange }: FeedbackModalProps
                 What kind of feedback?
               </span>
               <div className="grid grid-cols-2 gap-2">
-                {FEEDBACK_CATEGORIES.map((cat) => (
+                {FEEDBACK_CATEGORIES.filter((cat) => cat.value !== 'post_session').map((cat) => (
                   <button
                     key={cat.value}
                     type="button"

--- a/components/features/training/PostSessionFeedback.tsx
+++ b/components/features/training/PostSessionFeedback.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { X } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import { POST_SESSION_QUESTIONS } from '@/types/feedback'
 
@@ -15,6 +15,14 @@ export function PostSessionFeedback({ open, question, onClose }: PostSessionFeed
   const [message, setMessage] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cleanup auto-close timer on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
 
   if (!open) return null
 
@@ -35,7 +43,7 @@ export function PostSessionFeedback({ open, question, onClose }: PostSessionFeed
       })
       if (res.ok) {
         setSubmitted(true)
-        setTimeout(onClose, 1200)
+        closeTimerRef.current = setTimeout(onClose, 1200)
       } else {
         clientLogger.error('Failed to submit post-session feedback')
       }

--- a/components/features/training/PostSessionFeedback.tsx
+++ b/components/features/training/PostSessionFeedback.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { useState } from 'react'
+import { clientLogger } from '@/lib/client-logger'
+import { POST_SESSION_QUESTIONS } from '@/types/feedback'
+
+interface PostSessionFeedbackProps {
+  open: boolean
+  question: string
+  onClose: () => void
+}
+
+export function PostSessionFeedback({ open, question, onClose }: PostSessionFeedbackProps) {
+  const [message, setMessage] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  if (!open) return null
+
+  const handleSubmit = async () => {
+    if (!message.trim()) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          category: 'post_session',
+          message: message.trim(),
+          pageUrl: window.location.pathname,
+          userAgent: navigator.userAgent,
+          properties: { question },
+        }),
+      })
+      if (res.ok) {
+        setSubmitted(true)
+        setTimeout(onClose, 1200)
+      } else {
+        clientLogger.error('Failed to submit post-session feedback')
+      }
+    } catch (error) {
+      clientLogger.error('Error submitting post-session feedback:', error)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={-1}
+      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+      className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose() }}
+      aria-label="Close dialog"
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: presentation wrapper stops click propagation */}
+      <div
+        role="presentation"
+        style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)' }}
+        className="relative w-full max-w-md bg-card border-2 border-border doom-noise"
+        onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-border flex items-center justify-between">
+          <h2 className="text-lg font-bold text-foreground doom-heading uppercase tracking-wider">
+            Quick Check-In
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          {submitted ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              Thanks for the feedback.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">
+                {question}
+              </p>
+              <textarea
+                value={message}
+                onChange={e => setMessage(e.target.value)}
+                rows={3}
+                maxLength={2000}
+                placeholder="Type anything (optional)..."
+                className="w-full px-3 py-2 bg-input border-2 border-border text-foreground text-sm placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+                autoFocus
+              />
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        {!submitted && (
+          <div className="p-4 border-t border-border flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-3 bg-muted text-foreground hover:bg-secondary transition-colors font-semibold text-sm uppercase tracking-wider border-2 border-border doom-focus-ring"
+            >
+              Skip
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || !message.trim()}
+              className="flex-1 py-3 bg-primary text-primary-foreground hover:bg-primary/90 doom-button-3d doom-focus-ring font-semibold text-sm uppercase tracking-wider disabled:opacity-50"
+            >
+              {submitting ? 'Sending...' : 'Send'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Pick a random question from the bank */
+export function pickPostSessionQuestion(): string {
+  return POST_SESSION_QUESTIONS[Math.floor(Math.random() * POST_SESSION_QUESTIONS.length)]
+}

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -9,6 +9,8 @@ export type UserSettings = {
   dismissedWarmup: boolean
   dismissedStickNudge: boolean
   completedTours: string
+  postSessionPromptCount: number
+  lastPostSessionPromptAt: string | null
 }
 
 type UseUserSettingsReturn = {

--- a/prisma/migrations/20260409011359_post_session_feedback/migration.sql
+++ b/prisma/migrations/20260409011359_post_session_feedback/migration.sql
@@ -1,0 +1,9 @@
+-- Add properties column to Feedback for storing extra context (e.g. question shown)
+ALTER TABLE "Feedback" ADD COLUMN "properties" TEXT;
+
+-- Add category index for filtering
+CREATE INDEX "Feedback_category_idx" ON "Feedback"("category");
+
+-- Add post-session prompt tracking to UserSettings
+ALTER TABLE "UserSettings" ADD COLUMN "postSessionPromptCount" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "UserSettings" ADD COLUMN "lastPostSessionPromptAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -285,17 +285,19 @@ model UserCardioMetricPreferences {
 }
 
 model UserSettings {
-  id                     String   @id @default(cuid())
-  userId                 String   @unique
-  displayName            String?
-  defaultWeightUnit      String   @default("lbs")
-  defaultIntensityRating String   @default("rir")
-  dismissedPrimer        Boolean  @default(false)
-  dismissedWarmup        Boolean  @default(false)
-  dismissedStickNudge    Boolean  @default(false)
-  completedTours         String   @default("[]")
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  id                        String    @id @default(cuid())
+  userId                    String    @unique
+  displayName               String?
+  defaultWeightUnit         String    @default("lbs")
+  defaultIntensityRating    String    @default("rir")
+  dismissedPrimer           Boolean   @default(false)
+  dismissedWarmup           Boolean   @default(false)
+  dismissedStickNudge       Boolean   @default(false)
+  completedTours            String    @default("[]")
+  postSessionPromptCount    Int       @default(0)
+  lastPostSessionPromptAt   DateTime?
+  createdAt                 DateTime  @default(now())
+  updatedAt                 DateTime  @updatedAt
 
   @@index([userId])
 }
@@ -490,10 +492,11 @@ model ArticleComment {
 model Feedback {
   id        String   @id @default(cuid())
   userId    String
-  category  String   // "bug" | "feature" | "confusion" | "general"
+  category  String   // "bug" | "feature" | "confusion" | "general" | "post_session"
   message   String
   pageUrl   String
   userAgent String?
+  properties     String?  // JSON blob for extra context (e.g. question shown for post_session)
   status         String   @default("new") // "new" | "reviewed" | "resolved"
   adminNote      String?
   githubIssueUrl String?
@@ -502,5 +505,6 @@ model Feedback {
 
   @@index([userId])
   @@index([status])
+  @@index([category])
   @@index([createdAt(sort: Desc)])
 }

--- a/types/feedback.ts
+++ b/types/feedback.ts
@@ -1,4 +1,4 @@
-export type FeedbackCategory = 'bug' | 'feature' | 'confusion' | 'general'
+export type FeedbackCategory = 'bug' | 'feature' | 'confusion' | 'general' | 'post_session'
 export type FeedbackStatus = 'new' | 'reviewed' | 'resolved'
 
 export type FeedbackSubmission = {
@@ -6,6 +6,7 @@ export type FeedbackSubmission = {
   message: string
   pageUrl: string
   userAgent?: string
+  properties?: Record<string, string>
 }
 
 export const FEEDBACK_CATEGORIES: Array<{
@@ -18,7 +19,18 @@ export const FEEDBACK_CATEGORIES: Array<{
   { value: 'feature', label: 'Feature', description: 'Something missing', placeholder: 'What would you like to see added?' },
   { value: 'confusion', label: 'Confused', description: 'Something unclear', placeholder: 'What was confusing? Where did you get stuck?' },
   { value: 'general', label: 'General', description: 'Other feedback', placeholder: 'What\'s on your mind?' },
+  { value: 'post_session', label: 'Post-Session', description: 'Post-workout feedback', placeholder: '' },
 ]
 
-export const VALID_CATEGORIES: FeedbackCategory[] = ['bug', 'feature', 'confusion', 'general']
+export const VALID_CATEGORIES: FeedbackCategory[] = ['bug', 'feature', 'confusion', 'general', 'post_session']
 export const VALID_STATUSES: FeedbackStatus[] = ['new', 'reviewed', 'resolved']
+
+export const POST_SESSION_QUESTIONS = [
+  'How did that feel?',
+  'Anything confusing about logging today?',
+  'What almost made you skip today?',
+  'Was there an exercise you weren\'t sure how to do?',
+] as const
+
+/** Number of completed workouts between post-session prompts */
+export const POST_SESSION_COOLDOWN = 3


### PR DESCRIPTION
## Summary
- Adds a contextual post-session micro-survey shown after workout completion
- Shows a random question from a bank of 4, once every 3 completed workouts
- Skip/dismiss counts toward the cooldown (no feedback fatigue)
- Styled like existing contextual popup pattern (WarmupInterstitial)
- Stores question text in new `properties` JSON column on Feedback model
- Surfaces in /admin/feedback with purple post_session badge and "Question Asked" detail
- Discord webhook includes the question for post_session notifications
- Adds category filter param to GET /api/feedback for admin filtering

## Changes
- `prisma/schema.prisma` — Added `properties` to Feedback, `postSessionPromptCount`/`lastPostSessionPromptAt` to UserSettings, category index
- `types/feedback.ts` — Added `post_session` category, question bank, cooldown constant
- `app/api/feedback/route.ts` — Properties support, category filter on GET, Discord enrichment
- `app/api/settings/route.ts` — Support new UserSettings fields
- `hooks/useUserSettings.ts` — Updated type to include new fields
- `components/features/training/PostSessionFeedback.tsx` — New popup component
- `components/StrengthWeekView.tsx` — Integration after workout completion
- `app/(app)/admin/feedback/page.tsx` — Purple badge, question display, properties in type
- `prisma/migrations/20260409011359_post_session_feedback/migration.sql` — DB migration

## Test plan
- [ ] Complete a workout — no prompt should show (count starts at 0, 0 % 3 == 0 triggers on first)
- [ ] Verify prompt shows with a random question from the bank
- [ ] Skip the prompt — verify it counts toward cooldown (next prompt at workout #3)
- [ ] Submit feedback via the prompt — verify it appears in /admin/feedback with purple badge
- [ ] Expand post_session feedback in admin — verify "Question Asked" section shows
- [ ] Verify Discord notification includes question text
- [ ] Verify type-check and lint pass (pre-existing errors only)

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)