### PR TITLE
fix: apply raised shadow depth system to buttons app-wide

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -106,7 +106,7 @@ export default function SettingsPage() {
                     <DropdownMenu.Trigger asChild>
                       <button
                         type="button"
-                        className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
+                        className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2 doom-raised-subtle"
                       >
                         <Palette className="w-4 h-4" />
                         {preference ? THEME_LABELS[preference.themeName] : '...'}
@@ -153,7 +153,7 @@ export default function SettingsPage() {
                         mode: preference.mode === 'dark' ? 'light' : 'dark',
                       })
                     }
-                    className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2"
+                    className="w-full px-4 py-2 border-2 border-border bg-muted text-foreground font-semibold uppercase tracking-wider transition-colors hover:border-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background flex items-center justify-center gap-2 doom-raised-subtle"
                   >
                     {preference?.mode === 'dark' ? (
                       <>
@@ -187,8 +187,8 @@ export default function SettingsPage() {
                   onClick={() => setWeightUnit('lbs')}
                   className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                     weightUnit === 'lbs'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                   }`}
                 >
                   LBS
@@ -198,8 +198,8 @@ export default function SettingsPage() {
                   onClick={() => setWeightUnit('kg')}
                   className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                     weightUnit === 'kg'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                   }`}
                 >
                   KG
@@ -264,8 +264,8 @@ export default function SettingsPage() {
                       onClick={() => setIntensityRating('rpe')}
                       className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                         intensityRating === 'rpe'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted text-foreground border-border hover:bg-secondary'
+                          ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                       }`}
                     >
                       RPE
@@ -275,8 +275,8 @@ export default function SettingsPage() {
                       onClick={() => setIntensityRating('rir')}
                       className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                         intensityRating === 'rir'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted text-foreground border-border hover:bg-secondary'
+                          ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                       }`}
                     >
                       RIR
@@ -306,8 +306,8 @@ export default function SettingsPage() {
                   onClick={() => setLoggingMode('follow_along')}
                   className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                     loggingMode === 'follow_along'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                   }`}
                 >
                   Follow Along
@@ -317,8 +317,8 @@ export default function SettingsPage() {
                   onClick={() => setLoggingMode('full')}
                   className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                     loggingMode === 'full'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
+                      ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                      : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                   }`}
                 >
                   Log Sets
@@ -340,7 +340,7 @@ export default function SettingsPage() {
               type="button"
               onClick={handleSave}
               disabled={isSaving || !isDirty}
-              className={`w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 font-semibold uppercase tracking-wider flex items-center justify-center gap-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 disabled:cursor-not-allowed ${
+              className={`w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 font-semibold uppercase tracking-wider flex items-center justify-center gap-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 disabled:cursor-not-allowed doom-raised ${
                 saved
                   ? 'bg-success text-white border-success'
                   : 'bg-primary text-primary-foreground border-primary hover:bg-primary-hover'
@@ -390,7 +390,7 @@ export default function SettingsPage() {
                     setPasswordError(null)
                     setPasswordSuccess(false)
                   }}
-                  className="px-4 py-2 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center gap-2"
+                  className="px-4 py-2 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center gap-2 doom-raised-subtle"
                 >
                   <KeyRound size={16} />
                   Change Password
@@ -476,7 +476,7 @@ export default function SettingsPage() {
                         }
                       }}
                       disabled={isChangingPassword || !currentPassword || !newPassword || !confirmNewPassword}
-                      className="w-full md:w-auto md:min-w-[200px] px-4 py-2 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover transition-colors font-semibold uppercase tracking-wider text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full md:w-auto md:min-w-[200px] px-4 py-2 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover transition-colors font-semibold uppercase tracking-wider text-sm disabled:opacity-50 disabled:cursor-not-allowed doom-raised"
                     >
                       {isChangingPassword ? 'Changing...' : 'Update Password'}
                     </button>
@@ -499,7 +499,7 @@ export default function SettingsPage() {
                 </span>
                 <Link
                   href="/admin"
-                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2 doom-raised-subtle"
                 >
                   <Shield size={18} />
                   Admin Panel
@@ -516,7 +516,7 @@ export default function SettingsPage() {
                 <button
                   type="button"
                   onClick={() => setFeedbackOpen(true)}
-                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2 doom-raised-subtle"
                 >
                   <MessageSquarePlus size={18} />
                   Send Feedback
@@ -526,7 +526,7 @@ export default function SettingsPage() {
                   href={`https://venmo.com/${process.env.NEXT_PUBLIC_VENMO_HANDLE}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm flex items-center justify-center gap-2 doom-raised-subtle"
                 >
                   <Heart size={18} />
                   Support Ripit
@@ -541,7 +541,7 @@ export default function SettingsPage() {
               <form action="/api/auth/signout" method="POST">
                 <button
                   type="submit"
-                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm"
+                  className="w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 border-border bg-muted text-foreground hover:bg-secondary hover:border-primary transition-colors font-semibold uppercase tracking-wider text-sm doom-raised-subtle"
                 >
                   Sign Out
                 </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1961,6 +1961,34 @@ body > [data-training-widget] {
   z-index: 3;
 }
 
+/* Raised Shadow — primary/filled buttons */
+.doom-raised {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.20),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.30),
+    0 1px 0 rgba(0, 0, 0, 0.40);
+}
+
+.doom-raised:active:not(:disabled) {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.20);
+}
+
+/* Raised Shadow — outline/secondary buttons */
+.doom-raised-subtle {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.20),
+    0 1px 0 rgba(0, 0, 0, 0.30);
+}
+
+.doom-raised-subtle:active:not(:disabled) {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.10);
+}
+
 /* 3D Button Effect */
 .doom-button-3d {
   position: relative;

--- a/components/admin/DeleteExerciseDialog.tsx
+++ b/components/admin/DeleteExerciseDialog.tsx
@@ -155,7 +155,7 @@ export default function DeleteExerciseDialog({
             <AlertDialog.Cancel asChild>
               <button type="button"
                 disabled={isDeleting}
-                className="px-4 py-2 border-2 border-border text-foreground hover:border-primary hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-focus-ring"
+                className="px-4 py-2 border-2 border-border text-foreground hover:border-primary hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-focus-ring doom-raised-subtle"
               >
                 Cancel
               </button>
@@ -163,7 +163,7 @@ export default function DeleteExerciseDialog({
             <button type="button"
               onClick={handleDelete}
               disabled={isDeleting || !canDelete}
-              className="px-4 py-2 bg-error text-error-foreground hover:bg-error-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-button-3d doom-focus-ring"
+              className="px-4 py-2 bg-error text-error-foreground hover:bg-error-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-raised doom-focus-ring"
             >
               {isDeleting ? 'DELETING...' : 'DELETE'}
             </button>

--- a/components/community/UnpublishProgramDialog.tsx
+++ b/components/community/UnpublishProgramDialog.tsx
@@ -94,7 +94,7 @@ export default function UnpublishProgramDialog({
             <AlertDialog.Cancel asChild>
               <button type="button"
                 disabled={isDeleting}
-                className="px-4 py-2 border-2 border-border text-foreground hover:border-primary hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-focus-ring"
+                className="px-4 py-2 border-2 border-border text-foreground hover:border-primary hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-focus-ring doom-raised-subtle"
               >
                 Cancel
               </button>
@@ -103,7 +103,7 @@ export default function UnpublishProgramDialog({
               <button type="button"
                 onClick={handleUnpublish}
                 disabled={isDeleting}
-                className="px-4 py-2 bg-error text-error-foreground hover:bg-error-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-button-3d doom-focus-ring"
+                className="px-4 py-2 bg-error text-error-foreground hover:bg-error-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed uppercase tracking-wider font-semibold text-sm doom-raised doom-focus-ring"
               >
                 {isDeleting ? 'UNPUBLISHING...' : 'UNPUBLISH'}
               </button>

--- a/components/features/FeedbackModal.tsx
+++ b/components/features/FeedbackModal.tsx
@@ -127,8 +127,8 @@ export default function FeedbackModal({ open, onOpenChange }: FeedbackModalProps
                     onClick={() => setCategory(cat.value)}
                     className={`px-3 py-2 border-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                       category === cat.value
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-muted text-foreground border-border hover:bg-secondary'
+                        ? 'bg-primary text-primary-foreground border-primary doom-raised'
+                        : 'bg-muted text-foreground border-border hover:bg-secondary doom-raised-subtle'
                     }`}
                   >
                     <span className="block text-sm font-semibold uppercase tracking-wider">
@@ -183,7 +183,7 @@ export default function FeedbackModal({ open, onOpenChange }: FeedbackModalProps
                 type="button"
                 onClick={() => handleOpenChange(false)}
                 disabled={isSubmitting}
-                className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary transition-colors font-semibold uppercase tracking-wider disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+                className="flex-1 px-4 py-3 bg-muted text-foreground border-2 border-border hover:bg-secondary transition-colors font-semibold uppercase tracking-wider disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background doom-raised-subtle"
               >
                 Cancel
               </button>
@@ -191,7 +191,7 @@ export default function FeedbackModal({ open, onOpenChange }: FeedbackModalProps
                 type="button"
                 onClick={handleSubmit}
                 disabled={isSubmitting || !category || !message.trim()}
-                className="flex-1 px-4 py-3 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover transition-colors font-semibold uppercase tracking-wider flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+                className="flex-1 px-4 py-3 bg-primary text-primary-foreground border-2 border-primary hover:bg-primary-hover transition-colors font-semibold uppercase tracking-wider flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background doom-raised"
               >
                 <Send size={16} />
                 {isSubmitting ? 'Sending...' : 'Send'}

--- a/components/features/auth/OAuthButtons.tsx
+++ b/components/features/auth/OAuthButtons.tsx
@@ -62,7 +62,7 @@ export function OAuthButtons({ intent = 'login' }: OAuthButtonsProps = {}) {
         type="button"
         onClick={() => handleOAuth('google')}
         disabled={loadingProvider !== null}
-        className="flex w-full items-center justify-center gap-2 px-3 py-2.5 bg-white border border-gray-300 rounded-lg text-gray-700 font-medium text-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="flex w-full items-center justify-center gap-2 px-3 py-2.5 bg-white border border-gray-300 rounded-lg text-gray-700 font-medium text-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors doom-raised-subtle"
       >
         {loadingProvider === 'google' ? (
           <LoadingSpinner />

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -23,13 +23,13 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const baseStyles = 'inline-flex items-center justify-center font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
 
     const variantStyles = {
-      primary: 'bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active focus:ring-primary',
-      secondary: 'bg-muted text-foreground hover:bg-secondary-hover hover:text-foreground focus:ring-border',
-      accent: 'bg-accent text-accent-foreground hover:bg-accent-hover active:bg-accent-active focus:ring-accent',
-      success: 'bg-success text-success-foreground hover:bg-success-hover focus:ring-success',
-      danger: 'bg-error text-error-foreground hover:bg-error-hover focus:ring-error',
+      primary: 'bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active focus:ring-primary doom-raised',
+      secondary: 'bg-muted text-foreground hover:bg-secondary-hover hover:text-foreground focus:ring-border doom-raised-subtle',
+      accent: 'bg-accent text-accent-foreground hover:bg-accent-hover active:bg-accent-active focus:ring-accent doom-raised',
+      success: 'bg-success text-success-foreground hover:bg-success-hover focus:ring-success doom-raised',
+      danger: 'bg-error text-error-foreground hover:bg-error-hover focus:ring-error doom-raised',
       ghost: 'bg-transparent hover:bg-muted text-foreground',
-      outline: 'border-2 border-border bg-transparent hover:bg-muted text-foreground'
+      outline: 'border-2 border-border bg-transparent hover:bg-muted text-foreground doom-raised-subtle'
     }
 
     const sizeStyles = {

--- a/components/ui/radix/alert-dialog.tsx
+++ b/components/ui/radix/alert-dialog.tsx
@@ -86,7 +86,7 @@ const AlertDialogAction = React.forwardRef<
 >(({ className = '', ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={`inline-flex h-10 items-center justify-center rounded-none border-2 border-orange-600 bg-orange-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-700 hover:border-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    className={`inline-flex h-10 items-center justify-center rounded-none border-2 border-orange-600 bg-orange-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-700 hover:border-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 doom-raised ${className}`}
     {...props}
   />
 ))
@@ -98,7 +98,7 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className = '', ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={`inline-flex h-10 items-center justify-center rounded-none border-2 border-zinc-600 bg-transparent px-4 py-2 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-orange-50 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    className={`inline-flex h-10 items-center justify-center rounded-none border-2 border-zinc-600 bg-transparent px-4 py-2 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-orange-50 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 doom-raised-subtle ${className}`}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary

- Add `doom-raised` and `doom-raised-subtle` CSS utility classes in `globals.css` for the embossed shadow treatment from PR #582
- Apply `doom-raised` to filled/primary Button variants (primary, accent, success, danger) and AlertDialogAction
- Apply `doom-raised-subtle` to outline/secondary Button variants (secondary, outline) and AlertDialogCancel
- Add shadow treatment to all Settings page buttons (theme, mode, weight unit, intensity, workout mode, save, change password, admin, feedback, support, sign out)
- Add shadow to FeedbackModal category selectors, cancel, and send buttons
- Add shadow to OAuth Google sign-in button
- Add shadow to DeleteExerciseDialog and UnpublishProgramDialog cancel/action buttons

## Test plan

- [ ] Verify Settings page buttons have visible embossed shadow in both dark and light mode
- [ ] Verify Login/Signup page buttons have shadow (via Button component)
- [ ] Verify FeedbackModal category and action buttons have shadow
- [ ] Verify alert dialog confirm/cancel buttons have shadow
- [ ] Verify active pressed state reduces shadow depth
- [ ] Verify ghost buttons (no fill) do NOT have shadow
- [ ] Check no horizontal overflow on mobile (375px width)

Fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)