### PR TITLE
feat(auth): prominent Create Account CTA on login page

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -53,6 +53,20 @@ function LoginForm() {
       <div className="max-w-md w-full space-y-8 p-6 sm:p-8 bg-card rounded-lg shadow-lg border border-border">
         <AuthPageHeader />
 
+        {/* Primary CTA for new users — most arrivals (especially via gym QR code) don't have an account yet */}
+        <div className="space-y-3">
+          <p className="text-center text-sm font-medium text-foreground">
+            New to Ripit?
+          </p>
+          <Link href="/signup" className="block">
+            <Button variant="primary" doom className="w-full" type="button">
+              Create Account
+            </Button>
+          </Link>
+        </div>
+
+        <OrDivider label="already have an account?" />
+
         <OAuthButtons />
 
         <OrDivider />
@@ -105,19 +119,12 @@ function LoginForm() {
             type="submit"
             disabled={loading}
             loading={loading}
-            variant="primary"
+            variant="outline"
             doom
             className="w-full"
           >
             Sign in
           </Button>
-
-          <p className="text-center text-sm text-muted-foreground">
-            Don&apos;t have an account?{' '}
-            <Link href="/signup" className="font-medium text-primary hover:text-primary-hover">
-              Sign up
-            </Link>
-          </p>
         </form>
       </div>
     </div>

--- a/components/features/auth/OrDivider.tsx
+++ b/components/features/auth/OrDivider.tsx
@@ -1,11 +1,15 @@
-export function OrDivider() {
+interface OrDividerProps {
+  label?: string
+}
+
+export function OrDivider({ label = 'or' }: OrDividerProps = {}) {
   return (
     <div className="relative">
       <div className="absolute inset-0 flex items-center">
         <div className="w-full border-t border-border" />
       </div>
       <div className="relative flex justify-center text-sm">
-        <span className="px-2 bg-card text-muted-foreground">or</span>
+        <span className="px-2 bg-card text-muted-foreground">{label}</span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Surface Sign Up as the obvious primary action on `/login` — critical for gym-deployment arrivals via QR code where most users don't have an account yet.
- Replace the tiny "Don't have an account? Sign up" text link with a full-width DOOM primary **Create Account** button above OAuth + email/password form.
- Demote the Sign In submit button to the `outline` variant so the visual hierarchy matches the desired funnel (sign-up dominant, sign-in still easily findable).
- Extend `OrDivider` with an optional `label` prop so we can separate the "New to Ripit?" CTA section from the returning-user sign-in section using "already have an account?" text.

## Approach
Went with **Option A** from the issue — the simplest, minimal-scope change that keeps `/login` and `/signup` as separate pages while making Sign Up the visually dominant CTA on the login landing.

## Acceptance
- [x] Sign Up is visually dominant — full-width DOOM button, not a tiny text link
- [x] New users don't have to scroll or hunt — "Create Account" is the first action below the header
- [x] Existing users can still find Sign In easily — still a full-width button, labeled clearly, with a divider calling out "already have an account?"
- [x] Works in concert with #470 for email/password field reordering (unaffected)

## Test plan
- [ ] Visit `/login` and confirm the **Create Account** button is the primary CTA above the OAuth buttons
- [ ] Click **Create Account** → navigates to `/signup`
- [ ] Existing user: enter credentials in the email/password form and click **Sign in** → successful login
- [ ] OAuth flow still works (Google button)
- [ ] Mobile viewport: both buttons fit without overflow, divider label wraps nicely
- [ ] Error states (`?error=access_denied`, invalid credentials) still render above the form

Fixes #471

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)