### PR TITLE
Preload frog sprite images to prevent late rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,6 +57,8 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <link rel="preload" href="/green-frog-squat-1.png" as="image" type="image/png" />
+        <link rel="preload" href="/green-frog-squat-1-light.png" as="image" type="image/png" />
         <script
           dangerouslySetInnerHTML={{
             __html: `


### PR DESCRIPTION
## Summary
- Adds `<link rel="preload">` tags for both dark and light frog sprite images in the root layout `<head>`
- Previously, these images were only fetched when the `LoadingFrog` component rendered via CSS `backgroundImage`, causing a visible delay before the animation appeared
- Now the browser fetches them early as part of page load, so they're cached before any loading state triggers

## Test plan
- [ ] Open app on mobile, trigger any loading state (e.g., completing a workout, adding/swapping an exercise)
- [ ] Verify the frog animation appears immediately without a blank flash
- [ ] Check Network tab: both `green-frog-squat-1.png` and `green-frog-squat-1-light.png` should appear early in the waterfall with "preload" initiator
- [ ] Verify light mode and dark mode both show the correct sprite

Fixes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)