### PR TITLE
Default Browse Level filter to Beginner for beginner users

### DIFF
--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -37,6 +37,7 @@ type CommunityProgram = {
 type CommunityProgramsViewProps = {
   communityPrograms: CommunityProgram[]
   currentUserId: string
+  defaultLevel?: string | null
 }
 
 const ITEMS_PER_PAGE = 20
@@ -60,9 +61,12 @@ function getLevelPriority(level: string | null): number {
 export default function CommunityProgramsView({
   communityPrograms,
   currentUserId,
+  defaultLevel = null,
 }: CommunityProgramsViewProps) {
   const [selectedType] = useState<'all' | 'strength'>('all')
-  const [selectedLevel, setSelectedLevel] = useState<string | null>(null)
+  // undefined = user hasn't interacted, use defaultLevel; null = user chose "All"
+  const [userSelectedLevel, setUserSelectedLevel] = useState<string | null | undefined>(undefined)
+  const selectedLevel = userSelectedLevel === undefined ? (defaultLevel ?? null) : userSelectedLevel
   const [selectedGoals, setSelectedGoals] = useState<string[]>([])
   const [currentPage, setCurrentPage] = useState(1)
 
@@ -120,13 +124,13 @@ export default function CommunityProgramsView({
 
   // Handle level change
   const handleLevelChange = (level: string | null) => {
-    setSelectedLevel(level)
+    setUserSelectedLevel(level)
     setCurrentPage(1)
   }
 
   // Clear all filters
   const clearFilters = () => {
-    setSelectedLevel(null)
+    setUserSelectedLevel(null)
     setSelectedGoals([])
     setCurrentPage(1)
   }

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -320,6 +320,7 @@ export default function ConsolidatedProgramsView({
             <CommunityProgramsView
               communityPrograms={communityPrograms}
               currentUserId={currentUserId}
+              defaultLevel={settings?.experienceLevel === 'beginner' ? 'beginner' : null}
             />
           )}
         </div>

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -11,6 +11,7 @@ export type UserSettings = {
   completedTours: string
   postSessionPromptCount: number
   lastPostSessionPromptAt: string | null
+  experienceLevel: string | null
 }
 
 type UseUserSettingsReturn = {


### PR DESCRIPTION
## Summary
- Beginner users (experienceLevel='beginner' from onboarding) now land on Browse with the Level filter defaulted to "Beginner"
- Experienced users still see "All" (no change)
- Users can freely change the filter — it's a default, not a lock
- Uses a 3-state pattern (undefined/null/string) so the default from settings applies even when settings load asynchronously, without triggering setState-in-effect lint violations

## Changes
- `hooks/useUserSettings.ts`: Added `experienceLevel` to `UserSettings` type
- `components/community/CommunityProgramsView.tsx`: Accept `defaultLevel` prop, use 3-state pattern for level selection
- `components/programs/ConsolidatedProgramsView.tsx`: Pass `defaultLevel` based on user's experienceLevel setting

## Test plan
- [ ] Log in as a beginner user (experienceLevel='beginner') and navigate to Browse — Level filter should show "Beginner"
- [ ] Log in as an experienced user — Level filter should show "All"
- [ ] As a beginner, change the Level filter manually — should work without restriction
- [ ] As a beginner, click "Clear" filters — should reset to "All"
- [ ] Verify no layout/visual regressions on mobile and desktop

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)