### PR TITLE
docs: fix stale dev.sh docs, add new references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ doppler run --config dev_personal -- [command]
 
 # Primary repo: start all services (wraps overmind with OVERMIND_SOCKET in /tmp
 # so Turbopack doesn't panic trying to scan .overmind.sock in the project root)
-./scripts/dev.sh                              # Starts PostgreSQL, Redis, worker, Next.js
-./scripts/dev.sh start -l postgres,app        # Just DB + app (skip redis/worker)
+./scripts/dev.sh                              # Default: just PostgreSQL + Next.js app
+./scripts/dev.sh start                        # ALL services (postgres, redis, worker, minio, app)
+./scripts/dev.sh start -l postgres,app        # Just DB + app (explicit subset)
 
 # Worktree: port and auth URLs are auto-derived from worktree slot
 DOPPLER_CONFIG=dev_personal_worktree1 ./scripts/dev.sh start -l postgres,app
@@ -160,6 +161,7 @@ Program
 - **PrescribedSet**: Template/plan (what program prescribes)
 - **LoggedSet**: Actual performance (what user logged)
 - **WorkoutCompletion**: Tracks completed/incomplete/abandoned workouts
+- **AppEvent**: Client-side analytics events (signup source, page views)
 
 **Important**: We store BOTH prescribed and logged sets to enable plan vs reality comparison.
 
@@ -536,6 +538,7 @@ Self-hosted k8s infrastructure is operational (staging + production). PostgreSQL
 - `/docs/LOGGING.md` - Logging configuration and usage with Pino
 - `/docs/RATE_LIMITING.md` - Rate limiting tiers, patterns, and tuning guidance
 - `/docs/STYLING.md` - DOOM theme color system and styling guide
+- `/docs/ADDING_LEARN_ARTICLES.md` - Adding articles to the Learn tab (seed file + data migration pattern)
 - `/docs/IMAGE_TRACEABILITY.md` - Docker image SHA traceability
 - `/docs/features/PROGRAM_MANAGEMENT_IMPROVEMENTS.md` - Program management enhancements
 - `/docs/features/PERFORMANCE_ANALYSIS.md` - Performance analysis and optimizations

--- a/WORKTREE_SETUP.md
+++ b/WORKTREE_SETUP.md
@@ -51,7 +51,7 @@ No `DOPPLER_CONFIG` needed — defaults to `dev_personal`.
 - `scripts/worktree-env.sh` — Detects worktree slot, exports `PG_PORT`, `REDIS_PORT`, container names
 - `scripts/start-postgres.sh` — Starts Docker postgres, applies schema, seeds test user
 - `scripts/start-redis.sh` — Starts Docker redis with worktree-aware names/ports
-- `Procfile` — Sources `worktree-env.sh`, overrides `DATABASE_URL`/`REDIS_URL` after Doppler
+- `Procfile` — Sources `worktree-env.sh`, overrides `DATABASE_URL`/`DIRECT_URL`/`REDIS_URL` after Doppler
 
 ## After Schema Changes
 
@@ -59,7 +59,7 @@ No `DOPPLER_CONFIG` needed — defaults to `dev_personal`.
 # If you changed prisma/schema.prisma:
 doppler run --config dev_personal -- npx prisma db push   # or let dev.sh restart handle it
 doppler run --config dev_personal -- npx prisma generate
-overmind restart app   # if already running via dev.sh
+./scripts/dev.sh restart app   # if already running via dev.sh
 ```
 
 ## Running Multiple Worktrees Simultaneously


### PR DESCRIPTION
## Summary

Weekly documentation drift check against the last 14 commits.

- **CLAUDE.md dev.sh comment was wrong**: `./scripts/dev.sh` (no args) now defaults to `postgres,app` only, not all services. The `scripts/dev.sh` wrapper was added recently and changed the default behavior. Added `./scripts/dev.sh start` for all services.
- **CLAUDE.md missing reference**: `docs/ADDING_LEARN_ARTICLES.md` was added in #462 but not listed in the Reference Documents section.
- **CLAUDE.md missing table**: `AppEvent` table added in #480 (signup source analytics) wasn't in Key Database Tables.
- **WORKTREE_SETUP.md Procfile description**: Now exports `DIRECT_URL` alongside `DATABASE_URL`/`REDIS_URL` (needed since PgBouncer integration).
- **WORKTREE_SETUP.md overmind command**: Bare `overmind restart app` won't find the socket since it moved to `/tmp`. Updated to `./scripts/dev.sh restart app`.

## Triggering code changes

| Doc update | Triggered by |
|---|---|
| dev.sh default behavior | `scripts/dev.sh` (new file) |
| AppEvent table | #480 analytics tracking |
| ADDING_LEARN_ARTICLES.md reference | #462 learn article migration |
| DIRECT_URL in Procfile | `Procfile` + `scripts/start-postgres.sh` changes |
| dev.sh restart command | `scripts/worktree-env.sh` OVERMIND_SOCKET change |

## Test plan

- [ ] Verify `./scripts/dev.sh` with no args starts only postgres + app
- [ ] Verify `./scripts/dev.sh restart app` works when dev.sh is already running
- [ ] Confirm all referenced doc paths exist (validated in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)