### PR TITLE
fix: clone worker Redis keepalive + active readiness probe

### DIFF
--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -52,6 +52,8 @@ function parseRedisUrl(url: string) {
     port: parseInt(parsed.port || '6379', 10),
     password: parsed.password || undefined,
     maxRetriesPerRequest: null as null,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 30_000,
   }
 }
 
@@ -142,8 +144,27 @@ worker.on('error', (error) => {
   workerReady = false
 })
 
+worker.on('closed', () => {
+  workerReady = false
+  console.warn('Worker disconnected from Redis')
+})
+
+// Active readiness check: verify the worker can actually reach Redis,
+// not just that the flag is set. This lets k8s restart the pod if the
+// connection silently drops.
+async function isWorkerHealthy(): Promise<boolean> {
+  if (!workerReady) return false
+  try {
+    const client = await worker.client
+    const pong = await client.ping()
+    return pong === 'PONG'
+  } catch {
+    return false
+  }
+}
+
 // Health server for k8s probes
-const healthServer = http.createServer((req, res) => {
+const healthServer = http.createServer(async (req, res) => {
   if (req.url === '/healthz') {
     res.writeHead(200)
     res.end('OK')
@@ -151,7 +172,8 @@ const healthServer = http.createServer((req, res) => {
   }
 
   if (req.url === '/readyz') {
-    if (workerReady) {
+    const healthy = await isWorkerHealthy()
+    if (healthy) {
       res.writeHead(200)
       res.end('OK')
     } else {

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -39,6 +39,12 @@ const prisma = new PrismaClient({
   },
 })
 
+// Log DB target on startup (redact password)
+try {
+  const dbParsed = new URL(workerDbUrl!)
+  console.log(`DB target: ${dbParsed.hostname}:${dbParsed.port}${dbParsed.pathname} (source: ${process.env.DIRECT_URL ? 'DIRECT_URL' : 'DATABASE_URL'})`)
+} catch { /* startup logging only */ }
+
 const redisUrl = process.env.REDIS_URL
 if (!redisUrl) {
   console.error('REDIS_URL is not set')
@@ -87,10 +93,12 @@ async function processCloneJob(job: Job<ProgramCloneJob>): Promise<void> {
     return
   }
 
+  console.log(`Looking up community program: ${communityProgramId}`)
   const communityProgram = await prisma.communityProgram.findUnique({
     where: { id: communityProgramId },
-    select: { programData: true },
+    select: { id: true, programData: true },
   })
+  console.log(`Community program lookup: id=${communityProgramId} found=${!!communityProgram} hasData=${!!communityProgram?.programData}`)
 
   if (!communityProgram?.programData) {
     throw new Error(`Community program not found or has no data: ${communityProgramId}`)

--- a/lib/queue/clone-jobs.ts
+++ b/lib/queue/clone-jobs.ts
@@ -19,6 +19,8 @@ function parseRedisUrl(url: string) {
     port: parseInt(parsed.port || '6379', 10),
     password: parsed.password || undefined,
     maxRetriesPerRequest: null as null,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 30_000,
   }
 }
 


### PR DESCRIPTION
## Summary

- Clone worker was silently losing its Redis connection after idle periods in staging, causing clone jobs to queue without being processed (Job 68 never picked up after Job 67 succeeded)
- Root cause: ioredis has TCP keepalive disabled by default, so silent connection drops (NAT timeout, LB idle eviction) went undetected
- Adds TCP keepalive (30s) on both publisher and worker Redis connections
- Adds `closed` event handler to log disconnects
- Replaces boolean-flag `/readyz` probe with an active Redis PING check so k8s restarts the pod on silent connection loss

## Test plan

- [x] Verified clone flow works locally end-to-end
- [ ] After merge to staging, bounce the clone worker pod and verify stuck jobs get processed
- [ ] Monitor worker logs for keepalive behavior over 24h+ idle periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)