### PR TITLE
fix: activation modal skip button doesn't dismiss modal

### DIFF
--- a/components/StrengthActivationModal.tsx
+++ b/components/StrengthActivationModal.tsx
@@ -13,7 +13,7 @@ type StrengthActivationModalProps = {
 export default function StrengthActivationModal({
   programId,
   existingActiveProgram,
-  onClose: _onClose
+  onClose
 }: StrengthActivationModalProps) {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState(false)
@@ -45,7 +45,7 @@ export default function StrengthActivationModal({
   }
 
   const handleSkipActivation = () => {
-    // Redirect to programs list
+    onClose()
     router.push('/programs?tab=strength')
     router.refresh()
   }


### PR DESCRIPTION
## Summary
- Fixed the "NO, KEEP INACTIVE" button in the StrengthActivationModal not dismissing the modal
- Root cause: `handleSkipActivation` called `router.push('/programs?tab=strength')` but never called `onClose()` to update the parent's state. Since the user is already on `/programs`, the navigation doesn't trigger a remount, so `showActivationModal` remains `true`
- The `onClose` prop was received as `_onClose` (intentionally unused), confirming it was an oversight

## Test plan
- [ ] Clone a community program, wait for cloning to complete
- [ ] When the activation modal appears, click "NO, KEEP INACTIVE"
- [ ] Verify the modal dismisses and the user sees the programs list
- [ ] Also verify "YES, ACTIVATE" still works correctly

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)