### PR TITLE
Update when-to-stop article with post-review content

### DIFF
--- a/prisma/migrations/20260416221755_update_when_to_stop_article_content/migration.sql
+++ b/prisma/migrations/20260416221755_update_when_to_stop_article_content/migration.sql
@@ -1,0 +1,68 @@
+-- Update "when-to-stop" article with revised title and body
+--
+-- The initial migration (20260416173535) inserted the article. This
+-- follow-up applies the post-review content edits: new title, restructured
+-- sections, and updated disclaimer footer. The slug stays unchanged so
+-- bookmarks and collection placement are unaffected.
+--
+-- Idempotent: UPDATE is naturally idempotent (same row, same values).
+-- Skips silently if the article doesn't exist yet (fresh env handled by seed).
+
+UPDATE "Article"
+SET
+  title = 'When to Push, When to Pause',
+  body = $body$# When to Push, When to Pause
+
+*Heads up: this is general guidance to help you train safely, not medical advice. If something feels off and doesn't go away, talk to a doctor or physical therapist who can actually take a look.*
+
+Your first few weeks of training will throw new sensations at you. Most of them are your body adapting, and they're fine. A few are worth paying attention to. This guide is here so you can tell which is which.
+
+## The normal stuff
+
+Soreness a day or two after a session, especially after trying something new. Muscles burning on your last few reps. Shaky arms or legs after a hard set. Getting sweaty and out of breath. Stiff joints that loosen up once you start moving. A muscle feeling pumped and tight after you've worked it.
+
+All normal. Drink some water, eat something, get some sleep. By your next session it's gone.
+
+## When to call it on an exercise
+
+Sometimes a specific movement just isn't working that day. If you notice any of the following, rack the weight and move on to something else in your program:
+
+- A sharp, sudden pain that's different from muscle burn — more like a sting, pinch, or jolt
+- Pain inside a joint (shoulder, knee, elbow, lower back). Muscles are supposed to work hard. Joints should feel quiet and stable.
+- Numbness or tingling in your hands or feet during the movement
+- That gut feeling that something's wrong before you can explain why. Worth listening to.
+
+You don't need to figure out what happened. Finish the rest of your workout, and try the exercise again next session — lighter weight, or a different variation. If the same thing happens twice, give it a week off and come back to it.
+
+## When to call it on the workout
+
+Some things are worth ending the session for:
+
+- Chest tightness, pressure, or pain — especially if it spreads to your arm, jaw, or back
+- Dizziness that hangs around or gets worse after you sit down
+- Sudden nausea, cold sweat, or feeling like you might pass out
+- A sudden, severe headache during a heavy set
+
+These are the kinds of symptoms most guidance treats as reasons to stop, sit down, and get some water. If they don't pass in a few minutes, most folks would tell you to seek medical attention — and skip the drive home if you're still feeling rough. Most of the time it's nothing serious. Better to find out sitting down than mid-squat.
+
+## When it's worth getting checked out
+
+A few patterns are worth a visit to a doctor, PT, or sports medicine person:
+
+- Pain from training that's still bugging you a week later, outside the gym
+- A joint that gets worse session to session instead of better
+- The same spot — same knee, same shoulder — flaring up every time you train it
+- Anything that's changing how you walk, sleep, or move through your day
+- Chest stuff that keeps showing up during workouts, even if it's mild
+
+Going to see someone isn't a sign you broke yourself. People who lift for decades do this routinely. A good PT can usually spot what's going on in a session or two — often it's a mobility thing or a form tweak that's a quick fix.
+
+When you're not sure if it's worth a visit, that uncertainty is usually worth an hour of someone's time. While you're sorting it out, train the parts that feel good and let the cranky ones rest.
+
+You're going to have a long career of this. Pacing yourself early is how you get there.
+
+---
+
+*Ripit gives you general fitness guidance, not medical advice. For anything specific to your body, talk to a doctor or PT. Full terms in your user agreement.*$body$,
+  "updatedAt" = NOW()
+WHERE slug = 'when-to-stop';

--- a/prisma/seeds/dev-articles.ts
+++ b/prisma/seeds/dev-articles.ts
@@ -244,77 +244,64 @@ If your program includes dumbbells:
 }
 
 const whenToStop: ArticleDef = {
-  title: 'When to Stop and When to Ask for Help',
+  title: 'When to Push, When to Pause',
   slug: 'when-to-stop',
   level: 'beginner',
   readTimeMinutes: 4,
   tags: ['Beginner Basics'],
-  body: `# When to Stop and When to Ask for Help
+  body: `# When to Push, When to Pause
 
-"Staying Safe in the Gym" covered the basic distinction between pain and discomfort. This article goes one step further: when should you actually stop an exercise, stop the workout, or go see a professional?
+*Heads up: this is general guidance to help you train safely, not medical advice. If something feels off and doesn't go away, talk to a doctor or physical therapist who can actually take a look.*
 
-Most of what's below will never apply to you. Knowing the difference between something you can push through and something that needs attention is a skill worth having before you need it.
+Your first few weeks of training will throw new sensations at you. Most of them are your body adapting, and they're fine. A few are worth paying attention to. This guide is here so you can tell which is which.
 
-## Things that feel weird but are fine
+## The normal stuff
 
-Your first few weeks will include sensations you haven't felt before. Most of them are normal:
+Soreness a day or two after a session, especially after trying something new. Muscles burning on your last few reps. Shaky arms or legs after a hard set. Getting sweaty and out of breath. Stiff joints that loosen up once you start moving. A muscle feeling pumped and tight after you've worked it.
 
-- Soreness 24-48 hours after a workout, especially after new exercises
-- Muscles burning during the last few reps of a set
-- Arms or legs feeling shaky after a hard set
-- Feeling out of breath, sweaty, warm
-- Mild joint stiffness that loosens up during your warm-up
-- A muscle that feels pumped or tight after training it
+All normal. Drink some water, eat something, get some sleep. By your next session it's gone.
 
-None of these need any action. Drink water, move around, eat something. By your next session it's gone.
+## When to call it on an exercise
 
-## Stop the exercise
+Sometimes a specific movement just isn't working that day. If you notice any of the following, rack the weight and move on to something else in your program:
 
-Some sensations are your body telling you that the specific movement isn't working today. When you feel any of these, stop the set, rack the weight, and move on to something else:
+- A sharp, sudden pain that's different from muscle burn — more like a sting, pinch, or jolt
+- Pain inside a joint (shoulder, knee, elbow, lower back). Muscles are supposed to work hard. Joints should feel quiet and stable.
+- Numbness or tingling in your hands or feet during the movement
+- That gut feeling that something's wrong before you can explain why. Worth listening to.
 
-**Sharp or sudden pain.** A sting, a pinch, or a jolt that wasn't there on the previous rep. This is different from muscle burn — it's sharper and it grabs your attention.
+You don't need to figure out what happened. Finish the rest of your workout, and try the exercise again next session — lighter weight, or a different variation. If the same thing happens twice, give it a week off and come back to it.
 
-**Pain in a joint.** Shoulders, knees, elbows, lower back. Muscles should work during an exercise. Joints should feel stable and quiet. If your shoulder aches every time you press overhead, that's your shoulder asking you to stop.
+## When to call it on the workout
 
-**Numbness or tingling.** Hands or feet going numb, pins and needles down an arm or leg. This can be a nerve being pinched by your position. Adjust the machine or skip that exercise for the day.
+Some things are worth ending the session for:
 
-**An instinct to pull away.** Sometimes you feel a movement is wrong before you can describe why. Trust that. Stop the set.
+- Chest tightness, pressure, or pain — especially if it spreads to your arm, jaw, or back
+- Dizziness that hangs around or gets worse after you sit down
+- Sudden nausea, cold sweat, or feeling like you might pass out
+- A sudden, severe headache during a heavy set
 
-You don't need to diagnose what happened. Do the other exercises in your program, then try that one again next session with lighter weight or a different variation. If the same thing happens twice, leave it alone for a week and see how it feels later.
+These are the kinds of symptoms most guidance treats as reasons to stop, sit down, and get some water. If they don't pass in a few minutes, most folks would tell you to seek medical attention — and skip the drive home if you're still feeling rough. Most of the time it's nothing serious. Better to find out sitting down than mid-squat.
 
-## Stop the workout
+## When it's worth getting checked out
 
-A few signals mean the whole session is over, not just the one exercise:
+A few patterns are worth a visit to a doctor, PT, or sports medicine person:
 
-**Chest tightness, pressure, or pain.** Especially if it spreads to your arm, jaw, or back. Stop training, sit down, and tell someone. If it doesn't pass in a few minutes, call for help. This isn't common in gyms but it's not zero.
+- Pain from training that's still bugging you a week later, outside the gym
+- A joint that gets worse session to session instead of better
+- The same spot — same knee, same shoulder — flaring up every time you train it
+- Anything that's changing how you walk, sleep, or move through your day
+- Chest stuff that keeps showing up during workouts, even if it's mild
 
-**Dizziness that doesn't pass.** A brief head rush when you stand up from a machine is normal. Dizziness that sticks around, or gets worse after you sit down, is not. Sit, drink water, and give yourself a few minutes. If it doesn't clear up, go home — and don't drive if you still feel off.
+Going to see someone isn't a sign you broke yourself. People who lift for decades do this routinely. A good PT can usually spot what's going on in a session or two — often it's a mobility thing or a form tweak that's a quick fix.
 
-**Nausea or feeling faint.** Cold sweat, tunnel vision, nausea that comes on suddenly. Same protocol: sit down, drink water, wait it out, head home if it doesn't resolve.
+When you're not sure if it's worth a visit, that uncertainty is usually worth an hour of someone's time. While you're sorting it out, train the parts that feel good and let the cranky ones rest.
 
-**A sudden severe headache.** Especially one that comes on during a heavy set. Stop and give yourself time. If it's the worst headache you've ever had, that's an emergency room situation.
-
-Wrapping up early when something feels off is the right call. You'll train again tomorrow or the next day.
-
-## See a professional
-
-A few patterns are worth getting checked out by a doctor, physical therapist, or sports medicine provider:
-
-- Pain from an exercise that's still there a week later, outside the gym
-- Joint pain that gets worse session to session instead of better
-- A recurring issue — the same knee, the same shoulder — flaring up every time you train it
-- Any pain that changes how you walk, sleep, or move through normal daily things
-- Chest-related symptoms, even mild ones, if they keep showing up during training
-
-Seeing a professional isn't a sign you've done something wrong. It's what people who train seriously for decades do. A physical therapist can usually identify what's going on in a visit or two — often a mobility or form issue that's fixable, sometimes something that needs a different approach for a few weeks.
-
-If you're not sure whether something warrants a visit, it probably does. The cost of going is an hour of your time. The cost of not going is training through something that gets worse.
-
-In the meantime, train the parts of your body that aren't complaining, and give the ones that are a session or two off.
+You're going to have a long career of this. Pacing yourself early is how you get there.
 
 ---
 
-*This article is general guidance for training safely. It isn't medical advice. If something feels wrong and doesn't go away, see someone qualified who can actually examine what's going on.*`,
+*Ripit gives you general fitness guidance, not medical advice. For anything specific to your body, talk to a doctor or PT. Full terms in your user agreement.*`,
 }
 
 const gymEtiquette: ArticleDef = {


### PR DESCRIPTION
## Summary

- Updates the "when to stop" article title and body to match post-staging-review edits
- Title changed: "When to Stop and When to Ask for Help" -> "When to Push, When to Pause"
- Restructured sections with more conversational headings and tone
- Disclaimer moved to top as italic header; footer updated to reference user agreement
- Slug (`when-to-stop`) unchanged — bookmarks and collection placement preserved

## Implementation

Two files, same content:

1. **`prisma/seeds/dev-articles.ts`** — for fresh dev/CI/test environments
2. **New migration `20260416221755_update_when_to_stop_article_content`** — `UPDATE` for existing environments. Cannot modify the original migration (Prisma checksums already-applied migrations)

On prod (original migration not yet applied), both migrations run in sequence: first creates the article at position 6 as `pending_review`, second updates title and body. On staging (first migration already applied), only the second migration applies.

## Test plan

- [x] Type-check passes
- [x] Local migration test: first migration creates article, second updates content, position stays at 6, idempotent on re-run
- [ ] CI smoke test passes (existing `smoke-test-learn-content.sh` validates first migration; second migration is a simple UPDATE)
- [ ] Staging: verify article content matches after deploy
- [ ] Admin panel: review and publish when ready

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)