### PR TITLE
Style active program card with accent border and label

### DIFF
--- a/components/programs/ActiveProgramStrip.tsx
+++ b/components/programs/ActiveProgramStrip.tsx
@@ -26,7 +26,7 @@ export default function ActiveProgramStrip({
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <div className="border border-border bg-card doom-noise">
+    <div className="border border-primary/40 border-l-4 border-l-primary bg-primary/5 doom-noise">
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -34,9 +34,14 @@ export default function ActiveProgramStrip({
       >
         <Star size={18} className="text-success shrink-0" fill="currentColor" />
         <div className="flex-1 min-w-0">
-          <h3 className="text-base font-bold text-foreground doom-heading uppercase truncate">
-            {programName}
-          </h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-bold text-foreground doom-heading uppercase truncate">
+              {programName}
+            </h3>
+            <span className="text-xs font-bold text-primary uppercase tracking-wider shrink-0">
+              ACTIVE
+            </span>
+          </div>
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             {currentWeek && totalWeeks && (
               <span>Week {currentWeek} of {totalWeeks}</span>


### PR DESCRIPTION
## Summary
- Added primary-colored left border (4px) and subtle border tint (`border-primary/40`) to the active program card
- Added light primary background tint (`bg-primary/5`) to differentiate from inactive cards
- Added "ACTIVE" label badge next to program name in the accent color

All styling uses CSS custom property tokens (`primary`, `primary/40`, `primary/5`) so it works across all DOOM theme variants. No layout changes — purely visual enhancement.

## Test plan
- [ ] Active program card is visually distinct from inactive program cards at a glance
- [ ] "ACTIVE" label appears next to program name
- [ ] Left accent border is visible in primary color
- [ ] Subtle background tint differentiates from inactive cards
- [ ] Works in all DOOM theme variants (light/dark)
- [ ] No layout shifts or overflow on mobile (375px width)

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)