### PR TITLE
fix(pwa): safe-area on logger modal + bottom nav text bump

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2460,32 +2460,3 @@ body > [data-training-widget] {
   background: var(--muted);
   font-weight: 600;
 }
-
-/* ============================================
-   iOS PWA SAFE-AREA UTILITIES
-   ============================================
-   Apply env(safe-area-inset-bottom) only when running as an installed PWA
-   (display-mode: standalone). In a regular browser tab, the browser chrome
-   (URL bar / toolbar) sits above the home-indicator area, so no extra
-   padding is needed. In standalone mode the home indicator overlaps any
-   bottom-fixed/sticky UI, so we add the inset on top of the existing pb-N.
-
-   Usage: keep your existing `pb-N` (or `py-N`) class and add `pwa-pb-safe-N`
-   matching the same value. In browser mode the `pb-N` rule wins; in
-   standalone mode the `pwa-pb-safe-N` rule (defined later in the cascade)
-   wins and adds env(safe-area-inset-bottom) on top of the base.
-*/
-@media (display-mode: standalone) {
-  .pwa-pb-safe-0 {
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-  .pwa-pb-safe-2 {
-    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
-  }
-  .pwa-pb-safe-3 {
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
-  }
-  .pwa-pb-safe-4 {
-    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
-  }
-}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -19,7 +19,7 @@ export default function BottomNav() {
       className="md:hidden fixed bottom-0 left-0 right-0 border-t-2 border-border bg-muted/95 backdrop-blur-sm"
       style={{
         zIndex: 40,
-        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 2px)',
       }}
       aria-label="Main navigation"
     >
@@ -38,7 +38,7 @@ export default function BottomNav() {
               aria-current={isActive ? 'page' : undefined}
             >
               <Icon className="h-5 w-5" />
-              <span className="text-[10px] font-medium">{label}</span>
+              <span className="text-[11px] font-medium">{label}</span>
             </Link>
           )
         })}

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -422,7 +422,7 @@ export default function ExerciseLoggingModal({
     <>
       <div className="fixed inset-0 z-50 backdrop-blur-md bg-black/40 dark:bg-black/60 flex items-center justify-center">
         {/* Modal - Full screen on mobile, centered on desktop */}
-        <div className="bg-card w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg flex flex-col shadow-xl">
+        <div className="bg-card w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg flex flex-col shadow-xl pb-[env(safe-area-inset-bottom)]">
           {/* Header */}
           <ExerciseLoggingHeader
             currentExerciseIndex={currentIndex}

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -75,10 +75,7 @@ export default function ExerciseActionsFooter({
   ]
 
   return (
-    // pwa-pb-safe-2 keeps `pb-2` in browser mode and adds env(safe-area-inset-bottom)
-    // in iOS PWA standalone mode so the home indicator doesn't overlap the buttons.
-    // See globals.css for the utility definition.
-    <div className="border-t border-border px-3 pt-2 pb-2 bg-card flex-shrink-0 pwa-pb-safe-2">
+    <div className="border-t border-border px-3 py-2 bg-card flex-shrink-0">
       <div className="flex items-center gap-2">
         {/* Log Set Button */}
         <button type="button"


### PR DESCRIPTION
## Summary
- **Logger modal**: Move `env(safe-area-inset-bottom)` from the footer (`ExerciseActionsFooter`) to the modal container (`ExerciseLoggingModal`), matching the pattern used by `ProgramCompletionModal`, `ExerciseSearchModal`, and the Radix dialog fullScreenMobile variant. The previous approach (#493) padded the footer but the `h-[100dvh]` container still went edge-to-edge, so Log Set / Complete still sat behind the iOS home indicator.
- **Bottom nav**: Bump label font from `10px` to `11px` for readability; add `2px` extra bottom padding for breathing room above the home indicator.
- **Cleanup**: Remove unused `pwa-pb-safe-N` CSS utilities from `globals.css`; revert `ExerciseActionsFooter` to plain `py-2`.

Fixes #480

## Test plan
- [ ] On an iPhone with home indicator, install staging PWA → open a workout → confirm Log Set / Complete sit fully above the home indicator
- [ ] Confirm bottom nav labels are slightly larger and have clearance above the home indicator
- [ ] Open the same pages in regular Safari — no extra spacing or layout shift
- [ ] Spot-check ProgramCompletionModal, ExerciseSearchModal — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)