### PR TITLE
fix: add requireEditor() to admin/feedback/create-issue

### DIFF
--- a/app/api/admin/feedback/create-issue/route.ts
+++ b/app/api/admin/feedback/create-issue/route.ts
@@ -1,8 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { getCurrentUser } from '@/lib/auth/server'
+import { requireEditor } from '@/lib/admin/auth'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
-import { adminLimiter, checkRateLimit } from '@/lib/rate-limit'
 
 const GITHUB_REPO = 'aptx-health/ripit-fitness'
 
@@ -15,13 +14,8 @@ const CATEGORY_LABELS: Record<string, string> = {
 
 export async function POST(request: NextRequest) {
   try {
-    const { user, error } = await getCurrentUser()
-    if (error || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const limited = await checkRateLimit(adminLimiter, user.id)
-    if (limited) return limited
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
 
     const token = process.env.GH_ISSUE_TOKEN
     if (!token) {


### PR DESCRIPTION
## Summary
- Replace `getCurrentUser()` with `requireEditor({ rateLimit: true })` in the create-issue admin endpoint
- Enforces editor-level authorization, matching all other admin endpoints
- Previously any authenticated user could create GitHub issues via the privileged `GH_ISSUE_TOKEN`

## Test plan
- [ ] Verify non-editor users receive 403 Forbidden when calling this endpoint
- [ ] Verify editor users can still create GitHub issues from feedback
- [ ] Confirm rate limiting still applies (handled by `requireEditor({ rateLimit: true })`)

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)