### PR TITLE
Settings: add intensity (RIR/RPE) toggle with premium gate

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { Heart, KeyRound, Lock, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -24,6 +24,7 @@ export default function SettingsPage() {
   const userRole = (session?.user as Record<string, unknown>)?.role as string | undefined
   const isAdmin = userRole === 'admin' || userRole === 'editor'
   const [weightUnit, setWeightUnit] = useState<'lbs' | 'kg'>('lbs')
+  const [intensityEnabled, setIntensityEnabled] = useState(false)
   const [intensityRating, setIntensityRating] = useState<'rpe' | 'rir'>('rir')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -41,6 +42,7 @@ export default function SettingsPage() {
   useEffect(() => {
     if (settings) {
       setWeightUnit(settings.defaultWeightUnit)
+      setIntensityEnabled(settings.intensityEnabled)
       setIntensityRating(settings.defaultIntensityRating)
     }
   }, [settings])
@@ -62,7 +64,8 @@ export default function SettingsPage() {
     try {
       await updateSettings({
         defaultWeightUnit: weightUnit,
-        defaultIntensityRating: intensityRating,
+        ...(isAdmin ? { intensityEnabled } : {}),
+        ...(hasIntensityAccess ? { defaultIntensityRating: intensityRating } : {}),
       })
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
@@ -76,6 +79,7 @@ export default function SettingsPage() {
   const isDirty =
     settings &&
     (weightUnit !== settings.defaultWeightUnit ||
+      (isAdmin && intensityEnabled !== settings.intensityEnabled) ||
       (hasIntensityAccess && intensityRating !== settings.defaultIntensityRating))
 
   return (
@@ -199,20 +203,54 @@ export default function SettingsPage() {
               </fieldset>
             </div>
 
-            {/* Intensity Rating */}
-            <div className={!hasIntensityAccess ? 'opacity-60' : ''}>
-              <span
-                id="intensity-rating-label"
-                className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
-              >
-                Intensity Rating (RPE / RIR)
-              </span>
-              {!hasIntensityAccess ? (
-                <div className="px-4 py-3 border-2 border-border bg-muted text-muted-foreground text-sm">
-                  Premium Feature Coming Soon
+            {/* Intensity Tracking Toggle */}
+            <div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="block text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                    Intensity Tracking (RIR/RPE)
+                  </span>
+                  {!isAdmin && (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                      <Lock size={12} />
+                      Premium Feature Coming Soon
+                    </span>
+                  )}
                 </div>
-              ) : (
-                <>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={intensityEnabled}
+                  aria-label="Toggle intensity tracking"
+                  disabled={!isAdmin}
+                  onClick={() => setIntensityEnabled(!intensityEnabled)}
+                  className={`relative inline-flex h-7 w-12 min-w-12 items-center rounded-full border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                    !isAdmin
+                      ? 'border-border bg-muted cursor-not-allowed opacity-50'
+                      : intensityEnabled
+                        ? 'border-primary bg-primary'
+                        : 'border-border bg-muted hover:border-primary'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-5 w-5 rounded-full transition-transform ${
+                      intensityEnabled
+                        ? 'translate-x-[22px] bg-primary-foreground'
+                        : 'translate-x-[2px] bg-muted-foreground'
+                    }`}
+                  />
+                </button>
+              </div>
+
+              {/* RPE/RIR Selector — shown when intensity is enabled and user has access */}
+              {hasIntensityAccess && intensityEnabled && (
+                <div className="mt-3">
+                  <span
+                    id="intensity-rating-label"
+                    className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
+                  >
+                    Default Rating Type
+                  </span>
                   <fieldset
                     className="flex gap-2"
                     aria-labelledby="intensity-rating-label"
@@ -243,7 +281,7 @@ export default function SettingsPage() {
                   <p className="text-sm text-muted-foreground mt-1">
                     RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
                   </p>
-                </>
+                </div>
               )}
             </div>
 


### PR DESCRIPTION
## Summary
- Add a toggle switch for intensity tracking (RIR/RPE) in Settings page
- Non-premium users see toggle disabled with Lock icon + "Premium Feature Coming Soon" text
- Admin users can toggle on/off; enabling shows the RPE/RIR preference selector below
- Persists to `UserSettings.intensityEnabled` via existing settings API

## Test plan
- [ ] Verify toggle appears for all users in Settings
- [ ] Verify non-premium users see disabled toggle with Lock icon and premium text
- [ ] Verify admin users can toggle intensity on/off
- [ ] Verify toggling on shows RPE/RIR selector, toggling off hides it
- [ ] Verify changes persist after save (check both `intensityEnabled` and `defaultIntensityRating`)
- [ ] Verify styling is consistent with other Settings rows in both light and dark mode
- [ ] Verify touch target meets 48px minimum on mobile

Fixes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)