### PR TITLE
Analytics: track signup source (qr/organic/oauth) + gymSlug

### DIFF
--- a/__tests__/api/admin-analytics.test.ts
+++ b/__tests__/api/admin-analytics.test.ts
@@ -139,6 +139,129 @@ describe('Admin analytics — role-based filtering', () => {
     expect(data.retention.timeToFirstWorkout?.sampleSize).toBe(3)
   })
 
+  describe('signup attribution metrics (#490)', () => {
+    it('breaks down signup_completed events by source', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+
+      // 2 organic signups, 1 qr signup, 1 oauth signup, 1 legacy (no source)
+      await seedUser(prisma, 'u-org-1', 'org1@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'u-org-2', 'org2@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'u-qr-1', 'qr1@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'u-oauth-1', 'oauth1@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'u-legacy-1', 'legacy@test.com', 'user', tenDaysAgo)
+      // Staff account — must be excluded even with valid source attribution
+      await seedUser(prisma, 'staff-1', 'staff@test.com', 'admin', tenDaysAgo)
+
+      await seedSignupEvent(prisma, 'u-org-1', { source: 'organic', method: 'email' })
+      await seedSignupEvent(prisma, 'u-org-2', { source: 'organic', method: 'email' })
+      await seedSignupEvent(prisma, 'u-qr-1', {
+        source: 'qr',
+        method: 'email',
+        gymSlug: 'iron-works',
+      })
+      await seedSignupEvent(prisma, 'u-oauth-1', { source: 'oauth', method: 'google' })
+      await seedSignupEvent(prisma, 'u-legacy-1', null)
+      await seedSignupEvent(prisma, 'staff-1', { source: 'qr', method: 'email', gymSlug: 'iron-works' })
+
+      const data = await getAnalyticsData(prisma)
+
+      const map = new Map(
+        data.signupAttribution.sourceBreakdown.map((s) => [s.source, s.count])
+      )
+      expect(map.get('organic')).toBe(2)
+      expect(map.get('qr')).toBe(1)
+      expect(map.get('oauth')).toBe(1)
+      expect(map.get('unknown')).toBe(1)
+      // Staff signup must NOT inflate any bucket
+      const total = data.signupAttribution.sourceBreakdown.reduce(
+        (sum, s) => sum + s.count,
+        0
+      )
+      expect(total).toBe(5)
+    })
+
+    it('rolls up per-gym signups with first-workout conversion', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+
+      // gymA: 3 signups, 2 completed a workout
+      // gymB: 1 signup, 0 completed
+      await seedUser(prisma, 'a1', 'a1@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'a2', 'a2@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'a3', 'a3@test.com', 'user', tenDaysAgo)
+      await seedUser(prisma, 'b1', 'b1@test.com', 'user', tenDaysAgo)
+
+      await seedSignupEvent(prisma, 'a1', { source: 'qr', method: 'email', gymSlug: 'gym-a' })
+      await seedSignupEvent(prisma, 'a2', { source: 'qr', method: 'email', gymSlug: 'gym-a' })
+      await seedSignupEvent(prisma, 'a3', { source: 'qr', method: 'email', gymSlug: 'gym-a' })
+      await seedSignupEvent(prisma, 'b1', { source: 'qr', method: 'email', gymSlug: 'gym-b' })
+
+      await seedCompletions(prisma, 'a1', 1, 'completed')
+      await seedCompletions(prisma, 'a2', 1, 'completed')
+      // a3 and b1 have not completed any workouts
+
+      const data = await getAnalyticsData(prisma)
+
+      const gymA = data.signupAttribution.perGym.find((g) => g.gymSlug === 'gym-a')
+      const gymB = data.signupAttribution.perGym.find((g) => g.gymSlug === 'gym-b')
+      expect(gymA?.signupCount).toBe(3)
+      expect(gymA?.firstWorkoutCount).toBe(2)
+      expect(gymA?.firstWorkoutPct).toBe(67)
+      expect(gymB?.signupCount).toBe(1)
+      expect(gymB?.firstWorkoutCount).toBe(0)
+      expect(gymB?.firstWorkoutPct).toBe(0)
+    })
+
+    it('renders cleanly with a single gym slug', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+      await seedUser(prisma, 'solo-1', 'solo@test.com', 'user', tenDaysAgo)
+      await seedSignupEvent(prisma, 'solo-1', {
+        source: 'qr',
+        method: 'email',
+        gymSlug: 'only-gym',
+      })
+
+      const data = await getAnalyticsData(prisma)
+      expect(data.signupAttribution.perGym).toHaveLength(1)
+      expect(data.signupAttribution.perGym[0].gymSlug).toBe('only-gym')
+    })
+
+    it('builds the QR funnel from landing → started → completed', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+
+      // 4 users hit the landing page; 3 click signup; 2 complete signup
+      for (let i = 1; i <= 4; i++) {
+        await seedUser(prisma, `qr-${i}`, `qr${i}@test.com`, 'user', tenDaysAgo)
+        await seedEventWithProps(prisma, `qr-${i}`, 'qr_landing_viewed', {
+          gymSlug: 'iron-works',
+        })
+      }
+      for (let i = 1; i <= 3; i++) {
+        await seedEventWithProps(prisma, `qr-${i}`, 'signup_started', {
+          source: 'qr',
+          method: 'email',
+          gymSlug: 'iron-works',
+        })
+      }
+      for (let i = 1; i <= 2; i++) {
+        await seedSignupEvent(prisma, `qr-${i}`, {
+          source: 'qr',
+          method: 'email',
+          gymSlug: 'iron-works',
+        })
+      }
+
+      const data = await getAnalyticsData(prisma)
+      const funnel = data.signupAttribution.qrFunnel
+      expect(funnel).toHaveLength(3)
+      expect(funnel[0].count).toBe(4)
+      expect(funnel[1].count).toBe(3)
+      expect(funnel[2].count).toBe(2)
+      // step-to-step
+      expect(funnel[1].conversionPct).toBe(75) // 3/4
+      expect(funnel[2].conversionPct).toBe(67) // 2/3
+    })
+  })
+
   it('caps time-to-first-workout to signups within the last 90 days', async () => {
     // Arrange: 1 old user (signed up 200 days ago, first workout 1 day ago)
     // and 5 recent users (signed up 10 days ago, first workout shortly after).
@@ -248,6 +371,35 @@ async function seedEvent(
 ): Promise<void> {
   await prisma.appEvent.create({
     data: { userId, event },
+  })
+}
+
+async function seedSignupEvent(
+  prisma: PrismaClient,
+  userId: string,
+  properties: Record<string, unknown> | null
+): Promise<void> {
+  await prisma.appEvent.create({
+    data: {
+      userId,
+      event: 'signup_completed',
+      properties: properties === null ? undefined : (properties as never),
+    },
+  })
+}
+
+async function seedEventWithProps(
+  prisma: PrismaClient,
+  userId: string,
+  event: string,
+  properties: Record<string, unknown>
+): Promise<void> {
+  await prisma.appEvent.create({
+    data: {
+      userId,
+      event,
+      properties: properties as never,
+    },
   })
 }
 

--- a/app/(app)/admin/analytics/page.tsx
+++ b/app/(app)/admin/analytics/page.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
-import type { AnalyticsData } from '@/lib/admin/analytics-queries'
+import type {
+  AnalyticsData,
+  SignupAttributionMetrics,
+} from '@/lib/admin/analytics-queries'
 
 export default function AdminAnalyticsPage() {
   const [data, setData] = useState<AnalyticsData | null>(null)
@@ -297,6 +300,11 @@ export default function AdminAnalyticsPage() {
         </div>
       </Section>
 
+      {/* Signup Attribution */}
+      <Section title={`Signup Sources (last ${data.signupAttribution.windowDays}d)`}>
+        <SignupAttributionPanel attribution={data.signupAttribution} />
+      </Section>
+
       {/* Feedback Volume */}
       <Section title="Feedback This Week">
         {data.feedbackVolume.length === 0 ? (
@@ -415,6 +423,168 @@ function RetentionBadge({ pct }: { pct: number }) {
   else if (pct >= 10) color = 'text-orange-400'
 
   return <span className={`font-semibold ${color}`}>{pct}%</span>
+}
+
+function SignupAttributionPanel({
+  attribution,
+}: {
+  attribution: SignupAttributionMetrics
+}) {
+  const totalAttributed = attribution.sourceBreakdown.reduce(
+    (sum, s) => sum + s.count,
+    0
+  )
+
+  return (
+    <div className="space-y-6">
+      {/* Source breakdown */}
+      <div>
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+          Source Breakdown
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Where signups came from. <code>qr</code> = scanned a gym code,{' '}
+          <code>oauth</code> = social provider, <code>organic</code> = direct
+          arrival, <code>unknown</code> = pre-#490 signups (no attribution
+          recorded).
+        </p>
+        {attribution.sourceBreakdown.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">
+            No signups in the window yet.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {attribution.sourceBreakdown.map((s) => (
+              <div
+                key={s.source}
+                className="bg-background border border-border rounded-lg p-3"
+              >
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  {s.source}
+                </div>
+                <div className="text-2xl font-bold text-foreground">
+                  {s.count}
+                </div>
+                {totalAttributed > 0 && (
+                  <div className="text-xs text-muted-foreground mt-1">
+                    {Math.round((s.count / totalAttributed) * 100)}% of total
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Per-gym rollup */}
+      <div>
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+          Per-Gym Signups
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Signups attributed to a gym slug (via <code>/go/[slug]</code>) and how
+          many of those users completed at least one workout.
+        </p>
+        {attribution.perGym.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">
+            No gym-attributed signups yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left py-2 px-3 text-muted-foreground font-medium">
+                    Gym Slug
+                  </th>
+                  <th className="text-right py-2 px-3 text-muted-foreground font-medium">
+                    Signups
+                  </th>
+                  <th className="text-right py-2 px-3 text-muted-foreground font-medium">
+                    First Workout
+                  </th>
+                  <th className="text-right py-2 px-3 text-muted-foreground font-medium">
+                    Conversion
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {attribution.perGym.map((g) => (
+                  <tr
+                    key={g.gymSlug}
+                    className="border-b border-border/50"
+                  >
+                    <td className="py-2 px-3 text-foreground">{g.gymSlug}</td>
+                    <td className="py-2 px-3 text-right text-foreground">
+                      {g.signupCount}
+                    </td>
+                    <td className="py-2 px-3 text-right text-foreground">
+                      {g.firstWorkoutCount}
+                    </td>
+                    <td className="py-2 px-3 text-right">
+                      <RetentionBadge pct={g.firstWorkoutPct} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* QR funnel */}
+      <div>
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+          QR Landing Drop-off
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Of users who hit a <code>/go/[slug]</code> page, how many clicked
+          signup, and how many actually completed it.
+        </p>
+        <div className="space-y-2">
+          {attribution.qrFunnel.map((step, i) => (
+            <div key={step.step} className="flex items-center gap-3">
+              <div className="w-44 sm:w-52 text-sm text-foreground truncate">
+                {step.step}
+              </div>
+              <div className="flex-1 bg-background rounded-full h-6 overflow-hidden border border-border">
+                <div
+                  className="h-full bg-orange-600/60 rounded-full flex items-center justify-end pr-2"
+                  style={{
+                    width: `${
+                      attribution.qrFunnel[0].count > 0
+                        ? Math.min(
+                            100,
+                            Math.max(
+                              (step.count / attribution.qrFunnel[0].count) *
+                                100,
+                              5
+                            )
+                          )
+                        : 5
+                    }%`,
+                  }}
+                >
+                  <span className="text-xs font-semibold text-foreground">
+                    {step.count}
+                  </span>
+                </div>
+              </div>
+              <div className="w-14 text-right text-sm">
+                {i === 0 ? (
+                  <span className="text-muted-foreground">--</span>
+                ) : (
+                  <span className="text-orange-400 font-semibold">
+                    {step.conversionPct}%
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function FunnelRow({

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import BottomNav from '@/components/BottomNav'
 import FloatingDraftButton from '@/components/FloatingDraftButton'
 import FeedbackButton from '@/components/features/FeedbackButton'
+import { SignupCompletedTracker } from '@/components/features/SignupCompletedTracker'
 import Header from '@/components/Header'
 import { TourProvider } from '@/components/tour'
 import { getCurrentUser } from '@/lib/auth/server'
@@ -22,6 +23,7 @@ export default async function AppLayout({
     <DraftWorkoutProvider>
       <TourProvider>
       <div className="min-h-screen bg-background">
+        <SignupCompletedTracker />
         <Header userEmail={user.email || ''} />
         <FloatingDraftButton />
         <div className="pb-20 md:pb-0">

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -9,6 +9,11 @@ import { OrDivider } from '@/components/features/auth/OrDivider'
 import { Button } from '@/components/ui/Button'
 import { flushEvents, trackEvent } from '@/lib/analytics'
 import { signUp } from '@/lib/auth-client'
+import {
+  clearAttribution,
+  getAttribution,
+  resolveSource,
+} from '@/lib/signup-attribution'
 
 export default function SignupPage() {
   const _router = useRouter()
@@ -34,6 +39,13 @@ export default function SignupPage() {
       setError('Password must be at least 6 characters')
       return
     }
+
+    // Capture attribution at submit time so QR/organic source is preserved
+    const attribution = getAttribution()
+    const source = resolveSource('email', attribution)
+    const startedProps: Record<string, unknown> = { source, method: 'email' }
+    if (attribution.gymSlug) startedProps.gymSlug = attribution.gymSlug
+    trackEvent('signup_started', startedProps)
 
     setLoading(true)
 
@@ -67,7 +79,13 @@ export default function SignupPage() {
       // BetterAuth signs in immediately after signup.
       // Use sendBeacon so the signup_completed event survives the
       // navigation to '/' that happens right after.
-      trackEvent('signup_completed')
+      const completedProps: Record<string, unknown> = {
+        source,
+        method: 'email',
+      }
+      if (attribution.gymSlug) completedProps.gymSlug = attribution.gymSlug
+      trackEvent('signup_completed', completedProps)
+      clearAttribution()
       await flushEvents(true)
       window.location.href = '/'
     } catch {
@@ -81,7 +99,7 @@ export default function SignupPage() {
       <div className="max-w-md w-full space-y-8 p-6 sm:p-8 bg-card rounded-lg shadow-lg border border-border">
         <AuthPageHeader />
 
-        <OAuthButtons />
+        <OAuthButtons intent="signup" />
 
         <OrDivider />
 

--- a/app/go/[gymSlug]/page.tsx
+++ b/app/go/[gymSlug]/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link from 'next/link'
+import { use, useEffect } from 'react'
+import { AuthPageHeader } from '@/components/features/auth/AuthPageHeader'
+import { Button } from '@/components/ui/Button'
+import { trackEvent } from '@/lib/analytics'
+import { setAttribution } from '@/lib/signup-attribution'
+
+interface QrLandingPageProps {
+  params: Promise<{ gymSlug: string }>
+}
+
+/**
+ * QR landing page rendered when a user scans a gym-specific QR code.
+ *
+ * - Stores `{source: 'qr', gymSlug}` in sessionStorage so signup attribution
+ *   carries through to /signup (and through OAuth round-trips).
+ * - Fires `qr_landing_viewed` for the QR-funnel dashboard.
+ *
+ * The `signup_started` event fires later when the user clicks the primary CTA.
+ */
+export default function QrLandingPage({ params }: QrLandingPageProps) {
+  const { gymSlug } = use(params)
+
+  useEffect(() => {
+    if (!gymSlug) return
+    setAttribution({ source: 'qr', gymSlug })
+    trackEvent('qr_landing_viewed', { gymSlug })
+  }, [gymSlug])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="max-w-md w-full space-y-8 p-6 sm:p-8 bg-card rounded-lg shadow-lg border border-border">
+        <AuthPageHeader subtitle="A flexible strength tracker — built for the gym, no fluff." />
+
+        <div className="space-y-4 text-center">
+          <p className="text-sm text-muted-foreground">
+            You scanned a code from{' '}
+            <span className="font-semibold text-foreground">{gymSlug}</span>.
+            Create your free account to start logging workouts.
+          </p>
+
+          <Link href="/signup" className="block">
+            <Button variant="primary" doom className="w-full">
+              Create free account
+            </Button>
+          </Link>
+
+          <p className="text-center text-sm text-muted-foreground">
+            Already have an account?{' '}
+            <Link
+              href="/login"
+              className="font-medium text-primary hover:text-primary-hover"
+            >
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/SignupCompletedTracker.tsx
+++ b/components/features/SignupCompletedTracker.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+import { flushEvents, trackEvent } from '@/lib/analytics'
+import { useSession } from '@/lib/auth-client'
+import {
+  clearAttribution,
+  consumePendingOAuthSignup,
+  resolveSource,
+} from '@/lib/signup-attribution'
+
+/**
+ * Fires the `signup_completed` AppEvent once an OAuth signup completes.
+ *
+ * Email signups already fire `signup_completed` from the signup form. OAuth
+ * signups round-trip through the provider and land on `/`, so we drop a
+ * "pending OAuth signup" record into sessionStorage at click-time and consume
+ * it here once BetterAuth establishes a session.
+ *
+ * Guards against false positives:
+ *  - Only fires when a pending record exists (set by OAuthButtons w/ intent=signup)
+ *  - Verifies the user's createdAt is within 5 min so a returning OAuth user
+ *    who happened to start a signup-intent click doesn't fire a duplicate event
+ *  - Pending record is single-use (consumed atomically)
+ */
+const FRESH_SIGNUP_WINDOW_MS = 5 * 60 * 1000
+
+export function SignupCompletedTracker() {
+  const { data: session, isPending } = useSession()
+
+  useEffect(() => {
+    if (isPending) return
+    if (!session?.user) return
+
+    const pending = consumePendingOAuthSignup()
+    if (!pending) return
+
+    // Verify the account is genuinely new (avoids re-firing for repeat OAuth
+    // sign-ins that the click handler can't distinguish from real signups).
+    const createdAtMs = session.user.createdAt
+      ? new Date(session.user.createdAt).getTime()
+      : 0
+    if (!createdAtMs || Date.now() - createdAtMs > FRESH_SIGNUP_WINDOW_MS) return
+
+    const source = resolveSource(pending.method, pending.attribution)
+    const props: Record<string, unknown> = {
+      source,
+      method: pending.method,
+    }
+    if (pending.attribution.gymSlug) {
+      props.gymSlug = pending.attribution.gymSlug
+    }
+    trackEvent('signup_completed', props)
+    clearAttribution()
+    void flushEvents(true)
+  }, [session, isPending])
+
+  return null
+}

--- a/components/features/auth/OAuthButtons.tsx
+++ b/components/features/auth/OAuthButtons.tsx
@@ -1,15 +1,42 @@
 'use client'
 
 import { useState } from 'react'
+import { trackEvent } from '@/lib/analytics'
 import { signIn } from '@/lib/auth-client'
+import {
+  getAttribution,
+  resolveSource,
+  setPendingOAuthSignup,
+} from '@/lib/signup-attribution'
 
-export function OAuthButtons() {
+interface OAuthButtonsProps {
+  /**
+   * Distinguishes signup vs login surfaces. When `intent === 'signup'`
+   * we record a pending OAuth signup so the in-app tracker can fire
+   * `signup_completed` once BetterAuth establishes a session.
+   */
+  intent?: 'signup' | 'login'
+}
+
+export function OAuthButtons({ intent = 'login' }: OAuthButtonsProps = {}) {
   const [loadingProvider, setLoadingProvider] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const handleOAuth = async (provider: 'google' | 'discord') => {
     setError(null)
     setLoadingProvider(provider)
+
+    if (intent === 'signup') {
+      const attribution = getAttribution()
+      const source = resolveSource(provider, attribution)
+      const startedProps: Record<string, unknown> = {
+        source,
+        method: provider,
+      }
+      if (attribution.gymSlug) startedProps.gymSlug = attribution.gymSlug
+      trackEvent('signup_started', startedProps)
+      setPendingOAuthSignup(provider, attribution)
+    }
 
     try {
       await signIn.social({

--- a/lib/admin/analytics-queries.ts
+++ b/lib/admin/analytics-queries.ts
@@ -107,11 +107,42 @@ export interface FeedbackVolume {
   count: number
 }
 
+export interface SignupSourceBreakdown {
+  /** 'organic' | 'qr' | 'oauth' | 'unknown' (legacy signups w/o source prop) */
+  source: string
+  count: number
+}
+
+export interface PerGymSignup {
+  gymSlug: string
+  signupCount: number
+  /** Of the signups attributed to this gym, how many completed a workout */
+  firstWorkoutCount: number
+  /** firstWorkoutCount / signupCount as a 0–100 percent */
+  firstWorkoutPct: number
+}
+
+export interface QrFunnelStep {
+  step: string
+  count: number
+  /** Step-to-step conversion: this step vs. previous step (0 for first step) */
+  conversionPct: number
+}
+
+export interface SignupAttributionMetrics {
+  sourceBreakdown: SignupSourceBreakdown[]
+  perGym: PerGymSignup[]
+  qrFunnel: QrFunnelStep[]
+  /** Number of days the breakdown covers (currently the most recent 30 days). */
+  windowDays: number
+}
+
 export interface AnalyticsData {
   usage: UsageMetrics
   retention: RetentionMetrics
   funnel: FunnelStep[]
   feedbackVolume: FeedbackVolume[]
+  signupAttribution: SignupAttributionMetrics
   generatedAt: string
 }
 
@@ -426,24 +457,151 @@ async function getFeedbackVolume(db: Db): Promise<FeedbackVolume[]> {
   return feedback
 }
 
+async function getSignupAttributionMetrics(
+  db: Db
+): Promise<SignupAttributionMetrics> {
+  const windowDays = 30
+  const windowStart = daysAgo(windowDays)
+
+  // 1. Source breakdown over the window. Legacy signup_completed events
+  //    pre-#490 will have null properties — we coalesce them to 'unknown'
+  //    so the breakdown still totals up.
+  const sourceRows = await db.$queryRaw<
+    Array<{ source: string; count: bigint }>
+  >`
+    SELECT
+      COALESCE(NULLIF(e.properties->>'source', ''), 'unknown') as source,
+      COUNT(DISTINCT e."userId")::bigint as count
+    FROM "AppEvent" e
+    INNER JOIN "user" u ON u.id = e."userId"
+    WHERE e.event = 'signup_completed'
+      AND e."createdAt" >= ${windowStart}
+      ${ONLY_END_USERS_ON_U}
+    GROUP BY 1
+    ORDER BY count DESC
+  `
+  const sourceBreakdown: SignupSourceBreakdown[] = sourceRows.map((r) => ({
+    source: r.source,
+    count: Number(r.count),
+  }))
+
+  // 2. Per-gym signups + conversion to first workout. Joins back to
+  //    WorkoutCompletion to compute the conversion %.
+  const gymRows = await db.$queryRaw<
+    Array<{
+      gymSlug: string
+      signupCount: bigint
+      firstWorkoutCount: bigint
+    }>
+  >`
+    WITH gym_signups AS (
+      SELECT
+        e.properties->>'gymSlug' as "gymSlug",
+        e."userId" as "userId"
+      FROM "AppEvent" e
+      INNER JOIN "user" u ON u.id = e."userId"
+      WHERE e.event = 'signup_completed'
+        AND e."createdAt" >= ${windowStart}
+        AND e.properties->>'gymSlug' IS NOT NULL
+        AND e.properties->>'gymSlug' <> ''
+        ${ONLY_END_USERS_ON_U}
+    )
+    SELECT
+      gs."gymSlug" as "gymSlug",
+      COUNT(DISTINCT gs."userId")::bigint as "signupCount",
+      COUNT(DISTINCT wc."userId")::bigint as "firstWorkoutCount"
+    FROM gym_signups gs
+    LEFT JOIN "WorkoutCompletion" wc
+      ON wc."userId" = gs."userId"
+      AND wc.status = 'completed'
+    GROUP BY gs."gymSlug"
+    ORDER BY "signupCount" DESC, gs."gymSlug" ASC
+  `
+  const perGym: PerGymSignup[] = gymRows.map((r) => {
+    const signupCount = Number(r.signupCount)
+    const firstWorkoutCount = Number(r.firstWorkoutCount)
+    return {
+      gymSlug: r.gymSlug,
+      signupCount,
+      firstWorkoutCount,
+      firstWorkoutPct:
+        signupCount > 0
+          ? Math.round((firstWorkoutCount / signupCount) * 100)
+          : 0,
+    }
+  })
+
+  // 3. QR funnel: qr_landing_viewed → signup_started (source='qr') → signup_completed (source='qr')
+  //    Landing views can be from non-authenticated users if /go/[slug] is ever public —
+  //    today every event is auth-gated by /api/events, so we still INNER JOIN user.
+  const [landingViewed, signupStarted, signupCompleted] = await Promise.all([
+    db.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT e."userId")::bigint as count
+      FROM "AppEvent" e
+      INNER JOIN "user" u ON u.id = e."userId"
+      WHERE e.event = 'qr_landing_viewed'
+        AND e."createdAt" >= ${windowStart}
+        ${ONLY_END_USERS_ON_U}
+    `,
+    db.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT e."userId")::bigint as count
+      FROM "AppEvent" e
+      INNER JOIN "user" u ON u.id = e."userId"
+      WHERE e.event = 'signup_started'
+        AND e.properties->>'source' = 'qr'
+        AND e."createdAt" >= ${windowStart}
+        ${ONLY_END_USERS_ON_U}
+    `,
+    db.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT e."userId")::bigint as count
+      FROM "AppEvent" e
+      INNER JOIN "user" u ON u.id = e."userId"
+      WHERE e.event = 'signup_completed'
+        AND e.properties->>'source' = 'qr'
+        AND e."createdAt" >= ${windowStart}
+        ${ONLY_END_USERS_ON_U}
+    `,
+  ])
+
+  const qrSteps = [
+    { step: 'QR Landing Viewed', count: Number(landingViewed[0].count) },
+    { step: 'Signup Started', count: Number(signupStarted[0].count) },
+    { step: 'Signup Completed', count: Number(signupCompleted[0].count) },
+  ]
+  const qrFunnel: QrFunnelStep[] = qrSteps.map((s, i) => ({
+    ...s,
+    conversionPct:
+      i === 0
+        ? 0
+        : qrSteps[i - 1].count > 0
+          ? Math.round((s.count / qrSteps[i - 1].count) * 100)
+          : 0,
+  }))
+
+  return { sourceBreakdown, perGym, qrFunnel, windowDays }
+}
+
 // ---- Main ----
 
 export async function getAnalyticsData(
   db: Db = defaultPrisma,
 ): Promise<AnalyticsData> {
   try {
-    const [usage, retention, funnel, feedbackVolume] = await Promise.all([
-      getUsageMetrics(db),
-      getRetentionMetrics(db),
-      getFunnelMetrics(db),
-      getFeedbackVolume(db),
-    ])
+    const [usage, retention, funnel, feedbackVolume, signupAttribution] =
+      await Promise.all([
+        getUsageMetrics(db),
+        getRetentionMetrics(db),
+        getFunnelMetrics(db),
+        getFeedbackVolume(db),
+        getSignupAttributionMetrics(db),
+      ])
 
     return {
       usage,
       retention,
       funnel,
       feedbackVolume,
+      signupAttribution,
       generatedAt: new Date().toISOString(),
     }
   } catch (error) {

--- a/lib/signup-attribution.ts
+++ b/lib/signup-attribution.ts
@@ -1,0 +1,127 @@
+/**
+ * Signup attribution helpers.
+ *
+ * Tracks where a signup originated:
+ *  - `source: 'qr'`       — user arrived via /go/[gymSlug] QR code
+ *  - `source: 'organic'`  — user arrived directly (no attribution)
+ *  - `source: 'oauth'`    — user signed up via a social provider
+ *
+ * Attribution lives in `sessionStorage` so it survives in-app navigation
+ * (e.g., /go → /signup) without polluting cookies or the URL.
+ *
+ * For OAuth signups the user round-trips through the provider and lands
+ * on `/`. To detect that as a signup_completed event we stash a small
+ * "pending OAuth signup" record before redirecting; the in-app tracker
+ * picks it up after the session is established.
+ */
+
+'use client'
+
+export type SignupSource = 'qr' | 'organic' | 'oauth'
+export type SignupMethod = 'email' | 'google' | 'discord'
+
+export interface SignupAttribution {
+  source: SignupSource
+  gymSlug?: string
+}
+
+export interface PendingOAuthSignup {
+  method: 'google' | 'discord'
+  attribution: SignupAttribution
+  /** Unix ms timestamp; tracker drops anything older than 30 min. */
+  startedAt: number
+}
+
+const ATTRIBUTION_KEY = 'ripit:signup-attribution'
+const PENDING_OAUTH_KEY = 'ripit:pending-oauth-signup'
+
+/** Maximum age of a pending OAuth signup before we discard it. */
+const PENDING_OAUTH_TTL_MS = 30 * 60 * 1000
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined'
+}
+
+export function setAttribution(attribution: SignupAttribution): void {
+  if (!isBrowser()) return
+  try {
+    window.sessionStorage.setItem(ATTRIBUTION_KEY, JSON.stringify(attribution))
+  } catch {
+    // sessionStorage can throw in private browsing / quota errors — best effort
+  }
+}
+
+export function getAttribution(): SignupAttribution {
+  if (!isBrowser()) return { source: 'organic' }
+  try {
+    const raw = window.sessionStorage.getItem(ATTRIBUTION_KEY)
+    if (!raw) return { source: 'organic' }
+    const parsed = JSON.parse(raw) as SignupAttribution
+    if (parsed.source !== 'qr' && parsed.source !== 'organic' && parsed.source !== 'oauth') {
+      return { source: 'organic' }
+    }
+    return parsed
+  } catch {
+    return { source: 'organic' }
+  }
+}
+
+export function clearAttribution(): void {
+  if (!isBrowser()) return
+  try {
+    window.sessionStorage.removeItem(ATTRIBUTION_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+export function setPendingOAuthSignup(
+  method: 'google' | 'discord',
+  attribution: SignupAttribution
+): void {
+  if (!isBrowser()) return
+  const record: PendingOAuthSignup = {
+    method,
+    attribution,
+    startedAt: Date.now(),
+  }
+  try {
+    window.sessionStorage.setItem(PENDING_OAUTH_KEY, JSON.stringify(record))
+  } catch {
+    // ignore
+  }
+}
+
+export function consumePendingOAuthSignup(): PendingOAuthSignup | null {
+  if (!isBrowser()) return null
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_OAUTH_KEY)
+    if (!raw) return null
+    window.sessionStorage.removeItem(PENDING_OAUTH_KEY)
+    const parsed = JSON.parse(raw) as PendingOAuthSignup
+    if (!parsed || typeof parsed.startedAt !== 'number') return null
+    if (Date.now() - parsed.startedAt > PENDING_OAUTH_TTL_MS) return null
+    if (parsed.method !== 'google' && parsed.method !== 'discord') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Compute the canonical `source` from a method + attribution. Centralised
+ * so client and server agree on the rule.
+ *
+ * Rule:
+ *  - non-email method → `oauth` (overrides prior attribution)
+ *  - email + gymSlug attribution → `qr`
+ *  - otherwise → existing source (or `organic`)
+ */
+export function resolveSource(
+  method: SignupMethod,
+  attribution: SignupAttribution
+): SignupSource {
+  if (method !== 'email') return 'oauth'
+  if (attribution.gymSlug) return 'qr'
+  return attribution.source ?? 'organic'
+}


### PR DESCRIPTION
## Summary

Adds attribution to `signup_completed` and surfaces it in the admin analytics dashboard so the Iron Works beta can see where signups come from.

- New `/go/[gymSlug]` landing page fires `qr_landing_viewed` and stashes attribution in sessionStorage
- `signup_started` + `signup_completed` now carry `{ source, gymSlug, method }` for both email and OAuth flows
- New `SignupCompletedTracker` mounted in the app layout fires `signup_completed` for OAuth signups once the session is established (verified against `User.createdAt` to avoid false positives)
- Admin analytics gains a Signup Sources panel with source breakdown, per-gym signup table (with first-workout conversion), and a 3-step QR drop-off funnel

## Architecture notes

- `source` is derived: non-email method → `oauth`, else gymSlug present → `qr`, else `organic`. Centralised in `resolveSource()` so client and server agree on the rule.
- Legacy signups (pre-#490) have null properties — the source breakdown coalesces them to `unknown` so totals still match.
- All new metrics share the same staff-account exclusion (`role = 'user'`) used by existing analytics queries.
- 30-day rolling window for the attribution panel — matches existing dashboard patterns.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint` (no new errors/warnings on touched files)
- [x] `doppler run -- npm run test:run -- admin-analytics` (7 tests pass)
- [x] `doppler run -- npm run test:run -- events` (11 tests pass)
- [x] `doppler run -- npm run build` (succeeds; `/go/[gymSlug]` route registered)

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)