### PR TITLE
Admin: display structured post-workout feedback

### DIFF
--- a/app/(app)/admin/analytics/page.tsx
+++ b/app/(app)/admin/analytics/page.tsx
@@ -5,8 +5,10 @@ import { useCallback, useEffect, useState } from 'react'
 
 import type {
   AnalyticsData,
+  PostSessionMetrics,
   SignupAttributionMetrics,
 } from '@/lib/admin/analytics-queries'
+import { POST_SESSION_REFINEMENTS } from '@/types/feedback'
 
 export default function AdminAnalyticsPage() {
   const [data, setData] = useState<AnalyticsData | null>(null)
@@ -303,6 +305,11 @@ export default function AdminAnalyticsPage() {
       {/* Signup Attribution */}
       <Section title={`Signup Sources (last ${data.signupAttribution.windowDays}d)`}>
         <SignupAttributionPanel attribution={data.signupAttribution} />
+      </Section>
+
+      {/* Post-Session Feedback */}
+      <Section title="Post-Session Feedback">
+        <PostSessionPanel postSession={data.postSession} />
       </Section>
 
       {/* Feedback Volume */}
@@ -628,6 +635,155 @@ function FunnelRow({
       <div className="w-16 text-right text-sm">
         <span className="text-foreground font-semibold">{step.overallPct}%</span>
       </div>
+    </div>
+  )
+}
+
+function TrendArrow({ current, previous }: { current: number | null; previous: number | null }) {
+  if (current === null || previous === null) return null
+  const diff = Math.round((current - previous) * 10) / 10
+  if (diff === 0) return <span className="text-muted-foreground text-xs ml-1">--</span>
+  const isUp = diff > 0
+  return (
+    <span className={`text-xs ml-1 font-semibold ${isUp ? 'text-green-400' : 'text-red-400'}`}>
+      {isUp ? '\u2191' : '\u2193'} {Math.abs(diff)}
+    </span>
+  )
+}
+
+function PostSessionPanel({ postSession }: { postSession: PostSessionMetrics }) {
+  const refinementLabels: Record<string, string> = {}
+  for (const r of POST_SESSION_REFINEMENTS) {
+    refinementLabels[r.value] = r.label
+  }
+
+  const totalDistribution = Object.values(postSession.ratingDistribution).reduce(
+    (sum: number, c: number) => sum + c,
+    0
+  )
+
+  return (
+    <div className="space-y-6">
+      {/* Average ratings */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <MetricCard
+          label="Avg Rating (This Week)"
+          value={
+            postSession.avgRatingThisWeek !== null
+              ? `${postSession.avgRatingThisWeek}/5`
+              : '--'
+          }
+          info={`Based on ${postSession.sampleSizeThisWeek} ratings this week. Compare to last week to spot trends.`}
+        />
+        <div className="bg-background border border-border rounded-lg p-3">
+          <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+            vs. Last Week
+          </div>
+          <div className="text-2xl font-bold text-foreground">
+            {postSession.avgRatingLastWeek !== null
+              ? `${postSession.avgRatingLastWeek}/5`
+              : '--'}
+            <TrendArrow
+              current={postSession.avgRatingThisWeek}
+              previous={postSession.avgRatingLastWeek}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            n={postSession.sampleSizeLastWeek}
+          </p>
+        </div>
+        <MetricCard
+          label="5-Star Rate"
+          value={`${postSession.fiveStarPct}%`}
+          info="Percentage of all post-session ratings that are 5/5. A high number means users are consistently happy after workouts."
+        />
+        <MetricCard
+          label="Total Rated"
+          value={postSession.totalRated}
+          info="Total number of post-session feedback submissions with a rating, all time."
+        />
+      </div>
+
+      {/* Rating Distribution */}
+      <div>
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+          Rating Distribution
+        </h3>
+        <div className="space-y-2">
+          {[5, 4, 3, 2, 1].map((rating) => {
+            const count = postSession.ratingDistribution[rating] || 0
+            const pct = totalDistribution > 0 ? (count / totalDistribution) * 100 : 0
+            return (
+              <div key={rating} className="flex items-center gap-3">
+                <div className="w-8 text-sm text-foreground font-semibold text-right">
+                  {rating}
+                </div>
+                <div className="flex-1 bg-background rounded-full h-5 overflow-hidden border border-border">
+                  <div
+                    className={`h-full rounded-full flex items-center justify-end pr-2 ${
+                      rating >= 4
+                        ? 'bg-green-600/60'
+                        : rating === 3
+                          ? 'bg-yellow-600/60'
+                          : 'bg-red-600/60'
+                    }`}
+                    style={{ width: `${Math.max(pct, 3)}%` }}
+                  >
+                    <span className="text-xs font-semibold text-foreground">
+                      {count}
+                    </span>
+                  </div>
+                </div>
+                <div className="w-12 text-right text-xs text-muted-foreground">
+                  {Math.round(pct)}%
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Top Refinements */}
+      {postSession.topRefinements.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            Top Refinement Categories
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left py-2 px-3 text-muted-foreground font-medium">
+                    Category
+                  </th>
+                  <th className="text-right py-2 px-3 text-muted-foreground font-medium">
+                    Count
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {postSession.topRefinements.map((r) => (
+                  <tr key={r.refinement} className="border-b border-border/50">
+                    <td className="py-2 px-3 text-foreground">
+                      {refinementLabels[r.refinement] || r.refinement.replace(/_/g, ' ')}
+                    </td>
+                    <td className="py-2 px-3 text-right text-foreground font-semibold">
+                      {r.count}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <Link
+        href="/admin/feedback?tab=post_session"
+        className="inline-block text-sm text-orange-500 hover:text-orange-400 transition-colors"
+      >
+        View all post-session feedback
+      </Link>
     </div>
   )
 }

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { Check, CheckCheck, ExternalLink, Github, MessageSquarePlus, Tag } from 'lucide-react'
+import { ArrowDown, ArrowUp, Check, CheckCheck, ExternalLink, Github, MessageSquarePlus, Tag } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import type { FeedbackStatus } from '@/types/feedback'
+import { POST_SESSION_REFINEMENTS } from '@/types/feedback'
 
 interface FeedbackItem {
   id: string
@@ -22,7 +23,18 @@ interface FeedbackItem {
   refinements: string[]
 }
 
+interface PostSessionStats {
+  avgRatingOverall: number | null
+  avgRatingThisWeek: number | null
+  sampleSizeOverall: number
+  sampleSizeThisWeek: number
+  ratingDistribution: Record<number, number>
+  fiveStarPct: number
+  refinementCounts: Array<{ refinement: string; count: number }>
+}
+
 const STATUS_TABS = ['unresolved', 'all', 'new', 'reviewed', 'resolved'] as const
+type TabValue = typeof STATUS_TABS[number] | 'post_session'
 
 const CATEGORY_LABELS: Record<string, string> = {
   bug: 'bug',
@@ -32,11 +44,20 @@ const CATEGORY_LABELS: Record<string, string> = {
   post_session: 'post-session',
 }
 
+const REFINEMENT_LABELS: Record<string, string> = {}
+for (const r of POST_SESSION_REFINEMENTS) {
+  REFINEMENT_LABELS[r.value] = r.label
+}
+
+type SortOption = 'newest' | 'rating_asc' | 'rating_desc'
+
 export default function AdminFeedbackPage() {
   const [feedback, setFeedback] = useState<FeedbackItem[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
-  const [activeStatus, setActiveStatus] = useState<string>('unresolved')
+  const [activeTab, setActiveTab] = useState<TabValue>('unresolved')
+  const [sortBy, setSortBy] = useState<SortOption>('newest')
+  const [postSessionStats, setPostSessionStats] = useState<PostSessionStats | null>(null)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [adminNote, setAdminNote] = useState('')
   const [updating, setUpdating] = useState<string | null>(null)
@@ -48,8 +69,12 @@ export default function AdminFeedbackPage() {
   useEffect(() => {
     const expandId = searchParams.get('expand')
     if (expandId) {
-      setActiveStatus('all')
+      setActiveTab('all')
       setExpandedId(expandId)
+    }
+    const tab = searchParams.get('tab')
+    if (tab === 'post_session') {
+      setActiveTab('post_session')
     }
   }, [searchParams])
 
@@ -58,8 +83,19 @@ export default function AdminFeedbackPage() {
     setLoading(true)
 
     const params = new URLSearchParams()
-    if (activeStatus !== 'all') params.set('status', activeStatus)
-    // 'unresolved' is passed to API which handles it as status IN ['new', 'reviewed']
+    const isPostSession = activeTab === 'post_session'
+
+    if (isPostSession) {
+      params.set('category', 'post_session')
+    } else if (activeTab !== 'all') {
+      params.set('status', activeTab)
+    }
+
+    // Apply sort for post-session tab
+    if (isPostSession && sortBy !== 'newest') {
+      params.set('sort', sortBy)
+    }
+
     params.set('limit', '100')
 
     fetch(`/api/feedback?${params}`)
@@ -68,6 +104,7 @@ export default function AdminFeedbackPage() {
         if (!cancelled) {
           setFeedback(json.feedback || [])
           setTotal(json.total || 0)
+          setPostSessionStats(json.postSessionStats || null)
           setLoading(false)
 
           // If auto-expanding from URL, set the admin note for the expanded item
@@ -81,7 +118,7 @@ export default function AdminFeedbackPage() {
       .catch(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [activeStatus, searchParams])
+  }, [activeTab, sortBy, searchParams])
 
   const updateFeedback = async (id: string, status: FeedbackStatus, note?: string) => {
     setUpdating(id)
@@ -178,6 +215,8 @@ export default function AdminFeedbackPage() {
     }
   }
 
+  const isPostSessionTab = activeTab === 'post_session'
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -188,15 +227,15 @@ export default function AdminFeedbackPage() {
         <span className="text-sm text-muted-foreground">{total} total</span>
       </div>
 
-      {/* Status tabs */}
+      {/* Tabs: status tabs + post-session tab */}
       <div className="flex gap-1 mb-6 overflow-x-auto">
         {STATUS_TABS.map((tab) => (
           <button
             type="button"
             key={tab}
-            onClick={() => setActiveStatus(tab)}
+            onClick={() => { setActiveTab(tab); setSortBy('newest') }}
             className={`px-3 py-1.5 text-xs font-semibold uppercase tracking-wider border-2 transition-colors ${
-              activeStatus === tab
+              activeTab === tab
                 ? 'bg-primary text-primary-foreground border-primary'
                 : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
             }`}
@@ -204,14 +243,148 @@ export default function AdminFeedbackPage() {
             {tab}
           </button>
         ))}
+        <span className="w-px bg-border mx-1" />
+        <button
+          type="button"
+          onClick={() => { setActiveTab('post_session'); setSortBy('newest') }}
+          className={`px-3 py-1.5 text-xs font-semibold uppercase tracking-wider border-2 transition-colors ${
+            isPostSessionTab
+              ? 'bg-purple-600 text-white border-purple-600'
+              : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+          }`}
+        >
+          Post-Session
+        </button>
       </div>
+
+      {/* Post-session stats header */}
+      {isPostSessionTab && postSessionStats && (
+        <div className="mb-6 bg-card border-2 border-border p-4 space-y-4">
+          {/* Average ratings row */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className="bg-background border border-border p-3">
+              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                Avg Rating (Overall)
+              </div>
+              <div className="text-2xl font-bold text-foreground">
+                {postSessionStats.avgRatingOverall !== null
+                  ? `${postSessionStats.avgRatingOverall}/5`
+                  : '--'}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                n={postSessionStats.sampleSizeOverall}
+              </p>
+            </div>
+            <div className="bg-background border border-border p-3">
+              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                Avg Rating (This Week)
+              </div>
+              <div className="text-2xl font-bold text-foreground">
+                {postSessionStats.avgRatingThisWeek !== null
+                  ? `${postSessionStats.avgRatingThisWeek}/5`
+                  : '--'}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                n={postSessionStats.sampleSizeThisWeek}
+              </p>
+            </div>
+            <div className="bg-background border border-border p-3">
+              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                5-Star Rate
+              </div>
+              <div className="text-2xl font-bold text-foreground">
+                {postSessionStats.fiveStarPct}%
+              </div>
+            </div>
+            <div className="bg-background border border-border p-3">
+              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                Rating Distribution
+              </div>
+              <div className="flex items-end gap-1 h-8">
+                {[1, 2, 3, 4, 5].map((r) => {
+                  const count = postSessionStats.ratingDistribution[r] || 0
+                  const maxCount = Math.max(...Object.values(postSessionStats.ratingDistribution), 1)
+                  const height = Math.max((count / maxCount) * 100, 5)
+                  return (
+                    <div key={r} className="flex-1 flex flex-col items-center gap-0.5">
+                      <div
+                        className={`w-full ${r >= 4 ? 'bg-green-500' : r === 3 ? 'bg-yellow-500' : 'bg-red-500'}`}
+                        style={{ height: `${height}%` }}
+                        title={`${r}: ${count}`}
+                      />
+                      <span className="text-[10px] text-muted-foreground">{r}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* Refinement categories breakdown */}
+          {postSessionStats.refinementCounts.length > 0 && (
+            <div>
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+                Issue Categories
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {postSessionStats.refinementCounts.map((r) => (
+                  <span
+                    key={r.refinement}
+                    className="text-xs px-2 py-1 border font-semibold bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700"
+                  >
+                    {REFINEMENT_LABELS[r.refinement] || r.refinement.replace(/_/g, ' ')} ({r.count})
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Sort controls */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground uppercase tracking-wider">Sort:</span>
+            <button
+              type="button"
+              onClick={() => setSortBy('newest')}
+              className={`px-2 py-1 text-xs font-semibold border transition-colors ${
+                sortBy === 'newest'
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+              }`}
+            >
+              Newest
+            </button>
+            <button
+              type="button"
+              onClick={() => setSortBy('rating_asc')}
+              className={`px-2 py-1 text-xs font-semibold border transition-colors flex items-center gap-1 ${
+                sortBy === 'rating_asc'
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+              }`}
+            >
+              <ArrowUp size={12} /> Rating (Low First)
+            </button>
+            <button
+              type="button"
+              onClick={() => setSortBy('rating_desc')}
+              className={`px-2 py-1 text-xs font-semibold border transition-colors flex items-center gap-1 ${
+                sortBy === 'rating_desc'
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-muted text-muted-foreground border-border hover:bg-secondary'
+              }`}
+            >
+              <ArrowDown size={12} /> Rating (High First)
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Feedback list */}
       {loading ? (
         <div className="text-sm text-muted-foreground">Loading...</div>
       ) : feedback.length === 0 ? (
         <div className="text-sm text-muted-foreground py-8 text-center">
-          No {activeStatus === 'all' ? '' : activeStatus} feedback yet.
+          No {isPostSessionTab ? 'post-session' : activeTab === 'all' ? '' : activeTab} feedback yet.
         </div>
       ) : (
         <div className="space-y-2">
@@ -235,7 +408,7 @@ export default function AdminFeedbackPage() {
                     )}
                     {item.refinements?.length > 0 && (
                       <span className="text-sm text-muted-foreground">
-                        — {item.refinements.join(', ')}
+                        — {item.refinements.map((r) => REFINEMENT_LABELS[r] || r.replace(/_/g, ' ')).join(', ')}
                       </span>
                     )}
                     {item.message ? (
@@ -319,7 +492,7 @@ export default function AdminFeedbackPage() {
                       <div className="flex flex-wrap gap-1.5 bg-muted p-3 border border-border">
                         {item.refinements.map((r) => (
                           <span key={r} className="text-xs px-2 py-1 border font-semibold uppercase bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700">
-                            {r.replace(/_/g, ' ')}
+                            {REFINEMENT_LABELS[r] || r.replace(/_/g, ' ')}
                           </span>
                         ))}
                       </div>

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -154,6 +154,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const status = searchParams.get('status')
     const categoryFilter = searchParams.get('category')
+    const sort = searchParams.get('sort') // 'rating_asc' or 'rating_desc'
     const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100)
     const offset = parseInt(searchParams.get('offset') || '0', 10)
 
@@ -167,19 +168,105 @@ export async function GET(request: NextRequest) {
       where.category = categoryFilter
     }
 
-    const [feedback, total] = await Promise.all([
+    // Determine sort order
+    type OrderByClause = Record<string, 'asc' | 'desc'>
+    let orderBy: OrderByClause | OrderByClause[] = { createdAt: 'desc' as const }
+    if (sort === 'rating_asc') {
+      orderBy = [{ rating: 'asc' as const }, { createdAt: 'desc' as const }]
+    } else if (sort === 'rating_desc') {
+      orderBy = [{ rating: 'desc' as const }, { createdAt: 'desc' as const }]
+    }
+
+    const queries: [Promise<unknown[]>, Promise<number>, ...Promise<unknown>[]] = [
       prisma.feedback.findMany({
         where,
-        orderBy: { createdAt: 'desc' },
+        orderBy,
         take: limit,
         skip: offset,
       }),
       prisma.feedback.count({ where }),
-    ])
+    ]
 
-    return NextResponse.json({ feedback, total, limit, offset })
+    // When filtering by post_session, include aggregation stats
+    const isPostSession = categoryFilter === 'post_session'
+    if (isPostSession) {
+      queries.push(
+        prisma.feedback.aggregate({
+          where: { category: 'post_session' },
+          _avg: { rating: true },
+          _count: { rating: true },
+        }),
+        prisma.feedback.aggregate({
+          where: {
+            category: 'post_session',
+            createdAt: { gte: startOfWeek() },
+          },
+          _avg: { rating: true },
+          _count: { rating: true },
+        }),
+        prisma.feedback.groupBy({
+          by: ['rating'],
+          where: { category: 'post_session', rating: { not: null } },
+          _count: { rating: true },
+          orderBy: { rating: 'asc' },
+        }),
+        // Refinement counts via raw query (Prisma can't group by array elements)
+        prisma.$queryRaw`
+          SELECT unnest(refinements) as refinement, COUNT(*)::int as count
+          FROM "Feedback"
+          WHERE category = 'post_session' AND array_length(refinements, 1) > 0
+          GROUP BY refinement
+          ORDER BY count DESC
+        `,
+      )
+    }
+
+    const results = await Promise.all(queries)
+    const feedback = results[0]
+    const total = results[1] as number
+
+    const responseBody: Record<string, unknown> = { feedback, total, limit, offset }
+
+    if (isPostSession) {
+      const overallAgg = results[2] as { _avg: { rating: number | null }; _count: { rating: number } }
+      const weekAgg = results[3] as { _avg: { rating: number | null }; _count: { rating: number } }
+      const ratingGroups = results[4] as Array<{ rating: number; _count: { rating: number } }>
+      const refinementCounts = results[5] as Array<{ refinement: string; count: number }>
+
+      // Build rating distribution (1-5)
+      const ratingDistribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+      for (const g of ratingGroups) {
+        if (g.rating >= 1 && g.rating <= 5) {
+          ratingDistribution[g.rating] = g._count.rating
+        }
+      }
+
+      const totalRated = overallAgg._count.rating
+      const fiveStarCount = ratingDistribution[5]
+      const fiveStarPct = totalRated > 0 ? Math.round((fiveStarCount / totalRated) * 100) : 0
+
+      responseBody.postSessionStats = {
+        avgRatingOverall: overallAgg._avg.rating ? Math.round(overallAgg._avg.rating * 10) / 10 : null,
+        avgRatingThisWeek: weekAgg._avg.rating ? Math.round(weekAgg._avg.rating * 10) / 10 : null,
+        sampleSizeOverall: totalRated,
+        sampleSizeThisWeek: weekAgg._count.rating,
+        ratingDistribution,
+        fiveStarPct,
+        refinementCounts,
+      }
+    }
+
+    return NextResponse.json(responseBody)
   } catch (error) {
     logger.error({ error, context: 'feedback-list' }, 'Failed to list feedback')
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
+}
+
+/** Returns the start of the current week (Sunday 00:00:00) */
+function startOfWeek(): Date {
+  const d = new Date()
+  d.setDate(d.getDate() - d.getDay())
+  d.setHours(0, 0, 0, 0)
+  return d
 }

--- a/lib/admin/analytics-queries.ts
+++ b/lib/admin/analytics-queries.ts
@@ -137,12 +137,24 @@ export interface SignupAttributionMetrics {
   windowDays: number
 }
 
+export interface PostSessionMetrics {
+  avgRatingThisWeek: number | null
+  avgRatingLastWeek: number | null
+  sampleSizeThisWeek: number
+  sampleSizeLastWeek: number
+  ratingDistribution: Record<number, number>
+  topRefinements: Array<{ refinement: string; count: number }>
+  fiveStarPct: number
+  totalRated: number
+}
+
 export interface AnalyticsData {
   usage: UsageMetrics
   retention: RetentionMetrics
   funnel: FunnelStep[]
   feedbackVolume: FeedbackVolume[]
   signupAttribution: SignupAttributionMetrics
+  postSession: PostSessionMetrics
   generatedAt: string
 }
 
@@ -581,19 +593,81 @@ async function getSignupAttributionMetrics(
   return { sourceBreakdown, perGym, qrFunnel, windowDays }
 }
 
+async function getPostSessionMetrics(db: Db): Promise<PostSessionMetrics> {
+  const weekStart = startOfWeek()
+  const lastWeekStart = weeksAgo(1)
+
+  const [thisWeekAvg, lastWeekAvg, distribution, refinements] = await Promise.all([
+    db.$queryRaw<[{ avg: number | null; count: bigint }]>`
+      SELECT AVG(rating) as avg, COUNT(*)::bigint as count
+      FROM "Feedback"
+      WHERE category = 'post_session' AND rating IS NOT NULL
+        AND "createdAt" >= ${weekStart}
+    `,
+    db.$queryRaw<[{ avg: number | null; count: bigint }]>`
+      SELECT AVG(rating) as avg, COUNT(*)::bigint as count
+      FROM "Feedback"
+      WHERE category = 'post_session' AND rating IS NOT NULL
+        AND "createdAt" >= ${lastWeekStart} AND "createdAt" < ${weekStart}
+    `,
+    db.$queryRaw<Array<{ rating: number; count: bigint }>>`
+      SELECT rating, COUNT(*)::bigint as count
+      FROM "Feedback"
+      WHERE category = 'post_session' AND rating IS NOT NULL
+      GROUP BY rating
+      ORDER BY rating ASC
+    `,
+    db.$queryRaw<Array<{ refinement: string; count: bigint }>>`
+      SELECT unnest(refinements) as refinement, COUNT(*)::bigint as count
+      FROM "Feedback"
+      WHERE category = 'post_session' AND array_length(refinements, 1) > 0
+      GROUP BY refinement
+      ORDER BY count DESC
+    `,
+  ])
+
+  const ratingDistribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+  let totalRated = 0
+  for (const row of distribution) {
+    if (row.rating >= 1 && row.rating <= 5) {
+      const cnt = Number(row.count)
+      ratingDistribution[row.rating] = cnt
+      totalRated += cnt
+    }
+  }
+
+  const fiveStarCount = ratingDistribution[5]
+  const fiveStarPct = totalRated > 0 ? Math.round((fiveStarCount / totalRated) * 100) : 0
+
+  return {
+    avgRatingThisWeek: thisWeekAvg[0].avg ? Math.round(Number(thisWeekAvg[0].avg) * 10) / 10 : null,
+    avgRatingLastWeek: lastWeekAvg[0].avg ? Math.round(Number(lastWeekAvg[0].avg) * 10) / 10 : null,
+    sampleSizeThisWeek: Number(thisWeekAvg[0].count),
+    sampleSizeLastWeek: Number(lastWeekAvg[0].count),
+    ratingDistribution,
+    topRefinements: refinements.map((r) => ({
+      refinement: r.refinement,
+      count: Number(r.count),
+    })),
+    fiveStarPct,
+    totalRated,
+  }
+}
+
 // ---- Main ----
 
 export async function getAnalyticsData(
   db: Db = defaultPrisma,
 ): Promise<AnalyticsData> {
   try {
-    const [usage, retention, funnel, feedbackVolume, signupAttribution] =
+    const [usage, retention, funnel, feedbackVolume, signupAttribution, postSession] =
       await Promise.all([
         getUsageMetrics(db),
         getRetentionMetrics(db),
         getFunnelMetrics(db),
         getFeedbackVolume(db),
         getSignupAttributionMetrics(db),
+        getPostSessionMetrics(db),
       ])
 
     return {
@@ -602,6 +676,7 @@ export async function getAnalyticsData(
       funnel,
       feedbackVolume,
       signupAttribution,
+      postSession,
       generatedAt: new Date().toISOString(),
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds a **Post-Session tab** to the admin feedback page (`/admin/feedback`) showing only post-workout feedback entries with rating, refinement categories as chips, and optional comments
- Displays **average rating** (overall + this week), **5-star rate**, **rating distribution** mini-chart, and **refinement category breakdown** at the top of the post-session tab
- Adds **sort-by-rating** controls (low ratings first for triage, high first, newest) to the post-session tab
- Extends `GET /api/feedback` to support `sort=rating_asc|rating_desc` and returns aggregation stats (`postSessionStats`) when filtering by `category=post_session`
- Adds **Post-Session Feedback** section to the analytics page (`/admin/analytics`) with this-week vs last-week average rating trend arrows, rating distribution bar chart, top refinement categories table, and 5-star rate metric
- Adds `PostSessionMetrics` type and `getPostSessionMetrics()` query to `lib/admin/analytics-queries.ts`

## Pre-existing lint issues (not introduced by this PR)
- `__tests__/lib/rate-limit.test.ts`: missing `@ts-expect-error` description
- `app/(auth)/onboarding/page.tsx`: unused eslint-disable directives
- `components/ExerciseLoggingModal.tsx`: missing useCallback dependency
- `components/admin/MediaUploader.tsx`: `<img>` element warning
- `components/programs/ConsolidatedProgramsView.tsx`: unused variable

## Test plan
- [ ] Visit `/admin/feedback` and verify the Post-Session tab shows only post_session feedback
- [ ] Verify average rating stats, distribution chart, and refinement breakdown appear when post-session tab is active
- [ ] Verify sort controls work (low rating first surfaces problematic entries)
- [ ] Visit `/admin/analytics` and verify the Post-Session Feedback section shows rating trends with arrows, distribution bars, and refinement table
- [ ] Verify `?tab=post_session` URL param auto-selects the post-session tab on the feedback page
- [ ] Verify link from analytics page ("View all post-session feedback") navigates correctly

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)