### PR TITLE
fix(logger): iOS PWA bottom safe-area padding for Log Set / Complete buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2460,3 +2460,32 @@ body > [data-training-widget] {
   background: var(--muted);
   font-weight: 600;
 }
+
+/* ============================================
+   iOS PWA SAFE-AREA UTILITIES
+   ============================================
+   Apply env(safe-area-inset-bottom) only when running as an installed PWA
+   (display-mode: standalone). In a regular browser tab, the browser chrome
+   (URL bar / toolbar) sits above the home-indicator area, so no extra
+   padding is needed. In standalone mode the home indicator overlaps any
+   bottom-fixed/sticky UI, so we add the inset on top of the existing pb-N.
+
+   Usage: keep your existing `pb-N` (or `py-N`) class and add `pwa-pb-safe-N`
+   matching the same value. In browser mode the `pb-N` rule wins; in
+   standalone mode the `pwa-pb-safe-N` rule (defined later in the cascade)
+   wins and adds env(safe-area-inset-bottom) on top of the base.
+*/
+@media (display-mode: standalone) {
+  .pwa-pb-safe-0 {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .pwa-pb-safe-2 {
+    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+  }
+  .pwa-pb-safe-3 {
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  }
+  .pwa-pb-safe-4 {
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  }
+}

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -75,7 +75,10 @@ export default function ExerciseActionsFooter({
   ]
 
   return (
-    <div className="border-t border-border px-3 py-2 bg-card flex-shrink-0">
+    // pwa-pb-safe-2 keeps `pb-2` in browser mode and adds env(safe-area-inset-bottom)
+    // in iOS PWA standalone mode so the home indicator doesn't overlap the buttons.
+    // See globals.css for the utility definition.
+    <div className="border-t border-border px-3 pt-2 pb-2 bg-card flex-shrink-0 pwa-pb-safe-2">
       <div className="flex items-center gap-2">
         {/* Log Set Button */}
         <button type="button"


### PR DESCRIPTION
## Summary

Fixes #480 — in iOS PWA standalone mode, the training logger's bottom action bar (`ExerciseActionsFooter`) sat flush against the viewport bottom, letting the home indicator / grabber bar overlap and obscure the **Log Set** and **Complete** buttons.

- Add a small set of `pwa-pb-safe-N` CSS utilities in `globals.css`, gated by `@media (display-mode: standalone)`. Each utility layers `env(safe-area-inset-bottom)` on top of an existing `pb-N` base value.
- Apply `pwa-pb-safe-2` (matching the existing `pb-2`) to `ExerciseActionsFooter`.

In a regular browser tab, the base `pb-N` rule wins (no extra padding — browser chrome already handles its own safe area). When installed as a PWA, the matching `pwa-pb-safe-N` rule wins and adds the home-indicator inset.

## Audit of other bottom-fixed/sticky UI

Already include `env(safe-area-inset-bottom)` and continue to render correctly:
- `BottomNav.tsx` — `paddingBottom: env(safe-area-inset-bottom, 0px)`
- `ProgramCompletionModal.tsx`, `ExerciseSearchModal.tsx`, `components/ui/radix/dialog.tsx` (fullScreenMobile) — `pb-[env(safe-area-inset-bottom)]`
- `components/features/learn/ArticleDetail.tsx` collection prev/next bar — `bottom: calc(3.5rem + env(safe-area-inset-bottom, 0px))`

The training logger footer was the only bottom-fixed UI without any safe-area handling.

## Test plan

- [ ] On an iPhone with home-indicator-style hardware (no home button), install Ripit as a PWA from Safari → Share → Add to Home Screen.
- [ ] Open a workout and start logging; confirm **Log Set** and **Complete** buttons sit fully above the home indicator and are tappable.
- [ ] Open the same workout in regular Safari (not PWA); confirm the action bar's spacing is unchanged (no extra padding).
- [ ] Spot-check the bottom nav, the program-completion modal, the exercise-search modal, and Learn article prev/next nav — no visual regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)