### PR TITLE
feat: admin UI for editing community programs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -17,6 +17,6 @@
 
 postgres: ./scripts/start-postgres.sh
 redis: sleep 3 && ./scripts/start-redis.sh
-worker: sleep 8 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' DIRECT_URL='${DB_URL}' REDIS_URL='${R_URL}' && cd cloud-functions/clone-program && npm run dev"
+worker: sleep 8 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' DIRECT_URL='${DB_URL}' REDIS_URL='${R_URL}' && cd cloud-functions/clone-program && npm install --prefer-offline --no-audit && npm run dev"
 minio: sleep 2 && ./scripts/start-minio.sh
 app: sleep 5 && source ./scripts/worktree-env.sh && DB_URL="postgresql://postgres:postgres@localhost:${PG_PORT}/ripit" R_URL="redis://localhost:${REDIS_PORT}" M_PORT=$((9000 + WORKTREE_SLOT)) APP_PORT=$((3000 + WORKTREE_SLOT * 100)) APP_URL="http://localhost:${APP_PORT}" && doppler run --config ${DOPPLER_CONFIG:-dev_personal} -- sh -c "export DATABASE_URL='${DB_URL}' DIRECT_URL='${DB_URL}' REDIS_URL='${R_URL}' BETTER_AUTH_URL='${APP_URL}' NEXT_PUBLIC_APP_URL='${APP_URL}' MINIO_ENDPOINT='http://localhost:${M_PORT}' MINIO_ROOT_USER='minioadmin' MINIO_ROOT_PASSWORD='minioadmin' && npx next dev --turbopack --port ${APP_PORT}"

--- a/app/(app)/admin/community-programs/[id]/edit-structure/page.tsx
+++ b/app/(app)/admin/community-programs/[id]/edit-structure/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import CommunityProgramBuilderWrapper from '@/components/admin/CommunityProgramBuilderWrapper'
+import { getCurrentUser } from '@/lib/auth/server'
+import { isEditorRole } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { hydrateCommunityProgram } from '@/lib/admin/community-program-hydration'
+
+type Props = {
+  params: Promise<{ id: string }>
+  searchParams: Promise<{ week?: string }>
+}
+
+export default async function EditCommunityProgramStructurePage({ params, searchParams }: Props) {
+  const { id } = await params
+  const { week: weekParam } = await searchParams
+
+  const { user } = await getCurrentUser()
+
+  if (!user || !isEditorRole(user.role)) {
+    redirect('/login')
+  }
+
+  // Verify the community program exists and is curated
+  const communityProgram = await prisma.communityProgram.findUnique({
+    where: { id },
+    select: { id: true, name: true, curated: true },
+  })
+
+  if (!communityProgram) {
+    redirect('/admin/community-programs')
+  }
+
+  if (!communityProgram.curated) {
+    redirect(`/admin/community-programs/${id}/edit`)
+  }
+
+  // Hydrate community program into a temp program for editing
+  const hydrateResult = await hydrateCommunityProgram(prisma, id, user.id)
+
+  if (!hydrateResult.success || !hydrateResult.tempProgramId) {
+    return (
+      <div className="text-red-400 p-4">
+        Failed to prepare program for editing: {hydrateResult.error}
+      </div>
+    )
+  }
+
+  const tempProgramId = hydrateResult.tempProgramId
+
+  // Parse requested week (default to 1)
+  const requestedWeek = weekParam ? parseInt(weekParam, 10) : 1
+  const validWeekNumber = !Number.isNaN(requestedWeek) && requestedWeek > 0 ? requestedWeek : 1
+
+  // Fetch temp program metadata and week summary
+  const program = await prisma.program.findUnique({
+    where: { id: tempProgramId },
+    include: {
+      weeks: {
+        select: {
+          id: true,
+          weekNumber: true,
+        },
+        orderBy: { weekNumber: 'asc' },
+      },
+    },
+  })
+
+  if (!program) {
+    return <div className="text-red-400 p-4">Failed to load temp program</div>
+  }
+
+  // Fetch the current week's full data
+  const currentWeek = await prisma.week.findFirst({
+    where: {
+      programId: tempProgramId,
+      weekNumber: validWeekNumber,
+      userId: user.id,
+    },
+    include: {
+      workouts: {
+        include: {
+          exercises: {
+            include: {
+              prescribedSets: {
+                orderBy: { setNumber: 'asc' },
+              },
+              exerciseDefinition: {
+                select: {
+                  id: true,
+                  name: true,
+                  primaryFAUs: true,
+                  secondaryFAUs: true,
+                  isSystem: true,
+                  createdBy: true,
+                },
+              },
+            },
+            orderBy: { order: 'asc' },
+          },
+        },
+        orderBy: { dayNumber: 'asc' },
+      },
+    },
+  })
+
+  return (
+    <div className="bg-background doom-page-enter">
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        <div className="mb-6">
+          <div className="flex items-center gap-4 mb-4">
+            <Link
+              href={`/admin/community-programs/${id}/edit`}
+              className="text-primary hover:text-primary-hover text-sm flex items-center gap-1 doom-link"
+            >
+              ← Back to Program Editor
+            </Link>
+            <span className="text-muted-foreground">|</span>
+            <h1 className="text-2xl font-semibold text-foreground doom-heading">
+              EDIT STRUCTURE
+            </h1>
+          </div>
+          <div className="bg-amber-900/30 border-2 border-amber-700 p-4 mb-4">
+            <p className="text-sm text-amber-200">
+              Editing structure for <strong>{communityProgram.name}</strong>.
+              Changes are saved to a temporary draft. Click &quot;Save to Community Program&quot; when done.
+            </p>
+          </div>
+        </div>
+
+        <CommunityProgramBuilderWrapper
+          communityProgramId={id}
+          communityProgramName={communityProgram.name}
+          tempProgramId={tempProgramId}
+          existingProgram={{
+            id: program.id,
+            name: program.name,
+            description: program.description,
+            isActive: false,
+            weeksSummary: program.weeks,
+            initialWeek: currentWeek,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/admin/community-programs/[id]/edit/page.tsx
+++ b/app/(app)/admin/community-programs/[id]/edit/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useReducer, useState } from 'react'
+import CommunityProgramEditor from '@/components/admin/CommunityProgramEditor'
+
+interface ProgramData {
+  id: string
+  name: string
+  description: string
+  level: string | null
+  curated: boolean
+  goals: string[]
+  equipmentNeeded: string[]
+  focusAreas: string[]
+  targetDaysPerWeek: number | null
+  weekCount: number
+  workoutCount: number
+  exerciseCount: number
+  programData: Record<string, unknown>
+}
+
+export default function EditCommunityProgramPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [program, setProgram] = useState<ProgramData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey triggers re-fetch intentionally
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/admin/community-programs/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Not found')
+        return res.json()
+      })
+      .then((json) => { if (!cancelled) { setProgram(json.data); setLoading(false) } })
+      .catch(() => { if (!cancelled) { setError('Program not found'); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [id, refreshKey])
+
+  if (loading) return <div className="text-sm text-muted-foreground">Loading...</div>
+  if (error) return <div className="text-sm text-red-400">{error}</div>
+  if (!program) return null
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold uppercase tracking-wider mb-6">Edit Community Program</h1>
+      <CommunityProgramEditor
+        program={program}
+        onSave={() => refresh()}
+        onCancel={() => router.push('/admin/community-programs')}
+      />
+    </div>
+  )
+}

--- a/app/(app)/admin/community-programs/page.tsx
+++ b/app/(app)/admin/community-programs/page.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+interface CommunityProgram {
+  id: string
+  name: string
+  description: string
+  level: string | null
+  curated: boolean
+  weekCount: number
+  workoutCount: number
+  exerciseCount: number
+  goals: string[]
+  targetDaysPerWeek: number | null
+  publishedAt: string | null
+}
+
+const LEVEL_TABS = ['all', 'beginner', 'intermediate', 'advanced'] as const
+const CURATED_TABS = ['all', 'curated', 'user'] as const
+
+export default function AdminCommunityProgramsPage() {
+  const [programs, setPrograms] = useState<CommunityProgram[]>([])
+  const [loading, setLoading] = useState(true)
+  const [activeLevel, setActiveLevel] = useState<string>('all')
+  const [activeCurated, setActiveCurated] = useState<string>('all')
+  const [search, setSearch] = useState('')
+
+  const searchKey = `${activeLevel}-${activeCurated}-${search}`
+  const [prevSearchKey, setPrevSearchKey] = useState(searchKey)
+  if (prevSearchKey !== searchKey) {
+    setPrevSearchKey(searchKey)
+    setLoading(true)
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    const params = new URLSearchParams()
+    if (activeLevel !== 'all') params.set('level', activeLevel)
+    if (activeCurated === 'curated') params.set('curated', 'true')
+    if (activeCurated === 'user') params.set('curated', 'false')
+    if (search.trim()) params.set('search', search.trim())
+
+    fetch(`/api/admin/community-programs?${params}`)
+      .then((res) => res.json())
+      .then((json) => {
+        if (!cancelled) {
+          setPrograms(json.data || [])
+          setLoading(false)
+        }
+      })
+      .catch(() => { if (!cancelled) setLoading(false) })
+
+    return () => { cancelled = true }
+  }, [activeLevel, activeCurated, search])
+
+  const levelColor = (level: string | null) => {
+    switch (level) {
+      case 'beginner': return 'text-green-400 border-green-700'
+      case 'intermediate': return 'text-yellow-400 border-yellow-700'
+      case 'advanced': return 'text-red-400 border-red-700'
+      default: return 'text-zinc-400 border-zinc-600'
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold uppercase tracking-wider">Community Programs</h1>
+      </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search programs..."
+          className="w-full max-w-md px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex flex-wrap gap-4 mb-6">
+        <div className="flex gap-1">
+          {LEVEL_TABS.map((tab) => (
+            <button
+              type="button"
+              key={tab}
+              onClick={() => setActiveLevel(tab)}
+              className={`px-3 py-1.5 text-xs font-semibold uppercase tracking-wider border-2 transition-colors ${
+                activeLevel === tab
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-1">
+          {CURATED_TABS.map((tab) => (
+            <button
+              type="button"
+              key={tab}
+              onClick={() => setActiveCurated(tab)}
+              className={`px-3 py-1.5 text-xs font-semibold uppercase tracking-wider border-2 transition-colors ${
+                activeCurated === tab
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Program list */}
+      {loading ? (
+        <div className="text-sm text-muted-foreground">Loading...</div>
+      ) : programs.length === 0 ? (
+        <div className="text-sm text-muted-foreground py-8 text-center">
+          No community programs found.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {programs.map((program) => (
+            <Link
+              key={program.id}
+              href={program.curated ? `/admin/community-programs/${program.id}/edit` : '#'}
+              className={`block p-4 bg-card border-2 border-border transition-colors ${
+                program.curated ? 'hover:border-primary' : 'opacity-60 cursor-not-allowed'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <h3 className="font-semibold text-foreground truncate">{program.name}</h3>
+                  <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                    {program.description}
+                  </p>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {program.level && (
+                      <span className={`text-xs px-2 py-0.5 border ${levelColor(program.level)} font-semibold uppercase`}>
+                        {program.level}
+                      </span>
+                    )}
+                    <span className={`text-xs px-2 py-0.5 border font-semibold uppercase ${
+                      program.curated
+                        ? 'text-blue-400 border-blue-700'
+                        : 'text-zinc-400 border-zinc-600'
+                    }`}>
+                      {program.curated ? 'curated' : 'user'}
+                    </span>
+                    {program.targetDaysPerWeek && (
+                      <span className="text-xs text-muted-foreground">
+                        {program.targetDaysPerWeek} days/week
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right text-xs text-muted-foreground shrink-0">
+                  <div>{program.weekCount} weeks</div>
+                  <div>{program.workoutCount} workouts</div>
+                  <div>{program.exerciseCount} exercises</div>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/admin/layout.tsx
+++ b/app/(app)/admin/layout.tsx
@@ -23,6 +23,7 @@ export default async function AdminLayout({
     { href: '/admin/tags', label: 'Tags' },
     { href: '/admin/collections', label: 'Collections' },
     { href: '/admin/exercises', label: 'Exercises' },
+    { href: '/admin/community-programs', label: 'Programs' },
     { href: '/admin/feedback', label: 'Feedback' },
     { href: '/admin/analytics', label: 'Analytics' },
   ]

--- a/app/api/admin/community-programs/[id]/discard-draft/route.ts
+++ b/app/api/admin/community-programs/[id]/discard-draft/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { discardDraftProgram } from '@/lib/admin/community-program-hydration'
+
+/**
+ * POST /api/admin/community-programs/[id]/discard-draft
+ * Deletes a temporary admin draft program.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    await params // consume params (route requires [id] but we use tempProgramId from body)
+    const body = await request.json()
+    const { tempProgramId } = body
+
+    if (!tempProgramId || typeof tempProgramId !== 'string') {
+      return NextResponse.json(
+        { error: 'tempProgramId is required' },
+        { status: 422 }
+      )
+    }
+
+    const result = await discardDraftProgram(prisma, tempProgramId, auth.user.id)
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ error }, 'Error discarding admin draft')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/community-programs/[id]/hydrate/route.ts
+++ b/app/api/admin/community-programs/[id]/hydrate/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { hydrateCommunityProgram } from '@/lib/admin/community-program-hydration'
+
+/**
+ * POST /api/admin/community-programs/[id]/hydrate
+ * Creates a temporary Program from a CommunityProgram's programData JSON
+ * so it can be edited via ProgramBuilder.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    const { id } = await params
+
+    const result = await hydrateCommunityProgram(prisma, id, auth.user.id)
+
+    if (!result.success) {
+      const status = result.error === 'Community program not found' ? 404 : 400
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    return NextResponse.json({ tempProgramId: result.tempProgramId })
+  } catch (error) {
+    logger.error({ error }, 'Error hydrating community program')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/community-programs/[id]/route.ts
+++ b/app/api/admin/community-programs/[id]/route.ts
@@ -1,0 +1,149 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+/**
+ * GET /api/admin/community-programs/[id]
+ * Get a single community program with full programData.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    const { id } = await params
+
+    const program = await prisma.communityProgram.findUnique({
+      where: { id },
+    })
+
+    if (!program) {
+      return NextResponse.json({ error: 'Community program not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ data: program })
+  } catch (error) {
+    logger.error({ error }, 'Error fetching community program')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * PATCH /api/admin/community-programs/[id]
+ * Update a community program's content (name, description, metadata, week/workout names).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    const { id } = await params
+    const body = await request.json()
+
+    const existing = await prisma.communityProgram.findUnique({ where: { id } })
+    if (!existing) {
+      return NextResponse.json({ error: 'Community program not found' }, { status: 404 })
+    }
+
+    if (!existing.curated) {
+      return NextResponse.json(
+        { error: 'Only curated programs can be edited' },
+        { status: 403 }
+      )
+    }
+
+    const {
+      name,
+      description,
+      level,
+      goals,
+      equipmentNeeded,
+      focusAreas,
+      targetDaysPerWeek,
+      programData: updatedProgramData,
+    } = body
+
+    // Build update data for top-level columns
+    const data: Record<string, unknown> = {}
+
+    if (name !== undefined) {
+      if (!name.trim()) {
+        return NextResponse.json({ error: 'Name is required' }, { status: 422 })
+      }
+      data.name = name.trim()
+    }
+
+    if (description !== undefined) {
+      data.description = description.trim()
+    }
+
+    if (level !== undefined) data.level = level
+    if (goals !== undefined) data.goals = goals
+    if (equipmentNeeded !== undefined) data.equipmentNeeded = equipmentNeeded
+    if (focusAreas !== undefined) data.focusAreas = focusAreas
+    if (targetDaysPerWeek !== undefined) {
+      if (targetDaysPerWeek !== null && (targetDaysPerWeek < 1 || targetDaysPerWeek > 7)) {
+        return NextResponse.json(
+          { error: 'Target days per week must be between 1 and 7' },
+          { status: 422 }
+        )
+      }
+      data.targetDaysPerWeek = targetDaysPerWeek
+    }
+
+    // Handle programData updates (week descriptions, workout names)
+    if (updatedProgramData !== undefined) {
+      // Sync top-level name/description into programData
+      const newProgramData = { ...updatedProgramData }
+      if (data.name) newProgramData.name = data.name
+      if (data.description !== undefined) newProgramData.description = data.description ?? ''
+
+      data.programData = newProgramData
+
+      // Recalculate stats from programData
+      const weeks = newProgramData.weeks || []
+      let workoutCount = 0
+      let exerciseCount = 0
+      weeks.forEach((week: { workouts?: { exercises?: unknown[] }[] }) => {
+        workoutCount += week.workouts?.length || 0
+        week.workouts?.forEach((workout) => {
+          exerciseCount += workout.exercises?.length || 0
+        })
+      })
+      data.weekCount = weeks.length
+      data.workoutCount = workoutCount
+      data.exerciseCount = exerciseCount
+    } else {
+      // If name/description changed but no programData sent, sync into existing programData
+      if (data.name || data.description !== undefined) {
+        const currentProgramData = existing.programData as Record<string, unknown>
+        const synced = { ...currentProgramData }
+        if (data.name) synced.name = data.name
+        if (data.description !== undefined) synced.description = data.description
+        data.programData = synced
+      }
+    }
+
+    const updated = await prisma.communityProgram.update({
+      where: { id },
+      data,
+    })
+
+    logger.info(
+      { programId: id, changes: Object.keys(data) },
+      'Community program updated'
+    )
+
+    return NextResponse.json({ data: updated })
+  } catch (error) {
+    logger.error({ error }, 'Error updating community program')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/community-programs/[id]/save-from-builder/route.ts
+++ b/app/api/admin/community-programs/[id]/save-from-builder/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { serializeAndSaveToCommunity } from '@/lib/admin/community-program-hydration'
+
+/**
+ * POST /api/admin/community-programs/[id]/save-from-builder
+ * Serializes a temporary Program back into the CommunityProgram's programData JSON,
+ * then deletes the temp program.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    const { id } = await params
+    const body = await request.json()
+    const { tempProgramId } = body
+
+    if (!tempProgramId || typeof tempProgramId !== 'string') {
+      return NextResponse.json(
+        { error: 'tempProgramId is required' },
+        { status: 422 }
+      )
+    }
+
+    // Verify the temp program belongs to this admin
+    const tempProgram = await prisma.program.findUnique({
+      where: { id: tempProgramId },
+      select: { userId: true, copyStatus: true },
+    })
+
+    if (!tempProgram) {
+      return NextResponse.json({ error: 'Temp program not found' }, { status: 404 })
+    }
+
+    if (tempProgram.userId !== auth.user.id) {
+      return NextResponse.json({ error: 'Not authorized' }, { status: 403 })
+    }
+
+    if (tempProgram.copyStatus !== 'admin_draft') {
+      return NextResponse.json(
+        { error: 'Program is not an admin draft' },
+        { status: 400 }
+      )
+    }
+
+    const result = await serializeAndSaveToCommunity(prisma, tempProgramId, id)
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ error }, 'Error saving community program from builder')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/community-programs/route.ts
+++ b/app/api/admin/community-programs/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+/**
+ * GET /api/admin/community-programs
+ * List community programs with optional filters.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireEditor({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    const { searchParams } = new URL(request.url)
+    const level = searchParams.get('level')
+    const curated = searchParams.get('curated')
+    const search = searchParams.get('search')?.trim()
+
+    const where: Record<string, unknown> = {}
+
+    if (level) {
+      where.level = level
+    }
+
+    if (curated !== null) {
+      where.curated = curated === 'true'
+    }
+
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+      ]
+    }
+
+    const programs = await prisma.communityProgram.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        level: true,
+        curated: true,
+        weekCount: true,
+        workoutCount: true,
+        exerciseCount: true,
+        goals: true,
+        targetDaysPerWeek: true,
+        publishedAt: true,
+      },
+      orderBy: { publishedAt: 'desc' },
+    })
+
+    return NextResponse.json({ data: programs })
+  } catch (error) {
+    logger.error({ error }, 'Error listing community programs')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/cloud-functions/clone-program/package-lock.json
+++ b/cloud-functions/clone-program/package-lock.json
@@ -583,37 +583,37 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -624,25 +624,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
-      "integrity": "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
-      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -1180,15 +1180,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -1297,9 +1297,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/components/admin/CommunityProgramBuilderWrapper.tsx
+++ b/components/admin/CommunityProgramBuilderWrapper.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
+import ProgramBuilder from '@/components/ProgramBuilder'
+import type { ExistingProgram } from '@/types/program-builder'
+import { clientLogger } from '@/lib/client-logger'
+
+interface CommunityProgramBuilderWrapperProps {
+  communityProgramId: string
+  communityProgramName: string
+  tempProgramId: string
+  existingProgram: ExistingProgram
+}
+
+export default function CommunityProgramBuilderWrapper({
+  communityProgramId,
+  communityProgramName: _communityProgramName,
+  tempProgramId,
+  existingProgram,
+}: CommunityProgramBuilderWrapperProps) {
+  const router = useRouter()
+  const [saving, setSaving] = useState(false)
+  const [discarding, setDiscarding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSaveToCommunity = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+
+    try {
+      const res = await fetch(
+        `/api/admin/community-programs/${communityProgramId}/save-from-builder`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tempProgramId }),
+        }
+      )
+
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || 'Failed to save')
+        setSaving(false)
+        return
+      }
+
+      router.push(`/admin/community-programs/${communityProgramId}/edit`)
+    } catch (err) {
+      clientLogger.error('Error saving community program:', err)
+      setError('Failed to save community program')
+      setSaving(false)
+    }
+  }, [communityProgramId, tempProgramId, router])
+
+  const handleDiscard = useCallback(async () => {
+    if (!confirm('Discard all changes to this community program structure?')) return
+
+    setDiscarding(true)
+    setError(null)
+
+    try {
+      await fetch(
+        `/api/admin/community-programs/${communityProgramId}/discard-draft`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tempProgramId }),
+        }
+      )
+
+      router.push(`/admin/community-programs/${communityProgramId}/edit`)
+    } catch (err) {
+      clientLogger.error('Error discarding draft:', err)
+      setError('Failed to discard draft')
+      setDiscarding(false)
+    }
+  }, [communityProgramId, tempProgramId, router])
+
+  return (
+    <div>
+      {error && (
+        <div className="bg-red-900/30 border-2 border-red-700 p-3 mb-4 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {/* Admin action bar */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          type="button"
+          onClick={handleSaveToCommunity}
+          disabled={saving || discarding}
+          className="px-4 py-2 bg-green-700 hover:bg-green-600 text-white text-sm font-semibold uppercase tracking-wider border-2 border-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {saving ? 'Saving...' : 'Save to Community Program'}
+        </button>
+        <button
+          type="button"
+          onClick={handleDiscard}
+          disabled={saving || discarding}
+          className="px-4 py-2 bg-muted hover:bg-secondary text-muted-foreground text-sm font-semibold uppercase tracking-wider border-2 border-border disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {discarding ? 'Discarding...' : 'Discard Draft'}
+        </button>
+      </div>
+
+      <ProgramBuilder
+        editMode={true}
+        existingProgram={existingProgram}
+        onComplete={handleSaveToCommunity}
+      />
+    </div>
+  )
+}

--- a/components/admin/CommunityProgramEditor.tsx
+++ b/components/admin/CommunityProgramEditor.tsx
@@ -1,0 +1,379 @@
+'use client'
+
+import { ChevronDown, ChevronRight, Save } from 'lucide-react'
+import { useState } from 'react'
+
+interface ProgramExercise {
+  name: string
+  prescribedSets?: unknown[]
+}
+
+interface ProgramWorkout {
+  name: string
+  exercises?: ProgramExercise[]
+}
+
+interface ProgramWeek {
+  weekNumber?: number
+  description?: string
+  workouts?: ProgramWorkout[]
+}
+
+interface ProgramDataJson {
+  name?: string
+  description?: string
+  weeks?: ProgramWeek[]
+}
+
+interface ProgramData {
+  id: string
+  name: string
+  description: string
+  level: string | null
+  curated: boolean
+  goals: string[]
+  equipmentNeeded: string[]
+  focusAreas: string[]
+  targetDaysPerWeek: number | null
+  weekCount: number
+  workoutCount: number
+  exerciseCount: number
+  programData: ProgramDataJson
+}
+
+interface Props {
+  program: ProgramData
+  onSave: () => void
+  onCancel: () => void
+}
+
+const LEVELS = ['beginner', 'intermediate', 'advanced']
+
+export default function CommunityProgramEditor({ program, onSave, onCancel }: Props) {
+  const [name, setName] = useState(program.name)
+  const [description, setDescription] = useState(program.description)
+  const [level, setLevel] = useState(program.level || '')
+  const [goals, setGoals] = useState(program.goals.join(', '))
+  const [equipmentNeeded, setEquipmentNeeded] = useState(program.equipmentNeeded.join(', '))
+  const [focusAreas, setFocusAreas] = useState(program.focusAreas.join(', '))
+  const [targetDaysPerWeek, setTargetDaysPerWeek] = useState(
+    program.targetDaysPerWeek?.toString() || ''
+  )
+
+  const [weeks, setWeeks] = useState<ProgramWeek[]>(
+    () => (program.programData?.weeks || []) as ProgramWeek[]
+  )
+  const [expandedWeeks, setExpandedWeeks] = useState<Set<number>>(new Set())
+
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const toggleWeek = (index: number) => {
+    setExpandedWeeks((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) next.delete(index)
+      else next.add(index)
+      return next
+    })
+  }
+
+  const updateWeekDescription = (weekIndex: number, value: string) => {
+    setWeeks((prev) =>
+      prev.map((w, i) => (i === weekIndex ? { ...w, description: value } : w))
+    )
+  }
+
+  const updateWorkoutName = (weekIndex: number, workoutIndex: number, value: string) => {
+    setWeeks((prev) =>
+      prev.map((w, i) => {
+        if (i !== weekIndex) return w
+        const workouts = (w.workouts || []).map((wo, j) =>
+          j === workoutIndex ? { ...wo, name: value } : wo
+        )
+        return { ...w, workouts }
+      })
+    )
+  }
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError('Name is required')
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    setSuccess(false)
+
+    const parsedGoals = goals.split(',').map((g) => g.trim()).filter(Boolean)
+    const parsedEquipment = equipmentNeeded.split(',').map((e) => e.trim()).filter(Boolean)
+    const parsedFocus = focusAreas.split(',').map((f) => f.trim()).filter(Boolean)
+    const parsedDays = targetDaysPerWeek ? parseInt(targetDaysPerWeek, 10) : null
+
+    // Build updated programData
+    const updatedProgramData: ProgramDataJson = {
+      ...program.programData,
+      name: name.trim(),
+      description: description.trim(),
+      weeks,
+    }
+
+    try {
+      const res = await fetch(`/api/admin/community-programs/${program.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim(),
+          level: level || null,
+          goals: parsedGoals,
+          equipmentNeeded: parsedEquipment,
+          focusAreas: parsedFocus,
+          targetDaysPerWeek: parsedDays,
+          programData: updatedProgramData,
+        }),
+      })
+
+      if (!res.ok) {
+        const json = await res.json()
+        setError(json.error || 'Failed to save')
+        setSaving(false)
+        return
+      }
+
+      setSuccess(true)
+      setSaving(false)
+      onSave()
+    } catch {
+      setError('Network error')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Save/Cancel bar */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover font-semibold uppercase tracking-wider text-sm flex items-center gap-2 transition-colors disabled:opacity-50"
+        >
+          <Save size={16} />
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-muted text-muted-foreground border-2 border-border hover:bg-secondary font-semibold uppercase tracking-wider text-sm transition-colors"
+        >
+          Cancel
+        </button>
+        {error && <span className="text-sm text-red-400">{error}</span>}
+        {success && <span className="text-sm text-green-400">Saved</span>}
+      </div>
+
+      {/* Program metadata */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Name
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Level
+          </label>
+          <select
+            value={level}
+            onChange={(e) => setLevel(e.target.value)}
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="">-- Select --</option>
+            {LEVELS.map((l) => (
+              <option key={l} value={l}>{l}</option>
+            ))}
+          </select>
+        </div>
+        <div className="md:col-span-2">
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Description
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-y"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Goals (comma-separated)
+          </label>
+          <input
+            type="text"
+            value={goals}
+            onChange={(e) => setGoals(e.target.value)}
+            placeholder="strength, hypertrophy"
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Target Days/Week
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={7}
+            value={targetDaysPerWeek}
+            onChange={(e) => setTargetDaysPerWeek(e.target.value)}
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Equipment Needed (comma-separated)
+          </label>
+          <input
+            type="text"
+            value={equipmentNeeded}
+            onChange={(e) => setEquipmentNeeded(e.target.value)}
+            placeholder="barbell, dumbbells, bench"
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Focus Areas (comma-separated)
+          </label>
+          <input
+            type="text"
+            value={focusAreas}
+            onChange={(e) => setFocusAreas(e.target.value)}
+            placeholder="upper body, lower body"
+            className="w-full px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+      </div>
+
+      {/* Stats (read-only) */}
+      <div className="flex gap-4 text-sm text-muted-foreground">
+        <span>{program.weekCount} weeks</span>
+        <span>{program.workoutCount} workouts</span>
+        <span>{program.exerciseCount} exercises</span>
+      </div>
+
+      {/* Weeks section */}
+      <div>
+        <h2 className="text-lg font-bold uppercase tracking-wider mb-3">Program Structure</h2>
+        <div className="space-y-2">
+          {weeks.map((week, weekIndex) => (
+            <div key={weekIndex} className="border-2 border-border bg-card">
+              <button
+                type="button"
+                onClick={() => toggleWeek(weekIndex)}
+                className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-secondary transition-colors"
+              >
+                {expandedWeeks.has(weekIndex) ? (
+                  <ChevronDown size={16} />
+                ) : (
+                  <ChevronRight size={16} />
+                )}
+                <span className="font-semibold text-sm uppercase tracking-wider">
+                  Week {week.weekNumber ?? weekIndex + 1}
+                </span>
+                <span className="text-xs text-muted-foreground ml-2">
+                  {week.workouts?.length || 0} workouts
+                </span>
+              </button>
+
+              {expandedWeeks.has(weekIndex) && (
+                <div className="px-4 pb-4 space-y-4">
+                  {/* Week description */}
+                  <div>
+                    <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+                      Week Description
+                    </label>
+                    <textarea
+                      value={week.description || ''}
+                      onChange={(e) => updateWeekDescription(weekIndex, e.target.value)}
+                      rows={2}
+                      placeholder="Optional week description..."
+                      className="w-full px-3 py-2 bg-input border-2 border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-y text-sm"
+                    />
+                  </div>
+
+                  {/* Workouts */}
+                  {week.workouts?.map((workout, workoutIndex) => (
+                    <div key={workoutIndex} className="pl-4 border-l-2 border-border">
+                      <div className="flex items-center gap-3 mb-2">
+                        <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider shrink-0">
+                          Workout {workoutIndex + 1}
+                        </label>
+                        <input
+                          type="text"
+                          value={workout.name}
+                          onChange={(e) =>
+                            updateWorkoutName(weekIndex, workoutIndex, e.target.value)
+                          }
+                          className="flex-1 px-3 py-1.5 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                        />
+                      </div>
+                      {/* Exercises (read-only) */}
+                      {workout.exercises && workout.exercises.length > 0 && (
+                        <div className="ml-4 space-y-0.5">
+                          {workout.exercises.map((exercise, exIndex) => (
+                            <div
+                              key={exIndex}
+                              className="text-xs text-muted-foreground flex items-center gap-2"
+                            >
+                              <span>{exercise.name}</span>
+                              {exercise.prescribedSets && (
+                                <span className="text-zinc-600">
+                                  ({exercise.prescribedSets.length} sets)
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Bottom save bar */}
+      <div className="flex items-center gap-3 pt-4 border-t-2 border-border">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover font-semibold uppercase tracking-wider text-sm flex items-center gap-2 transition-colors disabled:opacity-50"
+        >
+          <Save size={16} />
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-muted text-muted-foreground border-2 border-border hover:bg-secondary font-semibold uppercase tracking-wider text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/CommunityProgramEditor.tsx
+++ b/components/admin/CommunityProgramEditor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChevronDown, ChevronRight, Save } from 'lucide-react'
+import Link from 'next/link'
 import { useState } from 'react'
 
 interface ProgramExercise {
@@ -274,7 +275,17 @@ export default function CommunityProgramEditor({ program, onSave, onCancel }: Pr
 
       {/* Weeks section */}
       <div>
-        <h2 className="text-lg font-bold uppercase tracking-wider mb-3">Program Structure</h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-bold uppercase tracking-wider">Program Structure</h2>
+          {program.curated && (
+            <Link
+              href={`/admin/community-programs/${program.id}/edit-structure`}
+              className="px-3 py-1.5 bg-primary text-primary-foreground text-xs font-semibold uppercase tracking-wider border-2 border-primary hover:bg-primary-hover transition-colors"
+            >
+              Edit in Program Builder
+            </Link>
+          )}
+        </div>
         <div className="space-y-2">
           {weeks.map((week, weekIndex) => (
             <div key={weekIndex} className="border-2 border-border bg-card">

--- a/components/program-builder/ProgramBuilder.tsx
+++ b/components/program-builder/ProgramBuilder.tsx
@@ -17,7 +17,7 @@ import ProgramDetailsForm from './ProgramDetailsForm'
 import WeekCard from './WeekCard'
 import WeekNavigation from './WeekNavigation'
 
-export default function ProgramBuilder({ editMode = false, existingProgram }: ProgramBuilderProps) {
+export default function ProgramBuilder({ editMode = false, existingProgram, onComplete }: ProgramBuilderProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [programId, setProgramId] = useState<string | null>(
@@ -44,6 +44,7 @@ export default function ProgramBuilder({ editMode = false, existingProgram }: Pr
     setWeeks: weekState.setWeeks,
     setIsLoading,
     setError,
+    onComplete,
   })
 
   const workoutActions = useWorkoutActions({

--- a/hooks/useProgramActions.ts
+++ b/hooks/useProgramActions.ts
@@ -15,6 +15,7 @@ type UseProgramActionsParams = {
   setWeeks: React.Dispatch<React.SetStateAction<Week[]>>
   setIsLoading: (loading: boolean) => void
   setError: (error: string | null) => void
+  onComplete?: () => void
 }
 
 export function useProgramActions({
@@ -29,6 +30,7 @@ export function useProgramActions({
   setWeeks,
   setIsLoading,
   setError,
+  onComplete,
 }: UseProgramActionsParams) {
   const router = useRouter()
 
@@ -136,6 +138,10 @@ export function useProgramActions({
     }
 
     if (editMode) {
+      if (onComplete) {
+        onComplete()
+        return
+      }
       router.push('/training')
       return
     }
@@ -157,7 +163,7 @@ export function useProgramActions({
     }
 
     setShowActivationModal(true)
-  }, [router, editMode, weeksCache, weeks, programId, setError])
+  }, [router, editMode, weeksCache, weeks, programId, setError, onComplete])
 
   const handleDuplicateProgram = useCallback(async () => {
     if (!programId) return

--- a/lib/admin/batch-insert-week.ts
+++ b/lib/admin/batch-insert-week.ts
@@ -1,0 +1,164 @@
+import { createId } from '@paralleldrive/cuid2'
+import { Prisma, type PrismaClient } from '@prisma/client'
+
+export interface WeekData {
+  weekNumber: number
+  description?: string | null
+  workouts?: WorkoutData[]
+}
+
+interface WorkoutData {
+  name: string
+  dayNumber: number
+  exercises: ExerciseData[]
+}
+
+interface ExerciseData {
+  name: string
+  exerciseDefinitionId: string
+  order: number
+  exerciseGroup?: string
+  notes?: string
+  prescribedSets?: PrescribedSetData[]
+}
+
+interface PrescribedSetData {
+  setNumber: number
+  reps: string
+  weight?: string
+  rpe?: number
+  rir?: number
+  isWarmup?: boolean
+}
+
+/**
+ * Batch inserts a strength program week with all workouts, exercises, and prescribed sets.
+ * Uses raw SQL batch INSERTs for performance.
+ * Ported from cloud-functions/clone-program/src/batch-insert.ts
+ */
+export async function batchInsertStrengthWeek(
+  tx: Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>,
+  weekData: WeekData,
+  programId: string,
+  userId: string
+): Promise<void> {
+  const weekId = createId()
+  const workouts = weekData.workouts || []
+
+  const workoutIds = workouts.map(() => createId())
+
+  const exercisesFlat: Array<{
+    workoutIndex: number
+    exercise: ExerciseData
+    exerciseId: string
+  }> = []
+
+  workouts.forEach((workout, workoutIndex) => {
+    workout.exercises.forEach((exercise) => {
+      exercisesFlat.push({
+        workoutIndex,
+        exercise,
+        exerciseId: createId(),
+      })
+    })
+  })
+
+  const setsFlat: Array<{
+    exerciseId: string
+    set: PrescribedSetData
+  }> = []
+
+  exercisesFlat.forEach(({ exerciseId, exercise }) => {
+    const sets = exercise.prescribedSets || []
+    sets.forEach((set) => {
+      setsFlat.push({
+        exerciseId,
+        set,
+      })
+    })
+  })
+
+  await tx.$executeRaw(Prisma.sql`
+    INSERT INTO "Week" (id, "weekNumber", description, "programId", "userId")
+    VALUES (${weekId}, ${weekData.weekNumber}, ${weekData.description || null}, ${programId}, ${userId})
+  `)
+
+  if (workouts.length > 0) {
+    const workoutValues = workouts.map((workout, idx) => {
+      return Prisma.sql`(
+        ${workoutIds[idx]},
+        ${workout.name},
+        ${workout.dayNumber},
+        ${weekId},
+        ${userId}
+      )`
+    })
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "Workout" (id, name, "dayNumber", "weekId", "userId")
+      VALUES ${Prisma.join(workoutValues, ',')}
+    `)
+  }
+
+  if (exercisesFlat.length > 0) {
+    const exerciseValues = exercisesFlat.map(({ workoutIndex, exercise, exerciseId }) => {
+      return Prisma.sql`(
+        ${exerciseId},
+        ${exercise.name},
+        ${exercise.exerciseDefinitionId},
+        ${exercise.order},
+        ${exercise.exerciseGroup || null},
+        ${workoutIds[workoutIndex]},
+        ${exercise.notes || null},
+        ${userId},
+        ${false}
+      )`
+    })
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "Exercise" (
+        id,
+        name,
+        "exerciseDefinitionId",
+        "order",
+        "exerciseGroup",
+        "workoutId",
+        notes,
+        "userId",
+        "isOneOff"
+      )
+      VALUES ${Prisma.join(exerciseValues, ',')}
+    `)
+  }
+
+  if (setsFlat.length > 0) {
+    const setValues = setsFlat.map(({ exerciseId, set }) => {
+      return Prisma.sql`(
+        ${createId()},
+        ${set.setNumber},
+        ${set.reps},
+        ${set.weight || null},
+        ${set.rpe || null},
+        ${set.rir || null},
+        ${set.isWarmup ?? false},
+        ${exerciseId},
+        ${userId}
+      )`
+    })
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "PrescribedSet" (
+        id,
+        "setNumber",
+        reps,
+        weight,
+        rpe,
+        rir,
+        "isWarmup",
+        "exerciseId",
+        "userId"
+      )
+      VALUES ${Prisma.join(setValues, ',')}
+    `)
+  }
+}

--- a/lib/admin/community-program-hydration.ts
+++ b/lib/admin/community-program-hydration.ts
@@ -1,0 +1,249 @@
+import type { Prisma, PrismaClient } from '@prisma/client'
+import { createId } from '@paralleldrive/cuid2'
+import { logger } from '@/lib/logger'
+import { batchInsertStrengthWeek, type WeekData } from './batch-insert-week'
+import { calculateProgramStats } from '@/lib/community/validation'
+
+const ADMIN_DRAFT_STATUS = 'admin_draft'
+const STALE_DRAFT_HOURS = 24
+
+interface HydrateResult {
+  success: boolean
+  tempProgramId?: string
+  error?: string
+}
+
+interface SerializeResult {
+  success: boolean
+  error?: string
+}
+
+/**
+ * Hydrates a CommunityProgram's programData JSON into a temporary Program
+ * with real relational records so it can be edited via ProgramBuilder.
+ *
+ * If an existing fresh draft is found for this admin, returns it (resume editing).
+ * Stale drafts (>24h) are cleaned up automatically.
+ */
+export async function hydrateCommunityProgram(
+  prisma: PrismaClient,
+  communityProgramId: string,
+  adminUserId: string
+): Promise<HydrateResult> {
+  const communityProgram = await prisma.communityProgram.findUnique({
+    where: { id: communityProgramId },
+  })
+
+  if (!communityProgram) {
+    return { success: false, error: 'Community program not found' }
+  }
+
+  if (!communityProgram.curated) {
+    return { success: false, error: 'Only curated programs can be edited' }
+  }
+
+  const programData = communityProgram.programData as Record<string, unknown>
+  if (!programData || !Array.isArray(programData.weeks)) {
+    return { success: false, error: 'Invalid programData structure' }
+  }
+
+  // Clean up stale drafts for this admin
+  const staleThreshold = new Date(Date.now() - STALE_DRAFT_HOURS * 60 * 60 * 1000)
+  const staleDrafts = await prisma.program.findMany({
+    where: {
+      userId: adminUserId,
+      copyStatus: ADMIN_DRAFT_STATUS,
+      createdAt: { lt: staleThreshold },
+    },
+    select: { id: true },
+  })
+
+  if (staleDrafts.length > 0) {
+    await prisma.program.deleteMany({
+      where: { id: { in: staleDrafts.map((d) => d.id) } },
+    })
+    logger.info(
+      { count: staleDrafts.length, adminUserId },
+      'Cleaned up stale admin draft programs'
+    )
+  }
+
+  // Check for existing fresh draft linked to this community program
+  // We tag drafts with a description containing the community program ID
+  const existingDraft = await prisma.program.findFirst({
+    where: {
+      userId: adminUserId,
+      copyStatus: ADMIN_DRAFT_STATUS,
+      description: { contains: `[admin-draft:${communityProgramId}]` },
+    },
+    select: { id: true },
+  })
+
+  if (existingDraft) {
+    return { success: true, tempProgramId: existingDraft.id }
+  }
+
+  // Create temp program from programData
+  const tempProgramId = createId()
+
+  await prisma.program.create({
+    data: {
+      id: tempProgramId,
+      name: communityProgram.name,
+      description: `[admin-draft:${communityProgramId}]`,
+      userId: adminUserId,
+      isActive: false,
+      isUserCreated: false,
+      programType: 'strength',
+      isArchived: false,
+      copyStatus: ADMIN_DRAFT_STATUS,
+      goals: communityProgram.goals,
+      level: communityProgram.level,
+      durationWeeks: communityProgram.durationWeeks,
+      durationDisplay: communityProgram.durationDisplay,
+      targetDaysPerWeek: communityProgram.targetDaysPerWeek,
+      equipmentNeeded: communityProgram.equipmentNeeded,
+      focusAreas: communityProgram.focusAreas,
+    },
+  })
+
+  // Insert weeks with all nested data in a transaction
+  const weeks = programData.weeks as WeekData[]
+
+  await prisma.$transaction(async (tx) => {
+    for (const week of weeks) {
+      await batchInsertStrengthWeek(tx, week, tempProgramId, adminUserId)
+    }
+  })
+
+  logger.info(
+    { communityProgramId, tempProgramId, weekCount: weeks.length },
+    'Hydrated community program into temp program'
+  )
+
+  return { success: true, tempProgramId }
+}
+
+/**
+ * Serializes a temporary Program back into a CommunityProgram's programData JSON,
+ * then deletes the temp program.
+ */
+export async function serializeAndSaveToCommunity(
+  prisma: PrismaClient,
+  tempProgramId: string,
+  communityProgramId: string
+): Promise<SerializeResult> {
+  // Fetch the full temp program with all relations
+  const tempProgram = await prisma.program.findUnique({
+    where: { id: tempProgramId },
+    include: {
+      weeks: {
+        orderBy: { weekNumber: 'asc' },
+        include: {
+          workouts: {
+            orderBy: { dayNumber: 'asc' },
+            include: {
+              exercises: {
+                orderBy: { order: 'asc' },
+                include: {
+                  prescribedSets: {
+                    orderBy: { setNumber: 'asc' },
+                  },
+                  exerciseDefinition: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!tempProgram) {
+    return { success: false, error: 'Temp program not found' }
+  }
+
+  if (tempProgram.copyStatus !== ADMIN_DRAFT_STATUS) {
+    return { success: false, error: 'Program is not an admin draft' }
+  }
+
+  const communityProgram = await prisma.communityProgram.findUnique({
+    where: { id: communityProgramId },
+  })
+
+  if (!communityProgram) {
+    return { success: false, error: 'Community program not found' }
+  }
+
+  if (!communityProgram.curated) {
+    return { success: false, error: 'Only curated programs can be edited' }
+  }
+
+  // Recalculate stats
+  const stats = calculateProgramStats(tempProgram)
+
+  // Serialize the temp program to JSON (same pattern as publishing.ts)
+  const programDataJson = tempProgram as unknown as Prisma.JsonObject
+
+  // Update community program with new data
+  await prisma.communityProgram.update({
+    where: { id: communityProgramId },
+    data: {
+      name: tempProgram.name,
+      description: communityProgram.description,
+      programData: programDataJson,
+      weekCount: stats.weekCount,
+      workoutCount: stats.workoutCount,
+      exerciseCount: stats.exerciseCount,
+      goals: tempProgram.goals,
+      level: tempProgram.level,
+      durationWeeks: tempProgram.durationWeeks || stats.weekCount,
+      durationDisplay: tempProgram.durationDisplay,
+      targetDaysPerWeek: tempProgram.targetDaysPerWeek,
+      equipmentNeeded: tempProgram.equipmentNeeded,
+      focusAreas: tempProgram.focusAreas,
+    },
+  })
+
+  // Delete temp program (cascade handles children)
+  await prisma.program.delete({ where: { id: tempProgramId } })
+
+  logger.info(
+    { communityProgramId, tempProgramId, stats },
+    'Serialized temp program back to community program'
+  )
+
+  return { success: true }
+}
+
+/**
+ * Discards an admin draft program by deleting it and all children.
+ */
+export async function discardDraftProgram(
+  prisma: PrismaClient,
+  tempProgramId: string,
+  adminUserId: string
+): Promise<{ success: boolean; error?: string }> {
+  const program = await prisma.program.findUnique({
+    where: { id: tempProgramId },
+    select: { userId: true, copyStatus: true },
+  })
+
+  if (!program) {
+    return { success: false, error: 'Program not found' }
+  }
+
+  if (program.userId !== adminUserId) {
+    return { success: false, error: 'Not authorized to delete this draft' }
+  }
+
+  if (program.copyStatus !== ADMIN_DRAFT_STATUS) {
+    return { success: false, error: 'Program is not an admin draft' }
+  }
+
+  await prisma.program.delete({ where: { id: tempProgramId } })
+
+  logger.info({ tempProgramId, adminUserId }, 'Discarded admin draft program')
+
+  return { success: true }
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -16,8 +16,8 @@ set -e
 source "$(dirname "$0")/worktree-env.sh"
 
 if [ $# -eq 0 ]; then
-  # Default: common minimal subset
-  exec overmind start -l postgres,app
+  # Default: postgres + redis + worker + app
+  exec overmind start -l postgres,redis,worker,app
 elif [[ "$1" == -* ]]; then
   # First arg is a flag (e.g. -l) — treat as `start` with those flags
   exec overmind start "$@"

--- a/types/program-builder.ts
+++ b/types/program-builder.ts
@@ -58,4 +58,5 @@ export type ExistingProgram = {
 export type ProgramBuilderProps = {
   editMode?: boolean
   existingProgram?: ExistingProgram
+  onComplete?: () => void
 }


### PR DESCRIPTION
## Summary
- Add admin list page for community programs with level/curated filters and search
- Add edit page for curated programs allowing changes to name, description, metadata (level, goals, equipment, focus areas, target days/week), week descriptions, and workout names
- Exercises shown read-only for context; stats recalculated on save
- Follows existing admin patterns (auth via `requireEditor`, rate limiting, logging)

## Test plan
- [ ] Navigate to Admin > Programs and verify list loads with filters
- [ ] Click a curated program to open editor
- [ ] Edit program name, description, and metadata fields; save and verify persistence
- [ ] Expand weeks, edit week descriptions and workout names; save and verify
- [ ] Confirm non-curated programs show as non-clickable
- [ ] Verify stats (weekCount, workoutCount, exerciseCount) recalculate after save

Fixes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)