### PR TITLE
test(primer): add regression safety net for first-workout primer

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -17,6 +17,7 @@ import WorkoutCard from '@/components/workout/WorkoutCard'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
+import { shouldShowPrimer } from '@/lib/training/primer'
 import { TRAINING_PAGE_STEPS, TRAINING_PAGE_TOUR_ID } from '@/lib/tour/steps/training-page'
 import { POST_SESSION_COOLDOWN } from '@/types/feedback'
 
@@ -186,7 +187,13 @@ export default function StrengthWeekView({
   const resumeWorkoutId = searchParams.get('resume')
 
   // Contextual content triggers
-  const showPrimer = historyCount === 0 && !settings?.dismissedPrimer && !settingsLoading
+  // Primer gating lives in lib/training/primer.ts with its own unit tests to
+  // guard against accidental removal during tutorial reworks (see issue #485).
+  const showPrimer = shouldShowPrimer({
+    historyCount,
+    dismissedPrimer: settings?.dismissedPrimer ?? false,
+    settingsLoading,
+  })
   const showWarmup = historyCount < 4 && !settings?.dismissedWarmup
   const showStickNudge = historyCount >= 3 && historyCount <= 8 && !settings?.dismissedStickNudge && !settingsLoading
 

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -17,8 +17,8 @@ import WorkoutCard from '@/components/workout/WorkoutCard'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
-import { shouldShowPrimer } from '@/lib/training/primer'
 import { TRAINING_PAGE_STEPS, TRAINING_PAGE_TOUR_ID } from '@/lib/tour/steps/training-page'
+import { shouldShowPrimer } from '@/lib/training/primer'
 import { POST_SESSION_COOLDOWN } from '@/types/feedback'
 
 type Workout = {

--- a/lib/training/primer.test.ts
+++ b/lib/training/primer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowPrimer } from './primer'
+
+/**
+ * Regression tests for the Beginner Primer visibility contract (issue #485).
+ *
+ * The primer is important beginner-facing UX that was specifically praised in
+ * the gym-owner demo. These tests exist to prevent accidental removal or
+ * regression of the "first workout only" trigger during tutorial reworks.
+ */
+describe('shouldShowPrimer', () => {
+  it('shows on first-ever workout (no history, not dismissed)', () => {
+    expect(
+      shouldShowPrimer({
+        historyCount: 0,
+        dismissedPrimer: false,
+        settingsLoading: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not show after the user has completed any workout', () => {
+    expect(
+      shouldShowPrimer({
+        historyCount: 1,
+        dismissedPrimer: false,
+        settingsLoading: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not show for users with long history', () => {
+    expect(
+      shouldShowPrimer({
+        historyCount: 42,
+        dismissedPrimer: false,
+        settingsLoading: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not show once the user has dismissed it', () => {
+    expect(
+      shouldShowPrimer({
+        historyCount: 0,
+        dismissedPrimer: true,
+        settingsLoading: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not show while settings are still loading (avoids flash)', () => {
+    expect(
+      shouldShowPrimer({
+        historyCount: 0,
+        dismissedPrimer: false,
+        settingsLoading: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('dismissal outranks history edge case (dismissed with no history)', () => {
+    // Defensive: if somehow dismissedPrimer is true before any history
+    // (e.g. user skipped via X on first render), we must still not re-show.
+    expect(
+      shouldShowPrimer({
+        historyCount: 0,
+        dismissedPrimer: true,
+        settingsLoading: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/lib/training/primer.ts
+++ b/lib/training/primer.ts
@@ -1,0 +1,44 @@
+/**
+ * Beginner Primer visibility logic.
+ *
+ * The pre-workout primer wizard (components/features/training/BeginnerPrimerWizard.tsx)
+ * must appear exactly once — before a user's very first workout — and never again.
+ *
+ * Gym-owner demo feedback (item 5.6, issue #485) specifically called this primer
+ * out as making newcomers feel prepared. This helper exists as a regression
+ * safety net: the rules for showing the primer are centralized here and covered
+ * by unit tests so they survive tutorial-system reworks.
+ *
+ * Note: the primer is intentionally kept OUTSIDE the tour/tutorial system
+ * (lib/tour/*). It triggers from StrengthWeekView based on UserSettings, not
+ * from the tour scheduler. If the tour system is rewritten, the primer should
+ * continue to work unchanged.
+ */
+
+export type PrimerGateInput = {
+  /** Number of completed workouts in the user's history. */
+  historyCount: number
+  /** Whether the user has already dismissed the primer (UserSettings.dismissedPrimer). */
+  dismissedPrimer: boolean
+  /** Whether user settings are still loading from the server. */
+  settingsLoading: boolean
+}
+
+/**
+ * Returns true iff the beginner primer should be shown to the user.
+ *
+ * Contract (enforced by primer.test.ts):
+ * - Must show before the user's very first workout (historyCount === 0)
+ * - Must NOT show on subsequent workouts (any history)
+ * - Must NOT show after dismissal
+ * - Must NOT show while settings are still loading (avoids flashing)
+ */
+export function shouldShowPrimer({
+  historyCount,
+  dismissedPrimer,
+  settingsLoading,
+}: PrimerGateInput): boolean {
+  if (settingsLoading) return false
+  if (dismissedPrimer) return false
+  return historyCount === 0
+}


### PR DESCRIPTION
## Summary

Defensive change for issue #485. The pre-workout Beginner Primer popup tested well during the gym-owner demo — the owner specifically called it out as making newcomers feel prepared. This PR adds a regression safety net to ensure the primer is preserved during future tutorial-system reworks (e.g. logger tutorial simplification in #483).

- Extracts primer visibility logic into `lib/training/primer.ts` (pure function, documented contract)
- Adds `lib/training/primer.test.ts` with 6 tests covering every gating condition (first workout, has history, dismissed, loading)
- `StrengthWeekView` now delegates to `shouldShowPrimer()` with a comment pointing to #485 and the unit tests

No user-visible behavior change — existing content, dismissal flow, and trigger timing are all preserved. The primer intentionally lives outside the tour/tutorial system so scheduler reworks can't accidentally affect it.

## Acceptance (from #485)

- [x] Primer popup still appears before a user's very first workout (guarded by `shouldShowPrimer` + unit tests)
- [x] Does NOT appear on subsequent workouts (unit-tested)
- [x] Content reviewed for beginner-friendliness — 4 pages are encouraging (app does the thinking, go lighter, you belong here, your body will talk to you)
- [x] Clear dismiss (X) and continue ("Let's Go") buttons
- [x] Tutorial scheduler independence: primer lives outside `lib/tour/*` — migration path is simply that no migration is needed

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` — no new errors (pre-existing `rate-limit.test.ts` error only)
- [x] `doppler run -- npx vitest run lib/training/primer.test.ts` — 6/6 passing

Fixes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)