### PR TITLE
feat: sort Browse programs by level (beginner first)

### DIFF
--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -41,6 +41,22 @@ type CommunityProgramsViewProps = {
 
 const ITEMS_PER_PAGE = 20
 
+// Sort priority: Beginner → Intermediate → Advanced → unspecified
+// Beginner programs (especially Machine Starter) should surface first for
+// new users coming in from the gym beta. Unknown/null levels sort last so
+// they don't push curated beginner content down.
+const LEVEL_SORT_PRIORITY: Record<string, number> = {
+  beginner: 0,
+  intermediate: 1,
+  advanced: 2,
+}
+const UNKNOWN_LEVEL_PRIORITY = 3
+
+function getLevelPriority(level: string | null): number {
+  if (!level) return UNKNOWN_LEVEL_PRIORITY
+  return LEVEL_SORT_PRIORITY[level] ?? UNKNOWN_LEVEL_PRIORITY
+}
+
 export default function CommunityProgramsView({
   communityPrograms,
   currentUserId,
@@ -71,7 +87,13 @@ export default function CommunityProgramsView({
       )
     }
 
-    return filtered
+    // Sort by level priority (beginner → intermediate → advanced) so gym-beta
+    // newcomers land on beginner content first. JS's Array.sort is stable
+    // (ES2019+), which preserves the server-side publishedAt DESC order
+    // within each level bucket.
+    return [...filtered].sort(
+      (a, b) => getLevelPriority(a.level) - getLevelPriority(b.level)
+    )
   }, [communityPrograms, selectedType, selectedLevel, selectedGoals])
 
   // Paginate filtered programs


### PR DESCRIPTION
## Summary
- Sort the Browse Programs list by fitness level: Beginner → Intermediate → Advanced → unspecified
- Preserve the existing secondary sort (server-side `publishedAt DESC`) within each level bucket via JavaScript's stable `Array.sort`
- Sort is applied after filtering so it always takes effect, regardless of active filters
- No filter UI changes

Surfaces curated beginner content (e.g. Machine Starter) near the top of the Browse list for the gym-beta audience.

Fixes #486

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` clean on the changed file (unrelated pre-existing warnings untouched)
- [ ] Manually verify on Browse tab: beginner programs appear before intermediate/advanced
- [ ] Manually verify Machine Starter (Community) is within the first few cards
- [ ] Apply level/goal filters and confirm the level ordering still holds
- [ ] Verify pagination still works with the new sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)