### PR TITLE
chore: fix import organization in 6 recently changed files

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -7,7 +7,7 @@ import { AuthPageHeader } from '@/components/features/auth/AuthPageHeader'
 import { OAuthButtons } from '@/components/features/auth/OAuthButtons'
 import { OrDivider } from '@/components/features/auth/OrDivider'
 import { Button } from '@/components/ui/Button'
-import { trackEvent, flushEvents } from '@/lib/analytics'
+import { flushEvents, trackEvent } from '@/lib/analytics'
 import { signUp } from '@/lib/auth-client'
 
 export default function SignupPage() {

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import type { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -3,4 +3,4 @@
  * external monitors don't break during the k8s probe split. New probes should
  * target /api/health/live (liveness) and /api/health/ready (readiness).
  */
-export { GET, dynamic } from './ready/route'
+export { dynamic, GET } from './ready/route'

--- a/components/features/training/BeginnerPrimerWizard.tsx
+++ b/components/features/training/BeginnerPrimerWizard.tsx
@@ -3,8 +3,8 @@
 import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
-import { trackEvent } from '@/lib/analytics'
 import { useUserSettings } from '@/hooks/useUserSettings'
+import { trackEvent } from '@/lib/analytics'
 
 interface BeginnerPrimerWizardProps {
   open: boolean

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,10 +1,10 @@
+import Redis from 'ioredis'
+import { NextResponse } from 'next/server'
 import {
-  RateLimiterRedis,
   RateLimiterMemory,
+  RateLimiterRedis,
   type RateLimiterRes,
 } from 'rate-limiter-flexible'
-import { NextResponse } from 'next/server'
-import Redis from 'ioredis'
 import { logger } from '@/lib/logger'
 
 // Lazy singleton Redis connection for rate limiting

--- a/lib/test/pgbouncer-container.ts
+++ b/lib/test/pgbouncer-container.ts
@@ -1,12 +1,12 @@
 import { execSync } from 'node:child_process'
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
 import {
   GenericContainer,
   Network,
-  Wait,
   type StartedNetwork,
   type StartedTestContainer,
+  Wait,
 } from 'testcontainers'
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
 
 /**
  * Spins up Postgres + PgBouncer (transaction mode) in a shared Docker network.


### PR DESCRIPTION
## Summary
- Auto-fixed biome `organizeImports` violations across 6 files changed in the last 7 days
- Pure import reordering — no behavior changes, no new code
- Files: events route, health route, signup page, beginner primer wizard, rate limiter, pgbouncer test harness

## Verification
- biome check: pass (0 violations in touched files)
- type-check: pass (1 pre-existing serwist type error, unrelated)
- No tests needed — changes are import ordering only (per lesson #103)

## Deferred follow-ups
- #466 — Remove unused `_router` variable in signup page (low)
- #467 — PostSessionFeedback autoFocus a11y lint violation (low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)