### PR TITLE
Fix auth form input text color

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -76,7 +76,7 @@ function LoginForm() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                 placeholder="you@example.com"
               />
             </div>
@@ -97,7 +97,7 @@ function LoginForm() {
                   required
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                   placeholder="••••••••"
                 />
                 <button

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -123,7 +123,7 @@ export default function SignupPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                 placeholder="you@example.com"
               />
             </div>
@@ -137,7 +137,7 @@ export default function SignupPage() {
                 type="text"
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                 placeholder="Optional"
               />
             </div>
@@ -153,7 +153,7 @@ export default function SignupPage() {
                   required
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                   placeholder="••••••••"
                 />
                 <button
@@ -178,7 +178,7 @@ export default function SignupPage() {
                   required
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-foreground placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  className="block w-full px-3 py-2 pr-16 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                   placeholder="••••••••"
                 />
                 <button


### PR DESCRIPTION
## Summary
- Changed input `text-foreground` to `text-gray-900` on login and signup forms
- The `text-foreground` token resolves to a light color (yellow/white) on dark DOOM themes, making typed text invisible against the `bg-white` input background
- Scoped only to auth form inputs — no impact on other pages

## Test plan
- [ ] Open /login in dark mode — type in email and password fields, text should be dark and readable
- [ ] Open /signup in dark mode — type in all fields (email, display name, password, confirm password), text should be dark and readable
- [ ] Verify /forgot-password and /reset-password still look correct (they use `bg-background` not `bg-white`, so were not affected)
- [ ] Check all DOOM theme variants

Fixes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)