### PR TITLE
fix: clone worker ioredis fix + CI smoke test

### DIFF
--- a/.github/workflows/deploy-clone-worker.yml
+++ b/.github/workflows/deploy-clone-worker.yml
@@ -9,6 +9,11 @@ on:
       - 'cloud-functions/clone-program/**'
       - 'prisma/schema.prisma'
       - '.github/workflows/deploy-clone-worker.yml'
+  pull_request:
+    paths:
+      - 'cloud-functions/clone-program/**'
+      - 'prisma/schema.prisma'
+      - '.github/workflows/deploy-clone-worker.yml'
 
 jobs:
   build-and-push:
@@ -17,6 +22,8 @@ jobs:
       contents: read
       packages: write
     environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'dev' && 'staging' || '' }}
+    # Only push images on merge to dev/main, not on PRs
+    if: github.event_name == 'push'
 
     env:
       IMAGE_NAME: ghcr.io/aptx-health/clone-program
@@ -68,3 +75,92 @@ jobs:
             ripit.branch=${{ github.ref_name }}
             ripit.actor=${{ github.actor }}
             ripit.workflow.run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  smoke-test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ripit_smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ripit_smoke
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/ripit_smoke
+      REDIS_URL: redis://localhost:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy Prisma schema into worker build context
+        run: |
+          mkdir -p cloud-functions/clone-program/prisma
+          cp prisma/schema.prisma cloud-functions/clone-program/prisma/schema.prisma
+
+      - name: Build clone worker image
+        run: |
+          docker build -t clone-worker-smoke \
+            ./cloud-functions/clone-program
+
+      - name: Smoke test — worker boots and health endpoint responds
+        run: |
+          docker run --rm -d \
+            --name smoke-worker \
+            --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e DIRECT_URL="$DIRECT_URL" \
+            -e REDIS_URL="$REDIS_URL" \
+            clone-worker-smoke
+
+          echo "Waiting for worker health endpoint..."
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+              echo "Health endpoint responded on attempt $i"
+              break
+            fi
+            if [ "$i" = "15" ]; then
+              echo "Worker failed to start within 15s"
+              docker logs smoke-worker
+              docker stop smoke-worker || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Verify readiness (connected to Redis)
+          READY_STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/readyz)
+          echo "Readiness status: $READY_STATUS"
+
+          if [ "$READY_STATUS" != "200" ]; then
+            echo "Worker not ready (expected 200, got $READY_STATUS)"
+            docker logs smoke-worker
+            docker stop smoke-worker || true
+            exit 1
+          fi
+
+          echo "Smoke test passed"
+          docker logs smoke-worker
+          docker stop smoke-worker

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -3,10 +3,6 @@ import { PrismaClient } from '@prisma/client'
 import { type Job, Worker } from 'bullmq'
 import { cloneStrengthProgramData, type ProgramCloneJob } from './cloning'
 
-// Use ioredis from BullMQ's own dependency to avoid version mismatch
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const IORedis = require('ioredis')
-
 const QUEUE_NAME = 'program-clone-jobs'
 
 // Clone worker bypasses PgBouncer and connects directly to Postgres (:5432).
@@ -69,19 +65,8 @@ function parseRedisUrl(url: string) {
 
 const connectionOpts = parseRedisUrl(redisUrl)
 
-// Create a shared Redis connection so we can observe its lifecycle events.
-// BullMQ will use this instead of creating its own internal connection.
-const redisConnection = new IORedis({
-  ...connectionOpts,
-  lazyConnect: false,
-})
-
-redisConnection.on('connect', () => console.log('[redis] connected'))
-redisConnection.on('ready', () => console.log('[redis] ready'))
-redisConnection.on('error', (err: Error) => console.error('[redis] error:', err.message))
-redisConnection.on('close', () => console.warn('[redis] connection closed'))
-redisConnection.on('reconnecting', (ms: number) => console.warn(`[redis] reconnecting in ${ms}ms`))
-redisConnection.on('end', () => console.error('[redis] connection ended (will not reconnect)'))
+// Redis connection event logging is attached after worker creation (see below)
+// so we can observe BullMQ's own ioredis connection without importing ioredis directly.
 
 /**
  * Process a program clone job from the BullMQ queue.
@@ -131,11 +116,24 @@ async function processCloneJob(job: Job<ProgramCloneJob>): Promise<void> {
 }
 
 const worker = new Worker(QUEUE_NAME, processCloneJob, {
-  connection: redisConnection,
+  connection: connectionOpts,
   concurrency: 1,
 })
 
 let workerReady = false
+
+// Attach Redis connection lifecycle logging via BullMQ's internal client
+worker.client.then((client) => {
+  console.log('[redis] attached lifecycle listeners to BullMQ connection')
+  client.on('connect', () => console.log('[redis] connected'))
+  client.on('ready', () => console.log('[redis] ready'))
+  client.on('error', (err: Error) => console.error('[redis] error:', err.message))
+  client.on('close', () => console.warn('[redis] connection closed'))
+  client.on('reconnecting', () => console.warn('[redis] reconnecting'))
+  client.on('end', () => console.error('[redis] connection ended (will not reconnect)'))
+}).catch((err) => {
+  console.error('[redis] failed to get client for lifecycle logging:', err)
+})
 
 worker.on('ready', () => {
   workerReady = true
@@ -211,7 +209,8 @@ setInterval(async () => {
   const isPaused = worker.isPaused()
   let redisPing = 'unknown'
   try {
-    redisPing = await redisConnection.ping()
+    const client = await worker.client
+    redisPing = await client.ping()
   } catch (err) {
     redisPing = `error: ${(err as Error).message}`
   }
@@ -225,7 +224,8 @@ async function isWorkerHealthy(): Promise<boolean> {
   if (!workerReady) return false
   if (!worker.isRunning()) return false
   try {
-    const pong = await redisConnection.ping()
+    const client = await worker.client
+    const pong = await client.ping()
     return pong === 'PONG'
   } catch {
     return false
@@ -267,7 +267,6 @@ async function shutdown() {
   await worker.close()
   healthServer.close()
   await prisma.$disconnect()
-  redisConnection.disconnect()
   process.exit(0)
 }
 


### PR DESCRIPTION
## Summary

- Fixes MODULE_NOT_FOUND error from #561 — removed direct `ioredis` import, uses BullMQ's internal `worker.client` instead
- Adds CI smoke test for clone worker Docker image (builds image, boots it with Redis, verifies `/healthz` and `/readyz` respond 200)
- Smoke test runs on PRs that touch `cloud-functions/clone-program/**` — would have caught the ioredis issue before merge

## Test plan

- [ ] Smoke test passes in this PR's CI run
- [ ] Clone worker deploys successfully to staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)