### PR TITLE
feat: Follow Along mode + logger visual overhaul (#577)

### DIFF
--- a/__tests__/api/guided-completion.test.ts
+++ b/__tests__/api/guided-completion.test.ts
@@ -1,0 +1,225 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import { createCompleteTestScenario, createTestUser } from '@/lib/test/factories'
+
+/**
+ * Simulates the workout complete API with guidedCompletion support.
+ * Mirrors the logic in app/api/workouts/[workoutId]/complete/route.ts
+ */
+async function simulateCompleteAPI(
+  prisma: PrismaClient,
+  workoutId: string,
+  userId: string,
+  options: {
+    fallbackSets?: Array<{
+      exerciseId: string
+      setNumber: number
+      reps: number
+      weight: number
+      weightUnit: string
+      rpe: number | null
+      rir: number | null
+    }>
+    guidedCompletion?: boolean
+  } = {}
+) {
+  const { fallbackSets, guidedCompletion } = options
+
+  const workout = await prisma.workout.findUnique({
+    where: { id: workoutId },
+    select: {
+      id: true,
+      week: { select: { program: { select: { userId: true } } } },
+    },
+  })
+
+  if (!workout) return { success: false, error: 'Workout not found' }
+  if (workout.week.program.userId !== userId) return { success: false, error: 'Unauthorized' }
+
+  try {
+    const completion = await prisma.$transaction(async (tx) => {
+      const existingCompleted = await tx.workoutCompletion.findFirst({
+        where: { workoutId, userId, status: 'completed', isArchived: false },
+      })
+      if (existingCompleted) throw new Error('ALREADY_COMPLETED')
+
+      const draft = await tx.workoutCompletion.findFirst({
+        where: { workoutId, userId, status: 'draft', isArchived: false },
+        include: { loggedSets: true },
+      })
+
+      const draftSetCount = draft?.loggedSets?.length ?? 0
+
+      if (draft && draftSetCount > 0) {
+        return tx.workoutCompletion.update({
+          where: { id: draft.id },
+          data: { status: 'completed', completedAt: new Date() },
+        })
+      }
+
+      // Guided completion — allow zero-set completion
+      if (guidedCompletion) {
+        const completionRecord = draft
+          ? await tx.workoutCompletion.update({
+              where: { id: draft.id },
+              data: { status: 'completed', completedAt: new Date() },
+            })
+          : await tx.workoutCompletion.create({
+              data: { workoutId, userId, status: 'completed', completedAt: new Date() },
+            })
+        return completionRecord
+      }
+
+      if (!fallbackSets || fallbackSets.length === 0) {
+        throw new Error('NO_SETS_TO_COMPLETE')
+      }
+
+      const completionRecord = draft
+        ? await tx.workoutCompletion.update({
+            where: { id: draft.id },
+            data: { status: 'completed', completedAt: new Date() },
+          })
+        : await tx.workoutCompletion.create({
+            data: { workoutId, userId, status: 'completed', completedAt: new Date() },
+          })
+
+      await tx.loggedSet.createMany({
+        data: fallbackSets.map((set) => ({
+          exerciseId: set.exerciseId,
+          completionId: completionRecord.id,
+          userId,
+          setNumber: set.setNumber,
+          reps: set.reps,
+          weight: set.weight,
+          weightUnit: set.weightUnit,
+          rpe: set.rpe,
+          rir: set.rir,
+          isWarmup: false,
+        })),
+      })
+
+      return completionRecord
+    })
+
+    return { success: true, completion }
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message }
+    }
+    return { success: false, error: 'Unknown error' }
+  }
+}
+
+describe('Guided Completion (Follow Along Mode)', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('should complete a workout with zero logged sets when guidedCompletion is true', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'draft',
+    })
+
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      guidedCompletion: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.completion).toBeDefined()
+    expect(result.completion!.status).toBe('completed')
+    expect(result.completion!.completedAt).toBeDefined()
+
+    // Verify no logged sets exist
+    const sets = await prisma.loggedSet.findMany({
+      where: { completionId: result.completion!.id },
+    })
+    expect(sets).toHaveLength(0)
+  })
+
+  it('should reject zero-set completion without guidedCompletion flag', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'draft',
+    })
+
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('NO_SETS_TO_COMPLETE')
+  })
+
+  it('should create a new completion record if no draft exists', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+    })
+
+    // Delete any draft that was created
+    await prisma.workoutCompletion.deleteMany({
+      where: { workoutId: scenario.workout.id },
+    })
+
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      guidedCompletion: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.completion!.status).toBe('completed')
+
+    // Verify exactly one completion record exists
+    const completions = await prisma.workoutCompletion.findMany({
+      where: { workoutId: scenario.workout.id, userId },
+    })
+    expect(completions).toHaveLength(1)
+    expect(completions[0].status).toBe('completed')
+  })
+
+  it('should flip existing empty draft to completed with guidedCompletion', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'draft',
+    })
+
+    const draft = await prisma.workoutCompletion.findFirst({
+      where: { workoutId: scenario.workout.id, userId, status: 'draft' },
+    })
+    expect(draft).toBeDefined()
+
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      guidedCompletion: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.completion!.id).toBe(draft!.id) // Same record, flipped status
+    expect(result.completion!.status).toBe('completed')
+  })
+
+  it('should not allow guided completion on already-completed workout', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'draft',
+    })
+
+    // First guided completion
+    await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      guidedCompletion: true,
+    })
+
+    // Second attempt
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      guidedCompletion: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('ALREADY_COMPLETED')
+  })
+})

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -25,6 +25,7 @@ export default function SettingsPage() {
   const isAdmin = userRole === 'admin' || userRole === 'editor'
   const [weightUnit, setWeightUnit] = useState<'lbs' | 'kg'>('lbs')
   const [intensityRating, setIntensityRating] = useState<'rpe' | 'rir'>('rir')
+  const [loggingMode, setLoggingMode] = useState<'full' | 'follow_along'>('full')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
@@ -42,6 +43,7 @@ export default function SettingsPage() {
     if (settings) {
       setWeightUnit(settings.defaultWeightUnit)
       setIntensityRating(settings.defaultIntensityRating)
+      setLoggingMode(settings.loggingMode || 'full')
     }
   }, [settings])
 
@@ -63,6 +65,7 @@ export default function SettingsPage() {
       await updateSettings({
         defaultWeightUnit: weightUnit,
         defaultIntensityRating: intensityRating,
+        loggingMode,
       })
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
@@ -76,7 +79,8 @@ export default function SettingsPage() {
   const isDirty =
     settings &&
     (weightUnit !== settings.defaultWeightUnit ||
-      (hasIntensityAccess && intensityRating !== settings.defaultIntensityRating))
+      (hasIntensityAccess && intensityRating !== settings.defaultIntensityRating) ||
+      loggingMode !== (settings.loggingMode || 'full'))
 
   return (
     <div className="bg-background px-4 sm:px-6 py-8">
@@ -245,6 +249,46 @@ export default function SettingsPage() {
                   </p>
                 </>
               )}
+            </div>
+
+            {/* Workout Mode */}
+            <div>
+              <span
+                id="workout-mode-label"
+                className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
+              >
+                Workout Mode
+              </span>
+              <fieldset
+                className="flex gap-2"
+                aria-labelledby="workout-mode-label"
+              >
+                <button
+                  type="button"
+                  onClick={() => setLoggingMode('follow_along')}
+                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                    loggingMode === 'follow_along'
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                  }`}
+                >
+                  Follow Along
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLoggingMode('full')}
+                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                    loggingMode === 'full'
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                  }`}
+                >
+                  Log Sets
+                </button>
+              </fieldset>
+              <p className="text-sm text-muted-foreground mt-1">
+                Follow Along guides you through exercises without tracking weights.
+              </p>
             </div>
 
             {/* Save Button */}

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
     if (experienceLevel === 'beginner') {
       settingsUpdate.equipmentPreference = equipmentPreference || 'machines'
       settingsUpdate.dismissedPrimer = true // they saw it during onboarding
+      settingsUpdate.loggingMode = 'follow_along'
     }
 
     await prisma.userSettings.upsert({

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -17,6 +17,7 @@ type UpdateSettingsRequest = {
   equipmentPreference?: 'machines' | 'free_weights_cables'
   onboardingCompleted?: boolean
   intensityEnabled?: boolean
+  loggingMode?: 'full' | 'follow_along'
 }
 
 export async function GET(_request: NextRequest) {
@@ -72,7 +73,7 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json() as UpdateSettingsRequest
-    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours, postSessionPromptCount, lastPostSessionPromptAt, experienceLevel, equipmentPreference, onboardingCompleted, intensityEnabled } = body
+    const { displayName, defaultWeightUnit, defaultIntensityRating, dismissedPrimer, dismissedWarmup, dismissedStickNudge, completedTours, postSessionPromptCount, lastPostSessionPromptAt, experienceLevel, equipmentPreference, onboardingCompleted, intensityEnabled, loggingMode } = body
 
     // Validate weight unit
     if (defaultWeightUnit && !['lbs', 'kg'].includes(defaultWeightUnit)) {
@@ -106,6 +107,14 @@ export async function PUT(request: NextRequest) {
       )
     }
 
+    // Validate logging mode
+    if (loggingMode && !['full', 'follow_along'].includes(loggingMode)) {
+      return NextResponse.json(
+        { error: 'Invalid logging mode. Must be "full" or "follow_along"' },
+        { status: 400 }
+      )
+    }
+
     // Validate equipment preference
     if (equipmentPreference && !['machines', 'free_weights_cables'].includes(equipmentPreference)) {
       return NextResponse.json(
@@ -131,6 +140,7 @@ export async function PUT(request: NextRequest) {
         ...(equipmentPreference !== undefined && { equipmentPreference }),
         ...(onboardingCompleted !== undefined && { onboardingCompleted }),
         ...(intensityEnabled !== undefined && { intensityEnabled }),
+        ...(loggingMode !== undefined && { loggingMode }),
         updatedAt: new Date()
       },
       create: {

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -33,7 +33,7 @@ export async function POST(
 
     // Parse optional fallback sets (used when some per-set writes failed)
     const body = await request.json()
-    const { fallbackSets } = body as { fallbackSets?: LoggedSetInput[] }
+    const { fallbackSets, guidedCompletion } = body as { fallbackSets?: LoggedSetInput[]; guidedCompletion?: boolean }
 
     // Verify workout exists
     const workout = await prisma.workout.findUnique({
@@ -99,6 +99,20 @@ export async function POST(
           where: { id: draft.id },
           data: { status: 'completed', completedAt: new Date() },
         })
+      }
+
+      // Guided completion (Follow Along mode) — allow zero-set completion
+      if (guidedCompletion) {
+        logger.info({ workoutId, guided: true }, 'Guided workout completed')
+        const completionRecord = draft
+          ? await tx.workoutCompletion.update({
+              where: { id: draft.id },
+              data: { status: 'completed', completedAt: new Date() },
+            })
+          : await tx.workoutCompletion.create({
+              data: { workoutId, userId: user.id, status: 'completed', completedAt: new Date() },
+            })
+        return completionRecord
       }
 
       // No draft with sets — need fallback sets to complete

--- a/app/globals.css
+++ b/app/globals.css
@@ -1987,15 +1987,6 @@ body > [data-training-widget] {
     inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
-/* Active tab — accent color with depth shadows */
-.doom-tab-active {
-  background-color: var(--accent, var(--primary));
-  color: var(--accent-foreground, var(--primary-foreground));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.15),
-    inset 0 -2px 0 rgba(0, 0, 0, 0.35);
-}
-
 /* Card Enhancements */
 .doom-card {
   background: var(--card);

--- a/app/globals.css
+++ b/app/globals.css
@@ -1987,6 +1987,15 @@ body > [data-training-widget] {
     inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
+/* Active tab — accent color with depth shadows */
+.doom-tab-active {
+  background-color: var(--accent, var(--primary));
+  color: var(--accent-foreground, var(--primary-foreground));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.15),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.35);
+}
+
 /* Card Enhancements */
 .doom-card {
   background: var(--card);

--- a/components/ActionsMenu.tsx
+++ b/components/ActionsMenu.tsx
@@ -22,7 +22,7 @@ type ActionsMenuProps = {
   icon?: React.ComponentType<{ size?: number; className?: string }>
   disabled?: boolean
   size?: 'sm' | 'md' | 'lg'
-  variant?: 'default' | 'primary' | 'accent'
+  variant?: 'default' | 'primary' | 'accent' | 'ghost'
   className?: string
 }
 
@@ -75,7 +75,8 @@ export default function ActionsMenu({
   const variantClasses = {
     default: 'bg-muted hover:bg-secondary',
     primary: 'bg-primary-muted hover:bg-primary hover:border-primary hover:text-white',
-    accent: 'bg-accent hover:bg-accent-hover text-white'
+    accent: 'bg-accent hover:bg-accent-hover text-white',
+    ghost: 'bg-transparent border-transparent hover:bg-transparent',
   }
 
   // Variant classes for action items

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -19,6 +19,9 @@ import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from './workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from './workout-logging/ExerciseLoggingHeader'
 import ExerciseNavigation from './workout-logging/ExerciseNavigation'
+import FollowAlongFooter from './workout-logging/FollowAlongFooter'
+import FollowAlongHeader from './workout-logging/FollowAlongHeader'
+import FollowAlongTabs from './workout-logging/FollowAlongTabs'
 import SetLoggingForm, { type ExpandedInput } from './workout-logging/SetLoggingForm'
 import { AddExerciseWizard } from './workout-logging/wizards/AddExerciseWizard'
 import { DeleteExerciseWizard } from './workout-logging/wizards/DeleteExerciseWizard'
@@ -39,6 +42,7 @@ type Props = {
   initialHistory?: ExerciseHistory | null
   initialExerciseIndex?: number
   showTips?: boolean
+  loggingMode?: 'full' | 'follow_along'
   onComplete: () => Promise<void>
   onRefresh?: () => Promise<void>
 }
@@ -53,6 +57,7 @@ export default function ExerciseLoggingModal({
   initialHistory,
   initialExerciseIndex = 0,
   showTips = false,
+  loggingMode: loggingModeProp = 'full',
   onComplete,
   onRefresh,
 }: Props) {
@@ -78,6 +83,20 @@ export default function ExerciseLoggingModal({
 
   // Extra sets mode: allows logging beyond prescribed sets
   const [extraSetsMode, setExtraSetsMode] = useState(false)
+
+  // Follow Along mode — local state allows in-session switching
+  const [mode, setMode] = useState<'full' | 'follow_along'>(loggingModeProp)
+  const isFollowAlong = mode === 'follow_along'
+
+  const handleSwitchToLogging = useCallback(() => {
+    setMode('full')
+    // Persist immediately
+    fetch('/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ loggingMode: 'full' }),
+    }).catch(() => {})
+  }, [])
 
   // Tip rotation — sequential through array order, then random
   const tierTips = useMemo(
@@ -211,6 +230,15 @@ export default function ExerciseLoggingModal({
 
     rotateTip()
 
+    // Auto-persist loggingMode if user was originally in follow_along and logged a set
+    if (loggingModeProp === 'follow_along') {
+      fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ loggingMode: 'full' }),
+      }).catch(() => {}) // fire-and-forget
+    }
+
     // Pre-fill for next set: reps from next prescribed, weight carried forward
     const nextNextSetNumber = nextSetNumber + 1
     const nextPrescribed = currentPrescribedSets.find(s => s.setNumber === nextNextSetNumber)
@@ -228,12 +256,13 @@ export default function ExerciseLoggingModal({
       rpe: nextRpe,
       rir: nextRir,
     })
-  }, [currentSet, currentExercise, nextSetNumber, currentPrescribedSets, prescribedSet, logSet, rotateTip])
+  }, [currentSet, currentExercise, nextSetNumber, currentPrescribedSets, prescribedSet, logSet, rotateTip, hasIntensityAccess, loggingModeProp])
 
   const handleNextExercise = () => {
     lastPrefillKey.current = ''
     setExtraSetsMode(false)
     goToNext()
+    rotateTip()
     setCurrentSet(prev => ({
       reps: '',
       weight: '',
@@ -247,6 +276,7 @@ export default function ExerciseLoggingModal({
     lastPrefillKey.current = ''
     setExtraSetsMode(false)
     goToPrevious()
+    rotateTip()
     setCurrentSet(prev => ({
       reps: '',
       weight: '',
@@ -360,6 +390,26 @@ export default function ExerciseLoggingModal({
     }
   }
 
+  const handleGuidedComplete = async () => {
+    setIsSubmitting(true)
+    try {
+      await completeDraft(workoutId, undefined, true)
+      clearCache()
+      await onComplete()
+    } catch (error) {
+      clientLogger.error('Error completing guided workout:', error)
+      setIsSubmitting(false)
+      setIsConfirming(false)
+      const message = !navigator.onLine
+        ? 'You\'re offline. Please try again when you have a connection.'
+        : 'Failed to save workout. Please try again.'
+      alert(message)
+      return
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   const performDeleteSet = useCallback((exerciseId: string, setNumber: number) => {
     const set = loggedSets.find(
       s => s.exerciseId === exerciseId && s.setNumber === setNumber
@@ -435,27 +485,38 @@ export default function ExerciseLoggingModal({
         {/* Modal - Full screen on mobile, centered on desktop */}
         <div className="bg-card w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg flex flex-col shadow-xl pb-[env(safe-area-inset-bottom)]">
           {/* Header */}
-          <ExerciseLoggingHeader
-            currentExerciseIndex={currentIndex}
-            totalExercises={totalExercises}
-            failedSetCount={failedSetCount}
-            onMinimize={handleExitSaveAsDraft}
-            onClose={handleExitWorkout}
-          />
-
-          {/* Exercise Navigation */}
-          {currentExercise ? (
-            <ExerciseNavigation
-              currentExercise={currentExercise}
+          {isFollowAlong ? (
+            <FollowAlongHeader
               currentExerciseIndex={currentIndex}
               totalExercises={totalExercises}
-              onPrevious={handlePreviousExercise}
-              onNext={handleNextExercise}
+              onClose={handleExitWorkout}
+              onSwitchToLogging={handleSwitchToLogging}
             />
           ) : (
-            <div className="px-4 py-3 border-b border-border">
-              <div className="h-8 bg-muted rounded animate-pulse" />
-            </div>
+            <ExerciseLoggingHeader
+              currentExerciseIndex={currentIndex}
+              totalExercises={totalExercises}
+              failedSetCount={failedSetCount}
+              onMinimize={handleExitSaveAsDraft}
+              onClose={handleExitWorkout}
+            />
+          )}
+
+          {/* Exercise Navigation — hidden in follow-along (title block shows name) */}
+          {!isFollowAlong && (
+            currentExercise ? (
+              <ExerciseNavigation
+                currentExercise={currentExercise}
+                currentExerciseIndex={currentIndex}
+                totalExercises={totalExercises}
+                onPrevious={handlePreviousExercise}
+                onNext={handleNextExercise}
+              />
+            ) : (
+              <div className="px-4 py-3 border-b border-border">
+                <div className="h-8 bg-muted rounded animate-pulse" />
+              </div>
+            )
           )}
 
           {/* Content area with tabs — swipeable */}
@@ -487,54 +548,73 @@ export default function ExerciseLoggingModal({
                 </button>
               </div>
             ) : currentExercise ? (
-              <ExerciseDisplayTabs
-                exercise={currentExercise}
-                prescribedSets={currentPrescribedSets}
-                loggedSets={currentExerciseLoggedSets}
-                exerciseHistory={currentExerciseHistory}
-                historyState={currentHistoryState}
-                hasHistoryIndicator={hasHistoryForCurrentExercise}
-                onDeleteSet={handleDeleteSet}
-                isInputExpanded={expandedInput !== null}
-                showIntensity={hasIntensityAccess}
-                tip={currentTip}
-                loggingForm={
-                  <SetLoggingForm
-                    prescribedSet={prescribedSet}
-                    hasLoggedAllPrescribed={hasLoggedAllPrescribed}
-                    extraSetsMode={extraSetsMode}
-                    hasRpe={hasRpe}
-                    hasRir={hasRir}
-                    currentSet={currentSet}
-                    onSetChange={setCurrentSet}
-                    expandedInput={expandedInput}
-                    onExpandedInputChange={setExpandedInput}
-                    onExtraSets={() => setExtraSetsMode(true)}
-                    onNextExercise={handleNextExercise}
-                    isLastExercise={currentIndex >= totalExercises - 1}
-                  />
-                }
-              />
+              isFollowAlong ? (
+                <FollowAlongTabs
+                  exercise={currentExercise}
+                  prescribedSets={currentPrescribedSets}
+                  tip={currentTip}
+                />
+              ) : (
+                <ExerciseDisplayTabs
+                  exercise={currentExercise}
+                  prescribedSets={currentPrescribedSets}
+                  loggedSets={currentExerciseLoggedSets}
+                  exerciseHistory={currentExerciseHistory}
+                  historyState={currentHistoryState}
+                  hasHistoryIndicator={hasHistoryForCurrentExercise}
+                  onDeleteSet={handleDeleteSet}
+                  isInputExpanded={expandedInput !== null}
+                  showIntensity={hasIntensityAccess}
+                  tip={currentTip}
+                  loggingForm={
+                    <SetLoggingForm
+                      prescribedSet={prescribedSet}
+                      hasLoggedAllPrescribed={hasLoggedAllPrescribed}
+                      extraSetsMode={extraSetsMode}
+                      hasRpe={hasRpe}
+                      hasRir={hasRir}
+                      currentSet={currentSet}
+                      onSetChange={setCurrentSet}
+                      expandedInput={expandedInput}
+                      onExpandedInputChange={setExpandedInput}
+                      onExtraSets={() => setExtraSetsMode(true)}
+                      onNextExercise={handleNextExercise}
+                      isLastExercise={currentIndex >= totalExercises - 1}
+                    />
+                  }
+                />
+              )
             ) : null}
           </div>
 
-          {/* Actions Footer - hidden when an input is expanded */}
-          {expandedInput === null && <ExerciseActionsFooter
-            currentExerciseName={currentExercise?.name || 'Exercise'}
-            nextSetNumber={nextSetNumber}
-            totalLoggedSets={totalLoggedSets}
-            canLogSet={!!canLogSet}
-            hasLoggedAllPrescribed={hasLoggedAllPrescribed}
-            extraSetsMode={extraSetsMode}
-            isSubmitting={isSubmitting}
-            onLogSet={handleLogSet}
-            onCompleteWorkout={() => setIsConfirming(true)}
-            onAddExercise={handleAddExercise}
-            onEditExercise={handleEditExercise}
-            onReplaceExercise={handleReplaceExercise}
-            onDeleteExercise={handleDeleteExercise}
-            onExitWorkout={handleExitWorkout}
-          />}
+          {/* Actions Footer */}
+          {isFollowAlong ? (
+            <FollowAlongFooter
+              currentIndex={currentIndex}
+              totalExercises={totalExercises}
+              isSubmitting={isSubmitting}
+              onPrevious={handlePreviousExercise}
+              onNext={handleNextExercise}
+              onFinish={() => setIsConfirming(true)}
+            />
+          ) : (
+            expandedInput === null && <ExerciseActionsFooter
+              currentExerciseName={currentExercise?.name || 'Exercise'}
+              nextSetNumber={nextSetNumber}
+              totalLoggedSets={totalLoggedSets}
+              canLogSet={!!canLogSet}
+              hasLoggedAllPrescribed={hasLoggedAllPrescribed}
+              extraSetsMode={extraSetsMode}
+              isSubmitting={isSubmitting}
+              onLogSet={handleLogSet}
+              onCompleteWorkout={() => setIsConfirming(true)}
+              onAddExercise={handleAddExercise}
+              onEditExercise={handleEditExercise}
+              onReplaceExercise={handleReplaceExercise}
+              onDeleteExercise={handleDeleteExercise}
+              onExitWorkout={handleExitWorkout}
+            />
+          )}
 
           {/* Workout completion confirmation */}
           {isConfirming && (
@@ -542,7 +622,9 @@ export default function ExerciseLoggingModal({
               <div className="bg-card border-2 border-border p-6 sm:p-8 text-center min-w-[300px] shadow-xl doom-corners">
                 {!isSubmitting ? (
                   <>
-                    <p className="text-lg sm:text-xl mb-6 text-foreground font-bold uppercase tracking-wider">Complete this workout?</p>
+                    <p className="text-lg sm:text-xl mb-6 text-foreground font-bold uppercase tracking-wider">
+                      {isFollowAlong ? 'Nice work! Mark this workout as done?' : 'Complete this workout?'}
+                    </p>
                     <div className="flex justify-center gap-3">
                       <button type="button"
                         onClick={() => setIsConfirming(false)}
@@ -551,10 +633,10 @@ export default function ExerciseLoggingModal({
                         Cancel
                       </button>
                       <button type="button"
-                        onClick={handleCompleteWorkout}
+                        onClick={isFollowAlong ? handleGuidedComplete : handleCompleteWorkout}
                         className="px-4 sm:px-6 py-2.5 sm:py-3 text-base bg-success text-success-foreground hover:bg-success/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
                       >
-                        Confirm
+                        {isFollowAlong ? 'Finish' : 'Confirm'}
                       </button>
                     </div>
                   </>

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, LogOut, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { LoadingFrog } from '@/components/ui/loading-frog'
@@ -14,6 +14,7 @@ import { clientLogger } from '@/lib/client-logger'
 import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
 import { TIP_LIBRARY } from '@/lib/data/tip-library'
 import type { LoggedSet } from '@/types/workout'
+import type { ActionItem } from './ActionsMenu'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
 import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from './workout-logging/ExerciseDisplayTabs'
@@ -497,12 +498,19 @@ export default function ExerciseLoggingModal({
               currentExerciseIndex={currentIndex}
               totalExercises={totalExercises}
               failedSetCount={failedSetCount}
-              onMinimize={handleExitSaveAsDraft}
+              onCompleteWorkout={() => setIsConfirming(true)}
               onClose={handleExitWorkout}
+              menuActions={[
+                { label: 'Edit this exercise', icon: Pencil, onClick: handleEditExercise },
+                { label: 'Add an exercise', icon: Plus, onClick: handleAddExercise },
+                { label: 'Swap this exercise', icon: RefreshCw, onClick: handleReplaceExercise },
+                { label: 'Delete this exercise', icon: Trash2, onClick: handleDeleteExercise, variant: 'danger' as const, requiresConfirmation: true, confirmationMessage: `Are you sure you want to delete "${currentExercise?.name || 'this exercise'}"?` },
+                { label: 'Exit workout', icon: LogOut, onClick: handleExitWorkout, variant: 'danger' as const },
+              ] satisfies ActionItem[]}
             />
           )}
 
-          {/* Exercise Navigation — hidden in follow-along (title block shows name) */}
+          {/* Exercise title — hidden in follow-along (title block shows name) */}
           {!isFollowAlong && (
             currentExercise ? (
               <ExerciseNavigation
@@ -511,10 +519,11 @@ export default function ExerciseLoggingModal({
                 totalExercises={totalExercises}
                 onPrevious={handlePreviousExercise}
                 onNext={handleNextExercise}
+                hideChevrons
               />
             ) : (
               <div className="px-4 py-3 border-b border-border">
-                <div className="h-8 bg-muted rounded animate-pulse" />
+                <div className="h-8 bg-muted animate-pulse" />
               </div>
             )
           )}
@@ -579,6 +588,7 @@ export default function ExerciseLoggingModal({
                       onExpandedInputChange={setExpandedInput}
                       onExtraSets={() => setExtraSetsMode(true)}
                       onNextExercise={handleNextExercise}
+                      onCompleteWorkout={() => setIsConfirming(true)}
                       isLastExercise={currentIndex >= totalExercises - 1}
                     />
                   }
@@ -599,20 +609,15 @@ export default function ExerciseLoggingModal({
             />
           ) : (
             expandedInput === null && <ExerciseActionsFooter
-              currentExerciseName={currentExercise?.name || 'Exercise'}
+              currentExerciseIndex={currentIndex}
+              totalExercises={totalExercises}
               nextSetNumber={nextSetNumber}
-              totalLoggedSets={totalLoggedSets}
               canLogSet={!!canLogSet}
               hasLoggedAllPrescribed={hasLoggedAllPrescribed}
               extraSetsMode={extraSetsMode}
-              isSubmitting={isSubmitting}
               onLogSet={handleLogSet}
-              onCompleteWorkout={() => setIsConfirming(true)}
-              onAddExercise={handleAddExercise}
-              onEditExercise={handleEditExercise}
-              onReplaceExercise={handleReplaceExercise}
-              onDeleteExercise={handleDeleteExercise}
-              onExitWorkout={handleExitWorkout}
+              onPrevious={handlePreviousExercise}
+              onNext={handleNextExercise}
             />
           )}
 

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -634,12 +634,14 @@ export default function ExerciseLoggingModal({
                       <button type="button"
                         onClick={() => setIsConfirming(false)}
                         className="px-4 sm:px-6 py-2.5 sm:py-3 text-base bg-muted text-foreground hover:bg-secondary transition-colors font-bold uppercase tracking-wider border-2 border-border hover:border-primary doom-focus-ring"
+                        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                       >
                         Cancel
                       </button>
                       <button type="button"
                         onClick={isFollowAlong ? handleGuidedComplete : handleCompleteWorkout}
-                        className="px-4 sm:px-6 py-2.5 sm:py-3 text-base bg-success text-success-foreground hover:bg-success/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
+                        className="px-4 sm:px-6 py-2.5 sm:py-3 text-base bg-success text-success-foreground hover:bg-success/90 transition-colors font-bold uppercase tracking-wider doom-focus-ring"
+                        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
                       >
                         {isFollowAlong ? 'Finish' : 'Confirm'}
                       </button>
@@ -763,19 +765,22 @@ export default function ExerciseLoggingModal({
               <div className="flex flex-col gap-3">
                 <button type="button"
                   onClick={handleExitSaveAsDraft}
-                  className="w-full px-4 py-3 text-base sm:text-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
+                  className="w-full px-4 py-3 text-base sm:text-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-bold uppercase tracking-wider doom-focus-ring"
+                  style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
                 >
                   Save as Draft
                 </button>
                 <button type="button"
                   onClick={handleExitDiscard}
-                  className="w-full px-4 py-3 text-base sm:text-lg bg-error text-error-foreground hover:bg-error/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
+                  className="w-full px-4 py-3 text-base sm:text-lg bg-error text-error-foreground hover:bg-error/90 transition-colors font-bold uppercase tracking-wider doom-focus-ring"
+                  style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
                 >
                   Discard All
                 </button>
                 <button type="button"
                   onClick={() => setShowExitConfirm(false)}
                   className="w-full px-4 py-3 text-base sm:text-lg bg-muted text-foreground hover:bg-secondary transition-colors font-bold uppercase tracking-wider border-2 border-border hover:border-primary doom-focus-ring"
+                  style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                 >
                   Cancel
                 </button>
@@ -785,12 +790,14 @@ export default function ExerciseLoggingModal({
                 <button type="button"
                   onClick={() => setShowExitConfirm(false)}
                   className="flex-1 px-4 py-3 text-base sm:text-lg bg-muted text-foreground hover:bg-secondary transition-colors font-bold uppercase tracking-wider border-2 border-border hover:border-primary doom-focus-ring"
+                  style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                 >
                   Cancel
                 </button>
                 <button type="button"
                   onClick={handleExitDiscard}
-                  className="flex-1 px-4 py-3 text-base sm:text-lg bg-error text-error-foreground hover:bg-error/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
+                  className="flex-1 px-4 py-3 text-base sm:text-lg bg-error text-error-foreground hover:bg-error/90 transition-colors font-bold uppercase tracking-wider doom-focus-ring"
+                  style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
                 >
                   Exit
                 </button>

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -137,6 +137,7 @@ export default function StrengthWeekView({
   // Contextual content triggers
   const showStickNudge = historyCount >= 3 && historyCount <= 8 && !settings?.dismissedStickNudge && !settingsLoading
   const showTips = historyCount <= 3 && settings?.experienceLevel === 'beginner'
+  const loggingMode = (settings?.loggingMode as 'full' | 'follow_along' | undefined) || 'full'
 
   const checkProgramCompletion = useCallback(async (openModal = false) => {
     // Skip check if we're currently restarting
@@ -464,7 +465,8 @@ export default function StrengthWeekView({
           initialExercise={workoutMetadata.firstExercise}
           initialHistory={workoutMetadata.firstExerciseHistory}
           initialExerciseIndex={workoutMetadata.resumeExerciseIndex ?? 0}
-          showTips={showTips}
+          showTips={showTips || loggingMode === 'follow_along'}
+          loggingMode={loggingMode}
           onComplete={handleCompleteWorkout}
           onRefresh={handleRefreshMetadata}
         />

--- a/components/programs/ActiveProgramStrip.tsx
+++ b/components/programs/ActiveProgramStrip.tsx
@@ -103,7 +103,8 @@ export default function ActiveProgramStrip({
           <div className="flex flex-wrap gap-2 pt-2">
             <Link
               href="/training"
-              className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-button-3d doom-focus-ring"
+              className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-focus-ring"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
             >
               <Dumbbell size={14} />
               TRAIN
@@ -111,6 +112,7 @@ export default function ActiveProgramStrip({
             <Link
               href={`/programs/${programId}/edit`}
               className="flex items-center gap-1.5 px-3 py-2 border border-border text-foreground text-sm font-semibold uppercase tracking-wider hover:bg-muted transition-colors doom-focus-ring"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
             >
               <Pencil size={14} />
               EDIT
@@ -119,6 +121,7 @@ export default function ActiveProgramStrip({
               type="button"
               onClick={() => setDeleteTarget(true)}
               className="flex items-center gap-1.5 px-3 py-2 border border-error/50 text-error text-sm font-semibold uppercase tracking-wider hover:bg-error/10 transition-colors doom-focus-ring"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
             >
               <Trash2 size={14} />
               DELETE

--- a/components/programs/MyProgramsList.tsx
+++ b/components/programs/MyProgramsList.tsx
@@ -204,7 +204,8 @@ export default function MyProgramsList({
                       type="button"
                       onClick={() => handleActivate(program.id, program.name)}
                       disabled={isLoading}
-                      className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-button-3d doom-focus-ring disabled:opacity-50"
+                      className="flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground text-sm font-semibold uppercase tracking-wider doom-focus-ring disabled:opacity-50"
+                      style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
                     >
                       <Star size={14} />
                       ACTIVATE
@@ -212,6 +213,7 @@ export default function MyProgramsList({
                     <Link
                       href={`/programs/${program.id}/edit`}
                       className="flex items-center gap-1.5 px-3 py-2 border border-border text-foreground text-sm font-semibold uppercase tracking-wider hover:bg-muted transition-colors doom-focus-ring"
+                      style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                     >
                       <Pencil size={14} />
                       EDIT
@@ -221,6 +223,7 @@ export default function MyProgramsList({
                       onClick={() => handleDuplicate(program.id)}
                       disabled={isLoading}
                       className="flex items-center gap-1.5 px-3 py-2 border border-border text-foreground text-sm font-semibold uppercase tracking-wider hover:bg-muted transition-colors doom-focus-ring disabled:opacity-50"
+                      style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                     >
                       {duplicating === program.id ? (
                         <div className="w-4 h-4 border-2 border-foreground border-t-transparent rounded-full animate-spin" />
@@ -235,6 +238,7 @@ export default function MyProgramsList({
                         onClick={() => setDeleteTarget({ id: program.id, name: program.name })}
                         disabled={isLoading}
                         className="flex items-center gap-1.5 px-3 py-2 border border-error/50 text-error text-sm font-semibold uppercase tracking-wider hover:bg-error/10 transition-colors doom-focus-ring disabled:opacity-50"
+                        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.20), 0 1px 0 rgba(0,0,0,0.30)' }}
                       >
                         {deleting === program.id ? (
                           <div className="w-4 h-4 border-2 border-error border-t-transparent rounded-full animate-spin" />

--- a/components/ui/ExerciseImageCrossfade.tsx
+++ b/components/ui/ExerciseImageCrossfade.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import Image from 'next/image'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface ExerciseImageCrossfadeProps {
+  /** Image URLs in order: [start, finish]. Supports 0, 1, or 2 images. */
+  imageUrls: string[]
+  exerciseName: string
+  /** Duration each position is held in ms. Default 1200. */
+  holdDuration?: number
+  /** Crossfade transition duration in ms. Default 300. */
+  fadeDuration?: number
+  /** Optional label override. Default uses "Exercise demonstration" */
+  label?: string
+}
+
+const POSITION_LABELS = ['START', 'FINISH'] as const
+
+function resolveUrl(url: string): string {
+  return url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
+}
+
+export default function ExerciseImageCrossfade({
+  imageUrls,
+  exerciseName,
+  holdDuration = 1200,
+  fadeDuration = 300,
+  label,
+}: ExerciseImageCrossfadeProps) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  })
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const resolved = imageUrls.map(resolveUrl)
+  const hasAnimation = resolved.length === 2 && !prefersReducedMotion
+
+  // Cycle between images
+  useEffect(() => {
+    if (!hasAnimation || paused) return
+    timerRef.current = setTimeout(() => {
+      setActiveIndex(prev => (prev === 0 ? 1 : 0))
+    }, holdDuration)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [activeIndex, paused, hasAnimation, holdDuration])
+
+  const togglePause = useCallback(() => {
+    if (!hasAnimation) return
+    setPaused(p => !p)
+  }, [hasAnimation])
+
+  // No images
+  if (resolved.length === 0) {
+    return (
+      <div className="border-2 border-border bg-muted/20">
+        <div className="aspect-[4/3] flex items-center justify-center">
+          <p className="text-sm text-muted-foreground uppercase tracking-wider">
+            More images to come
+          </p>
+        </div>
+        {label && (
+          <div className="border-t border-border px-3 py-1.5 bg-card">
+            <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{label}</p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Single image — no animation, no labels
+  if (resolved.length === 1) {
+    return (
+      <div className="border-2 border-border">
+        <div className="relative aspect-[4/3] bg-muted">
+          <Image
+            src={resolved[0]}
+            alt={`${exerciseName} demonstration`}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 600px"
+          />
+        </div>
+        {label && (
+          <div className="border-t border-border px-3 py-1.5 bg-card">
+            <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{label}</p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Reduced motion — stacked layout with labels
+  if (prefersReducedMotion) {
+    return (
+      <div className="space-y-2">
+        {resolved.map((src, i) => (
+          <div key={src} className="border-2 border-border">
+            <div className="relative aspect-[4/3] bg-muted">
+              <Image
+                src={src}
+                alt={`${exerciseName} - ${POSITION_LABELS[i].toLowerCase()} position`}
+                fill
+                className="object-cover"
+                sizes="(max-width: 640px) 100vw, 600px"
+              />
+            </div>
+            <div className="border-t border-border px-3 py-1.5 bg-card">
+              <p className="text-xs font-bold text-primary uppercase tracking-wider">
+                {POSITION_LABELS[i]}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  // Two images — crossfade animation
+  return (
+    <div className="border-2 border-border">
+      <button
+        type="button"
+        onClick={togglePause}
+        className="relative aspect-[4/3] w-full bg-muted cursor-pointer block"
+        aria-label={paused ? 'Resume animation' : 'Pause animation'}
+      >
+        {resolved.map((src, i) => (
+          <Image
+            key={src}
+            src={src}
+            alt={`${exerciseName} - ${POSITION_LABELS[i].toLowerCase()} position`}
+            fill
+            className="object-cover"
+            style={{
+              opacity: activeIndex === i ? 1 : 0,
+              transition: `opacity ${fadeDuration}ms ease-in-out`,
+            }}
+            sizes="(max-width: 640px) 100vw, 600px"
+          />
+        ))}
+
+        {/* Position label pill */}
+        <span className="absolute bottom-3 left-3 px-2.5 py-1 text-xs font-bold uppercase tracking-wider text-primary bg-background/80 border border-primary">
+          {POSITION_LABELS[activeIndex]}
+        </span>
+
+        {/* Pause indicator */}
+        {paused && (
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="w-14 h-14 flex items-center justify-center bg-background/70 border-2 border-border">
+              <svg aria-hidden="true" className="w-6 h-6 text-foreground ml-0.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </span>
+          </span>
+        )}
+      </button>
+      <div className="border-t border-border px-3 py-1.5 bg-card flex items-center justify-between">
+        <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+          {label || 'Exercise demonstration'}
+        </p>
+        {/* Dot indicators for current position */}
+        <div className="flex gap-1.5">
+          {POSITION_LABELS.map((pos, i) => (
+            <span
+              key={pos}
+              className={`w-2 h-2 transition-colors ${
+                activeIndex === i ? 'bg-primary' : 'bg-border'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/radix/tabs.tsx
+++ b/components/ui/radix/tabs.tsx
@@ -23,7 +23,7 @@ const TabsTrigger = React.forwardRef<
 >(({ className = '', ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary data-[state=active]:border-b-[3px] data-[state=active]:border-primary data-[state=active]:-mb-[2px] data-[state=inactive]:text-foreground/50 hover:text-foreground ${className}`}
+    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary data-[state=active]:border-b-2 data-[state=active]:border-primary/50 data-[state=active]:-mb-[2px] data-[state=inactive]:text-foreground/50 hover:text-foreground ${className}`}
     {...props}
   />
 ))

--- a/components/ui/radix/tabs.tsx
+++ b/components/ui/radix/tabs.tsx
@@ -23,7 +23,7 @@ const TabsTrigger = React.forwardRef<
 >(({ className = '', ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:doom-button-3d text-muted-foreground hover:text-foreground ${className}`}
+    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary-foreground data-[state=active]:doom-tab-active text-muted-foreground hover:text-foreground ${className}`}
     {...props}
   />
 ))

--- a/components/ui/radix/tabs.tsx
+++ b/components/ui/radix/tabs.tsx
@@ -23,7 +23,7 @@ const TabsTrigger = React.forwardRef<
 >(({ className = '', ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary-foreground data-[state=active]:doom-tab-active text-muted-foreground hover:text-foreground ${className}`}
+    className={`inline-flex items-center justify-center gap-1 whitespace-nowrap px-4 sm:px-5 py-2.5 sm:py-3 text-base sm:text-lg font-bold uppercase tracking-wider ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary data-[state=active]:border-b-[3px] data-[state=active]:border-primary data-[state=active]:-mb-[2px] data-[state=inactive]:text-foreground/50 hover:text-foreground ${className}`}
     {...props}
   />
 ))

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -44,7 +44,7 @@ export default function ExerciseActionsFooter({
           type="button"
           onClick={onPrevious}
           disabled={isFirst}
-          className="w-10 h-11 flex items-center justify-center text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
+          className="w-10 h-11 flex items-center justify-center text-secondary-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
           style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RECESSED_SHADOW }}
           aria-label="Previous exercise"
         >
@@ -65,7 +65,7 @@ export default function ExerciseActionsFooter({
           type="button"
           onClick={onNext}
           disabled={isLast}
-          className="w-10 h-11 flex items-center justify-center text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
+          className="w-10 h-11 flex items-center justify-center text-secondary-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
           style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RECESSED_SHADOW }}
           aria-label="Next exercise"
         >

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -77,14 +77,16 @@ export default function ExerciseActionsFooter({
   return (
     <div className="border-t border-border px-3 py-2 bg-card flex-shrink-0">
       <div className="flex items-center gap-2">
-        {/* Log Set Button */}
-        <button type="button"
-          onClick={onLogSet}
-          disabled={!canLogSet || (hasLoggedAllPrescribed && !extraSetsMode)}
-          className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
-        >
-          LOG SET {nextSetNumber}
-        </button>
+        {/* Log Set Button — hidden when celebration card is showing */}
+        {!(hasLoggedAllPrescribed && !extraSetsMode) && (
+          <button type="button"
+            onClick={onLogSet}
+            disabled={!canLogSet}
+            className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
+          >
+            LOG SET {nextSetNumber}
+          </button>
+        )}
 
         {/* Complete Workout Button */}
         <button type="button"

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -1,113 +1,76 @@
 'use client'
 
-import { LogOut, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
-import ActionsMenu, { type ActionItem } from '../ActionsMenu'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
+const RECESSED_SHADOW = 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)'
 
 interface ExerciseActionsFooterProps {
-  currentExerciseName: string
+  currentExerciseIndex: number
+  totalExercises: number
   nextSetNumber: number
-  totalLoggedSets: number
   canLogSet: boolean
   hasLoggedAllPrescribed: boolean
   extraSetsMode: boolean
-  isSubmitting: boolean
   onLogSet: () => void
-  onCompleteWorkout: () => void
-  onAddExercise: () => void
-  onEditExercise: () => void
-  onReplaceExercise: () => void
-  onDeleteExercise: () => void
-  onExitWorkout: () => void
+  onPrevious: () => void
+  onNext: () => void
 }
 
 export default function ExerciseActionsFooter({
-  currentExerciseName,
+  currentExerciseIndex,
+  totalExercises,
   nextSetNumber,
-  totalLoggedSets,
   canLogSet,
   hasLoggedAllPrescribed,
   extraSetsMode,
-  isSubmitting,
   onLogSet,
-  onCompleteWorkout,
-  onAddExercise,
-  onEditExercise,
-  onReplaceExercise,
-  onDeleteExercise,
-  onExitWorkout,
+  onPrevious,
+  onNext,
 }: ExerciseActionsFooterProps) {
-  const actions: ActionItem[] = [
-    {
-      label: 'Edit this exercise',
-      icon: Pencil,
-      onClick: onEditExercise,
-      disabled: false
-    },
-    {
-      label: 'Add an exercise',
-      icon: Plus,
-      onClick: onAddExercise,
-      disabled: false
-    },
-    {
-      label: 'Swap this exercise',
-      icon: RefreshCw,
-      onClick: onReplaceExercise,
-      disabled: false
-    },
-    {
-      label: 'Delete this exercise',
-      icon: Trash2,
-      onClick: onDeleteExercise,
-      disabled: false,
-      variant: 'danger' as const,
-      requiresConfirmation: true,
-      confirmationMessage: `Are you sure you want to delete "${currentExerciseName}"?`
-    },
-    {
-      label: 'Exit workout',
-      icon: LogOut,
-      onClick: onExitWorkout,
-      disabled: false,
-      variant: 'danger' as const,
-      requiresConfirmation: false
-    }
-  ]
+  const isFirst = currentExerciseIndex === 0
+  const isLast = currentExerciseIndex >= totalExercises - 1
+  const showLogSet = !(hasLoggedAllPrescribed && !extraSetsMode)
+
+  if (!showLogSet) return null
 
   return (
-    <div className="border-t border-border px-3 py-2 bg-card flex-shrink-0">
-      <div className="flex items-center gap-2">
-        {/* Log Set Button — hidden when celebration card is showing */}
-        {!(hasLoggedAllPrescribed && !extraSetsMode) && (
-          <button type="button"
-            onClick={onLogSet}
-            disabled={!canLogSet}
-            className="flex-1 py-2.5 bg-accent text-accent-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
-          >
-            LOG SET {nextSetNumber}
-          </button>
-        )}
-
-        {/* Complete Workout Button */}
-        <button type="button"
-          disabled={isSubmitting || totalLoggedSets === 0}
-          className="py-2.5 px-4 border border-success text-success text-sm font-bold uppercase tracking-wider transition-all hover:bg-success hover:text-success-foreground disabled:opacity-30 disabled:cursor-not-allowed doom-button-3d doom-focus-ring"
-          onMouseDown={(e) => {
-            if (isSubmitting || totalLoggedSets === 0) return;
-            e.preventDefault();
-            onCompleteWorkout();
-          }}
+    <div
+      className="bg-secondary px-4 py-3 flex-shrink-0"
+      style={{ boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)' }}
+    >
+      <div className="flex items-center gap-2.5">
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={isFirst}
+          className="w-10 h-11 flex items-center justify-center text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
+          style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RECESSED_SHADOW }}
+          aria-label="Previous exercise"
         >
-          {isSubmitting ? 'SAVING...' : 'COMPLETE'}
+          <ChevronLeft size={18} strokeWidth={2.5} />
         </button>
 
-        {/* Actions Menu */}
-        <ActionsMenu
-          variant="default"
-          size="md"
-          className="self-stretch w-10"
-          actions={actions}
-        />
+        <button
+          type="button"
+          onClick={onLogSet}
+          disabled={!canLogSet}
+          className="flex-1 h-11 bg-accent text-accent-foreground text-sm font-medium uppercase tracking-widest transition-all disabled:opacity-40 disabled:cursor-not-allowed doom-focus-ring"
+          style={{ boxShadow: RAISED_SHADOW }}
+        >
+          LOG SET {nextSetNumber}
+        </button>
+
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={isLast}
+          className="w-10 h-11 flex items-center justify-center text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
+          style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RECESSED_SHADOW }}
+          aria-label="Next exercise"
+        >
+          <ChevronRight size={18} strokeWidth={2.5} />
+        </button>
       </div>
     </div>
   )

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,13 +1,11 @@
 'use client'
 
-import Image from 'next/image'
-import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
-import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
 import type { LoggedSet } from '@/types/workout'
 import BeginnerTipCard from './BeginnerTipCard'
+import ExerciseInfoContent from './ExerciseInfoContent'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -61,27 +59,6 @@ interface ExerciseDisplayTabsProps {
   tip?: string
 }
 
-const FAU_DISPLAY_NAMES: Record<string, string> = {
-  chest: 'Chest',
-  'mid-back': 'Mid Back',
-  'lower-back': 'Lower Back',
-  'front-delts': 'Front Delts',
-  'side-delts': 'Side Delts',
-  'rear-delts': 'Rear Delts',
-  lats: 'Lats',
-  traps: 'Traps',
-  biceps: 'Biceps',
-  triceps: 'Triceps',
-  forearms: 'Forearms',
-  quads: 'Quads',
-  adductors: 'Adductors',
-  hamstrings: 'Hamstrings',
-  glutes: 'Glutes',
-  calves: 'Calves',
-  abs: 'Abs',
-  obliques: 'Obliques',
-}
-
 // Loading skeleton for history tab
 function HistoryLoadingSkeleton() {
   return (
@@ -107,7 +84,6 @@ export default function ExerciseDisplayTabs({
   showIntensity = true,
   tip,
 }: ExerciseDisplayTabsProps) {
-  const [expandedImage, setExpandedImage] = useState<string | null>(null)
   const hasNotes = !!exercise.notes
 
   return (
@@ -151,100 +127,10 @@ export default function ExerciseDisplayTabs({
       </TabsContent>
 
       <TabsContent value="info" className="flex-1 overflow-y-auto px-4">
-        <div className="space-y-6">
-          {exercise.exerciseDefinition?.imageUrls && exercise.exerciseDefinition.imageUrls.length > 0 && (
-            <div>
-              <div className="grid grid-cols-2 gap-3">
-                {exercise.exerciseDefinition.imageUrls.map((url, i) => {
-                  const src = url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
-                  return (
-                    <button
-                      key={url}
-                      type="button"
-                      onClick={() => setExpandedImage(src)}
-                      className="relative aspect-square rounded-lg overflow-hidden bg-muted cursor-pointer"
-                    >
-                      <Image
-                        src={src}
-                        alt={`${exercise.name} - ${i === 0 ? 'start' : 'end'} position`}
-                        fill
-                        className="object-cover"
-                        sizes="(max-width: 640px) 45vw, 300px"
-                      />
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          {exercise.exerciseDefinition?.instructions && (
-            <div>
-              <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">INSTRUCTIONS</h4>
-              <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
-                {exercise.exerciseDefinition.instructions}
-              </p>
-            </div>
-          )}
-
-          {exercise.exerciseDefinition?.primaryFAUs && exercise.exerciseDefinition.primaryFAUs.length > 0 && (
-            <div>
-              <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">PRIMARY MUSCLES</h4>
-              <div className="flex flex-wrap gap-1.5">
-                {exercise.exerciseDefinition.primaryFAUs.map((fau) => (
-                  <span
-                    key={fau}
-                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
-                  >
-                    {FAU_DISPLAY_NAMES[fau] || fau}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {exercise.exerciseDefinition?.secondaryFAUs && exercise.exerciseDefinition.secondaryFAUs.length > 0 && (
-            <div>
-              <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">SECONDARY MUSCLES</h4>
-              <div className="flex flex-wrap gap-1.5">
-                {exercise.exerciseDefinition.secondaryFAUs.map((fau) => (
-                  <span
-                    key={fau}
-                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
-                  >
-                    {FAU_DISPLAY_NAMES[fau] || fau}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {exercise.exerciseDefinition?.equipment && exercise.exerciseDefinition.equipment.length > 0 && (
-            <div>
-              <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">EQUIPMENT</h4>
-              <div className="flex flex-wrap gap-1.5">
-                {exercise.exerciseDefinition.equipment.map((item) => (
-                  <span
-                    key={item}
-                    className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
-                  >
-                    {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {!exercise.exerciseDefinition?.imageUrls?.length &&
-            !exercise.exerciseDefinition?.instructions &&
-            !exercise.exerciseDefinition?.primaryFAUs?.length &&
-            !exercise.exerciseDefinition?.secondaryFAUs?.length &&
-            !exercise.exerciseDefinition?.equipment?.length && (
-            <div className="flex items-center justify-center h-full py-12">
-              <p className="text-base sm:text-lg text-muted-foreground">No info available for this exercise</p>
-            </div>
-          )}
-        </div>
+        <ExerciseInfoContent
+          exerciseName={exercise.name}
+          exerciseDefinition={exercise.exerciseDefinition}
+        />
       </TabsContent>
 
       {hasNotes && (
@@ -321,27 +207,6 @@ export default function ExerciseDisplayTabs({
           </div>
         )}
       </TabsContent>
-
-      {expandedImage && (
-        <div
-          role="button"
-          tabIndex={0}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
-          style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-          onClick={() => setExpandedImage(null)}
-          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setExpandedImage(null) }}
-        >
-          <div className="relative w-[90vw] max-w-lg aspect-square">
-            <Image
-              src={expandedImage}
-              alt={exercise.name}
-              fill
-              className="object-contain"
-              sizes="90vw"
-            />
-          </div>
-        </div>
-      )}
     </Tabs>
   )
 }

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -90,22 +90,22 @@ export default function ExerciseDisplayTabs({
   return (
     <Tabs defaultValue="log-sets" className="w-full h-full flex flex-col">
       <TabsList className="flex-shrink-0 sticky top-0 z-10 overflow-hidden">
-        <TabsTrigger value="log-sets">
+        <TabsTrigger value="log-sets" className="flex-1">
           <span>Log Sets</span>
         </TabsTrigger>
-        <TabsTrigger value="info">
+        <TabsTrigger value="info" className="flex-1">
           <span>Info</span>
         </TabsTrigger>
         {hasNotes && (
-          <TabsTrigger value="notes" className="relative">
+          <TabsTrigger value="notes" className="relative flex-1">
             <span>Notes</span>
-            <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-primary"></span>
+            <span className="absolute top-1 right-1 w-2 h-2 bg-primary"></span>
           </TabsTrigger>
         )}
-        <TabsTrigger value="history" className="relative">
+        <TabsTrigger value="history" className="relative flex-1">
           <span>History</span>
           {hasHistoryIndicator && (
-            <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-primary"></span>
+            <span className="absolute top-1 right-1 w-2 h-2 bg-primary"></span>
           )}
         </TabsTrigger>
       </TabsList>

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Check } from 'lucide-react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
@@ -170,42 +171,36 @@ export default function ExerciseDisplayTabs({
               <p className="text-sm text-muted-foreground">{exerciseHistory.workoutName}</p>
             </div>
 
-            {/* Sets table */}
+            {/* Sets completed — matching logged set row format */}
             <div>
               <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">
                 SETS COMPLETED
               </h4>
-              <div className="border border-border divide-y divide-border bg-card doom-noise">
-                {/* Header row */}
-                <div className="flex items-center px-3 py-1.5 text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                  <span className="w-10">#</span>
-                  <span className="flex-1">WEIGHT</span>
-                  <span className="w-16 text-right">REPS</span>
-                  <span className="w-16 text-right">
-                    {exerciseHistory.sets.some(s => s.rir !== null) ? 'RIR' : exerciseHistory.sets.some(s => s.rpe !== null) ? 'RPE' : ''}
-                  </span>
-                </div>
-                {exerciseHistory.sets.map((set) => (
-                  <div
-                    key={set.setNumber}
-                    className="flex items-center px-3 py-2.5 text-base"
-                  >
-                    <span className="w-10 font-bold text-muted-foreground">{set.setNumber}</span>
-                    <span className="flex-1 font-bold text-foreground">{set.weight}{set.weightUnit}</span>
-                    <span className="w-16 text-right font-semibold text-foreground">{set.reps}</span>
-                    <span className="w-16 text-right text-muted-foreground">
-                      {set.rir !== null ? set.rir : set.rpe !== null ? set.rpe : ''}
-                    </span>
-                  </div>
-                ))}
+              <div className="divide-y divide-border/30">
+                {exerciseHistory.sets.map((set) => {
+                  const weight = set.weight === 0 ? 'Bodyweight' : `${set.weight} ${set.weightUnit}`
+                  const intensity = set.rir !== null ? `RIR ${set.rir}` : set.rpe !== null ? `RPE ${set.rpe}` : null
+                  return (
+                    <div key={set.setNumber} className="px-2 py-2">
+                      <div className="flex items-start gap-2">
+                        <Check size={16} className="text-success flex-shrink-0 mt-0.5" />
+                        <div>
+                          <span className="block text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                            Set {set.setNumber}
+                          </span>
+                          <span className="block text-base font-bold text-foreground">
+                            {weight} &times; {set.reps}
+                            {intensity ? ` \u00b7 ${intensity}` : ''}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
               </div>
             </div>
           </div>
-        ) : (
-          <div className="flex items-center justify-center h-full py-12">
-            <p className="text-base sm:text-lg text-muted-foreground">No history available for this exercise</p>
-          </div>
-        )}
+        ) : null}
       </TabsContent>
     </Tabs>
   )

--- a/components/workout-logging/ExerciseInfoContent.tsx
+++ b/components/workout-logging/ExerciseInfoContent.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
+
+interface ExerciseDefinition {
+  primaryFAUs: string[]
+  secondaryFAUs: string[]
+  equipment: string[]
+  instructions?: string
+  imageUrls?: string[]
+}
+
+interface ExerciseInfoContentProps {
+  exerciseName: string
+  exerciseDefinition?: ExerciseDefinition
+}
+
+const FAU_DISPLAY_NAMES: Record<string, string> = {
+  chest: 'Chest',
+  'mid-back': 'Mid Back',
+  'lower-back': 'Lower Back',
+  'front-delts': 'Front Delts',
+  'side-delts': 'Side Delts',
+  'rear-delts': 'Rear Delts',
+  lats: 'Lats',
+  traps: 'Traps',
+  biceps: 'Biceps',
+  triceps: 'Triceps',
+  forearms: 'Forearms',
+  quads: 'Quads',
+  adductors: 'Adductors',
+  hamstrings: 'Hamstrings',
+  glutes: 'Glutes',
+  calves: 'Calves',
+  abs: 'Abs',
+  obliques: 'Obliques',
+}
+
+export default function ExerciseInfoContent({ exerciseName, exerciseDefinition }: ExerciseInfoContentProps) {
+  const [expandedImage, setExpandedImage] = useState<string | null>(null)
+
+  const hasImages = exerciseDefinition?.imageUrls && exerciseDefinition.imageUrls.length > 0
+  const hasInstructions = !!exerciseDefinition?.instructions
+  const hasPrimaryFAUs = exerciseDefinition?.primaryFAUs && exerciseDefinition.primaryFAUs.length > 0
+  const hasSecondaryFAUs = exerciseDefinition?.secondaryFAUs && exerciseDefinition.secondaryFAUs.length > 0
+  const hasEquipment = exerciseDefinition?.equipment && exerciseDefinition.equipment.length > 0
+  const hasAnyInfo = hasImages || hasInstructions || hasPrimaryFAUs || hasSecondaryFAUs || hasEquipment
+
+  return (
+    <>
+      <div className="space-y-6">
+        {hasImages ? (
+          <div>
+            <div className="grid grid-cols-2 gap-3">
+              {exerciseDefinition!.imageUrls!.map((url, i) => {
+                const src = url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
+                return (
+                  <button
+                    key={url}
+                    type="button"
+                    onClick={() => setExpandedImage(src)}
+                    className="relative aspect-square rounded-lg overflow-hidden bg-muted cursor-pointer"
+                  >
+                    <Image
+                      src={src}
+                      alt={`${exerciseName} - ${i === 0 ? 'start' : 'end'} position`}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 640px) 45vw, 300px"
+                    />
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center py-8 border border-dashed border-border/40 bg-muted/20">
+            <p className="text-sm text-muted-foreground uppercase tracking-wider">
+              More images to come
+            </p>
+          </div>
+        )}
+
+        {hasInstructions && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">INSTRUCTIONS</h4>
+            <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
+              {exerciseDefinition!.instructions}
+            </p>
+          </div>
+        )}
+
+        {hasPrimaryFAUs && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">PRIMARY MUSCLES</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {exerciseDefinition!.primaryFAUs.map((fau) => (
+                <span
+                  key={fau}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
+                >
+                  {FAU_DISPLAY_NAMES[fau] || fau}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {hasSecondaryFAUs && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">SECONDARY MUSCLES</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {exerciseDefinition!.secondaryFAUs.map((fau) => (
+                <span
+                  key={fau}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
+                >
+                  {FAU_DISPLAY_NAMES[fau] || fau}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {hasEquipment && (
+          <div>
+            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">EQUIPMENT</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {exerciseDefinition!.equipment.map((item) => (
+                <span
+                  key={item}
+                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
+                >
+                  {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!hasAnyInfo && (
+          <div className="flex items-center justify-center h-full py-12">
+            <p className="text-base sm:text-lg text-muted-foreground">No info available for this exercise</p>
+          </div>
+        )}
+      </div>
+
+      {expandedImage && (
+        <div
+          role="button"
+          tabIndex={0}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+          onClick={() => setExpandedImage(null)}
+          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setExpandedImage(null) }}
+        >
+          <div className="relative w-[90vw] max-w-lg aspect-square">
+            <Image
+              src={expandedImage}
+              alt={exerciseName}
+              fill
+              className="object-contain"
+              sizes="90vw"
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/workout-logging/ExerciseInfoContent.tsx
+++ b/components/workout-logging/ExerciseInfoContent.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import Image from 'next/image'
-import { useState } from 'react'
+import ExerciseImageCrossfade from '@/components/ui/ExerciseImageCrossfade'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
 
 interface ExerciseDefinition {
@@ -39,134 +38,83 @@ const FAU_DISPLAY_NAMES: Record<string, string> = {
 }
 
 export default function ExerciseInfoContent({ exerciseName, exerciseDefinition }: ExerciseInfoContentProps) {
-  const [expandedImage, setExpandedImage] = useState<string | null>(null)
-
-  const hasImages = exerciseDefinition?.imageUrls && exerciseDefinition.imageUrls.length > 0
+  const imageUrls = exerciseDefinition?.imageUrls || []
   const hasInstructions = !!exerciseDefinition?.instructions
   const hasPrimaryFAUs = exerciseDefinition?.primaryFAUs && exerciseDefinition.primaryFAUs.length > 0
   const hasSecondaryFAUs = exerciseDefinition?.secondaryFAUs && exerciseDefinition.secondaryFAUs.length > 0
   const hasEquipment = exerciseDefinition?.equipment && exerciseDefinition.equipment.length > 0
-  const hasAnyInfo = hasImages || hasInstructions || hasPrimaryFAUs || hasSecondaryFAUs || hasEquipment
+  const hasAnyInfo = imageUrls.length > 0 || hasInstructions || hasPrimaryFAUs || hasSecondaryFAUs || hasEquipment
 
   return (
-    <>
-      <div className="space-y-6">
-        {hasImages ? (
-          <div>
-            <div className="grid grid-cols-2 gap-3">
-              {exerciseDefinition!.imageUrls!.map((url, i) => {
-                const src = url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
-                return (
-                  <button
-                    key={url}
-                    type="button"
-                    onClick={() => setExpandedImage(src)}
-                    className="relative aspect-square rounded-lg overflow-hidden bg-muted cursor-pointer"
-                  >
-                    <Image
-                      src={src}
-                      alt={`${exerciseName} - ${i === 0 ? 'start' : 'end'} position`}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 640px) 45vw, 300px"
-                    />
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-center py-8 border border-dashed border-border/40 bg-muted/20">
-            <p className="text-sm text-muted-foreground uppercase tracking-wider">
-              More images to come
-            </p>
-          </div>
-        )}
+    <div className="space-y-6">
+      {/* Exercise demonstration — animated crossfade */}
+      <ExerciseImageCrossfade
+        imageUrls={imageUrls}
+        exerciseName={exerciseName}
+      />
 
-        {hasInstructions && (
-          <div>
-            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">INSTRUCTIONS</h4>
-            <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
-              {exerciseDefinition!.instructions}
-            </p>
-          </div>
-        )}
+      {hasInstructions && (
+        <div>
+          <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">INSTRUCTIONS</h4>
+          <p className="text-base text-muted-foreground leading-relaxed whitespace-pre-line">
+            {exerciseDefinition!.instructions}
+          </p>
+        </div>
+      )}
 
-        {hasPrimaryFAUs && (
-          <div>
-            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">PRIMARY MUSCLES</h4>
-            <div className="flex flex-wrap gap-1.5">
-              {exerciseDefinition!.primaryFAUs.map((fau) => (
-                <span
-                  key={fau}
-                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
-                >
-                  {FAU_DISPLAY_NAMES[fau] || fau}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {hasSecondaryFAUs && (
-          <div>
-            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">SECONDARY MUSCLES</h4>
-            <div className="flex flex-wrap gap-1.5">
-              {exerciseDefinition!.secondaryFAUs.map((fau) => (
-                <span
-                  key={fau}
-                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
-                >
-                  {FAU_DISPLAY_NAMES[fau] || fau}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {hasEquipment && (
-          <div>
-            <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">EQUIPMENT</h4>
-            <div className="flex flex-wrap gap-1.5">
-              {exerciseDefinition!.equipment.map((item) => (
-                <span
-                  key={item}
-                  className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
-                >
-                  {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {!hasAnyInfo && (
-          <div className="flex items-center justify-center h-full py-12">
-            <p className="text-base sm:text-lg text-muted-foreground">No info available for this exercise</p>
-          </div>
-        )}
-      </div>
-
-      {expandedImage && (
-        <div
-          role="button"
-          tabIndex={0}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
-          style={{ position: 'fixed', inset: 0, zIndex: 50 }}
-          onClick={() => setExpandedImage(null)}
-          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setExpandedImage(null) }}
-        >
-          <div className="relative w-[90vw] max-w-lg aspect-square">
-            <Image
-              src={expandedImage}
-              alt={exerciseName}
-              fill
-              className="object-contain"
-              sizes="90vw"
-            />
+      {hasPrimaryFAUs && (
+        <div>
+          <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">PRIMARY MUSCLES</h4>
+          <div className="flex flex-wrap gap-1.5">
+            {exerciseDefinition!.primaryFAUs.map((fau) => (
+              <span
+                key={fau}
+                className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border-2 border-primary text-primary bg-primary/10"
+              >
+                {FAU_DISPLAY_NAMES[fau] || fau}
+              </span>
+            ))}
           </div>
         </div>
       )}
-    </>
+
+      {hasSecondaryFAUs && (
+        <div>
+          <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">SECONDARY MUSCLES</h4>
+          <div className="flex flex-wrap gap-1.5">
+            {exerciseDefinition!.secondaryFAUs.map((fau) => (
+              <span
+                key={fau}
+                className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-foreground bg-muted/50"
+              >
+                {FAU_DISPLAY_NAMES[fau] || fau}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {hasEquipment && (
+        <div>
+          <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-2">EQUIPMENT</h4>
+          <div className="flex flex-wrap gap-1.5">
+            {exerciseDefinition!.equipment.map((item) => (
+              <span
+                key={item}
+                className="px-2.5 py-1 text-sm font-bold uppercase tracking-wider border border-border text-muted-foreground bg-card"
+              >
+                {EQUIPMENT_LABELS[item] || item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!hasAnyInfo && (
+        <div className="flex items-center justify-center h-full py-12">
+          <p className="text-base sm:text-lg text-muted-foreground">No info available for this exercise</p>
+        </div>
+      )}
+    </div>
   )
 }

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -8,6 +8,7 @@ interface ExerciseLoggingHeaderProps {
   failedSetCount?: number
   onMinimize: () => void
   onClose: () => void
+  modeToggle?: React.ReactNode
 }
 
 export default function ExerciseLoggingHeader({
@@ -16,6 +17,7 @@ export default function ExerciseLoggingHeader({
   failedSetCount = 0,
   onMinimize,
   onClose,
+  modeToggle,
 }: ExerciseLoggingHeaderProps) {
   return (
     <div
@@ -52,6 +54,11 @@ export default function ExerciseLoggingHeader({
           </button>
         </div>
       </div>
+      {modeToggle && (
+        <div className="text-center pb-1">
+          {modeToggle}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -1,56 +1,107 @@
 'use client'
 
-import { AlertCircle, ChevronDown, X } from 'lucide-react'
+import { Check, X } from 'lucide-react'
+import ActionsMenu, { type ActionItem } from '@/components/ActionsMenu'
+import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
 
 interface ExerciseLoggingHeaderProps {
   currentExerciseIndex: number
   totalExercises: number
   failedSetCount?: number
-  onMinimize: () => void
+  onCompleteWorkout: () => void
   onClose: () => void
+  menuActions: ActionItem[]
   modeToggle?: React.ReactNode
+}
+
+function ProgressIndicator({ current, total }: { current: number; total: number }) {
+  const useDoubleRow = total > 5
+  const topCount = useDoubleRow ? Math.ceil(total / 2) : total
+  const bottomCount = useDoubleRow ? total - topCount : 0
+
+  const renderRow = (count: number, startIndex: number) => (
+    <div className="flex gap-[3px]" style={{ width: '110px' }}>
+      {Array.from({ length: count }, (_, i) => {
+        const exerciseIndex = startIndex + i
+        return (
+          <div
+            key={exerciseIndex}
+            className="h-[5px] flex-1 transition-colors"
+            style={{
+              backgroundColor: exerciseIndex <= current
+                ? 'var(--primary)'
+                : 'rgba(0,0,0,0.25)',
+              boxShadow: exerciseIndex <= current
+                ? undefined
+                : 'inset 0 1px 0 rgba(0,0,0,0.20)',
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col gap-[3px]" style={{ width: '110px' }}>
+      {renderRow(topCount, 0)}
+      {useDoubleRow && renderRow(bottomCount, topCount)}
+    </div>
+  )
 }
 
 export default function ExerciseLoggingHeader({
   currentExerciseIndex,
   totalExercises,
   failedSetCount = 0,
-  onMinimize,
+  onCompleteWorkout,
   onClose,
+  menuActions,
   modeToggle,
 }: ExerciseLoggingHeaderProps) {
+  const { formatted: elapsedTime } = useWorkoutTimer()
+
   return (
     <div
-      className="bg-primary text-primary-foreground px-4 py-2 border-b border-primary-muted-dark flex-shrink-0"
-      style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.5rem)' }}
+      className="bg-secondary text-secondary-foreground flex-shrink-0"
+      style={{ paddingTop: 'env(safe-area-inset-top)', boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.25)' }}
     >
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-sm text-primary-foreground/80 uppercase tracking-wider font-bold">
-          EXERCISE {currentExerciseIndex + 1} OF {totalExercises}
+      <div className="px-4 py-3 grid items-center" style={{ gridTemplateColumns: '1fr auto 1fr' }}>
+        {/* Left: progress indicator */}
+        <div className="flex items-center">
+          <ProgressIndicator current={currentExerciseIndex} total={totalExercises} />
+          {failedSetCount > 0 && (
+            <span className="ml-2 text-xs text-warning font-semibold">{failedSetCount} unsaved</span>
+          )}
         </div>
 
-        <div className="flex items-center gap-1.5">
-          {failedSetCount > 0 && (
-            <div className="flex items-center gap-1 text-warning text-xs font-semibold">
-              <AlertCircle size={14} />
-              <span>{failedSetCount} unsaved</span>
-            </div>
-          )}
+        {/* Center: elapsed time */}
+        <span className="text-lg font-medium text-foreground tabular-nums" style={{ minWidth: '5ch' }}>
+          {elapsedTime}
+        </span>
+
+        {/* Right: action icons */}
+        <div className="flex items-center justify-end gap-3.5">
+          <ActionsMenu
+            actions={menuActions}
+            size="sm"
+            variant="ghost"
+            className="text-foreground/80 hover:text-foreground"
+          />
           <button
             type="button"
-            onClick={onMinimize}
-            className="min-h-12 min-w-12 flex items-center justify-center text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary-foreground/15 transition-colors doom-focus-ring"
-            aria-label="Minimize workout"
+            onClick={onCompleteWorkout}
+            className="p-1 text-primary hover:text-primary/80 transition-colors doom-focus-ring"
+            aria-label="Complete workout"
           >
-            <ChevronDown className="h-5 w-5" />
+            <Check size={18} strokeWidth={2.5} />
           </button>
           <button
             type="button"
             onClick={onClose}
-            className="min-h-12 min-w-12 flex items-center justify-center text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary-foreground/15 transition-colors doom-focus-ring"
-            aria-label="Close workout"
+            className="p-1 text-foreground/80 hover:text-foreground transition-colors doom-focus-ring"
+            aria-label="Exit workout"
           >
-            <X className="h-5 w-5" />
+            <X size={18} strokeWidth={2.5} />
           </button>
         </div>
       </div>

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -75,7 +75,7 @@ export default function ExerciseLoggingHeader({
         </div>
 
         {/* Center: elapsed time */}
-        <span className="text-lg font-medium text-foreground tabular-nums" style={{ minWidth: '5ch' }}>
+        <span className="text-lg font-medium text-secondary-foreground tabular-nums" style={{ minWidth: '5ch' }}>
           {elapsedTime}
         </span>
 
@@ -85,7 +85,7 @@ export default function ExerciseLoggingHeader({
             actions={menuActions}
             size="sm"
             variant="ghost"
-            className="text-foreground/80 hover:text-foreground"
+            className="text-secondary-foreground/80 hover:text-secondary-foreground"
           />
           <button
             type="button"
@@ -98,7 +98,7 @@ export default function ExerciseLoggingHeader({
           <button
             type="button"
             onClick={onClose}
-            className="p-1 text-foreground/80 hover:text-foreground transition-colors doom-focus-ring"
+            className="p-1 text-secondary-foreground/80 hover:text-secondary-foreground transition-colors doom-focus-ring"
             aria-label="Exit workout"
           >
             <X size={18} strokeWidth={2.5} />

--- a/components/workout-logging/ExerciseNavigation.tsx
+++ b/components/workout-logging/ExerciseNavigation.tsx
@@ -15,6 +15,7 @@ interface ExerciseNavigationProps {
   totalExercises: number
   onPrevious: () => void
   onNext: () => void
+  hideChevrons?: boolean
 }
 
 export default function ExerciseNavigation({
@@ -23,6 +24,7 @@ export default function ExerciseNavigation({
   totalExercises,
   onPrevious,
   onNext,
+  hideChevrons = false,
 }: ExerciseNavigationProps) {
   // Determine if this is part of a superset
   const isSuperset = currentExercise.exerciseGroup !== null
@@ -30,18 +32,20 @@ export default function ExerciseNavigation({
 
   return (
     <div className="border-b border-border px-3 py-2 flex items-center justify-between bg-card flex-shrink-0">
-      <button type="button"
-        onClick={onPrevious}
-        disabled={currentExerciseIndex === 0}
-        className={`p-2 transition-all doom-focus-ring ${
-          currentExerciseIndex === 0
-            ? 'opacity-20 cursor-not-allowed'
-            : 'text-muted-foreground hover:text-foreground'
-        }`}
-        aria-label="Previous exercise"
-      >
-        <ChevronLeft size={20} strokeWidth={2.5} />
-      </button>
+      {!hideChevrons && (
+        <button type="button"
+          onClick={onPrevious}
+          disabled={currentExerciseIndex === 0}
+          className={`p-2 transition-all doom-focus-ring ${
+            currentExerciseIndex === 0
+              ? 'opacity-20 cursor-not-allowed'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          aria-label="Previous exercise"
+        >
+          <ChevronLeft size={20} strokeWidth={2.5} />
+        </button>
+      )}
 
       <div className="text-center flex-1 min-w-0 px-2">
         {isSuperset && (
@@ -52,18 +56,20 @@ export default function ExerciseNavigation({
         <h3 className="text-lg font-bold text-foreground uppercase tracking-wide truncate doom-heading">{currentExercise.name}</h3>
       </div>
 
-      <button type="button"
-        onClick={onNext}
-        disabled={currentExerciseIndex === totalExercises - 1}
-        className={`p-2 transition-all doom-focus-ring ${
-          currentExerciseIndex === totalExercises - 1
-            ? 'opacity-20 cursor-not-allowed'
-            : 'text-muted-foreground hover:text-foreground'
-        }`}
-        aria-label="Next exercise"
-      >
-        <ChevronRight size={20} strokeWidth={2.5} />
-      </button>
+      {!hideChevrons && (
+        <button type="button"
+          onClick={onNext}
+          disabled={currentExerciseIndex === totalExercises - 1}
+          className={`p-2 transition-all doom-focus-ring ${
+            currentExerciseIndex === totalExercises - 1
+              ? 'opacity-20 cursor-not-allowed'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          aria-label="Next exercise"
+        >
+          <ChevronRight size={20} strokeWidth={2.5} />
+        </button>
+      )}
     </div>
   )
 }

--- a/components/workout-logging/FollowAlongFooter.tsx
+++ b/components/workout-logging/FollowAlongFooter.tsx
@@ -2,6 +2,9 @@
 
 import { CheckCircle, ChevronLeft, ChevronRight } from 'lucide-react'
 
+const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
+const RECESSED_SHADOW = 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)'
+
 interface FollowAlongFooterProps {
   currentIndex: number
   totalExercises: number
@@ -23,15 +26,19 @@ export default function FollowAlongFooter({
   const isLast = currentIndex >= totalExercises - 1
 
   return (
-    <div className="flex-shrink-0 border-t border-border px-3 py-2 bg-card flex gap-2">
+    <div
+      className="flex-shrink-0 bg-secondary px-4 py-3 flex gap-2.5"
+      style={{ boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)' }}
+    >
       <button
         type="button"
         disabled={isFirst}
         onClick={onPrevious}
-        className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-muted text-foreground font-bold uppercase tracking-wider border-2 border-border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:bg-secondary doom-focus-ring"
+        className="w-10 h-11 flex items-center justify-center text-secondary-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed doom-focus-ring"
+        style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RECESSED_SHADOW }}
+        aria-label="Previous exercise"
       >
-        <ChevronLeft size={18} />
-        Previous
+        <ChevronLeft size={18} strokeWidth={2.5} />
       </button>
 
       {isLast ? (
@@ -39,19 +46,21 @@ export default function FollowAlongFooter({
           type="button"
           disabled={isSubmitting}
           onClick={onFinish}
-          className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-success text-success-foreground font-bold uppercase tracking-wider transition-colors disabled:opacity-50 doom-button-3d doom-focus-ring"
+          className="flex-1 h-11 flex items-center justify-center gap-1.5 bg-primary text-primary-foreground font-medium uppercase tracking-widest text-sm transition-colors disabled:opacity-50 doom-focus-ring"
+          style={{ boxShadow: RAISED_SHADOW }}
         >
-          <CheckCircle size={18} />
+          <CheckCircle size={16} />
           Finish Workout
         </button>
       ) : (
         <button
           type="button"
           onClick={onNext}
-          className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-primary text-primary-foreground font-bold uppercase tracking-wider transition-colors hover:bg-primary/90 doom-button-3d doom-focus-ring"
+          className="flex-1 h-11 flex items-center justify-center gap-1.5 bg-accent text-accent-foreground font-medium uppercase tracking-widest text-sm transition-colors doom-focus-ring"
+          style={{ boxShadow: RAISED_SHADOW }}
         >
           Next Exercise
-          <ChevronRight size={18} />
+          <ChevronRight size={16} />
         </button>
       )}
     </div>

--- a/components/workout-logging/FollowAlongFooter.tsx
+++ b/components/workout-logging/FollowAlongFooter.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChevronLeft, ChevronRight, CheckCircle } from 'lucide-react'
+import { CheckCircle, ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface FollowAlongFooterProps {
   currentIndex: number

--- a/components/workout-logging/FollowAlongFooter.tsx
+++ b/components/workout-logging/FollowAlongFooter.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { ChevronLeft, ChevronRight, CheckCircle } from 'lucide-react'
+
+interface FollowAlongFooterProps {
+  currentIndex: number
+  totalExercises: number
+  isSubmitting: boolean
+  onPrevious: () => void
+  onNext: () => void
+  onFinish: () => void
+}
+
+export default function FollowAlongFooter({
+  currentIndex,
+  totalExercises,
+  isSubmitting,
+  onPrevious,
+  onNext,
+  onFinish,
+}: FollowAlongFooterProps) {
+  const isFirst = currentIndex === 0
+  const isLast = currentIndex >= totalExercises - 1
+
+  return (
+    <div className="flex-shrink-0 border-t border-border px-3 py-2 bg-card flex gap-2">
+      <button
+        type="button"
+        disabled={isFirst}
+        onClick={onPrevious}
+        className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-muted text-foreground font-bold uppercase tracking-wider border-2 border-border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:bg-secondary doom-focus-ring"
+      >
+        <ChevronLeft size={18} />
+        Previous
+      </button>
+
+      {isLast ? (
+        <button
+          type="button"
+          disabled={isSubmitting}
+          onClick={onFinish}
+          className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-success text-success-foreground font-bold uppercase tracking-wider transition-colors disabled:opacity-50 doom-button-3d doom-focus-ring"
+        >
+          <CheckCircle size={18} />
+          Finish Workout
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex-1 min-h-[48px] flex items-center justify-center gap-1.5 px-4 py-2 bg-primary text-primary-foreground font-bold uppercase tracking-wider transition-colors hover:bg-primary/90 doom-button-3d doom-focus-ring"
+        >
+          Next Exercise
+          <ChevronRight size={18} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/workout-logging/FollowAlongHeader.tsx
+++ b/components/workout-logging/FollowAlongHeader.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+interface FollowAlongHeaderProps {
+  currentExerciseIndex: number
+  totalExercises: number
+  onClose: () => void
+  onSwitchToLogging: () => void
+}
+
+export default function FollowAlongHeader({
+  currentExerciseIndex,
+  totalExercises,
+  onClose,
+  onSwitchToLogging,
+}: FollowAlongHeaderProps) {
+  const [bannerVisible, setBannerVisible] = useState(true)
+  const [bannerFading, setBannerFading] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  // Auto-fade the banner after 5 seconds
+  useEffect(() => {
+    if (!bannerVisible || showConfirm) return
+    const timer = setTimeout(() => {
+      setBannerFading(true)
+      setTimeout(() => setBannerVisible(false), 500)
+    }, 15000)
+    return () => clearTimeout(timer)
+  }, [bannerVisible, showConfirm])
+
+  const handleBannerTap = useCallback(() => {
+    setShowConfirm(true)
+  }, [])
+
+  const handleConfirmSwitch = useCallback(() => {
+    setShowConfirm(false)
+    setBannerVisible(false)
+    onSwitchToLogging()
+  }, [onSwitchToLogging])
+
+  return (
+    <>
+      <div
+        className="bg-primary text-primary-foreground px-4 py-2 border-b border-primary-muted-dark flex-shrink-0"
+        style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.5rem)' }}
+      >
+        <div className="flex items-center gap-3">
+          {/* Segmented progress bar */}
+          <div className="flex-1 flex gap-1" role="progressbar" aria-valuenow={currentExerciseIndex + 1} aria-valuemin={1} aria-valuemax={totalExercises} aria-label={`Exercise ${currentExerciseIndex + 1} of ${totalExercises}`}>
+            {Array.from({ length: totalExercises }, (_, i) => (
+              <div
+                key={i}
+                className={`h-2 flex-1 transition-colors ${
+                  i <= currentExerciseIndex
+                    ? 'bg-primary-foreground'
+                    : 'bg-primary-foreground/20'
+                }`}
+              />
+            ))}
+          </div>
+
+          {/* Close button */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="min-h-12 min-w-12 flex items-center justify-center text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary-foreground/15 transition-colors doom-focus-ring"
+            aria-label="Close workout"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Auto-fade banner */}
+        {bannerVisible && (
+          <button
+            type="button"
+            onClick={handleBannerTap}
+            className={`w-full text-center text-sm text-primary-foreground/70 py-1 transition-opacity duration-500 ${
+              bannerFading ? 'opacity-0' : 'opacity-100'
+            }`}
+          >
+            Ready to track weights? Tap here to switch to logging.
+          </button>
+        )}
+      </div>
+
+      {/* Switch to logging confirmation */}
+      {showConfirm && (
+        <div className="fixed inset-0 backdrop-blur-md bg-black/40 dark:bg-black/60 flex items-center justify-center z-[60] p-4">
+          <div className="bg-card border-2 border-border p-6 sm:p-8 text-center max-w-sm w-full shadow-xl doom-corners">
+            <h3 className="text-lg font-bold text-foreground mb-3 uppercase tracking-wider">
+              Switch to Logging Mode?
+            </h3>
+            <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+              This will let you track your weights and reps for each set. You can always switch back to Follow Along mode in Settings.
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowConfirm(false)}
+                className="flex-1 px-4 py-3 text-base bg-muted text-foreground hover:bg-secondary transition-colors font-bold uppercase tracking-wider border-2 border-border hover:border-primary doom-focus-ring"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmSwitch}
+                className="flex-1 px-4 py-3 text-base bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-bold uppercase tracking-wider doom-button-3d doom-focus-ring"
+              >
+                Switch
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/workout-logging/FollowAlongHeader.tsx
+++ b/components/workout-logging/FollowAlongHeader.tsx
@@ -10,6 +10,41 @@ interface FollowAlongHeaderProps {
   onSwitchToLogging: () => void
 }
 
+function ProgressIndicator({ current, total }: { current: number; total: number }) {
+  const useDoubleRow = total > 5
+  const topCount = useDoubleRow ? Math.ceil(total / 2) : total
+  const bottomCount = useDoubleRow ? total - topCount : 0
+
+  const renderRow = (count: number, startIndex: number) => (
+    <div className="flex gap-[3px]" style={{ width: '110px' }}>
+      {Array.from({ length: count }, (_, i) => {
+        const exerciseIndex = startIndex + i
+        return (
+          <div
+            key={exerciseIndex}
+            className="h-[5px] flex-1 transition-colors"
+            style={{
+              backgroundColor: exerciseIndex <= current
+                ? 'var(--primary)'
+                : 'rgba(0,0,0,0.25)',
+              boxShadow: exerciseIndex <= current
+                ? undefined
+                : 'inset 0 1px 0 rgba(0,0,0,0.20)',
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col gap-[3px]" style={{ width: '110px' }}>
+      {renderRow(topCount, 0)}
+      {useDoubleRow && renderRow(bottomCount, topCount)}
+    </div>
+  )
+}
+
 export default function FollowAlongHeader({
   currentExerciseIndex,
   totalExercises,
@@ -20,7 +55,6 @@ export default function FollowAlongHeader({
   const [bannerFading, setBannerFading] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
 
-  // Auto-fade the banner after 5 seconds
   useEffect(() => {
     if (!bannerVisible || showConfirm) return
     const timer = setTimeout(() => {
@@ -43,41 +77,27 @@ export default function FollowAlongHeader({
   return (
     <>
       <div
-        className="bg-primary text-primary-foreground px-4 py-2 border-b border-primary-muted-dark flex-shrink-0"
-        style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.5rem)' }}
+        className="bg-secondary text-secondary-foreground flex-shrink-0"
+        style={{ paddingTop: 'env(safe-area-inset-top)', boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.25)' }}
       >
-        <div className="flex items-center gap-3">
-          {/* Segmented progress bar */}
-          <div className="flex-1 flex gap-1" role="progressbar" aria-valuenow={currentExerciseIndex + 1} aria-valuemin={1} aria-valuemax={totalExercises} aria-label={`Exercise ${currentExerciseIndex + 1} of ${totalExercises}`}>
-            {Array.from({ length: totalExercises }, (_, i) => (
-              <div
-                key={i}
-                className={`h-2 flex-1 transition-colors ${
-                  i <= currentExerciseIndex
-                    ? 'bg-primary-foreground'
-                    : 'bg-primary-foreground/20'
-                }`}
-              />
-            ))}
-          </div>
+        <div className="px-4 py-3 flex items-center justify-between gap-3">
+          <ProgressIndicator current={currentExerciseIndex} total={totalExercises} />
 
-          {/* Close button */}
           <button
             type="button"
             onClick={onClose}
-            className="min-h-12 min-w-12 flex items-center justify-center text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary-foreground/15 transition-colors doom-focus-ring"
+            className="p-1 text-secondary-foreground/80 hover:text-secondary-foreground transition-colors doom-focus-ring"
             aria-label="Close workout"
           >
-            <X className="h-5 w-5" />
+            <X size={18} strokeWidth={2.5} />
           </button>
         </div>
 
-        {/* Auto-fade banner */}
         {bannerVisible && (
           <button
             type="button"
             onClick={handleBannerTap}
-            className={`w-full text-center text-sm text-primary-foreground/70 py-1 transition-opacity duration-500 ${
+            className={`w-full text-center text-sm text-secondary-foreground/50 pb-2 transition-opacity duration-500 ${
               bannerFading ? 'opacity-0' : 'opacity-100'
             }`}
           >
@@ -86,7 +106,6 @@ export default function FollowAlongHeader({
         )}
       </div>
 
-      {/* Switch to logging confirmation */}
       {showConfirm && (
         <div className="fixed inset-0 backdrop-blur-md bg-black/40 dark:bg-black/60 flex items-center justify-center z-[60] p-4">
           <div className="bg-card border-2 border-border p-6 sm:p-8 text-center max-w-sm w-full shadow-xl doom-corners">

--- a/components/workout-logging/FollowAlongHeader.tsx
+++ b/components/workout-logging/FollowAlongHeader.tsx
@@ -97,7 +97,7 @@ export default function FollowAlongHeader({
           <button
             type="button"
             onClick={handleBannerTap}
-            className={`w-full text-center text-sm text-secondary-foreground/50 pb-2 transition-opacity duration-500 ${
+            className={`w-full text-center text-sm text-secondary-foreground/80 pb-2 transition-opacity duration-500 ${
               bannerFading ? 'opacity-0' : 'opacity-100'
             }`}
           >

--- a/components/workout-logging/FollowAlongTabs.tsx
+++ b/components/workout-logging/FollowAlongTabs.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import ExerciseImageCrossfade from '@/components/ui/ExerciseImageCrossfade'
+import BeginnerTipCard from './BeginnerTipCard'
+
+interface PrescribedSet {
+  id: string
+  setNumber: number
+  reps: string
+  weight: string | null
+  rpe: number | null
+  rir: number | null
+}
+
+interface Exercise {
+  id: string
+  name: string
+  notes: string | null
+  exerciseDefinition?: {
+    primaryFAUs: string[]
+    secondaryFAUs: string[]
+    equipment: string[]
+    instructions?: string
+    imageUrls?: string[]
+  }
+}
+
+interface FollowAlongViewProps {
+  exercise: Exercise
+  prescribedSets: PrescribedSet[]
+  tip: string
+}
+
+const FAU_DISPLAY_NAMES: Record<string, string> = {
+  chest: 'Chest', 'mid-back': 'Mid Back', 'lower-back': 'Lower Back',
+  'front-delts': 'Front Delts', 'side-delts': 'Side Delts', 'rear-delts': 'Rear Delts',
+  lats: 'Lats', traps: 'Traps', biceps: 'Biceps', triceps: 'Triceps',
+  forearms: 'Forearms', quads: 'Quads', adductors: 'Adductors',
+  hamstrings: 'Hamstrings', glutes: 'Glutes', calves: 'Calves',
+  abs: 'Abs', obliques: 'Obliques',
+}
+
+/**
+ * Format prescribed sets as compact subtitle: "3 x 12" or "3 sets x 12 reps".
+ * For varying reps: "3 sets: 12, 10, 8"
+ */
+function formatPrescriptionSubtitle(prescribedSets: PrescribedSet[]): string {
+  if (prescribedSets.length === 0) return 'No sets prescribed'
+
+  const repsValues = prescribedSets.map(s => {
+    const match = s.reps.match(/(\d+)(?:\s*-\s*(\d+))?/)
+    if (!match) return s.reps
+    return match[2] || match[1]
+  })
+
+  const allSame = repsValues.every(r => r === repsValues[0])
+  const count = prescribedSets.length
+
+  if (allSame) {
+    return `${count} sets of ${repsValues[0]} repetitions`
+  }
+
+  return `${count} sets: ${repsValues.join(', ')} repetitions`
+}
+
+/**
+ * Single-scroll follow-along view. No tabs — all content flows top to bottom:
+ * title block, exercise image (crossfade), instructions, coaching tip.
+ */
+export default function FollowAlongTabs({
+  exercise,
+  prescribedSets,
+  tip,
+}: FollowAlongViewProps) {
+  const subtitle = formatPrescriptionSubtitle(prescribedSets)
+  const primaryMuscles = exercise.exerciseDefinition?.primaryFAUs
+    ?.map(fau => FAU_DISPLAY_NAMES[fau] || fau.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()))
+  const imageUrls = exercise.exerciseDefinition?.imageUrls || []
+
+  // Track whether content is scrollable and not fully scrolled
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [showScrollFade, setShowScrollFade] = useState(false)
+
+  const checkScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const hasMoreBelow = el.scrollHeight - el.scrollTop - el.clientHeight > 8
+    setShowScrollFade(hasMoreBelow)
+  }, [])
+
+  useEffect(() => {
+    checkScroll()
+  }, [checkScroll, exercise.id])
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="relative flex-1 min-h-0">
+        <div ref={scrollRef} onScroll={checkScroll} className="h-full overflow-y-auto">
+        {/* Title block */}
+        <div className="bg-card border-b border-border px-4 py-4 text-center">
+          <h2 className="text-xl font-bold text-foreground uppercase tracking-wider doom-heading">
+            {exercise.name}
+          </h2>
+          <p className="text-base text-primary font-semibold mt-1">
+            {subtitle}
+          </p>
+          {primaryMuscles && primaryMuscles.length > 0 && (
+            <p className="text-xs text-muted-foreground uppercase tracking-widest mt-1.5">
+              {primaryMuscles.join(' \u00b7 ')}
+            </p>
+          )}
+        </div>
+
+        {/* Exercise demonstration */}
+        <div className="px-4 pt-4">
+          <ExerciseImageCrossfade
+            imageUrls={imageUrls}
+            exerciseName={exercise.name}
+          />
+        </div>
+
+        {/* Instructions */}
+        {exercise.exerciseDefinition?.instructions && (
+          <div className="px-4 pt-5">
+            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-2">
+              Instructions
+            </h4>
+            <p className="text-[17px] leading-[1.5] text-muted-foreground whitespace-pre-line">
+              {exercise.exerciseDefinition.instructions}
+            </p>
+          </div>
+        )}
+
+        {/* Coaching tip */}
+        {tip && (
+          <div className="px-4 pt-4 pb-4">
+            <BeginnerTipCard tip={tip} />
+          </div>
+        )}
+        </div>
+
+        {/* Scroll fade gradient */}
+        {showScrollFade && (
+          <div className="absolute bottom-0 left-0 right-0 h-12 pointer-events-none bg-gradient-to-t from-card to-transparent" />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -29,12 +29,26 @@ export default function RestStopwatch({
   if (!isRunning || dismissed) return null
 
   return (
-    <div className="border-2 border-primary/40 bg-primary/5 p-3 my-1">
-      <div className="flex items-center justify-between mb-1">
-        <span className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-widest">
-          <span className="w-2 h-2 bg-primary rounded-full animate-pulse" />
-          Resting
-        </span>
+    <div
+      className="px-2.5 py-3"
+      style={{
+        backgroundColor: 'color-mix(in srgb, var(--success) 8%, transparent)',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.30)',
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 bg-primary rounded-full animate-pulse flex-shrink-0" />
+          <span className="text-[10px] font-bold text-primary uppercase tracking-widest">Resting</span>
+          <span
+            role="timer"
+            className="text-2xl font-medium text-foreground tabular-nums select-none leading-none"
+            aria-label={`Rest timer: ${formatted}`}
+            aria-live="off"
+          >
+            {formatted}
+          </span>
+        </div>
         {onDismiss && (
           <button
             type="button"
@@ -46,14 +60,6 @@ export default function RestStopwatch({
           </button>
         )}
       </div>
-      <span
-        role="timer"
-        className="block text-4xl font-bold tracking-wider text-foreground tabular-nums select-none"
-        aria-label={`Rest timer: ${formatted}`}
-        aria-live="off"
-      >
-        {formatted}
-      </span>
     </div>
   )
 }

--- a/components/workout-logging/RestStopwatch.tsx
+++ b/components/workout-logging/RestStopwatch.tsx
@@ -1,34 +1,56 @@
 'use client'
 
+import { X } from 'lucide-react'
 import { useRestTimer } from '@/hooks/useRestTimer'
 
 interface RestStopwatchProps {
   loggedSetCount: number
   exerciseId: string
+  dismissed?: boolean
+  onDismiss?: () => void
 }
 
 /**
- * Subtle watermark-style rest stopwatch displayed below the set list.
- * Resets on each logged set (including extra sets and re-logged sets after deletion).
- * Hides when no sets are logged.
+ * Prominent rest timer card displayed between logged and prescribed sets.
+ * Large glanceable time readable from across the gym.
+ * Resets on each logged set. Dismissible via X button.
  */
 export default function RestStopwatch({
   loggedSetCount,
   exerciseId,
+  dismissed = false,
+  onDismiss,
 }: RestStopwatchProps) {
   const { formatted, isRunning } = useRestTimer(
     loggedSetCount,
     exerciseId
   )
 
-  if (!isRunning) return null
+  if (!isRunning || dismissed) return null
 
   return (
-    <div className="flex items-center justify-center py-4 select-none" aria-live="off">
+    <div className="border-2 border-primary/40 bg-primary/5 p-3 my-1">
+      <div className="flex items-center justify-between mb-1">
+        <span className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-widest">
+          <span className="w-2 h-2 bg-primary rounded-full animate-pulse" />
+          Resting
+        </span>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="p-1 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            aria-label="Dismiss rest timer"
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
       <span
         role="timer"
-        className="text-5xl font-bold tracking-wider text-muted-foreground/15 tabular-nums"
+        className="block text-4xl font-bold tracking-wider text-foreground tabular-nums select-none"
         aria-label={`Rest timer: ${formatted}`}
+        aria-live="off"
       >
         {formatted}
       </span>

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertCircle, Check, Circle, Trash2 } from 'lucide-react'
+import { AlertCircle, Check, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import type { LoggedSet } from '@/types/workout'
 import RestStopwatch from './RestStopwatch'
@@ -150,7 +150,7 @@ export default function SetList({
 
       {/* Per-row view: logged + rest timer + prescribed */}
       {!showCollapsedSummary && (
-        <div className="divide-y divide-border/30">
+        <div>
           {/* Logged sets */}
           {loggedSets.map((set) => {
             const isFailed = set._syncStatus === 'error'
@@ -158,16 +158,20 @@ export default function SetList({
             return (
               <div
                 key={`logged-${set.exerciseId}-${set.setNumber}`}
-                className={`px-2 py-2 ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
+                className={`px-2.5 py-3 ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
+                style={{
+                  backgroundColor: 'color-mix(in srgb, var(--success) 8%, transparent)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.30)',
+                }}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-start gap-2 flex-1 min-w-0">
-                    {/* State indicator */}
-                    <span className="flex-shrink-0 mt-0.5">
+                    {/* State indicator — filled circle */}
+                    <span className="flex-shrink-0 mt-0.5 w-[22px] h-[22px] flex items-center justify-center" style={{ backgroundColor: isFailed ? 'var(--warning)' : 'var(--success)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -1px 0 rgba(0,0,0,0.20)' }}>
                       {isFailed ? (
-                        <AlertCircle size={16} className="text-warning" />
+                        <AlertCircle size={12} className="text-white" />
                       ) : (
-                        <Check size={16} className="text-success" />
+                        <Check size={12} className="text-white" strokeWidth={3} />
                       )}
                     </span>
                     <div className="min-w-0">
@@ -181,11 +185,11 @@ export default function SetList({
                       {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
                     </div>
                   </div>
-                  {/* Delete — subtle, only visible on hover/focus */}
+                  {/* Delete — hidden by default, visible on hover */}
                   <button
                     type="button"
                     onClick={() => onDeleteSet(set.setNumber)}
-                    className="text-muted-foreground/30 hover:text-error p-1 transition-colors doom-focus-ring"
+                    className="opacity-0 hover:opacity-100 focus:opacity-100 text-muted-foreground/30 hover:text-error p-1 transition-all doom-focus-ring"
                     aria-label={`Delete set ${set.setNumber}`}
                   >
                     <Trash2 size={14} />
@@ -209,18 +213,15 @@ export default function SetList({
           {remainingSets.map((set) => (
             <div
               key={`prescribed-${set.id}`}
-              className="px-2 py-2"
+              className="px-2.5 py-3 opacity-55"
             >
               <div className="flex items-start gap-2">
-                <span className="flex-shrink-0 mt-0.5">
-                  <Circle size={16} className="text-muted-foreground/40" />
+                <span className="flex-shrink-0 mt-0.5 w-[22px] h-[22px] flex items-center justify-center text-xs font-bold text-muted-foreground" style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 1px rgba(0,0,0,0.30)' }}>
+                  {set.setNumber}
                 </span>
                 <div>
-                  <span className="block text-xs font-bold text-muted-foreground/60 uppercase tracking-wider">
-                    Set {set.setNumber}
-                  </span>
-                  <span className="block text-sm text-muted-foreground/70">
-                    {set.reps} reps @ {set.weight || '—'}
+                  <span className="block text-[13px] text-muted-foreground">
+                    {set.reps} reps{set.weight ? ` @ ${set.weight}` : ''}
                     {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
                   </span>
                 </div>

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { AlertCircle, Trash2 } from 'lucide-react'
+import { AlertCircle, Check, Circle, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { useRestTimer } from '@/hooks/useRestTimer'
 import type { LoggedSet } from '@/types/workout'
+import RestStopwatch from './RestStopwatch'
 
 interface PrescribedSet {
   id: string
@@ -44,6 +44,24 @@ function formatIntensity(set: { rpe: number | null; rir: number | null }) {
   return null
 }
 
+function formatWeight(weight: number, weightUnit: string): string {
+  if (weight === 0) return 'Bodyweight'
+  return `${weight} ${weightUnit}`
+}
+
+/**
+ * Check if all prescribed sets are uniform (same reps and intensity).
+ */
+function isUniformPrescription(sets: PrescribedSet[]): boolean {
+  if (sets.length <= 1) return true
+  const first = sets[0]
+  return sets.every(s =>
+    s.reps === first.reps &&
+    s.rpe === first.rpe &&
+    s.rir === first.rir
+  )
+}
+
 export default function SetList({
   prescribedSets,
   loggedSets,
@@ -55,12 +73,20 @@ export default function SetList({
   const loggedSetNumbers = new Set(loggedSets.map(s => s.setNumber))
   const remainingSets = prescribedSets.filter(s => !loggedSetNumbers.has(s.setNumber))
 
-  const { formatted: restFormatted, isRunning: restRunning } = useRestTimer(
-    loggedSets.length,
-    exerciseId || ''
-  )
+  // Rest timer dismiss state — resets when a new set is logged
+  const [restDismissed, setRestDismissed] = useState(false)
+  const prevLogCountRef = useRef(loggedSets.length)
 
-  // Track which set was just logged for the power-up flash animation
+  useEffect(() => {
+    if (loggedSets.length > prevLogCountRef.current) {
+      const frame = requestAnimationFrame(() => setRestDismissed(false))
+      prevLogCountRef.current = loggedSets.length
+      return () => cancelAnimationFrame(frame)
+    }
+    prevLogCountRef.current = loggedSets.length
+  }, [loggedSets.length])
+
+  // Track which set was just logged for the flash animation
   const prevExerciseRef = useRef(exerciseId)
   const prevCountRef = useRef(loggedSets.length)
   const [flashSetNumber, setFlashSetNumber] = useState<number | null>(null)
@@ -68,18 +94,15 @@ export default function SetList({
   useEffect(() => {
     const count = loggedSets.length
 
-    // Exercise changed — reset tracking, no animation
     if (exerciseId !== prevExerciseRef.current) {
       prevExerciseRef.current = exerciseId
       prevCountRef.current = count
-      // Defer reset to avoid synchronous setState in useEffect
       const frame = requestAnimationFrame(() => setFlashSetNumber(null))
       return () => cancelAnimationFrame(frame)
     }
 
     if (count > prevCountRef.current) {
       const newest = loggedSets[count - 1]
-      // Defer to avoid synchronous setState in useEffect
       const frame = requestAnimationFrame(() => setFlashSetNumber(newest.setNumber))
       const flashOffTimer = setTimeout(() => setFlashSetNumber(null), 650)
       prevCountRef.current = count
@@ -91,6 +114,10 @@ export default function SetList({
     prevCountRef.current = count
   }, [loggedSets, exerciseId])
 
+  // Collapsed summary: show when no sets logged and prescription is uniform
+  const showCollapsedSummary = loggedSets.length === 0 && isUniformPrescription(prescribedSets) && prescribedSets.length > 1
+  const firstPrescribed = prescribedSets[0]
+
   return (
     <div className="space-y-1">
       {/* Last Performance — compact inline */}
@@ -101,83 +128,115 @@ export default function SetList({
           {exerciseHistory.sets.map((set, i) => (
             <span key={set.setNumber}>
               {i > 0 && ' · '}
-              {set.reps}×{set.weight}{set.weightUnit}
+              {formatWeight(set.weight, set.weightUnit)} × {set.reps}
               {showIntensity && formatIntensity(set) ? ` ${formatIntensity(set)}` : ''}
             </span>
           ))}
         </div>
       )}
 
-      {/* Logged sets */}
-      {loggedSets.length > 0 && (
-        <div>
-          <span className="block text-xs font-bold text-success-text/60 uppercase tracking-wider px-1 mb-0.5">
-            LOGGED
-          </span>
+      {/* Sets header */}
+      <span className="block text-xs font-bold text-muted-foreground uppercase tracking-wider px-1 mb-0.5">
+        Sets
+      </span>
+
+      {/* Collapsed prescription summary */}
+      {showCollapsedSummary && firstPrescribed && (
+        <div className="px-2 py-2 text-base text-muted-foreground">
+          Prescribed: {prescribedSets.length} × {firstPrescribed.reps} reps
+          {showIntensity && formatIntensity(firstPrescribed) ? ` @ ${formatIntensity(firstPrescribed)}` : ''}
+        </div>
+      )}
+
+      {/* Per-row view: logged + rest timer + prescribed */}
+      {!showCollapsedSummary && (
+        <div className="divide-y divide-border/30">
+          {/* Logged sets */}
           {loggedSets.map((set) => {
             const isFailed = set._syncStatus === 'error'
             const isPending = set._syncStatus === 'pending'
             return (
               <div
-                key={`${set.exerciseId}-${set.setNumber}`}
-                className={`flex items-center justify-between px-2 py-1.5 text-base ${
-                  isFailed
-                    ? 'text-warning'
-                    : 'text-success-text opacity-70'
-                } ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
+                key={`logged-${set.exerciseId}-${set.setNumber}`}
+                className={`px-2 py-2 ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
               >
-                <span className="flex items-center gap-1.5">
-                  {isFailed && <AlertCircle size={14} className="flex-shrink-0" />}
-                  <span className="font-bold">{set.setNumber}.</span>
-                  {set.reps}×{set.weight}{set.weightUnit}
-                  {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
-                  {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => onDeleteSet(set.setNumber)}
-                  className="text-error/50 hover:text-error p-0.5"
-                >
-                  <Trash2 size={14} />
-                </button>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-start gap-2 flex-1 min-w-0">
+                    {/* State indicator */}
+                    <span className="flex-shrink-0 mt-0.5">
+                      {isFailed ? (
+                        <AlertCircle size={16} className="text-warning" />
+                      ) : (
+                        <Check size={16} className="text-success" />
+                      )}
+                    </span>
+                    <div className="min-w-0">
+                      <span className="block text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                        Set {set.setNumber}
+                      </span>
+                      <span className={`block text-base font-bold ${isFailed ? 'text-warning' : 'text-foreground'}`}>
+                        {formatWeight(set.weight, set.weightUnit)} × {set.reps}
+                        {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                      </span>
+                      {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
+                    </div>
+                  </div>
+                  {/* Delete — subtle, only visible on hover/focus */}
+                  <button
+                    type="button"
+                    onClick={() => onDeleteSet(set.setNumber)}
+                    className="text-muted-foreground/30 hover:text-error p-1 transition-colors doom-focus-ring"
+                    aria-label={`Delete set ${set.setNumber}`}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
               </div>
             )
           })}
-        </div>
-      )}
 
-      {/* Remaining prescribed sets */}
-      {remainingSets.length > 0 && (
-        <div className="mt-1">
-          <span className="flex items-baseline justify-between px-1 mb-0.5">
-            <span className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-              PRESCRIBED
-            </span>
-            {restRunning && (
-              <span
-                role="timer"
-                className="text-sm font-bold tracking-wider text-muted-foreground/30 tabular-nums"
-                aria-label={`Rest timer: ${restFormatted}`}
-                aria-live="off"
-              >
-                {restFormatted}
-              </span>
-            )}
-          </span>
-          <div className="border border-border/50 divide-y divide-border/30">
-            {remainingSets.map((set) => (
-              <div
-                key={set.id}
-                className="flex items-center px-2 py-1.5 text-base text-muted-foreground/70"
-              >
-                <span className="font-bold w-6">{set.setNumber}.</span>
-                <span>
-                  {set.reps} reps @ {set.weight || '—'}
-                  {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+          {/* Rest timer card — between logged and prescribed */}
+          {loggedSets.length > 0 && remainingSets.length > 0 && (
+            <RestStopwatch
+              loggedSetCount={loggedSets.length}
+              exerciseId={exerciseId || ''}
+              dismissed={restDismissed}
+              onDismiss={() => setRestDismissed(true)}
+            />
+          )}
+
+          {/* Prescribed sets */}
+          {remainingSets.map((set) => (
+            <div
+              key={`prescribed-${set.id}`}
+              className="px-2 py-2"
+            >
+              <div className="flex items-start gap-2">
+                <span className="flex-shrink-0 mt-0.5">
+                  <Circle size={16} className="text-muted-foreground/40" />
                 </span>
+                <div>
+                  <span className="block text-xs font-bold text-muted-foreground/60 uppercase tracking-wider">
+                    Set {set.setNumber}
+                  </span>
+                  <span className="block text-sm text-muted-foreground/70">
+                    {set.reps} reps @ {set.weight || '—'}
+                    {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
+                  </span>
+                </div>
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
+
+          {/* Rest timer when all sets logged (no more prescribed) */}
+          {loggedSets.length > 0 && remainingSets.length === 0 && (
+            <RestStopwatch
+              loggedSetCount={loggedSets.length}
+              exerciseId={exerciseId || ''}
+              dismissed={restDismissed}
+              onDismiss={() => setRestDismissed(true)}
+            />
+          )}
         </div>
       )}
     </div>

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -41,6 +41,7 @@ interface SetLoggingFormProps {
   onExpandedInputChange: (input: ExpandedInput) => void
   onExtraSets: () => void
   onNextExercise: () => void
+  onCompleteWorkout?: () => void
   isLastExercise: boolean
 }
 
@@ -56,6 +57,7 @@ export default function SetLoggingForm({
   onExpandedInputChange,
   onExtraSets,
   onNextExercise,
+  onCompleteWorkout,
   isLastExercise,
 }: SetLoggingFormProps) {
   const { settings } = useUserSettings()
@@ -84,18 +86,22 @@ export default function SetLoggingForm({
           >
             Extra Sets
           </button>
-          {!isLastExercise ? (
+          {isLastExercise ? (
+            <button
+              type="button"
+              onClick={onCompleteWorkout}
+              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-focus-ring"
+            >
+              Complete Workout
+            </button>
+          ) : (
             <button
               type="button"
               onClick={onNextExercise}
-              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-button-3d doom-focus-ring"
+              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-focus-ring"
             >
               Next Exercise
             </button>
-          ) : (
-            <div className="flex-1 py-2.5 text-center text-sm text-success-text font-bold uppercase tracking-wider">
-              Last exercise
-            </div>
           )}
         </div>
       </div>

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -41,9 +41,9 @@ export function IntensitySelector({
           type="button"
           onClick={onExpand}
           className="w-full h-12 px-4 flex items-center justify-center
-            bg-card border border-border
             hover:border-primary
             transition-all duration-75"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)' }}
         >
           <span className="text-2xl font-bold text-foreground tabular-nums">
             {value || '--'}
@@ -60,7 +60,7 @@ export function IntensitySelector({
         {label}
       </span>
 
-      <div className="border border-border divide-y divide-border">
+      <div className="border border-border divide-y divide-border" style={{ boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)' }}>
         {presets.map((preset) => {
           const isSelected = numericValue === preset.value
           return (

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -2,6 +2,9 @@
 
 import { Minus, Plus } from 'lucide-react'
 
+const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
+const RECESSED_SHADOW = 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)'
+
 interface RepsStepperProps {
   value: string
   onChange: (value: string) => void
@@ -33,21 +36,20 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
           type="button"
           onClick={handleDecrement}
           disabled={!hasValue || numericValue <= 0}
-          className="flex-shrink-0 min-w-[56px] min-h-[56px] flex items-center justify-center
-            border-2 border-border bg-muted text-foreground
-            hover:bg-secondary hover:text-foreground
-            active:bg-secondary active:text-foreground
+          className="flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center
+            text-foreground
             disabled:opacity-30
             transition-all duration-75"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: RAISED_SHADOW }}
           aria-label="Decrease reps"
         >
           <Minus size={24} strokeWidth={3} />
         </button>
 
         <div
-          className="flex-1 min-h-[56px] flex items-center justify-center
-            bg-card border-y-2 border-border
+          className="flex-1 min-h-[44px] flex items-center justify-center
             text-2xl font-bold text-foreground tabular-nums min-w-[60px]"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: RECESSED_SHADOW }}
         >
           {hasValue ? numericValue : (
             <span className="text-muted-foreground text-lg">
@@ -59,11 +61,12 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
         <button
           type="button"
           onClick={handleIncrement}
-          className="flex-shrink-0 min-w-[56px] min-h-[56px] flex items-center justify-center
-            border-2 border-success-border bg-success-muted text-success-text
+          className="flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center
+            bg-success-muted text-success-text
             hover:bg-success hover:text-success-foreground
             active:bg-success-hover active:text-success-foreground
             transition-all duration-75"
+          style={{ boxShadow: RAISED_SHADOW }}
           aria-label="Increase reps"
         >
           <Plus size={24} strokeWidth={3} />

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -34,9 +34,9 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
           onClick={handleDecrement}
           disabled={!hasValue || numericValue <= 0}
           className="flex-shrink-0 min-w-[56px] min-h-[56px] flex items-center justify-center
-            border-2 border-error-border bg-error-muted text-error-text
-            hover:bg-error hover:text-error-foreground
-            active:bg-error-hover active:text-error-foreground
+            border-2 border-border bg-muted text-foreground
+            hover:bg-secondary hover:text-foreground
+            active:bg-secondary active:text-foreground
             disabled:opacity-30
             transition-all duration-75"
           aria-label="Decrease reps"

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -98,10 +98,10 @@ export function WeightKeypad({
           type="button"
           onClick={handleExpand}
           className="w-full h-12 px-4 flex items-center justify-center
-            bg-card border border-border
             text-2xl font-bold text-foreground tabular-nums
             hover:border-primary
             transition-all duration-75"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)' }}
         >
           {value || '0'}
           <span className="text-sm font-semibold text-muted-foreground ml-2">
@@ -122,9 +122,9 @@ export function WeightKeypad({
       {/* Current value display */}
       <div
         className="w-full h-12 px-4 flex items-center justify-center
-          bg-card border-2 border-primary
-          text-2xl font-bold text-foreground tabular-nums
-          shadow-[0_0_8px_rgba(var(--primary-rgb),0.2)]"
+          border-2 border-primary
+          text-2xl font-bold text-foreground tabular-nums"
+        style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), 0 0 8px rgba(var(--primary-rgb),0.2)' }}
       >
         {value || '0'}
         <span className="text-sm font-semibold text-muted-foreground ml-2">
@@ -162,6 +162,7 @@ export function WeightKeypad({
           font-bold uppercase tracking-wider text-sm
           hover:bg-primary/90 active:bg-primary/80
           transition-colors"
+        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
       >
         DONE
       </button>

--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -152,6 +152,7 @@ export default function WorkoutCard({
             type="button"
             onClick={() => onLog(workout.id)}
             className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-primary text-primary-foreground hover:bg-primary-hover font-bold uppercase tracking-wider text-sm transition-colors doom-focus-ring"
+            style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
           >
             <Play size={16} />
             {isDraft ? 'Continue Workout' : 'Start Workout'}
@@ -162,6 +163,7 @@ export default function WorkoutCard({
               onClick={() => onSkip(workout.id)}
               disabled={isSkipping}
               className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-secondary text-secondary-foreground hover:bg-secondary-hover font-semibold uppercase tracking-wider text-sm transition-colors doom-focus-ring disabled:opacity-50"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
             >
               <SkipForward size={14} />
               Skip

--- a/hooks/useIntensityAccess.ts
+++ b/hooks/useIntensityAccess.ts
@@ -1,21 +1,14 @@
 import { useUserSettings } from '@/hooks/useUserSettings'
-import { useSession } from '@/lib/auth-client'
 
 /**
  * Returns whether the current user has access to intensity features (RIR/RPE).
- * Access is granted if:
- * - intensityEnabled is true in their settings, OR
- * - the user has an admin role (automatic premium access)
+ * Access requires intensityEnabled in settings. Admins can toggle this on/off
+ * in settings — admin role grants the ability to toggle, not automatic access.
  */
 export function useIntensityAccess() {
-  const { settings, isLoading: settingsLoading } = useUserSettings()
-  const { data: session, isPending: sessionLoading } = useSession()
+  const { settings, isLoading } = useUserSettings()
 
-  const userRole = (session?.user as Record<string, unknown>)?.role as string | undefined
-  const isAdmin = userRole === 'admin'
-
-  const hasAccess = isAdmin || (settings?.intensityEnabled ?? false)
-  const isLoading = settingsLoading || sessionLoading
+  const hasAccess = settings?.intensityEnabled ?? false
 
   return { hasAccess, isLoading }
 }

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -13,6 +13,7 @@ export type UserSettings = {
   lastPostSessionPromptAt: string | null
   experienceLevel: string | null
   intensityEnabled: boolean
+  loggingMode: 'full' | 'follow_along'
 }
 
 type UseUserSettingsReturn = {

--- a/hooks/useWorkoutTimer.ts
+++ b/hooks/useWorkoutTimer.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Timestamp-based elapsed workout timer that survives browser backgrounding.
+ * Starts when the hook mounts (workout opens) and counts up.
+ */
+export function useWorkoutTimer() {
+  const startRef = useRef<number>(0)
+  const [elapsed, setElapsed] = useState(0)
+
+  // Initialize start time on mount
+  useEffect(() => {
+    startRef.current = Date.now()
+  }, [])
+
+  useEffect(() => {
+    const tick = () => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000))
+    }
+
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  // Recalculate on tab visibility change (phone sleep/wake)
+  useEffect(() => {
+    const handler = () => {
+      if (!document.hidden) {
+        setElapsed(Math.floor((Date.now() - startRef.current) / 1000))
+      }
+    }
+    document.addEventListener('visibilitychange', handler)
+    return () => document.removeEventListener('visibilitychange', handler)
+  }, [])
+
+  const minutes = Math.floor(elapsed / 60)
+  const seconds = elapsed % 60
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+
+  const formatted = hours > 0
+    ? `${hours}:${String(remainingMinutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+    : `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+
+  return { elapsed, formatted }
+}

--- a/lib/api/workout-sets.ts
+++ b/lib/api/workout-sets.ts
@@ -124,7 +124,8 @@ export async function fetchDraft(workoutId: string): Promise<DraftResponse> {
 
 export async function completeDraft(
   workoutId: string,
-  fallbackSets?: LoggedSet[]
+  fallbackSets?: LoggedSet[],
+  guidedCompletion?: boolean
 ): Promise<void> {
   await fetchWithRetry<{ success: boolean }>(
     `/api/workouts/${workoutId}/complete`,
@@ -142,6 +143,7 @@ export async function completeDraft(
           rir: s.rir,
           isWarmup: s.isWarmup ?? false,
         })),
+        ...(guidedCompletion && { guidedCompletion: true }),
       }),
     }
   )

--- a/prisma/migrations/20260424220558_add_logging_mode/migration.sql
+++ b/prisma/migrations/20260424220558_add_logging_mode/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "UserSettings" ADD COLUMN "loggingMode" TEXT NOT NULL DEFAULT 'full';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -303,6 +303,7 @@ model UserSettings {
   onboardingCompleted       Boolean   @default(false)
   customProgramLimitBypass  Boolean   @default(false)
   intensityEnabled          Boolean   @default(false)
+  loggingMode               String    @default("full")
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
 


### PR DESCRIPTION
## Summary

- **Follow Along workout mode** for beginner lifters who opt out of set-by-set logging. Single-scroll guided experience: animated start/finish exercise images (crossfade), plain-language prescription, full instructions at arm's-length readable size, coaching tips, and segmented progress bar header.
- **Logger mode visual overhaul**: redesigned header (progress bar, elapsed timer, action icons), redesigned footer (prev/LOG SET/next), promoted rest timer card, unified sets list with checkmark/circle state indicators, shadow depth system across all interactive elements.
- **Backend**: `loggingMode` field on UserSettings, `guidedCompletion` flag on workout complete endpoint (allows zero-set completion), auto-set `follow_along` for beginners during onboarding. Settings page toggle to switch modes.
- **Cross-theme contrast fixes**: active tab uses primary bottom border, header/footer use `--secondary-foreground` for readable text on all themes.
- **Raised shadow treatment** applied to buttons across Programs, Training, and logger modal pages.

## Test plan

- [x] Type-check passes (`npm run type-check`)
- [x] Lint passes (`npm run lint`)
- [x] Guided completion integration tests pass (`npm test guided-completion`)
- [x] Manual: create beginner account via onboarding, verify follow-along mode activates
- [x] Manual: navigate exercises in follow-along, verify crossfade animation, finish workout with zero sets
- [x] Manual: switch to logging mode via settings, verify logger uses new header/footer/sets styling
- [x] Manual: verify visual consistency across Ripit Dark, Ripit Light, Clyde Light, Clyde Dark themes
- [x] Manual: verify shadow depth on buttons (Programs, Training, logger modals)
- [x] Schema migration: `loggingMode` column added to UserSettings

🤖 Generated with [Claude Code](https://claude.com/claude-code)