### PR TITLE
Restyle onboarding flow to match app visual system

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -48,10 +48,10 @@ export default function OnboardingPage() {
   const [copyProgress, setCopyProgress] = useState<string | null>(null)
   const [fadeKey, setFadeKey] = useState(0)
 
-  const changeStep = (next: Step) => {
+  const changeStep = useCallback((next: Step) => {
     setFadeKey(k => k + 1)
     setStep(next)
-  }
+  }, [])
 
   useEffect(() => {
     async function check() {
@@ -72,7 +72,7 @@ export default function OnboardingPage() {
       }
     }
     check()
-  }, [router])
+  }, [router, changeStep])
 
   const completeOnboarding = useCallback(async (
     level: ExperienceLevel,
@@ -159,7 +159,7 @@ export default function OnboardingPage() {
       setError('Network error. Please try again.')
       changeStep(level === 'beginner' ? 'info' : 'experience')
     }
-  }, [])
+  }, [changeStep])
 
   const handleExperienceSelect = (level: ExperienceLevel) => {
     setSelectedCard(level)
@@ -577,7 +577,6 @@ function SelectionCard({
     <button
       type="button"
       onClick={onClick}
-      role="button"
       tabIndex={0}
       style={{
         width: '100%',

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -2,39 +2,36 @@
 
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { CURRENT_WAIVER_VERSION, WAIVER_TEXT } from '@/lib/constants/waiver'
 
-type Step = 'loading' | 'waiver' | 'experience' | 'equipment' | 'primer' | 'completing'
+type Step = 'loading' | 'experience' | 'equipment' | 'info' | 'completing'
 
 type ExperienceLevel = 'beginner' | 'experienced'
 type EquipmentPreference = 'machines' | 'free_weights_cables'
 
-const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
-const RAISED_SHADOW_SECONDARY = 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.25), 0 1px 0 rgba(0,0,0,0.30)'
+const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
 
-const PRIMER_PAGES = [
+const INFO_GROUPS = [
   {
-    title: 'Just follow along',
-    lines: [
-      'Your program tells you exactly what to do each day: which exercises, how many sets, how many reps. No planning required.',
-      'Start lighter than you think. Controlled reps at moderate effort beat heavy weight with sloppy form. Your first week, pick weights that feel almost too easy -- you\'ll dial it in.',
+    header: 'THE PROGRAM GUIDES YOU',
+    bullets: [
+      'Tells you what to do each day',
+      'Start lighter than feels right -- controlled reps beat heavy and sloppy',
     ],
   },
   {
-    title: 'Respect the space',
-    lines: [
-      'Grab a wipe and clean any bench, pad, or handle you used. It takes five seconds and everyone notices.',
-      'If someone\'s waiting, offer to let them work in between your sets. It\'s the gym equivalent of holding the door.',
-      'Take calls outside if you can. But keep your rest -- step off the equipment if you need to send a long text.',
-      'Lower weights back to the rack -- don\'t drop them. It\'s loud, it wears on equipment, and it startles everyone around you.',
+    header: 'SHARE THE SPACE',
+    bullets: [
+      'Wipe down what you used',
+      'Offer to work in if someone\u2019s waiting',
+      'Lower weights -- don\u2019t drop them',
     ],
   },
   {
-    title: 'You belong here',
-    lines: [
-      'Everyone in the gym started somewhere. Nobody is watching you as closely as you think. If you\'re unsure how a machine works, ask someone -- gym regulars genuinely like helping.',
-      'Feeling sore a day or two after your first workout is completely normal. Sharp pain during a lift is not -- stop, lower the weight, or skip that exercise.',
-      'Rest 2-3 minutes between the big lifts. There\'s no rush.',
+    header: 'YOU BELONG HERE',
+    bullets: [
+      'Soreness 1\u20132 days after is normal; sharp pain during is not',
+      'Ask gym regulars if you\u2019re unsure -- they like helping',
+      'Rest 2\u20133 minutes between heavier lifts',
     ],
   },
 ]
@@ -42,15 +39,13 @@ const PRIMER_PAGES = [
 export default function OnboardingPage() {
   const router = useRouter()
   const [step, setStep] = useState<Step>('loading')
-  const [primerPage, setPrimerPage] = useState(0)
   const [experienceLevel, setExperienceLevel] = useState<ExperienceLevel | null>(null)
   const [equipmentPreference, setEquipmentPreference] = useState<EquipmentPreference | null>(null)
+  const [selectedCard, setSelectedCard] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [completingProgramName, setCompletingProgramName] = useState<string | null>(null)
   const [copyFailed, setCopyFailed] = useState(false)
   const [copyProgress, setCopyProgress] = useState<string | null>(null)
-
-  // Fade-in key: changes on every step/page transition
   const [fadeKey, setFadeKey] = useState(0)
 
   const changeStep = (next: Step) => {
@@ -63,7 +58,7 @@ export default function OnboardingPage() {
       try {
         const res = await fetch('/api/settings')
         if (!res.ok) {
-          changeStep('waiver')
+          changeStep('experience')
           return
         }
         const data = await res.json()
@@ -71,9 +66,9 @@ export default function OnboardingPage() {
           router.replace('/')
           return
         }
-        changeStep('waiver')
+        changeStep('experience')
       } catch {
-        changeStep('waiver')
+        changeStep('experience')
       }
     }
     check()
@@ -101,14 +96,13 @@ export default function OnboardingPage() {
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         setError(data.error || 'Something went wrong. Please try again.')
-        changeStep(level === 'beginner' ? 'primer' : 'experience')
+        changeStep(level === 'beginner' ? 'info' : 'experience')
         return
       }
 
       const data = await res.json()
       setCompletingProgramName(data.programName || null)
 
-      // For beginners with a program being cloned, poll for completion
       if (level === 'beginner' && data.programId) {
         const TIMEOUT_MS = 20000
         const POLL_INTERVAL_MS = 1500
@@ -134,13 +128,11 @@ export default function OnboardingPage() {
               return
             }
 
-            // Week 1 is done when the worker moves to week 2+
             if (statusData.progress?.currentWeek >= 2) {
               ready = true
               break
             }
 
-            // Show progress to the user
             if (statusData.progress) {
               setCopyProgress(
                 `Week ${statusData.progress.currentWeek} of ${statusData.progress.totalWeeks}`
@@ -156,81 +148,65 @@ export default function OnboardingPage() {
           return
         }
       } else if (level === 'beginner') {
-        // Beginner but clone failed to enqueue (e.g. Redis down) — show failure
         setCopyFailed(true)
         return
       } else {
-        // Experienced users — brief transition
         await new Promise(resolve => setTimeout(resolve, 2500))
       }
 
       window.location.href = data.redirect || '/'
     } catch {
       setError('Network error. Please try again.')
-      changeStep(level === 'beginner' ? 'primer' : 'experience')
+      changeStep(level === 'beginner' ? 'info' : 'experience')
     }
   }, [])
 
-  const handleWaiverAccept = async () => {
-    setError(null)
-    try {
-      const res = await fetch('/api/waiver/accept', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ waiverVersion: CURRENT_WAIVER_VERSION }),
-      })
+  const handleExperienceSelect = (level: ExperienceLevel) => {
+    setSelectedCard(level)
+    setExperienceLevel(level)
 
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        setError(data.error || 'Failed to accept waiver')
-        return
+    setTimeout(() => {
+      if (level === 'experienced') {
+        completeOnboarding(level)
+      } else {
+        setSelectedCard(null)
+        changeStep('equipment')
       }
-
-      changeStep('experience')
-    } catch {
-      setError('Network error. Please try again.')
-    }
+    }, 200)
   }
 
-  const handleExperience = (level: ExperienceLevel) => {
-    setExperienceLevel(level)
-    if (level === 'experienced') {
-      completeOnboarding(level)
-    } else {
+  const handleEquipmentSelect = (pref: EquipmentPreference) => {
+    setSelectedCard(pref)
+    setEquipmentPreference(pref)
+
+    setTimeout(() => {
+      setSelectedCard(null)
+      changeStep('info')
+    }, 200)
+  }
+
+  const handleBack = () => {
+    if (step === 'equipment') {
+      changeStep('experience')
+    } else if (step === 'info') {
       changeStep('equipment')
     }
   }
 
-  const handleEquipment = (pref: EquipmentPreference) => {
-    setEquipmentPreference(pref)
-    setPrimerPage(0)
-    setFadeKey(k => k + 1)
-    setStep('primer')
-  }
-
-  const handlePrimerNext = () => {
-    setPrimerPage(p => p + 1)
-    setFadeKey(k => k + 1)
-  }
-
-  const handlePrimerBack = () => {
-    setPrimerPage(p => p - 1)
-    setFadeKey(k => k + 1)
-  }
-
-  const handlePrimerFinish = () => {
+  const handleFinish = () => {
     completeOnboarding(experienceLevel!, equipmentPreference!)
   }
 
-  const handleBack = () => {
-    if (step === 'equipment') changeStep('experience')
-    else if (step === 'primer' && primerPage > 0) handlePrimerBack()
-    else if (step === 'primer' && primerPage === 0) changeStep('equipment')
-  }
+  // --- Progress bar math ---
+  const totalSegments = 3
+  const currentSegment =
+    step === 'experience' ? 0 :
+    step === 'equipment' ? 1 :
+    step === 'info' ? 2 : 0
 
-  const canGoBack = step === 'equipment' || step === 'primer'
+  const canGoBack = step === 'equipment' || step === 'info'
 
-  // Full-screen loading states
+  // --- Loading ---
   if (step === 'loading') {
     return (
       <Shell>
@@ -241,23 +217,33 @@ export default function OnboardingPage() {
     )
   }
 
+  // --- Completing ---
   if (step === 'completing') {
     return (
       <Shell>
         <div className="flex flex-1 flex-col items-center justify-center gap-8 px-6">
           {copyFailed ? (
             <FadeIn key="completing-failed" className="text-center max-w-sm">
-              <p className="text-lg text-foreground mb-3">
+              <p style={{ fontSize: 18, color: '#FEF3C7' }} className="mb-3">
                 Failed to load the program
               </p>
-              <p className="text-base text-muted-foreground mb-6">
+              <p style={{ fontSize: 15, color: 'rgba(254,243,199,0.75)', lineHeight: 1.5 }} className="mb-6">
                 Go to the Programs tab and browse available programs.
               </p>
               <button
                 type="button"
                 onClick={() => { window.location.href = '/programs' }}
-                className="bg-primary px-6 h-11 text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
-                style={{ boxShadow: RAISED_SHADOW }}
+                className="w-full doom-focus-ring"
+                style={{
+                  height: 48,
+                  backgroundColor: '#10B981',
+                  color: '#fff',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase',
+                  boxShadow: RAISED_SHADOW,
+                }}
               >
                 Go to Programs
               </button>
@@ -267,24 +253,24 @@ export default function OnboardingPage() {
               <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
               {completingProgramName ? (
                 <FadeIn key="completing-beginner" className="text-center">
-                  <p className="text-lg text-foreground">
-                    Copying <span className="font-semibold text-primary">{completingProgramName}</span> to your profile
+                  <p style={{ fontSize: 18, color: '#FEF3C7' }}>
+                    Copying <span className="font-semibold" style={{ color: '#10B981' }}>{completingProgramName}</span> to your profile
                   </p>
                   {copyProgress && (
-                    <p className="mt-2 text-sm text-muted-foreground">{copyProgress}</p>
+                    <p className="mt-2" style={{ fontSize: 14, color: 'rgba(254,243,199,0.75)' }}>{copyProgress}</p>
                   )}
                 </FadeIn>
               ) : experienceLevel === 'experienced' ? (
                 <FadeIn key="completing-experienced" className="text-center max-w-sm">
-                  <p className="text-lg text-foreground mb-3">
-                    Taking you to <span className="font-semibold text-primary">Programs</span>
+                  <p style={{ fontSize: 18, color: '#FEF3C7' }} className="mb-3">
+                    Taking you to <span className="font-semibold" style={{ color: '#10B981' }}>Programs</span>
                   </p>
-                  <p className="text-base text-muted-foreground">
+                  <p style={{ fontSize: 15, color: 'rgba(254,243,199,0.75)', lineHeight: 1.5 }}>
                     Browse the library and find a program that fits your goals. Use filters to narrow by equipment, level, or focus area.
                   </p>
                 </FadeIn>
               ) : (
-                <p className="text-lg text-muted-foreground">Getting things ready...</p>
+                <p style={{ fontSize: 18, color: 'rgba(254,243,199,0.75)' }}>Getting things ready...</p>
               )}
             </>
           )}
@@ -293,106 +279,80 @@ export default function OnboardingPage() {
     )
   }
 
-  const totalDots = step === 'equipment' || step === 'primer' ? 6 : 2
-  const currentDot =
-    step === 'waiver' ? 0 :
-    step === 'experience' ? 1 :
-    step === 'equipment' ? 2 :
-    step === 'primer' ? 3 + primerPage : 0
-
   return (
     <Shell>
-      {/* Progress bar */}
-      <div className="px-6 pt-6">
-        <div className="mx-auto flex max-w-lg items-center gap-1.5">
-          {Array.from({ length: totalDots }).map((_, i) => (
-            <div
-              key={i}
-              className={`h-[5px] flex-1 transition-all duration-500`}
-              style={{
-                backgroundColor: i <= currentDot
-                  ? 'var(--primary)'
-                  : 'rgba(0,0,0,0.25)',
-                boxShadow: i <= currentDot
-                  ? undefined
-                  : 'inset 0 1px 0 rgba(0,0,0,0.20)',
-              }}
-            />
-          ))}
-        </div>
+      {/* Progress segments — flush to top edge */}
+      <div style={{ display: 'flex', gap: 3, padding: '0 24px' }}>
+        {Array.from({ length: totalSegments }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              flex: 1,
+              height: 5,
+              backgroundColor: i <= currentSegment
+                ? '#10B981'
+                : 'rgba(0,0,0,0.25)',
+            }}
+          />
+        ))}
       </div>
 
       {/* Error toast */}
       {error && (
-        <div className="mx-auto mt-4 max-w-lg px-6">
+        <div className="mx-auto mt-4 max-w-lg" style={{ padding: '0 24px' }}>
           <div className="border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
             {error}
           </div>
         </div>
       )}
 
-      {/* Step content — centered vertically, fades in */}
-      <FadeIn key={fadeKey} className="flex flex-1 flex-col px-6 pt-12 pb-4">
-        <div className="mx-auto w-full max-w-lg flex-1">
-          {step === 'waiver' && <WaiverContent />}
-          {step === 'experience' && <ExperienceContent />}
-          {step === 'equipment' && <EquipmentContent onSelect={handleEquipment} />}
-          {step === 'primer' && <PrimerContent page={primerPage} />}
+      {/* Content area */}
+      <FadeIn key={fadeKey} className="flex flex-1 flex-col" style={{ padding: '0 24px' }}>
+        <div className={`mx-auto w-full max-w-lg flex-1 flex flex-col ${step !== 'info' ? 'justify-center' : ''}`} style={{ paddingTop: 32, paddingBottom: 24 }}>
+          {/* Back link */}
+          {canGoBack && (
+            <button
+              type="button"
+              onClick={handleBack}
+              style={{
+                color: 'rgba(254,243,199,0.5)',
+                fontSize: 13,
+                fontWeight: 500,
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                marginBottom: 24,
+                alignSelf: 'flex-start',
+              }}
+            >
+              &larr; BACK
+            </button>
+          )}
+
+          {step === 'experience' && (
+            <ExperienceScreen
+              selected={selectedCard}
+              previousChoice={experienceLevel}
+              onSelect={handleExperienceSelect}
+            />
+          )}
+
+          {step === 'equipment' && (
+            <EquipmentScreen
+              selected={selectedCard}
+              previousChoice={equipmentPreference}
+              onSelect={handleEquipmentSelect}
+            />
+          )}
+
+          {step === 'info' && (
+            <InfoScreen onFinish={handleFinish} />
+          )}
         </div>
       </FadeIn>
-
-      {/* Bottom action bar — fixed to bottom, PWA safe */}
-      <div
-        className="bg-secondary px-6"
-        style={{
-          paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
-          boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)',
-        }}
-      >
-        <div className="mx-auto max-w-lg py-3">
-          <div className="flex items-center gap-2.5">
-            {canGoBack && (
-              <button
-                type="button"
-                onClick={handleBack}
-                className="px-5 h-11 text-sm font-medium uppercase tracking-wider text-secondary-foreground transition-colors doom-focus-ring"
-                style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RAISED_SHADOW_SECONDARY }}
-              >
-                Back
-              </button>
-            )}
-            <div className="flex-1">
-              {step === 'waiver' && (
-                <WaiverAction onAccept={handleWaiverAccept} />
-              )}
-              {step === 'experience' && (
-                <ExperienceActions onSelect={handleExperience} />
-              )}
-              {step === 'equipment' && (
-                <p className="h-11 flex items-center justify-center text-sm uppercase tracking-wider text-secondary-foreground/60">Pick one above</p>
-              )}
-              {step === 'primer' && (
-                <div className="flex flex-col gap-2.5">
-                  <PrimerAction
-                    isLast={primerPage === PRIMER_PAGES.length - 1}
-                    onNext={handlePrimerNext}
-                    onFinish={handlePrimerFinish}
-                  />
-                  {primerPage < PRIMER_PAGES.length - 1 && (
-                    <button
-                      type="button"
-                      onClick={handlePrimerFinish}
-                      className="w-full h-11 text-sm font-medium uppercase tracking-wider text-secondary-foreground/60 transition-colors hover:text-secondary-foreground doom-focus-ring"
-                    >
-                      Skip tips
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
     </Shell>
   )
 }
@@ -401,27 +361,29 @@ export default function OnboardingPage() {
 
 function Shell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] flex-col bg-background">
-      <div
-        className="pointer-events-none absolute inset-x-0 top-0 h-72"
-        style={{
-          background: 'radial-gradient(ellipse 80% 50% at 50% 0%, rgba(234,88,12,0.06), transparent)',
-        }}
-      />
-      <div className="relative z-10 flex min-h-[100dvh] flex-col">
-        {children}
-      </div>
+    <div
+      className="flex min-h-[100dvh] flex-col"
+      style={{ backgroundColor: 'var(--background)' }}
+    >
+      {children}
     </div>
   )
 }
 
-function FadeIn({ children, className }: { children: React.ReactNode; className?: string }) {
+function FadeIn({
+  children,
+  className,
+  style,
+}: {
+  children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
+}) {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    // Force reflow so the animation replays
     el.style.animation = 'none'
     void el.offsetHeight
     el.style.animation = ''
@@ -431,7 +393,7 @@ function FadeIn({ children, className }: { children: React.ReactNode; className?
     <div
       ref={ref}
       className={className}
-      style={{ animation: 'onboarding-fade-in 0.4s ease-out both' }}
+      style={{ animation: 'onboarding-fade-in 0.4s ease-out both', ...style }}
     >
       <style>{`
         @keyframes onboarding-fade-in {
@@ -444,194 +406,230 @@ function FadeIn({ children, className }: { children: React.ReactNode; className?
   )
 }
 
-// --- Step Content (body area, scrollable) ---
+// --- Screen 1: Experience ---
 
-function WaiverContent() {
+function ExperienceScreen({
+  selected,
+  previousChoice,
+  onSelect,
+}: {
+  selected: string | null
+  previousChoice: ExperienceLevel | null
+  onSelect: (level: ExperienceLevel) => void
+}) {
   return (
     <>
-      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">
-        Before we begin
+      <h1 style={{ fontSize: 28, fontWeight: 600, color: '#FEF3C7', marginBottom: 8 }}>
+        New to strength training?
       </h1>
-      <p className="mb-6 text-sm text-muted-foreground">
-        Version {CURRENT_WAIVER_VERSION}
+      <p style={{ fontSize: 15, lineHeight: 1.5, color: 'rgba(254,243,199,0.75)', marginBottom: 32 }}>
+        This shapes your starting point.
       </p>
-      <div className="max-h-[50vh] overflow-y-auto border border-border/40 bg-card/60 p-5 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
-        {WAIVER_TEXT}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <SelectionCard
+          label="YES, I'M NEW"
+          isSelected={selected === 'beginner' || (!selected && previousChoice === 'beginner')}
+          onClick={() => onSelect('beginner')}
+        />
+        <SelectionCard
+          label="I HAVE EXPERIENCE"
+          isSelected={selected === 'experienced' || (!selected && previousChoice === 'experienced')}
+          onClick={() => onSelect('experienced')}
+        />
       </div>
     </>
   )
 }
 
-function ExperienceContent() {
-  return (
-    <>
-      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">
-        New to strength training?
-      </h1>
-      <p className="text-base text-muted-foreground">
-        This helps us set up the right experience for you.
-      </p>
-    </>
-  )
-}
+// --- Screen 2: Equipment ---
 
-function EquipmentContent({ onSelect }: { onSelect: (pref: EquipmentPreference) => void }) {
+function EquipmentScreen({
+  selected,
+  previousChoice,
+  onSelect,
+}: {
+  selected: string | null
+  previousChoice: EquipmentPreference | null
+  onSelect: (pref: EquipmentPreference) => void
+}) {
   return (
     <>
-      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">
+      <h1 style={{ fontSize: 28, fontWeight: 600, color: '#FEF3C7', marginBottom: 8 }}>
         What equipment are you most comfortable with?
       </h1>
-      <p className="mb-8 text-base text-muted-foreground">
+      <p style={{ fontSize: 15, lineHeight: 1.5, color: 'rgba(254,243,199,0.75)', marginBottom: 32 }}>
         We&apos;ll match you with a program that fits.
       </p>
 
-      <div className="flex flex-col gap-4">
-        <ChoiceCard
-          title="Machines"
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <SelectionCard
+          label="MACHINES"
           description="Fixed paths, easy to learn. Great for getting started."
+          isSelected={selected === 'machines' || (!selected && previousChoice === 'machines')}
           onClick={() => onSelect('machines')}
         />
-        <ChoiceCard
-          title="Free weights & cables"
+        <SelectionCard
+          label="FREE WEIGHTS & CABLES"
           description="Dumbbells, cable machines, and some barbell work."
+          isSelected={selected === 'free_weights_cables' || (!selected && previousChoice === 'free_weights_cables')}
           onClick={() => onSelect('free_weights_cables')}
         />
-        <ChoiceCard
-          title="I'm not sure"
+        <SelectionCard
+          label="I'M NOT SURE"
           description="We'll start you on machines -- the easiest way to begin."
+          isSelected={false}
           onClick={() => onSelect('machines')}
-          subtle
         />
       </div>
     </>
   )
 }
 
-function PrimerContent({ page }: { page: number }) {
-  const data = PRIMER_PAGES[page]
+// --- Screen 3: Consolidated Info ---
 
+function InfoScreen({ onFinish }: { onFinish: () => void }) {
   return (
     <>
-      <h2 className="mb-6 text-3xl font-bold tracking-tight text-foreground">
-        {data.title}
-      </h2>
+      <h1 style={{ fontSize: 32, fontWeight: 600, color: '#FEF3C7', marginBottom: 36 }}>
+        Before you start
+      </h1>
 
-      <div className="space-y-4">
-        {data.lines.map((line, i) => (
-          <p key={i} className="text-base leading-relaxed text-muted-foreground">
-            {line}
-          </p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+        {INFO_GROUPS.map((group) => (
+          <div key={group.header}>
+            <p style={{
+              fontSize: 14,
+              fontWeight: 500,
+              letterSpacing: '0.1em',
+              color: '#10B981',
+              textTransform: 'uppercase',
+              fontVariant: 'small-caps',
+              marginBottom: 12,
+            }}>
+              {group.header}
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {group.bullets.map((bullet, i) => (
+                <div key={i} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      width: 5,
+                      height: 5,
+                      backgroundColor: '#10B981',
+                      marginTop: 9,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span style={{
+                    fontSize: 16,
+                    lineHeight: 1.6,
+                    color: 'rgba(254,243,199,0.85)',
+                  }}>
+                    {bullet}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
         ))}
       </div>
 
+      <button
+        type="button"
+        onClick={onFinish}
+        className="w-full doom-focus-ring"
+        style={{
+          marginTop: 32,
+          height: 48,
+          backgroundColor: '#10B981',
+          color: '#fff',
+          fontSize: 14,
+          fontWeight: 500,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          border: 'none',
+          cursor: 'pointer',
+          boxShadow: RAISED_SHADOW,
+        }}
+      >
+        LET&apos;S GO
+      </button>
     </>
   )
 }
 
-// --- Bottom Actions ---
+// --- Shared Components ---
 
-function WaiverAction({ onAccept }: { onAccept: () => void }) {
-  const [accepting, setAccepting] = useState(false)
-
-  const handleAccept = async () => {
-    setAccepting(true)
-    await onAccept()
-    setAccepting(false)
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleAccept}
-      disabled={accepting}
-      className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50 doom-focus-ring"
-      style={{ boxShadow: RAISED_SHADOW }}
-    >
-      {accepting ? 'Submitting...' : 'I Agree'}
-    </button>
-  )
-}
-
-function ExperienceActions({ onSelect }: { onSelect: (level: ExperienceLevel) => void }) {
-  return (
-    <div className="flex flex-col gap-2.5">
-      <button
-        type="button"
-        onClick={() => onSelect('beginner')}
-        className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
-        style={{ boxShadow: RAISED_SHADOW }}
-      >
-        Yes, I&apos;m new
-      </button>
-      <button
-        type="button"
-        onClick={() => onSelect('experienced')}
-        className="w-full h-11 bg-secondary text-sm font-medium uppercase tracking-wider text-secondary-foreground transition-colors doom-focus-ring"
-        style={{ boxShadow: RAISED_SHADOW_SECONDARY }}
-      >
-        I have experience
-      </button>
-    </div>
-  )
-}
-
-function PrimerAction({
-  isLast,
-  onNext,
-  onFinish,
-}: {
-  isLast: boolean
-  onNext: () => void
-  onFinish: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={isLast ? onFinish : onNext}
-      className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
-      style={{ boxShadow: RAISED_SHADOW }}
-    >
-      {isLast ? "Let's go" : 'Next'}
-    </button>
-  )
-}
-
-function ChoiceCard({
-  title,
+function SelectionCard({
+  label,
   description,
+  isSelected,
   onClick,
-  subtle,
 }: {
-  title: string
-  description: string
+  label: string
+  description?: string
+  isSelected: boolean
   onClick: () => void
-  subtle?: boolean
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`group w-full border p-5 text-left transition-all ${
-        subtle
-          ? 'border-border/30 hover:border-border hover:bg-card/50'
-          : 'border-border bg-card hover:border-primary/40'
-      }`}
+      role="button"
+      tabIndex={0}
       style={{
-        boxShadow: subtle
-          ? undefined
-          : 'inset 0 1px 0 rgba(255,255,255,0.05), 0 1px 0 rgba(0,0,0,0.30)',
+        width: '100%',
+        padding: 20,
+        textAlign: 'left',
+        cursor: 'pointer',
+        position: 'relative',
+        backgroundColor: isSelected
+          ? 'rgba(16,185,129,0.08)'
+          : 'rgba(254,243,199,0.04)',
+        border: isSelected
+          ? '1px solid #10B981'
+          : '1px solid rgba(254,243,199,0.12)',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.05), 0 1px 0 rgba(0,0,0,0.30)',
+        transition: 'border-color 0.15s, background-color 0.15s',
       }}
     >
-      <p className={`text-base font-semibold uppercase tracking-wider transition-colors ${
-        subtle
-          ? 'text-muted-foreground group-hover:text-foreground'
-          : 'text-foreground group-hover:text-primary'
-      }`}>
-        {title}
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {description}
-      </p>
+      {/* Checkmark */}
+      {isSelected && (
+        <span style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          color: '#10B981',
+          fontSize: 16,
+          fontWeight: 700,
+        }}>
+          &#10003;
+        </span>
+      )}
+
+      <span style={{
+        display: 'block',
+        fontSize: 14,
+        fontWeight: 500,
+        letterSpacing: '0.08em',
+        color: '#FEF3C7',
+      }}>
+        {label}
+      </span>
+
+      {description && (
+        <span style={{
+          display: 'block',
+          marginTop: 4,
+          fontSize: 14,
+          lineHeight: 1.5,
+          color: 'rgba(254,243,199,0.75)',
+        }}>
+          {description}
+        </span>
+      )}
     </button>
   )
 }

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -9,6 +9,9 @@ type Step = 'loading' | 'waiver' | 'experience' | 'equipment' | 'primer' | 'comp
 type ExperienceLevel = 'beginner' | 'experienced'
 type EquipmentPreference = 'machines' | 'free_weights_cables'
 
+const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
+const RAISED_SHADOW_SECONDARY = 'inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -2px 0 rgba(0,0,0,0.25), 0 1px 0 rgba(0,0,0,0.30)'
+
 const PRIMER_PAGES = [
   {
     title: 'Just follow along',
@@ -253,7 +256,8 @@ export default function OnboardingPage() {
               <button
                 type="button"
                 onClick={() => { window.location.href = '/programs' }}
-                className="rounded-lg bg-primary px-6 py-3 text-base font-semibold text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active"
+                className="bg-primary px-6 h-11 text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
+                style={{ boxShadow: RAISED_SHADOW }}
               >
                 Go to Programs
               </button>
@@ -304,9 +308,15 @@ export default function OnboardingPage() {
           {Array.from({ length: totalDots }).map((_, i) => (
             <div
               key={i}
-              className={`h-1 flex-1 rounded-full transition-all duration-500 ${
-                i <= currentDot ? 'bg-primary' : 'bg-muted'
-              }`}
+              className={`h-[5px] flex-1 transition-all duration-500`}
+              style={{
+                backgroundColor: i <= currentDot
+                  ? 'var(--primary)'
+                  : 'rgba(0,0,0,0.25)',
+                boxShadow: i <= currentDot
+                  ? undefined
+                  : 'inset 0 1px 0 rgba(0,0,0,0.20)',
+              }}
             />
           ))}
         </div>
@@ -315,7 +325,7 @@ export default function OnboardingPage() {
       {/* Error toast */}
       {error && (
         <div className="mx-auto mt-4 max-w-lg px-6">
-          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+          <div className="border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
             {error}
           </div>
         </div>
@@ -333,16 +343,20 @@ export default function OnboardingPage() {
 
       {/* Bottom action bar — fixed to bottom, PWA safe */}
       <div
-        className="border-t border-border/30 bg-background/80 px-6 backdrop-blur-sm"
-        style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
+        className="bg-secondary px-6"
+        style={{
+          paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
+          boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)',
+        }}
       >
-        <div className="mx-auto max-w-lg py-4">
-          <div className="flex items-center gap-3">
+        <div className="mx-auto max-w-lg py-3">
+          <div className="flex items-center gap-2.5">
             {canGoBack && (
               <button
                 type="button"
                 onClick={handleBack}
-                className="rounded-lg border border-border px-5 py-3.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/20"
+                className="px-5 h-11 text-sm font-medium uppercase tracking-wider text-secondary-foreground transition-colors doom-focus-ring"
+                style={{ backgroundColor: 'rgba(0,0,0,0.35)', boxShadow: RAISED_SHADOW_SECONDARY }}
               >
                 Back
               </button>
@@ -355,10 +369,10 @@ export default function OnboardingPage() {
                 <ExperienceActions onSelect={handleExperience} />
               )}
               {step === 'equipment' && (
-                <p className="py-3.5 text-center text-sm text-muted-foreground">Pick one above</p>
+                <p className="h-11 flex items-center justify-center text-sm uppercase tracking-wider text-secondary-foreground/60">Pick one above</p>
               )}
               {step === 'primer' && (
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-2.5">
                   <PrimerAction
                     isLast={primerPage === PRIMER_PAGES.length - 1}
                     onNext={handlePrimerNext}
@@ -368,7 +382,7 @@ export default function OnboardingPage() {
                     <button
                       type="button"
                       onClick={handlePrimerFinish}
-                      className="w-full py-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      className="w-full h-11 text-sm font-medium uppercase tracking-wider text-secondary-foreground/60 transition-colors hover:text-secondary-foreground doom-focus-ring"
                     >
                       Skip tips
                     </button>
@@ -441,7 +455,7 @@ function WaiverContent() {
       <p className="mb-6 text-sm text-muted-foreground">
         Version {CURRENT_WAIVER_VERSION}
       </p>
-      <div className="max-h-[50vh] overflow-y-auto rounded-lg border border-border/40 bg-card/60 p-5 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
+      <div className="max-h-[50vh] overflow-y-auto border border-border/40 bg-card/60 p-5 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
         {WAIVER_TEXT}
       </div>
     </>
@@ -530,7 +544,8 @@ function WaiverAction({ onAccept }: { onAccept: () => void }) {
       type="button"
       onClick={handleAccept}
       disabled={accepting}
-      className="w-full rounded-lg bg-primary py-4 text-base font-semibold text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50"
+      className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50 doom-focus-ring"
+      style={{ boxShadow: RAISED_SHADOW }}
     >
       {accepting ? 'Submitting...' : 'I Agree'}
     </button>
@@ -539,20 +554,22 @@ function WaiverAction({ onAccept }: { onAccept: () => void }) {
 
 function ExperienceActions({ onSelect }: { onSelect: (level: ExperienceLevel) => void }) {
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-2.5">
       <button
         type="button"
         onClick={() => onSelect('beginner')}
-        className="w-full rounded-lg bg-primary py-4 text-base font-semibold text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active"
+        className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
+        style={{ boxShadow: RAISED_SHADOW }}
       >
-        Yes, I&apos;m new to this
+        Yes, I&apos;m new
       </button>
       <button
         type="button"
         onClick={() => onSelect('experienced')}
-        className="w-full rounded-lg border border-border py-4 text-base font-medium text-foreground transition-colors hover:bg-card"
+        className="w-full h-11 bg-secondary text-sm font-medium uppercase tracking-wider text-secondary-foreground transition-colors doom-focus-ring"
+        style={{ boxShadow: RAISED_SHADOW_SECONDARY }}
       >
-        I have some experience
+        I have experience
       </button>
     </div>
   )
@@ -571,7 +588,8 @@ function PrimerAction({
     <button
       type="button"
       onClick={isLast ? onFinish : onNext}
-      className="w-full rounded-lg bg-primary py-3.5 text-base font-semibold text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active"
+      className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active doom-focus-ring"
+      style={{ boxShadow: RAISED_SHADOW }}
     >
       {isLast ? "Let's go" : 'Next'}
     </button>
@@ -593,13 +611,18 @@ function ChoiceCard({
     <button
       type="button"
       onClick={onClick}
-      className={`group w-full rounded-lg border p-5 text-left transition-all ${
+      className={`group w-full border p-5 text-left transition-all ${
         subtle
           ? 'border-border/30 hover:border-border hover:bg-card/50'
           : 'border-border bg-card hover:border-primary/40'
       }`}
+      style={{
+        boxShadow: subtle
+          ? undefined
+          : 'inset 0 1px 0 rgba(255,255,255,0.05), 0 1px 0 rgba(0,0,0,0.30)',
+      }}
     >
-      <p className={`text-lg font-semibold transition-colors ${
+      <p className={`text-base font-semibold uppercase tracking-wider transition-colors ${
         subtle
           ? 'text-muted-foreground group-hover:text-foreground'
           : 'text-foreground group-hover:text-primary'

--- a/app/waiver/page.tsx
+++ b/app/waiver/page.tsx
@@ -64,7 +64,7 @@ export default function WaiverPage() {
           type="button"
           onClick={handleAccept}
           disabled={accepting}
-          className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover disabled:opacity-50 doom-focus-ring"
+          className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50 doom-focus-ring"
           style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
         >
           {accepting ? 'Submitting...' : 'I Agree'}

--- a/app/waiver/page.tsx
+++ b/app/waiver/page.tsx
@@ -44,15 +44,17 @@ export default function WaiverPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="w-full max-w-lg rounded-lg border border-border bg-card p-6 shadow-lg">
-        <h1 className="mb-4 text-xl font-bold text-foreground">
+    <div className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
+      <div className="w-full max-w-lg border border-border bg-card p-6"
+        style={{ boxShadow: '0 2px 0 rgba(0,0,0,0.40), inset 0 1px 0 rgba(255,255,255,0.05)' }}
+      >
+        <h1 className="mb-4 text-xl font-bold uppercase tracking-wider text-foreground">
           Waiver &amp; Assumption of Risk
         </h1>
         <p className="mb-2 text-xs text-muted-foreground">
           Version {CURRENT_WAIVER_VERSION}
         </p>
-        <div className="mb-6 max-h-64 overflow-y-auto rounded border border-border bg-muted p-4 text-sm text-foreground whitespace-pre-wrap">
+        <div className="mb-6 max-h-64 overflow-y-auto border border-border bg-muted p-4 text-sm text-foreground whitespace-pre-wrap">
           {WAIVER_TEXT}
         </div>
         {error && (
@@ -62,7 +64,8 @@ export default function WaiverPage() {
           type="button"
           onClick={handleAccept}
           disabled={accepting}
-          className="w-full rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover disabled:opacity-50 doom-focus-ring"
+          style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
         >
           {accepting ? 'Submitting...' : 'I Agree'}
         </button>

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -171,7 +171,7 @@ worker.on('failed', async (job, error) => {
 })
 
 worker.on('error', (error) => {
-  console.error('[worker] error:', error.message)
+  console.error('[worker] error:', error.message || error)
   workerReady = false
 })
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,8 +2,8 @@
 # Entry point for local dev: sources worktree-env.sh (so OVERMIND_SOCKET,
 # PG_PORT, etc. are exported) and then execs overmind.
 #
-# Default (no args) starts just postgres + app — the common subset.
-# Worker and minio are opt-in.
+# Default (no args) starts postgres + redis + worker + app.
+# Minio is opt-in.
 #
 # Usage:
 #   ./scripts/dev.sh                            # postgres + app

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,6 +13,14 @@
 #   ./scripts/dev.sh restart worker             # any overmind subcommand
 #   ./scripts/dev.sh connect app
 set -e
+
+# Pre-flight: verify Docker is responsive (hangs when VM is frozen)
+if ! perl -e 'alarm 5; exec @ARGV' -- docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker is not running or not responding (timed out after 5s)." >&2
+  echo "Try: open -a Docker   (or restart Docker Desktop)" >&2
+  exit 1
+fi
+
 source "$(dirname "$0")/worktree-env.sh"
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Restyle onboarding from 6+ steps to a focused 3-screen flow (experience, equipment, info)
- Remove waiver step from onboarding (already handled by `/waiver` route guard)
- Consolidate 3 primer tip pages into single scannable info screen with grouped bullets
- Replace brown footer bar with card-based tap-to-advance selection
- Apply spec typography: cream/mint hardcoded colors, larger info text, mint square bullet markers
- Add selection persistence when navigating back between screens

## Test plan
- [ ] Navigate to `/onboarding` and verify 3-screen flow: experience → equipment → info → completing
- [ ] Tap "YES, I'M NEW" — verify mint border/checkmark appears briefly, then advances to equipment
- [ ] Tap "I HAVE EXPERIENCE" — verify it goes to completing state (programs redirect)
- [ ] On equipment screen, tap back — verify previous experience choice shows as pre-selected
- [ ] On info screen, verify all 3 bullet groups render with mint square markers
- [ ] Tap "LET'S GO" — verify program clone + redirect works
- [ ] Check mobile viewport — info screen should fill available space without dead whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)