### PR TITLE
Add cancel buttons to weight keypad and intensity selector

### DIFF
--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { IntensitySelector } from './inputs/IntensitySelector'
 import { RepsStepper } from './inputs/RepsStepper'
@@ -72,6 +72,29 @@ export default function SetLoggingForm({
     }
   }, [settings?.defaultWeightUnit, currentSet, onSetChange])
 
+  // Capture the value before expansion so cancel can restore it
+  const valueBeforeExpand = useRef<string>('')
+
+  const handleExpand = useCallback((input: ExpandedInput) => {
+    if (input === 'weight') valueBeforeExpand.current = currentSet.weight
+    else if (input === 'rpe') valueBeforeExpand.current = currentSet.rpe
+    else if (input === 'rir') valueBeforeExpand.current = currentSet.rir
+    onExpandedInputChange(input)
+  }, [currentSet.weight, currentSet.rpe, currentSet.rir, onExpandedInputChange])
+
+  const handleCollapse = useCallback(() => {
+    onExpandedInputChange(null)
+  }, [onExpandedInputChange])
+
+  const handleCancel = useCallback((input: ExpandedInput) => {
+    // Restore the value from before expansion
+    const restored = valueBeforeExpand.current
+    if (input === 'weight') onSetChange({ ...currentSet, weight: restored })
+    else if (input === 'rpe') onSetChange({ ...currentSet, rpe: restored })
+    else if (input === 'rir') onSetChange({ ...currentSet, rir: restored })
+    onExpandedInputChange(null)
+  }, [currentSet, onSetChange, onExpandedInputChange])
+
   if (hasLoggedAllPrescribed && !extraSetsMode) {
     return (
       <div className="bg-success-muted border-2 border-success-border p-4 flex-shrink-0">
@@ -108,14 +131,6 @@ export default function SetLoggingForm({
     )
   }
 
-  const handleExpand = (input: ExpandedInput) => {
-    onExpandedInputChange(input)
-  }
-
-  const handleCollapse = () => {
-    onExpandedInputChange(null)
-  }
-
   const showReps = expandedInput === null
   const showWeight = expandedInput === null || expandedInput === 'weight'
   const showIntensity = expandedInput === null || expandedInput === 'rpe' || expandedInput === 'rir'
@@ -143,6 +158,7 @@ export default function SetLoggingForm({
                 isExpanded={false}
                 onExpand={() => handleExpand('weight')}
                 onCollapse={handleCollapse}
+                onCancel={() => handleCancel('weight')}
               />
             </div>
             <div className="flex-1">
@@ -155,6 +171,7 @@ export default function SetLoggingForm({
                   isExpanded={false}
                   onExpand={() => handleExpand('rir')}
                   onCollapse={handleCollapse}
+                  onCancel={() => handleCancel('rir')}
                 />
               )}
               {hasRpe && (
@@ -166,6 +183,7 @@ export default function SetLoggingForm({
                   isExpanded={false}
                   onExpand={() => handleExpand('rpe')}
                   onCollapse={handleCollapse}
+                  onCancel={() => handleCancel('rpe')}
                 />
               )}
             </div>
@@ -181,6 +199,7 @@ export default function SetLoggingForm({
                 isExpanded={expandedInput === 'weight'}
                 onExpand={() => handleExpand('weight')}
                 onCollapse={handleCollapse}
+                onCancel={() => handleCancel('weight')}
               />
             )}
 
@@ -194,6 +213,7 @@ export default function SetLoggingForm({
                 isExpanded={expandedInput === 'rir'}
                 onExpand={() => handleExpand('rir')}
                 onCollapse={handleCollapse}
+                onCancel={() => handleCancel('rir')}
               />
             )}
 
@@ -206,6 +226,7 @@ export default function SetLoggingForm({
                 isExpanded={expandedInput === 'rpe'}
                 onExpand={() => handleExpand('rpe')}
                 onCollapse={handleCollapse}
+                onCancel={() => handleCancel('rpe')}
               />
             )}
           </>

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -10,6 +10,7 @@ interface IntensitySelectorProps {
   isExpanded: boolean
   onExpand: () => void
   onCollapse: () => void
+  onCancel: () => void
 }
 
 export function IntensitySelector({
@@ -19,6 +20,7 @@ export function IntensitySelector({
   isExpanded,
   onExpand,
   onCollapse,
+  onCancel,
 }: IntensitySelectorProps) {
   const presets: IntensityPreset[] = type === 'rpe' ? RPE_PRESETS : RIR_PRESETS
   const label = type === 'rpe' ? 'RPE' : 'RIR'
@@ -88,19 +90,31 @@ export function IntensitySelector({
           )
         })}
 
-        {/* Clear / Skip button */}
-        <button
-          type="button"
-          onClick={() => {
-            onChange('')
-            onCollapse()
-          }}
-          className="w-full px-3 py-2.5 bg-card
-            text-muted-foreground font-bold uppercase tracking-wider text-sm
-            hover:bg-muted transition-colors"
-        >
-          SKIP {label}
-        </button>
+        {/* Cancel + Skip buttons */}
+        <div className="flex">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 px-3 py-2.5 bg-error text-error-foreground
+              font-bold uppercase tracking-wider text-sm
+              hover:bg-error-hover transition-colors"
+            aria-label={`Cancel ${label} selection`}
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onChange('')
+              onCollapse()
+            }}
+            className="flex-1 px-3 py-2.5 bg-card
+              text-muted-foreground font-bold uppercase tracking-wider text-sm
+              hover:bg-muted transition-colors border-l border-border"
+          >
+            SKIP {label}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -10,6 +10,7 @@ interface WeightKeypadProps {
   isExpanded: boolean
   onExpand: () => void
   onCollapse: () => void
+  onCancel: () => void
 }
 
 const KEYPAD_KEYS = [
@@ -26,6 +27,7 @@ export function WeightKeypad({
   isExpanded,
   onExpand,
   onCollapse,
+  onCancel,
 }: WeightKeypadProps) {
   const replaceOnNext = useRef(false)
 
@@ -154,18 +156,32 @@ export function WeightKeypad({
         ))}
       </div>
 
-      {/* Done button */}
-      <button
-        type="button"
-        onClick={handleDone}
-        className="w-full mt-px h-11 bg-primary text-primary-foreground
-          font-bold uppercase tracking-wider text-sm
-          hover:bg-primary/90 active:bg-primary/80
-          transition-colors"
-        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
-      >
-        DONE
-      </button>
+      {/* Cancel + Done buttons */}
+      <div className="flex gap-px mt-px">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 h-11 bg-error text-error-foreground
+            font-bold uppercase tracking-wider text-sm
+            hover:bg-error-hover active:bg-error/80
+            transition-colors"
+          aria-label="Cancel weight entry"
+          style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
+        >
+          CANCEL
+        </button>
+        <button
+          type="button"
+          onClick={handleDone}
+          className="flex-[2] h-11 bg-primary text-primary-foreground
+            font-bold uppercase tracking-wider text-sm
+            hover:bg-primary/90 active:bg-primary/80
+            transition-colors"
+          style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
+        >
+          DONE
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds red CANCEL buttons to the weight keypad and intensity selector expanded views
- Cancel restores the previous value (leaves last entry or empty) and collapses back to the base log tab
- Weight keypad: CANCEL (1/3 width) + DONE (2/3 width) side by side at bottom
- Intensity selector: CANCEL + SKIP side by side at bottom of preset list
- Uses `--error` / `--error-hover` theme tokens for the red cancel styling
- Added `aria-label` attributes for accessibility

## Test plan
- [ ] Open workout logger, tap weight button, verify CANCEL appears next to DONE
- [ ] Tap CANCEL on weight keypad -- should return to compact view with original value preserved
- [ ] Type a new weight, tap CANCEL -- original value should be restored
- [ ] Tap intensity button (RIR/RPE), verify CANCEL appears next to SKIP
- [ ] Tap CANCEL on intensity selector -- should return with original value preserved
- [ ] Select an intensity value -- should still work normally (collapse on select)
- [ ] Tap SKIP -- should still clear value and collapse
- [ ] Verify buttons meet 48px touch target (h-11 = 44px, py-2.5 padding brings it close)
- [ ] Verify theme colors look correct in dark mode

Fixes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)