### PR TITLE
fix: rest timer triggers for all newly logged sets

### DIFF
--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useRestTimer } from '@/hooks/useRestTimer'
+
+// Mock requestAnimationFrame to execute synchronously in tests
+beforeEach(() => {
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useRestTimer', () => {
+  it('starts the timer when a prescribed set is logged', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      { initialProps: { count: 0 } }
+    )
+
+    expect(result.current.isRunning).toBe(false)
+
+    // Log set 1
+    rerender({ count: 1 })
+    expect(result.current.isRunning).toBe(true)
+  })
+
+  it('restarts the timer on each new set including the final prescribed set', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      { initialProps: { count: 0 } }
+    )
+
+    // Log sets 1, 2, 3 (the final prescribed set)
+    rerender({ count: 1 })
+    expect(result.current.isRunning).toBe(true)
+
+    rerender({ count: 2 })
+    expect(result.current.isRunning).toBe(true)
+
+    // Set 3 is the last prescribed set — timer should STILL start
+    rerender({ count: 3 })
+    expect(result.current.isRunning).toBe(true)
+  })
+
+  it('starts the timer for extra sets beyond prescribed count', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      { initialProps: { count: 3 } }
+    )
+
+    // Timer not running initially (all prescribed sets already logged)
+    expect(result.current.isRunning).toBe(false)
+
+    // Log extra set 4
+    rerender({ count: 4 })
+    expect(result.current.isRunning).toBe(true)
+
+    // Log extra set 5
+    rerender({ count: 5 })
+    expect(result.current.isRunning).toBe(true)
+  })
+
+  it('starts the timer when a deleted set is re-logged', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      { initialProps: { count: 3 } }
+    )
+
+    // Delete a set (count goes from 3 to 2)
+    rerender({ count: 2 })
+    // Timer should still be running from before (count decreased, not zeroed)
+
+    // Re-log the set (count goes from 2 to 3)
+    rerender({ count: 3 })
+    expect(result.current.isRunning).toBe(true)
+  })
+
+  it('stops the timer when all sets are deleted', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      { initialProps: { count: 0 } }
+    )
+
+    // Log a set
+    rerender({ count: 1 })
+    expect(result.current.isRunning).toBe(true)
+
+    // Delete all sets
+    rerender({ count: 0 })
+    expect(result.current.isRunning).toBe(false)
+  })
+
+  it('resets when exercise changes', () => {
+    const { result, rerender } = renderHook(
+      ({ count, exId }) => useRestTimer(count, 3, exId),
+      { initialProps: { count: 1, exId: 'ex-1' } }
+    )
+
+    expect(result.current.isRunning).toBe(false) // Initial mount, no increase
+
+    // Switch exercise
+    act(() => {
+      // Need to rerender with new exercise
+    })
+    rerender({ count: 0, exId: 'ex-2' })
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.elapsed).toBe(0)
+  })
+
+  it('works with zero prescribed sets (extra-only scenario)', () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRestTimer(count, 0, 'ex-1'),
+      { initialProps: { count: 0 } }
+    )
+
+    // Log a set even though there are 0 prescribed
+    rerender({ count: 1 })
+    expect(result.current.isRunning).toBe(true)
+  })
+})

--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useRestTimer } from '@/hooks/useRestTimer'
 
@@ -103,9 +103,6 @@ describe('useRestTimer', () => {
     expect(result.current.isRunning).toBe(false) // Initial mount, no increase
 
     // Switch exercise
-    act(() => {
-      // Need to rerender with new exercise
-    })
     rerender({ count: 0, exId: 'ex-2' })
     expect(result.current.isRunning).toBe(false)
     expect(result.current.elapsed).toBe(0)

--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useRestTimer } from '@/hooks/useRestTimer'
 
 // Mock requestAnimationFrame to execute synchronously in tests
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('useRestTimer', () => {
   it('starts the timer when a prescribed set is logged', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 0 } }
     )
 
@@ -30,7 +30,7 @@ describe('useRestTimer', () => {
 
   it('restarts the timer on each new set including the final prescribed set', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 0 } }
     )
 
@@ -48,7 +48,7 @@ describe('useRestTimer', () => {
 
   it('starts the timer for extra sets beyond prescribed count', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 3 } }
     )
 
@@ -66,7 +66,7 @@ describe('useRestTimer', () => {
 
   it('starts the timer when a deleted set is re-logged', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 3 } }
     )
 
@@ -81,7 +81,7 @@ describe('useRestTimer', () => {
 
   it('stops the timer when all sets are deleted', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 3, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 0 } }
     )
 
@@ -96,7 +96,7 @@ describe('useRestTimer', () => {
 
   it('resets when exercise changes', () => {
     const { result, rerender } = renderHook(
-      ({ count, exId }) => useRestTimer(count, 3, exId),
+      ({ count, exId }) => useRestTimer(count, exId),
       { initialProps: { count: 1, exId: 'ex-1' } }
     )
 
@@ -108,13 +108,12 @@ describe('useRestTimer', () => {
     expect(result.current.elapsed).toBe(0)
   })
 
-  it('works with zero prescribed sets (extra-only scenario)', () => {
+  it('starts the timer when logging a set from zero', () => {
     const { result, rerender } = renderHook(
-      ({ count }) => useRestTimer(count, 0, 'ex-1'),
+      ({ count }) => useRestTimer(count, 'ex-1'),
       { initialProps: { count: 0 } }
     )
 
-    // Log a set even though there are 0 prescribed
     rerender({ count: 1 })
     expect(result.current.isRunning).toBe(true)
   })

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -142,7 +142,6 @@ export default function ExerciseDisplayTabs({
             />
             <RestStopwatch
               loggedSetCount={loggedSets.length}
-              prescribedSetCount={prescribedSets.length}
               exerciseId={exercise.id}
             />
           </>

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -4,7 +4,6 @@ import { useRestTimer } from '@/hooks/useRestTimer'
 
 interface RestStopwatchProps {
   loggedSetCount: number
-  prescribedSetCount: number
   exerciseId: string
 }
 
@@ -15,12 +14,10 @@ interface RestStopwatchProps {
  */
 export default function RestStopwatch({
   loggedSetCount,
-  prescribedSetCount,
   exerciseId,
 }: RestStopwatchProps) {
   const { formatted, isRunning } = useRestTimer(
     loggedSetCount,
-    prescribedSetCount,
     exerciseId
   )
 

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -10,7 +10,8 @@ interface RestStopwatchProps {
 
 /**
  * Subtle watermark-style rest stopwatch displayed below the set list.
- * Resets on each logged set. Hides when no sets are logged or all sets are complete.
+ * Resets on each logged set (including extra sets and re-logged sets after deletion).
+ * Hides when no sets are logged.
  */
 export default function RestStopwatch({
   loggedSetCount,

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -8,11 +8,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  * Uses Date.now() difference instead of counting intervals, so elapsed time
  * is always accurate regardless of tab throttling or suspension.
  *
- * Resets when a non-final set is logged. Stops when all sets are complete.
+ * Resets whenever a new set is logged — including extra sets beyond the
+ * prescribed count and re-logged sets after deletion.
  */
 export function useRestTimer(
   loggedSetCount: number,
-  prescribedSetCount: number,
+  _prescribedSetCount: number,
   exerciseId: string
 ) {
   const [elapsed, setElapsed] = useState(0)
@@ -20,9 +21,6 @@ export function useRestTimer(
   const startRef = useRef<number | null>(null)
   const prevExerciseRef = useRef(exerciseId)
   const prevCountRef = useRef(loggedSetCount)
-
-  // Determine if the timer should be running
-  const isComplete = loggedSetCount >= prescribedSetCount && prescribedSetCount > 0
 
   // Reset when exercise changes or sets change
   useEffect(() => {
@@ -39,8 +37,8 @@ export function useRestTimer(
       return () => cancelAnimationFrame(frame)
     }
 
-    // New set logged (and not all sets complete) — reset the timer
-    if (loggedSetCount > prevCountRef.current && !isComplete) {
+    // New set logged — reset the timer
+    if (loggedSetCount > prevCountRef.current) {
       startRef.current = Date.now()
       const frame = requestAnimationFrame(() => {
         setElapsed(0)
@@ -61,16 +59,8 @@ export function useRestTimer(
       return () => cancelAnimationFrame(frame)
     }
 
-    // All sets complete — stop the timer
-    if (isComplete && startRef.current !== null) {
-      startRef.current = null
-      const frame = requestAnimationFrame(() => setIsRunning(false))
-      prevCountRef.current = loggedSetCount
-      return () => cancelAnimationFrame(frame)
-    }
-
     prevCountRef.current = loggedSetCount
-  }, [loggedSetCount, exerciseId, isComplete])
+  }, [loggedSetCount, exerciseId])
 
   // Tick the display every second
   useEffect(() => {

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  */
 export function useRestTimer(
   loggedSetCount: number,
-  _prescribedSetCount: number,
   exerciseId: string
 ) {
   const [elapsed, setElapsed] = useState(0)


### PR DESCRIPTION
## Summary
- Rest timer (stopwatch) now triggers for **any** newly logged set, not just sets before the prescribed count
- Fixes timer not appearing for extra sets beyond prescribed count
- Fixes timer not appearing when a deleted set is re-logged
- Removes the `isComplete` guard that stopped the timer prematurely

## Root Cause
The `useRestTimer` hook had an `isComplete` condition (`loggedSetCount >= prescribedSetCount`) that prevented the timer from starting once all prescribed sets were logged. This blocked the timer for:
1. The final prescribed set (set N of N)
2. Extra sets beyond prescribed (set N+1, N+2, etc.)
3. Re-logged sets after deletion (count drops then increases back)

## Changes
- `hooks/useRestTimer.ts` — Remove `isComplete` guard; timer starts on any set count increase
- `components/workout-logging/RestStopwatch.tsx` — Update docstring

## Test plan
- [x] New unit tests for extra sets, re-logged sets, and final prescribed set
- [x] Type-check passes
- [x] Lint passes
- [ ] Manual: log all prescribed sets, verify timer appears on last set
- [ ] Manual: log an extra set, verify timer appears
- [ ] Manual: delete a set and re-log it, verify timer appears

Fixes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)