### PR TITLE
Increase exercise instruction char limit to 1000

### DIFF
--- a/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
+++ b/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
@@ -401,13 +401,13 @@ export default function ExerciseDefinitionEditorModal({
                   <label htmlFor="exercise-instructions" className="block text-sm font-semibold text-foreground uppercase tracking-wide">
                     Instructions
                   </label>
-                  <span className="text-xs text-muted-foreground">{formData.instructions.length} / 400</span>
+                  <span className="text-xs text-muted-foreground">{formData.instructions.length} / 1000</span>
                 </div>
                 <textarea
                   id="exercise-instructions"
                   value={formData.instructions}
                   onChange={(e) => setFormData({ ...formData, instructions: e.target.value })}
-                  maxLength={400}
+                  maxLength={1000}
                   rows={4}
                   className={`w-full px-3 py-2 border-2 rounded bg-background text-foreground ${
                     errors.instructions ? 'border-error' : 'border-border focus:border-primary'


### PR DESCRIPTION
## Summary
- Bumps the instructions textarea `maxLength` from 400 to 1000 in the admin exercise definition editor
- Updates the character counter display to reflect the new limit
- No schema migration needed — Prisma uses unlimited `String` for the instructions field

Fixes #588

## Test plan
- [ ] Open admin exercise definition editor
- [ ] Verify instructions textarea accepts up to 1000 characters
- [ ] Verify character counter shows `X / 1000`
- [ ] Edit an existing exercise with >400 char instructions — confirm no truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)