### PR TITLE
feat(logger): green/red +/- buttons with larger tap targets

### DIFF
--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -33,20 +33,20 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
           type="button"
           onClick={handleDecrement}
           disabled={!hasValue || numericValue <= 0}
-          className="flex-shrink-0 w-12 h-12 flex items-center justify-center
-            border border-border text-muted-foreground
-            hover:text-error hover:border-error hover:bg-error/10
-            active:bg-error active:text-white
-            disabled:opacity-20 disabled:hover:text-muted-foreground disabled:hover:border-border disabled:hover:bg-transparent
+          className="flex-shrink-0 min-w-[56px] min-h-[56px] flex items-center justify-center
+            border-2 border-error-border bg-error-muted text-error-text
+            hover:bg-error hover:text-error-foreground
+            active:bg-error-hover active:text-error-foreground
+            disabled:opacity-30
             transition-all duration-75"
           aria-label="Decrease reps"
         >
-          <Minus size={18} strokeWidth={2.5} />
+          <Minus size={24} strokeWidth={3} />
         </button>
 
         <div
-          className="flex-1 h-12 flex items-center justify-center
-            bg-card border-y border-border
+          className="flex-1 min-h-[56px] flex items-center justify-center
+            bg-card border-y-2 border-border
             text-2xl font-bold text-foreground tabular-nums min-w-[60px]"
         >
           {hasValue ? numericValue : (
@@ -59,14 +59,14 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
         <button
           type="button"
           onClick={handleIncrement}
-          className="flex-shrink-0 w-12 h-12 flex items-center justify-center
-            border border-border text-muted-foreground
-            hover:text-success hover:border-success hover:bg-success/10
-            active:bg-success active:text-white
+          className="flex-shrink-0 min-w-[56px] min-h-[56px] flex items-center justify-center
+            border-2 border-success-border bg-success-muted text-success-text
+            hover:bg-success hover:text-success-foreground
+            active:bg-success-hover active:text-success-foreground
             transition-all duration-75"
           aria-label="Increase reps"
         >
-          <Plus size={18} strokeWidth={2.5} />
+          <Plus size={24} strokeWidth={3} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Reps stepper +/- buttons now use semantic green/red color treatment by default (not just on hover) so they read as distinct, actionable controls instead of blending into the input chrome.
- Tap targets bumped from 48x48 to 56x56 px (well above the 44x44 WCAG AAA / Apple HIG minimum); icon glyph enlarged from 18px/2.5 stroke to 24px/3 stroke for legibility.
- Borders strengthened from 1px to 2px so the buttons clearly separate from the value display.

Uses the existing per-theme `--success-*` / `--error-*` tokens (`bg-{success,error}-muted` background, `border-{success,error}-border` border, `text-{success,error}-text` icon), which are already defined for every DOOM theme variant in `app/globals.css` and follow the same WCAG-AA-passing pattern used elsewhere (e.g. `SetLoggingForm`, `OAuthButtons`, `ActivationConfirmModal`). Hover/active escalates to the full-saturation `bg-{success,error}` and `bg-{success,error}-hover` for tactile press feedback.

Fixes #479

## Test plan
- [ ] Visually verify on each theme variant (DOOM light/dark, Cyber, Synthwave, Dracula, GitHub light/dark, Catppuccin, RIPIT, BLOSSOM, OKABE, Forest, Clyde, 90s Kid) that the + button reads green and the - button reads red against the page/card background.
- [ ] Confirm tap targets feel comfortable on iOS PWA / Android.
- [ ] Confirm disabled state of `-` button (when reps == 0) fades visibly via `opacity-30`.
- [ ] Confirm active/pressed state inverts to a saturated colored fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)