### PR TITLE
feat: gate intensity (RIR/RPE) behind premium flag

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -5,6 +5,7 @@ import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
+import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useThemePreference } from '@/hooks/useThemePreference'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { authClient, useSession } from '@/lib/auth-client'
@@ -19,6 +20,7 @@ export default function SettingsPage() {
   const { data: session } = useSession()
   const { settings, isLoading, updateSettings } = useUserSettings()
   const { preference, updateTheme } = useThemePreference()
+  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
   const userRole = (session?.user as Record<string, unknown>)?.role as string | undefined
   const isAdmin = userRole === 'admin' || userRole === 'editor'
   const [weightUnit, setWeightUnit] = useState<'lbs' | 'kg'>('lbs')
@@ -74,7 +76,7 @@ export default function SettingsPage() {
   const isDirty =
     settings &&
     (weightUnit !== settings.defaultWeightUnit ||
-      intensityRating !== settings.defaultIntensityRating)
+      (hasIntensityAccess && intensityRating !== settings.defaultIntensityRating))
 
   return (
     <div className="bg-background px-4 sm:px-6 py-8">
@@ -198,43 +200,51 @@ export default function SettingsPage() {
             </div>
 
             {/* Intensity Rating */}
-            <div>
+            <div className={!hasIntensityAccess ? 'opacity-60' : ''}>
               <span
                 id="intensity-rating-label"
                 className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
               >
-                Default Intensity Rating
+                Intensity Rating (RPE / RIR)
               </span>
-              <fieldset
-                className="flex gap-2"
-                aria-labelledby="intensity-rating-label"
-              >
-                <button
-                  type="button"
-                  onClick={() => setIntensityRating('rpe')}
-                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    intensityRating === 'rpe'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
-                  }`}
-                >
-                  RPE
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setIntensityRating('rir')}
-                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    intensityRating === 'rir'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
-                  }`}
-                >
-                  RIR
-                </button>
-              </fieldset>
-              <p className="text-sm text-muted-foreground mt-1">
-                RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
-              </p>
+              {!hasIntensityAccess ? (
+                <div className="px-4 py-3 border-2 border-border bg-muted text-muted-foreground text-sm">
+                  Coming soon as a premium feature
+                </div>
+              ) : (
+                <>
+                  <fieldset
+                    className="flex gap-2"
+                    aria-labelledby="intensity-rating-label"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => setIntensityRating('rpe')}
+                      className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                        intensityRating === 'rpe'
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      }`}
+                    >
+                      RPE
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setIntensityRating('rir')}
+                      className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                        intensityRating === 'rir'
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      }`}
+                    >
+                      RIR
+                    </button>
+                  </fieldset>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
+                  </p>
+                </>
+              )}
             </div>
 
             {/* Save Button */}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -209,7 +209,7 @@ export default function SettingsPage() {
               </span>
               {!hasIntensityAccess ? (
                 <div className="px-4 py-3 border-2 border-border bg-muted text-muted-foreground text-sm">
-                  Coming soon as a premium feature
+                  Premium Feature Coming Soon
                 </div>
               ) : (
                 <>

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -16,6 +16,7 @@ type UpdateSettingsRequest = {
   experienceLevel?: 'beginner' | 'experienced'
   equipmentPreference?: 'machines' | 'free_weights_cables'
   onboardingCompleted?: boolean
+  intensityEnabled?: boolean
 }
 
 export async function GET(_request: NextRequest) {
@@ -71,7 +72,7 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json() as UpdateSettingsRequest
-    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours, postSessionPromptCount, lastPostSessionPromptAt, experienceLevel, equipmentPreference, onboardingCompleted } = body
+    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours, postSessionPromptCount, lastPostSessionPromptAt, experienceLevel, equipmentPreference, onboardingCompleted, intensityEnabled } = body
 
     // Validate weight unit
     if (defaultWeightUnit && !['lbs', 'kg'].includes(defaultWeightUnit)) {
@@ -129,6 +130,7 @@ export async function PUT(request: NextRequest) {
         ...(experienceLevel !== undefined && { experienceLevel }),
         ...(equipmentPreference !== undefined && { equipmentPreference }),
         ...(onboardingCompleted !== undefined && { onboardingCompleted }),
+        ...(intensityEnabled !== undefined && { intensityEnabled }),
         updatedAt: new Date()
       },
       create: {

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { useImagePrefetch } from '@/hooks/useImagePrefetch'
+import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { type Exercise, type ExerciseHistory, useProgressiveExercises } from '@/hooks/useProgressiveExercises'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import { useWorkoutDraft } from '@/hooks/useWorkoutDraft'
@@ -127,9 +128,12 @@ export default function ExerciseLoggingModal({
     (s) => s.setNumber === nextSetNumber
   )
 
-  // Check if current exercise has any prescribed RPE/RIR
-  const hasRpe = currentPrescribedSets.some((s) => s.rpe !== null)
-  const hasRir = currentPrescribedSets.some((s) => s.rir !== null)
+  // Premium intensity gate: admins always have access, others need intensityEnabled
+  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
+
+  // Check if current exercise has any prescribed RPE/RIR (gated by premium)
+  const hasRpe = hasIntensityAccess && currentPrescribedSets.some((s) => s.rpe !== null)
+  const hasRir = hasIntensityAccess && currentPrescribedSets.some((s) => s.rir !== null)
 
   // Pre-fill form when exercise loads or set number changes
   const lastPrefillKey = useRef<string>('')
@@ -173,8 +177,8 @@ export default function ExerciseLoggingModal({
       reps: parseInt(currentSet.reps, 10),
       weight: parseFloat(currentSet.weight),
       weightUnit: currentSet.weightUnit,
-      rpe: currentSet.rpe ? parseFloat(currentSet.rpe) : null,
-      rir: currentSet.rir ? parseInt(currentSet.rir, 10) : null,
+      rpe: hasIntensityAccess && currentSet.rpe ? parseFloat(currentSet.rpe) : null,
+      rir: hasIntensityAccess && currentSet.rir ? parseInt(currentSet.rir, 10) : null,
     })
 
     // Pre-fill for next set: reps from next prescribed, weight carried forward
@@ -462,6 +466,7 @@ export default function ExerciseLoggingModal({
                 hasHistoryIndicator={hasHistoryForCurrentExercise}
                 onDeleteSet={handleDeleteSet}
                 isInputExpanded={expandedInput !== null}
+                showIntensity={hasIntensityAccess}
                 loggingForm={
                   <SetLoggingForm
                     prescribedSet={prescribedSet}

--- a/components/SetDefinitionModal.tsx
+++ b/components/SetDefinitionModal.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { X } from 'lucide-react'
+import { Lock, X } from 'lucide-react'
 import { useState } from 'react'
+import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 
 interface SetDefinitionModalProps {
   isOpen: boolean
@@ -79,6 +80,7 @@ function SetDefinitionForm({
   initialNotes,
   mode = 'add'
 }: SetDefinitionFormProps) {
+  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
   const initialIntensity = deriveIntensityType(initialSets)
   const [setCount, setSetCount] = useState(initialSets?.length || 3)
   const [exerciseIntensityType, setExerciseIntensityType] = useState(initialIntensity)
@@ -182,16 +184,23 @@ function SetDefinitionForm({
             <label htmlFor="intensity-type" className="block text-sm font-medium text-foreground mb-2">
               Intensity Type
             </label>
-            <select
-              id="intensity-type"
-              value={exerciseIntensityType}
-              onChange={(e) => handleIntensityTypeChange(e.target.value as 'RIR' | 'RPE' | 'NONE')}
-              className="w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-muted text-foreground"
-            >
-              <option value="NONE">None</option>
-              <option value="RIR">RIR (Reps in Reserve)</option>
-              <option value="RPE">RPE (Rate of Perceived Exertion)</option>
-            </select>
+            {hasIntensityAccess ? (
+              <select
+                id="intensity-type"
+                value={exerciseIntensityType}
+                onChange={(e) => handleIntensityTypeChange(e.target.value as 'RIR' | 'RPE' | 'NONE')}
+                className="w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-muted text-foreground"
+              >
+                <option value="NONE">None</option>
+                <option value="RIR">RIR (Reps in Reserve)</option>
+                <option value="RPE">RPE (Rate of Perceived Exertion)</option>
+              </select>
+            ) : (
+              <div className="w-full px-3 py-2 border border-input rounded-lg bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
+                <Lock size={14} />
+                <span className="text-sm">Premium</span>
+              </div>
+            )}
           </div>
         </div>
 

--- a/components/SetDefinitionModal.tsx
+++ b/components/SetDefinitionModal.tsx
@@ -227,7 +227,7 @@ function SetDefinitionForm({
                   />
                 </div>
 
-                {exerciseIntensityType !== 'NONE' && (
+                {hasIntensityAccess && exerciseIntensityType !== 'NONE' && (
                   <div className="flex-1">
                     <label htmlFor={`set-${set.setNumber}-intensity`} className="block text-xs text-muted-foreground mb-1">
                       {exerciseIntensityType} Value

--- a/components/SetDefinitionModal.tsx
+++ b/components/SetDefinitionModal.tsx
@@ -198,7 +198,7 @@ function SetDefinitionForm({
             ) : (
               <div className="w-full px-3 py-2 border border-input rounded-lg bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
                 <Lock size={14} />
-                <span className="text-sm">Premium</span>
+                <span className="text-sm">Premium Feature Coming Soon</span>
               </div>
             )}
           </div>

--- a/components/TransformWeekModal.tsx
+++ b/components/TransformWeekModal.tsx
@@ -173,7 +173,7 @@ export default function TransformWeekModal({
             {!hasIntensityAccess ? (
               <div className="px-3 py-2.5 border-2 border-border bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
                 <Lock size={14} />
-                <span className="text-sm">Premium feature</span>
+                <span className="text-sm">Premium Feature Coming Soon</span>
               </div>
             ) : (
               <>

--- a/components/TransformWeekModal.tsx
+++ b/components/TransformWeekModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { Minus, Plus, X } from 'lucide-react'
+import { Lock, Minus, Plus, X } from 'lucide-react'
 import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
+import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import type { Week } from '@/types/program-builder'
 
 interface TransformWeekModalProps {
@@ -27,6 +28,7 @@ export default function TransformWeekModal({
   weekNumber,
   onTransform
 }: TransformWeekModalProps) {
+  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
   const [intensityDirection, setIntensityDirection] = useState<'MORE' | 'LESS' | 'NONE'>('NONE')
   const [intensityMagnitude, setIntensityMagnitude] = useState<number>(1)
   const [volumeAdjustment, setVolumeAdjustment] = useState<number>(0)
@@ -168,69 +170,78 @@ export default function TransformWeekModal({
           <div className="space-y-3">
             <h3 className="text-sm font-bold text-foreground doom-heading uppercase tracking-wider">Adjust Intensity</h3>
 
-            {/* Intensity Direction Selection */}
-            <div className="flex gap-2">
-              <button type="button"
-                onClick={() => setIntensityDirection('NONE')}
-                disabled={isSubmitting || stats !== null}
-                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                  intensityDirection === 'NONE'
-                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                } disabled:opacity-50`}
-              >
-                None
-              </button>
-              <button type="button"
-                onClick={() => setIntensityDirection('MORE')}
-                disabled={isSubmitting || stats !== null}
-                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                  intensityDirection === 'MORE'
-                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                } disabled:opacity-50`}
-              >
-                More
-              </button>
-              <button type="button"
-                onClick={() => setIntensityDirection('LESS')}
-                disabled={isSubmitting || stats !== null}
-                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                  intensityDirection === 'LESS'
-                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                } disabled:opacity-50`}
-              >
-                Less
-              </button>
-            </div>
-
-            {/* Intensity Magnitude Stepper */}
-            {intensityDirection !== 'NONE' && (
-              <div className="flex items-center gap-3">
-                <button type="button"
-                  onClick={decrementMagnitude}
-                  disabled={isSubmitting || stats !== null || intensityMagnitude <= 1}
-                  className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
-                >
-                  <Minus size={16} />
-                </button>
-                <div className="flex-1 text-center">
-                  <div className="text-3xl font-bold text-foreground doom-heading">
-                    {intensityDirection === 'MORE' ? '+' : '-'}{intensityMagnitude}
-                  </div>
-                  <div className="text-xs text-muted-foreground uppercase tracking-wide">
-                    Intensity adjustment
-                  </div>
-                </div>
-                <button type="button"
-                  onClick={incrementMagnitude}
-                  disabled={isSubmitting || stats !== null || intensityMagnitude >= 5}
-                  className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
-                >
-                  <Plus size={16} />
-                </button>
+            {!hasIntensityAccess ? (
+              <div className="px-3 py-2.5 border-2 border-border bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
+                <Lock size={14} />
+                <span className="text-sm">Premium feature</span>
               </div>
+            ) : (
+              <>
+                {/* Intensity Direction Selection */}
+                <div className="flex gap-2">
+                  <button type="button"
+                    onClick={() => setIntensityDirection('NONE')}
+                    disabled={isSubmitting || stats !== null}
+                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                      intensityDirection === 'NONE'
+                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                    } disabled:opacity-50`}
+                  >
+                    None
+                  </button>
+                  <button type="button"
+                    onClick={() => setIntensityDirection('MORE')}
+                    disabled={isSubmitting || stats !== null}
+                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                      intensityDirection === 'MORE'
+                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                    } disabled:opacity-50`}
+                  >
+                    More
+                  </button>
+                  <button type="button"
+                    onClick={() => setIntensityDirection('LESS')}
+                    disabled={isSubmitting || stats !== null}
+                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                      intensityDirection === 'LESS'
+                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                    } disabled:opacity-50`}
+                  >
+                    Less
+                  </button>
+                </div>
+
+                {/* Intensity Magnitude Stepper */}
+                {intensityDirection !== 'NONE' && (
+                  <div className="flex items-center gap-3">
+                    <button type="button"
+                      onClick={decrementMagnitude}
+                      disabled={isSubmitting || stats !== null || intensityMagnitude <= 1}
+                      className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
+                    >
+                      <Minus size={16} />
+                    </button>
+                    <div className="flex-1 text-center">
+                      <div className="text-3xl font-bold text-foreground doom-heading">
+                        {intensityDirection === 'MORE' ? '+' : '-'}{intensityMagnitude}
+                      </div>
+                      <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                        Intensity adjustment
+                      </div>
+                    </div>
+                    <button type="button"
+                      onClick={incrementMagnitude}
+                      disabled={isSubmitting || stats !== null || intensityMagnitude >= 5}
+                      className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
+                    >
+                      <Plus size={16} />
+                    </button>
+                  </div>
+                )}
+              </>
             )}
           </div>
 

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { Plus, Trash } from 'lucide-react'
+import { Lock, Plus, Trash } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
+import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { RIR_PRESETS, RPE_PRESETS } from '@/lib/constants/intensity-presets'
@@ -62,9 +63,11 @@ export function SetConfigurationInterface({
   onEditExercise
 }: SetConfigurationInterfaceProps) {
   const { settings } = useUserSettings()
+  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
 
-  // Determine default intensity type
+  // Determine default intensity type (forced to NONE for non-premium users)
   const getDefaultIntensityType = (): 'RIR' | 'RPE' | 'NONE' => {
+    if (!hasIntensityAccess) return 'NONE'
     if (initialConfig) return initialConfig.intensityType
 
     if (!settings?.defaultIntensityRating) {
@@ -275,16 +278,23 @@ export function SetConfigurationInterface({
               <label htmlFor="exercise-intensity-type" className="block text-sm font-bold text-muted-foreground mb-1.5 uppercase tracking-wider">
                 INTENSITY TYPE
               </label>
-              <select
-                id="exercise-intensity-type"
-                value={exerciseIntensityType}
-                onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
-                className="w-full px-3 py-2.5 border border-border focus:outline-none focus:border-primary bg-card text-foreground text-base"
-              >
-                <option value="NONE">None</option>
-                <option value="RIR">RIR (Reps in Reserve)</option>
-                <option value="RPE">RPE (Rate of Perceived Exertion)</option>
-              </select>
+              {hasIntensityAccess ? (
+                <select
+                  id="exercise-intensity-type"
+                  value={exerciseIntensityType}
+                  onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
+                  className="w-full px-3 py-2.5 border border-border focus:outline-none focus:border-primary bg-card text-foreground text-base"
+                >
+                  <option value="NONE">None</option>
+                  <option value="RIR">RIR (Reps in Reserve)</option>
+                  <option value="RPE">RPE (Rate of Perceived Exertion)</option>
+                </select>
+              ) : (
+                <div className="w-full px-3 py-2.5 border border-border bg-card text-muted-foreground opacity-60 flex items-center gap-2">
+                  <Lock size={14} />
+                  <span className="text-sm">Premium feature</span>
+                </div>
+              )}
             </div>
 
             {/* Individual Set Configuration - Table Layout */}

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -296,7 +296,7 @@ export function SetConfigurationInterface({
               ) : (
                 <div className="w-full px-3 py-2.5 border border-border bg-card text-muted-foreground opacity-60 flex items-center gap-2">
                   <Lock size={14} />
-                  <span className="text-sm">Premium feature</span>
+                  <span className="text-sm">Premium Feature Coming Soon</span>
                 </div>
               )}
             </div>

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -100,6 +100,10 @@ export function SetConfigurationInterface({
 
   // Update intensity type when settings load (only for new exercises, not when editing)
   useEffect(() => {
+    if (!hasIntensityAccess) {
+      setExerciseIntensityType('NONE')
+      return
+    }
     if (!initialConfig && settings?.defaultIntensityRating) {
       const newIntensityType = settings.defaultIntensityRating === 'rpe'
         ? 'RPE'
@@ -109,7 +113,7 @@ export function SetConfigurationInterface({
 
       setExerciseIntensityType(newIntensityType)
     }
-  }, [settings?.defaultIntensityRating, initialConfig])
+  }, [settings?.defaultIntensityRating, initialConfig, hasIntensityAccess])
 
   // Update parent whenever form state changes
   useEffect(() => {
@@ -305,7 +309,7 @@ export function SetConfigurationInterface({
                 <div className="flex items-center px-3 py-1.5 bg-muted/50">
                   <span className="w-12 text-sm font-bold text-muted-foreground uppercase tracking-wider">#</span>
                   <span className="flex-1 text-sm font-bold text-muted-foreground uppercase tracking-wider">REPS</span>
-                  {exerciseIntensityType !== 'NONE' && (
+                  {hasIntensityAccess && exerciseIntensityType !== 'NONE' && (
                     <span className="flex-1 text-sm font-bold text-muted-foreground uppercase tracking-wider">{exerciseIntensityType}</span>
                   )}
                   <span className="w-10" />
@@ -395,7 +399,7 @@ export function SetConfigurationInterface({
                     </div>
 
                     {/* Intensity Value */}
-                    {exerciseIntensityType !== 'NONE' && (
+                    {hasIntensityAccess && exerciseIntensityType !== 'NONE' && (
                       <div className="flex-1">
                         <Popover>
                           <PopoverTrigger asChild>

--- a/components/features/training/BeginnerPrimerWizard.tsx
+++ b/components/features/training/BeginnerPrimerWizard.tsx
@@ -36,7 +36,7 @@ const PAGES = [
           Controlled reps at moderate effort beat heavy weight with sloppy form. Your first week, pick weights that feel almost too easy — you&apos;ll dial it in.
         </p>
         <p className="text-muted-foreground mb-4">
-          The app tracks something called RIR (reps in reserve). It just means &ldquo;how many more could you have done?&rdquo; You&apos;ll get a feel for it.
+          A good rule of thumb: after each set, you should feel like you could have done 2-3 more reps. If you&apos;re grinding out every rep, go lighter.
         </p>
         <Link href="/learn/choosing-the-right-weight" className="text-sm text-primary hover:text-primary/80 font-semibold uppercase tracking-wider">
           Read more: Choosing the Right Weight

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -57,6 +57,7 @@ interface ExerciseDisplayTabsProps {
   onDeleteSet: (setNumber: number) => void
   loggingForm: React.ReactNode
   isInputExpanded?: boolean
+  showIntensity?: boolean
 }
 
 const FAU_DISPLAY_NAMES: Record<string, string> = {
@@ -102,6 +103,7 @@ export default function ExerciseDisplayTabs({
   onDeleteSet,
   loggingForm,
   isInputExpanded = false,
+  showIntensity = true,
 }: ExerciseDisplayTabsProps) {
   const [expandedImage, setExpandedImage] = useState<string | null>(null)
   const hasNotes = !!exercise.notes
@@ -139,6 +141,7 @@ export default function ExerciseDisplayTabs({
               exerciseHistory={null}
               onDeleteSet={onDeleteSet}
               exerciseId={exercise.id}
+              showIntensity={showIntensity}
             />
             <RestStopwatch
               loggedSetCount={loggedSets.length}

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -34,6 +34,7 @@ interface SetListProps {
   exerciseHistory: ExerciseHistory | null
   onDeleteSet: (setNumber: number) => void
   exerciseId?: string
+  showIntensity?: boolean
 }
 
 function formatIntensity(set: { rpe: number | null; rir: number | null }) {
@@ -48,6 +49,7 @@ export default function SetList({
   exerciseHistory,
   onDeleteSet,
   exerciseId,
+  showIntensity = true,
 }: SetListProps) {
   const loggedSetNumbers = new Set(loggedSets.map(s => s.setNumber))
   const remainingSets = prescribedSets.filter(s => !loggedSetNumbers.has(s.setNumber))
@@ -94,7 +96,7 @@ export default function SetList({
             <span key={set.setNumber}>
               {i > 0 && ' · '}
               {set.reps}×{set.weight}{set.weightUnit}
-              {formatIntensity(set) ? ` ${formatIntensity(set)}` : ''}
+              {showIntensity && formatIntensity(set) ? ` ${formatIntensity(set)}` : ''}
             </span>
           ))}
         </div>
@@ -122,7 +124,7 @@ export default function SetList({
                   {isFailed && <AlertCircle size={14} className="flex-shrink-0" />}
                   <span className="font-bold">{set.setNumber}.</span>
                   {set.reps}×{set.weight}{set.weightUnit}
-                  {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                  {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
                   {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
                 </span>
                 <button
@@ -153,7 +155,7 @@ export default function SetList({
                 <span className="font-bold w-6">{set.setNumber}.</span>
                 <span>
                   {set.reps} reps @ {set.weight || '—'}
-                  {formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                  {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
                 </span>
               </div>
             ))}

--- a/hooks/useIntensityAccess.ts
+++ b/hooks/useIntensityAccess.ts
@@ -1,0 +1,21 @@
+import { useSession } from '@/lib/auth-client'
+import { useUserSettings } from '@/hooks/useUserSettings'
+
+/**
+ * Returns whether the current user has access to intensity features (RIR/RPE).
+ * Access is granted if:
+ * - intensityEnabled is true in their settings, OR
+ * - the user has an admin role (automatic premium access)
+ */
+export function useIntensityAccess() {
+  const { settings, isLoading: settingsLoading } = useUserSettings()
+  const { data: session, isPending: sessionLoading } = useSession()
+
+  const userRole = (session?.user as Record<string, unknown>)?.role as string | undefined
+  const isAdmin = userRole === 'admin'
+
+  const hasAccess = isAdmin || (settings?.intensityEnabled ?? false)
+  const isLoading = settingsLoading || sessionLoading
+
+  return { hasAccess, isLoading }
+}

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -12,6 +12,7 @@ export type UserSettings = {
   postSessionPromptCount: number
   lastPostSessionPromptAt: string | null
   experienceLevel: string | null
+  intensityEnabled: boolean
 }
 
 type UseUserSettingsReturn = {

--- a/prisma/migrations/20260420222732_add_intensity_enabled/migration.sql
+++ b/prisma/migrations/20260420222732_add_intensity_enabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN "intensityEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -299,6 +299,7 @@ model UserSettings {
   experienceLevel           String?
   equipmentPreference       String?
   onboardingCompleted       Boolean   @default(false)
+  intensityEnabled          Boolean   @default(false)
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
 


### PR DESCRIPTION
## Summary
- Adds `intensityEnabled` boolean to UserSettings (default `false`). Admin users automatically bypass the gate via `useIntensityAccess` hook.
- Gates intensity across all surfaces: settings page, exercise logger, program builder (SetDefinitionModal, SetConfigurationInterface, TransformWeekModal), and set display lists.
- Replaces RIR-specific text in BeginnerPrimerWizard with general effort guidance.
- Follow-up issue #550 created for manual article audit.

## Test plan
- [x] Non-admin user: intensity toggle shows "Premium Feature Coming Soon" in settings
- [x] Non-admin user: program builder hides intensity type dropdown and per-set intensity inputs
- [x] Non-admin user: TransformWeekModal shows locked intensity section
- [x] Non-admin user: logger hides RPE/RIR fields and set list suppresses intensity display
- [x] Admin user: all intensity features work as before
- [x] Existing logged sets with intensity data still display correctly in history

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)