### PR TITLE
Admin: add image URLs and preview to exercise editor

### DIFF
--- a/app/api/admin/exercise-definitions/[id]/route.ts
+++ b/app/api/admin/exercise-definitions/[id]/route.ts
@@ -37,6 +37,7 @@ export async function GET(
         aliases: true,
         instructions: true,
         notes: true,
+        imageUrls: true,
         isSystem: true,
         createdBy: true,
         userId: true,
@@ -123,6 +124,7 @@ export async function PATCH(
       aliases: body.aliases,
       instructions: body.instructions,
       notes: body.notes,
+      imageUrls: body.imageUrls,
     }
 
     // Validate input
@@ -170,6 +172,7 @@ export async function PATCH(
     if (input.aliases !== undefined) updateData.aliases = input.aliases
     if (input.instructions !== undefined) updateData.instructions = input.instructions
     if (input.notes !== undefined) updateData.notes = input.notes
+    if (input.imageUrls !== undefined) updateData.imageUrls = input.imageUrls
 
     // Update exercise definition
     const updated = await prisma.exerciseDefinition.update({
@@ -186,6 +189,7 @@ export async function PATCH(
         aliases: true,
         instructions: true,
         notes: true,
+        imageUrls: true,
         isSystem: true,
         createdBy: true,
         createdAt: true,

--- a/app/api/admin/exercise-definitions/route.ts
+++ b/app/api/admin/exercise-definitions/route.ts
@@ -195,6 +195,7 @@ export async function POST(request: NextRequest) {
       aliases: body.aliases || [],
       instructions: body.instructions,
       notes: body.notes,
+      imageUrls: body.imageUrls || [],
     }
 
     // Validate input
@@ -234,6 +235,7 @@ export async function POST(request: NextRequest) {
         aliases: input.aliases || [],
         instructions: input.instructions,
         notes: input.notes,
+        imageUrls: input.imageUrls || [],
         isSystem: true, // Admin creates system exercises
         createdBy: user.id,
         userId: user.id, // Track who created it even for system exercises
@@ -249,6 +251,7 @@ export async function POST(request: NextRequest) {
         aliases: true,
         instructions: true,
         notes: true,
+        imageUrls: true,
         isSystem: true,
         createdBy: true,
         createdAt: true,

--- a/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
+++ b/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
+import { useToast } from '@/components/ToastProvider';
 import { Button } from '@/components/ui/Button';
 import { clientLogger } from '@/lib/client-logger';
 import EquipmentSelector from './EquipmentSelector';
+import ExerciseInfoPreview from './ExerciseInfoPreview';
 import FAUSelector from './FAUSelector';
 
 export interface ExerciseDefinition {
@@ -16,6 +19,7 @@ export interface ExerciseDefinition {
   aliases: string[];
   instructions?: string;
   notes?: string;
+  imageUrls?: string[];
 }
 
 export interface ExerciseDefinitionEditorModalProps {
@@ -37,6 +41,8 @@ export default function ExerciseDefinitionEditorModal({
   onSuccess,
   apiBasePath = '/api/exercise-definitions',
 }: ExerciseDefinitionEditorModalProps) {
+  const toast = useToast();
+  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
   const [formData, setFormData] = useState({
     name: initialName,
     equipment: [] as string[],
@@ -46,6 +52,7 @@ export default function ExerciseDefinitionEditorModal({
     aliases: [] as string[],
     instructions: '',
     notes: '',
+    imageUrls: [] as string[],
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isDuplicateName, setIsDuplicateName] = useState(false);
@@ -73,6 +80,7 @@ export default function ExerciseDefinitionEditorModal({
               aliases: exercise.aliases || [],
               instructions: exercise.instructions || '',
               notes: exercise.notes || '',
+              imageUrls: exercise.imageUrls || [],
             });
             setUsageCount(exercise.usageCount || 0);
           }
@@ -94,9 +102,11 @@ export default function ExerciseDefinitionEditorModal({
         aliases: [],
         instructions: '',
         notes: '',
+        imageUrls: [],
       });
       setUsageCount(0);
     }
+    setActiveTab('edit');
   }, [isOpen, mode, exerciseId, initialName, apiBasePath]);
 
   // Debounced duplicate check
@@ -149,6 +159,7 @@ export default function ExerciseDefinitionEditorModal({
           aliases: formData.aliases,
           instructions: formData.instructions || null,
           notes: formData.notes || null,
+          imageUrls: formData.imageUrls,
         }),
       });
 
@@ -171,6 +182,12 @@ export default function ExerciseDefinitionEditorModal({
         onSuccess(data.data);
       }
 
+      const action = mode === 'create' ? 'Created' : 'Updated';
+      toast.success(
+        `${action}: ${data.data?.name || formData.name}`,
+        data.data?.id ? `ID: ${data.data.id}` : undefined
+      );
+
       onClose();
     } catch (error) {
       clientLogger.error('Error saving exercise:', error);
@@ -178,7 +195,7 @@ export default function ExerciseDefinitionEditorModal({
     } finally {
       setIsSubmitting(false);
     }
-  }, [mode, exerciseId, formData, onSuccess, onClose, apiBasePath]);
+  }, [mode, exerciseId, formData, onSuccess, onClose, apiBasePath, toast]);
 
   const handleClose = useCallback(() => {
     setFormData({
@@ -190,10 +207,12 @@ export default function ExerciseDefinitionEditorModal({
       aliases: [],
       instructions: '',
       notes: '',
+      imageUrls: [],
     });
     setErrors({});
     setIsDuplicateName(false);
     setUsageCount(0);
+    setActiveTab('edit');
     onClose();
   }, [onClose]);
 
@@ -222,12 +241,46 @@ export default function ExerciseDefinitionEditorModal({
           </h2>
         </div>
 
+        {/* Tab Switcher */}
+        <div className="flex border-b-2 border-border">
+          <button
+            type="button"
+            onClick={() => setActiveTab('edit')}
+            className={`flex-1 px-4 py-2 text-sm font-bold uppercase tracking-wide transition-colors ${
+              activeTab === 'edit'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/30 text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('preview')}
+            className={`flex-1 px-4 py-2 text-sm font-bold uppercase tracking-wide transition-colors ${
+              activeTab === 'preview'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/30 text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Preview
+          </button>
+        </div>
+
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-6 space-y-6">
           {isLoading ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-muted-foreground">Loading...</div>
             </div>
+          ) : activeTab === 'preview' ? (
+            <ExerciseInfoPreview
+              imageUrls={formData.imageUrls}
+              instructions={formData.instructions}
+              primaryFAUs={formData.primaryFAUs}
+              secondaryFAUs={formData.secondaryFAUs}
+              equipment={formData.equipment}
+            />
           ) : (
             <>
               {/* Usage Warning */}
@@ -384,6 +437,88 @@ export default function ExerciseDefinitionEditorModal({
                   placeholder="Additional notes or tips..."
                 />
                 {errors.notes && <p className="text-sm text-error font-medium mt-1">{errors.notes}</p>}
+              </div>
+
+              {/* Image URLs */}
+              <div>
+                <div className="flex justify-between items-center mb-2">
+                  <span className="block text-sm font-semibold text-foreground uppercase tracking-wide">
+                    Image URLs
+                  </span>
+                  <span className="text-xs text-muted-foreground">{formData.imageUrls.length} / 10</span>
+                </div>
+                <p className="text-xs text-muted-foreground mb-3">
+                  Add image URLs for this exercise. Order determines display order in the Info tab.
+                </p>
+
+                {formData.imageUrls.map((url, index) => (
+                  <div key={index} className="flex items-center gap-2 mb-2">
+                    <div className="flex flex-col gap-0.5">
+                      <button
+                        type="button"
+                        disabled={index === 0}
+                        onClick={() => {
+                          const urls = [...formData.imageUrls];
+                          [urls[index - 1], urls[index]] = [urls[index], urls[index - 1]];
+                          setFormData({ ...formData, imageUrls: urls });
+                        }}
+                        className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                        aria-label={`Move image ${index + 1} up`}
+                      >
+                        <ArrowUp size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        disabled={index === formData.imageUrls.length - 1}
+                        onClick={() => {
+                          const urls = [...formData.imageUrls];
+                          [urls[index], urls[index + 1]] = [urls[index + 1], urls[index]];
+                          setFormData({ ...formData, imageUrls: urls });
+                        }}
+                        className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                        aria-label={`Move image ${index + 1} down`}
+                      >
+                        <ArrowDown size={14} />
+                      </button>
+                    </div>
+                    <input
+                      type="text"
+                      value={url}
+                      onChange={(e) => {
+                        const urls = [...formData.imageUrls];
+                        urls[index] = e.target.value;
+                        setFormData({ ...formData, imageUrls: urls });
+                      }}
+                      className="flex-1 px-3 py-2 border-2 border-border rounded bg-background text-foreground text-sm focus:border-primary"
+                      placeholder="https://..."
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const urls = formData.imageUrls.filter((_, i) => i !== index);
+                        setFormData({ ...formData, imageUrls: urls });
+                      }}
+                      className="p-1.5 text-muted-foreground hover:text-error transition-colors"
+                      aria-label={`Remove image ${index + 1}`}
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
+                ))}
+
+                {formData.imageUrls.length < 10 && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFormData({ ...formData, imageUrls: [...formData.imageUrls, ''] });
+                    }}
+                    className="flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 font-medium mt-1"
+                  >
+                    <Plus size={16} />
+                    Add Image URL
+                  </button>
+                )}
+                {errors.imageUrls && <p className="text-sm text-error font-medium mt-1">{errors.imageUrls}</p>}
               </div>
             </>
           )}

--- a/components/features/exercise-definition/ExerciseInfoPreview.tsx
+++ b/components/features/exercise-definition/ExerciseInfoPreview.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
+import { FAU_DISPLAY_NAMES } from '@/lib/fau-volume'
+
+interface ExerciseInfoPreviewProps {
+  imageUrls: string[]
+  instructions: string
+  primaryFAUs: string[]
+  secondaryFAUs: string[]
+  equipment: string[]
+}
+
+/**
+ * Preview component that mirrors the Info tab rendering from ExerciseDisplayTabs.
+ * Used in the admin exercise editor to preview how exercise info will appear
+ * in the workout logger.
+ */
+export default function ExerciseInfoPreview({
+  imageUrls,
+  instructions,
+  primaryFAUs,
+  secondaryFAUs,
+  equipment,
+}: ExerciseInfoPreviewProps) {
+  const [expandedImage, setExpandedImage] = useState<string | null>(null)
+
+  const hasContent =
+    imageUrls.length > 0 ||
+    instructions.trim() ||
+    primaryFAUs.length > 0 ||
+    secondaryFAUs.length > 0 ||
+    equipment.length > 0
+
+  return (
+    <div className="border-2 border-border rounded bg-background p-4">
+      <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-3">
+        Info Tab Preview
+      </h4>
+
+      {!hasContent && (
+        <div className="flex items-center justify-center py-8">
+          <p className="text-sm text-muted-foreground">No info available for this exercise</p>
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {imageUrls.length > 0 && (
+          <div>
+            <div className="grid grid-cols-2 gap-3">
+              {imageUrls.map((url, i) => {
+                const src = url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
+                return (
+                  <button
+                    key={`${url}-${i}`}
+                    type="button"
+                    onClick={() => setExpandedImage(src)}
+                    className="relative aspect-square rounded-lg overflow-hidden bg-muted cursor-pointer"
+                  >
+                    <Image
+                      src={src}
+                      alt={`Exercise image ${i + 1}`}
+                      fill
+                      className="object-cover"
+                      sizes="200px"
+                    />
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {instructions.trim() && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">
+              INSTRUCTIONS
+            </h4>
+            <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
+              {instructions}
+            </p>
+          </div>
+        )}
+
+        {primaryFAUs.length > 0 && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">
+              PRIMARY MUSCLES
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {primaryFAUs.map((fau) => (
+                <span
+                  key={fau}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
+                >
+                  {FAU_DISPLAY_NAMES[fau] || fau}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {secondaryFAUs.length > 0 && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">
+              SECONDARY MUSCLES
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {secondaryFAUs.map((fau) => (
+                <span
+                  key={fau}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
+                >
+                  {FAU_DISPLAY_NAMES[fau] || fau}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {equipment.length > 0 && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">
+              EQUIPMENT
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {equipment.map((item) => (
+                <span
+                  key={item}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
+                >
+                  {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Fullscreen image viewer */}
+      {expandedImage && (
+        <div
+          style={{ position: 'fixed', inset: 0, zIndex: 200 }}
+          className="bg-black/90 flex items-center justify-center"
+        >
+          <button
+            type="button"
+            onClick={() => setExpandedImage(null)}
+            className="absolute inset-0 w-full h-full"
+            aria-label="Close image"
+          />
+          <div className="relative w-[90vw] h-[90vh]">
+            <Image
+              src={expandedImage}
+              alt="Exercise image expanded"
+              fill
+              className="object-contain"
+              sizes="90vw"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/validators/exercise-definition.ts
+++ b/lib/validators/exercise-definition.ts
@@ -11,6 +11,7 @@ export interface CreateExerciseDefinitionInput {
   aliases?: string[];
   instructions?: string;
   notes?: string;
+  imageUrls?: string[];
 }
 
 export interface UpdateExerciseDefinitionInput {
@@ -22,6 +23,7 @@ export interface UpdateExerciseDefinitionInput {
   aliases?: string[];
   instructions?: string;
   notes?: string;
+  imageUrls?: string[];
 }
 
 export interface ValidationError {
@@ -37,6 +39,8 @@ const MAX_ALIAS_LENGTH = 50;
 const MAX_ALIASES = 10;
 const MAX_INSTRUCTIONS_LENGTH = 400;
 const MAX_NOTES_LENGTH = 400;
+const MAX_IMAGE_URLS = 10;
+const MAX_IMAGE_URL_LENGTH = 500;
 
 export function normalizeExerciseName(name: string): string {
   return name
@@ -151,6 +155,32 @@ export function validateExerciseDefinition(
       field: 'notes',
       message: `Notes must be ${MAX_NOTES_LENGTH} characters or less`,
     });
+  }
+
+  // Image URLs validation (optional)
+  if (input.imageUrls) {
+    if (input.imageUrls.length > MAX_IMAGE_URLS) {
+      errors.push({
+        field: 'imageUrls',
+        message: `Maximum ${MAX_IMAGE_URLS} image URLs allowed`,
+      });
+    }
+    const tooLongUrls = input.imageUrls.filter(
+      (url) => url.length > MAX_IMAGE_URL_LENGTH
+    );
+    if (tooLongUrls.length > 0) {
+      errors.push({
+        field: 'imageUrls',
+        message: `Image URLs must be ${MAX_IMAGE_URL_LENGTH} characters or less`,
+      });
+    }
+    const emptyUrls = input.imageUrls.filter((url) => !url.trim());
+    if (emptyUrls.length > 0) {
+      errors.push({
+        field: 'imageUrls',
+        message: 'Image URLs must not be empty',
+      });
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Summary

- Add image URL management to the admin exercise definition editor with add/remove/reorder controls
- Add Preview tab that mirrors the logger's Info tab display (images, instructions, muscles, equipment)
- Add toast notification on successful save showing exercise name and ID
- Add `imageUrls` validation to the exercise definition validator (max 10 URLs, max 500 chars each)
- Wire `imageUrls` through both admin GET/PATCH/POST API routes

## Test plan

- [ ] Open admin exercise editor, add image URLs, verify ordering controls work
- [ ] Switch to Preview tab, verify it matches the Info tab in the workout logger
- [ ] Save changes, verify toast notification shows exercise name and ID
- [ ] Verify existing exercises with no images still work correctly
- [ ] Verify validation rejects more than 10 URLs or empty URLs

Fixes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)