### PR TITLE
feat(tour): always-visible Tutorial banner, progress, and Skip button

### DIFF
--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom'
-import { ChevronLeft, X } from 'lucide-react'
+import { ChevronLeft } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { TourStep } from './tour-types'
@@ -73,53 +73,59 @@ export function TourTooltip({
         zIndex: 56,
       }}
       className="w-72 max-w-[calc(100vw-2rem)]"
+      role="dialog"
+      aria-label="Tutorial"
     >
       <div className="bg-card border-2 border-primary doom-noise p-5 shadow-lg">
-        {/* Header */}
-        <div className="flex items-start justify-between gap-2 mb-3">
-          <h3 className="text-base font-bold text-foreground doom-heading uppercase tracking-wider">
-            {step.title}
-          </h3>
+        {/* Tutorial banner: always-visible label, progress, and Skip */}
+        <div className="flex items-center justify-between gap-2 mb-3 pb-2 border-b border-primary/30">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-xs font-bold text-primary doom-heading uppercase tracking-wider">
+              Tutorial
+            </span>
+            <span className="text-xs text-muted-foreground tabular-nums uppercase tracking-wider">
+              Step {stepIndex + 1} of {totalSteps}
+            </span>
+          </div>
           <button
             type="button"
             onClick={onSkip}
-            className="shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Skip tour"
+            className="shrink-0 px-2 py-1 text-xs font-semibold text-muted-foreground hover:text-foreground border border-muted-foreground/40 hover:border-foreground uppercase tracking-wider transition-colors"
+            aria-label="Skip tutorial"
           >
-            <X size={16} />
+            Skip
           </button>
         </div>
+
+        {/* Step title */}
+        <h3 className="text-base font-bold text-foreground doom-heading uppercase tracking-wider mb-2">
+          {step.title}
+        </h3>
 
         {/* Body */}
         <p className="text-base text-muted-foreground mb-5 leading-relaxed">
           {step.body}
         </p>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground tabular-nums">
-            {stepIndex + 1} of {totalSteps}
-          </span>
-
-          <div className="flex items-center gap-1">
-            {stepIndex > 0 && (
-              <button
-                type="button"
-                onClick={onPrev}
-                className="p-2 text-muted-foreground hover:text-foreground transition-colors"
-                aria-label="Previous step"
-              >
-                <ChevronLeft size={18} />
-              </button>
-            )}
+        {/* Footer: navigation */}
+        <div className="flex items-center justify-end gap-1">
+          {stepIndex > 0 && (
             <button
               type="button"
-              onClick={onNext}
-              className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 text-sm font-semibold uppercase tracking-wider"
+              onClick={onPrev}
+              className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Previous step"
             >
-              {isLastStep ? 'Done' : 'Next'}
+              <ChevronLeft size={18} />
             </button>
-          </div>
+          )}
+          <button
+            type="button"
+            onClick={onNext}
+            className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 text-sm font-semibold uppercase tracking-wider"
+          >
+            {isLastStep ? 'Done' : 'Next'}
+          </button>
         </div>
       </div>
     </div>,

--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -80,10 +80,10 @@ export function TourTooltip({
         {/* Tutorial banner: always-visible label, progress, and Skip */}
         <div className="flex items-center justify-between gap-2 mb-3 pb-2 border-b border-primary/30">
           <div className="flex items-center gap-2 min-w-0">
-            <span className="text-xs font-bold text-primary doom-heading uppercase tracking-wider">
+            <span className="text-sm font-bold text-primary uppercase tracking-wider">
               Tutorial
             </span>
-            <span className="text-xs text-muted-foreground tabular-nums uppercase tracking-wider">
+            <span className="text-sm text-muted-foreground tabular-nums uppercase tracking-wider">
               Step {stepIndex + 1} of {totalSteps}
             </span>
           </div>


### PR DESCRIPTION
## Summary
- Adds a persistent "TUTORIAL" banner above each tour step so users clearly know they're in a guided walkthrough
- Changes progress indicator to "Step X of Y" format and moves it into the always-visible banner
- Replaces the subtle X-icon skip with a prominent text "Skip" button in the banner (visible on every step)
- Adds `role="dialog"` + `aria-label="Tutorial"` to the tooltip for improved a11y

## Skip persistence
`skipTour` already calls `completeTour`, which writes the tour id to the user's `completedTours` setting, so skip already persists across sessions. No changes needed there — the existing behavior already meets the acceptance criterion.

## Test plan
- [ ] Start a tour (e.g., workout-logger) and verify every step shows the TUTORIAL label, Step X of Y, and a Skip button
- [ ] Verify Skip dismisses the entire sequence (not just one step)
- [ ] Reload/log out and back in and verify the tour does not reappear
- [ ] Verify Back/Next navigation still works
- [ ] Verify tooltip still positions correctly next to target elements

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)