### PR TITLE
Fix workout feedback disappearing and theme FOUC

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-theme="ripit" data-mode="dark" className="dark" suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -334,7 +334,11 @@ export default function ExerciseLoggingModal({
       await completeDraft(workoutId, fallback)
       clearCache()
       await onComplete()
-      onClose()
+      // Do not call onClose() here — onComplete() already closes the modal
+      // via handleCloseModal(true) with router.refresh() inside startTransition.
+      // Calling onClose() again triggers a second router.refresh() outside
+      // startTransition, which activates the Suspense boundary (loading.tsx),
+      // unmounting the parent and losing post-session feedback state.
     } catch (error) {
       clientLogger.error('Error completing workout:', error)
       setIsSubmitting(false)


### PR DESCRIPTION
## Summary

- **Workout completion feedback**: Fixed post-session feedback modal disappearing immediately after workout completion. `ExerciseLoggingModal.handleCompleteWorkout()` was calling both `onComplete()` and `onClose()`, but `onComplete()` already closes the modal via `handleCloseModal(true)` with `router.refresh()` inside `startTransition`. The redundant `onClose()` triggered a second `router.refresh()` **outside** `startTransition`, which activated the Suspense boundary (`loading.tsx`), unmounting `StrengthWeekView` and losing the `postSessionQuestion` state.

- **Theme persistence**: Added `data-theme="ripit" data-mode="dark"` as server-side defaults on the `<html>` element. Previously, the element had no theme attributes in the server-rendered HTML, so the CSS `:root` (which defines DOOM light theme) would briefly flash before the inline script set the correct theme from localStorage.

## Test plan

- [ ] Complete a workout where post-session feedback would appear (every 3rd completion) — feedback modal should stay open until user interacts
- [ ] Refresh the page — theme should not flash DOOM light before settling on user's selected theme
- [ ] Verify theme persists correctly across full page reloads
- [ ] Verify workout completion still saves correctly (no regression from removing `onClose()`)

Fixes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)