### PR TITLE
feat: follow-along mode prescription card and tip navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2356,6 +2356,28 @@ body > [data-training-widget] {
   z-index: 1;
 }
 
+/* "What To Do" prescription card — double pulse on exercise load */
+@keyframes wtd-pulse {
+  0%, 28.6%, 57.1%, 100% {
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--primary) 30%, transparent),
+      inset 0 -1px 0 rgba(0,0,0,0.30),
+      inset 0 0 0 1px color-mix(in srgb, var(--primary) 25%, transparent),
+      0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+  14.3%, 42.9% {
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--primary) 40%, transparent),
+      inset 0 -1px 0 rgba(0,0,0,0.30),
+      inset 0 0 0 1px color-mix(in srgb, var(--primary) 55%, transparent),
+      0 0 12px 0 color-mix(in srgb, var(--primary) 18%, transparent);
+  }
+}
+
+.wtd-pulse {
+  animation: wtd-pulse 2.8s ease-out 0.2s 1;
+}
+
 /* Prose styles for Learn article markdown content */
 .prose-learn {
   color: var(--foreground);

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -562,6 +562,8 @@ export default function ExerciseLoggingModal({
                   exercise={currentExercise}
                   prescribedSets={currentPrescribedSets}
                   tip={currentTip}
+                  tipCount={tierTips.length}
+                  onNextTip={rotateTip}
                 />
               ) : (
                 <ExerciseDisplayTabs

--- a/components/workout-logging/BeginnerTipCard.tsx
+++ b/components/workout-logging/BeginnerTipCard.tsx
@@ -1,15 +1,23 @@
 'use client'
 
+import { ChevronRight } from 'lucide-react'
 import { clientLogger } from '@/lib/client-logger'
 
 interface BeginnerTipCardProps {
   tip: string
   visible?: boolean
+  tipCount?: number
+  onNextTip?: () => void
 }
 
 const MAX_TIP_LENGTH = 180
 
-export default function BeginnerTipCard({ tip, visible = true }: BeginnerTipCardProps) {
+export default function BeginnerTipCard({
+  tip,
+  visible = true,
+  tipCount = 0,
+  onNextTip,
+}: BeginnerTipCardProps) {
   if (!visible || !tip) return null
 
   let displayText = tip
@@ -18,32 +26,50 @@ export default function BeginnerTipCard({ tip, visible = true }: BeginnerTipCard
     displayText = `${tip.slice(0, MAX_TIP_LENGTH - 3)}...`
   }
 
+  const hasNavigation = onNextTip && tipCount > 1
+
   return (
     <div
       role="note"
-      className="flex items-start gap-2.5 mt-3 p-3.5 border border-dashed border-border/40 bg-muted/35"
+      className="relative mt-3 p-3.5 border border-dashed border-border/40 bg-muted/35"
     >
-      <svg
-        aria-hidden="true"
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        className="shrink-0 mt-[5px] stroke-muted-foreground"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M9 18h6" />
-        <path d="M10 22h4" />
-        <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5C8.35 12.26 8.82 13.02 9 14" />
-      </svg>
-      <span
-        aria-live="polite"
-        className="text-lg leading-relaxed text-muted-foreground"
-      >
-        {displayText}
-      </span>
+      <div className="flex items-start gap-2.5">
+        <svg
+          aria-hidden="true"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          className="shrink-0 mt-[5px] stroke-muted-foreground"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M9 18h6" />
+          <path d="M10 22h4" />
+          <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5C8.35 12.26 8.82 13.02 9 14" />
+        </svg>
+        <span
+          aria-live="polite"
+          className={`text-lg leading-relaxed text-muted-foreground ${hasNavigation ? 'pr-6' : ''}`}
+        >
+          {displayText}
+        </span>
+      </div>
+
+      {hasNavigation && (
+        <button
+          type="button"
+          onClick={onNextTip}
+          className="absolute right-0 top-0 bottom-0 w-10 flex items-center justify-end pr-2 doom-focus-ring"
+          style={{
+            background: 'linear-gradient(to right, transparent, color-mix(in srgb, var(--muted) 85%, transparent) 40%)',
+          }}
+          aria-label="Next tip"
+        >
+          <ChevronRight size={16} className="text-muted-foreground/60" />
+        </button>
+      )}
     </div>
   )
 }

--- a/components/workout-logging/FollowAlongTabs.tsx
+++ b/components/workout-logging/FollowAlongTabs.tsx
@@ -30,22 +30,15 @@ interface FollowAlongViewProps {
   exercise: Exercise
   prescribedSets: PrescribedSet[]
   tip: string
-}
-
-const FAU_DISPLAY_NAMES: Record<string, string> = {
-  chest: 'Chest', 'mid-back': 'Mid Back', 'lower-back': 'Lower Back',
-  'front-delts': 'Front Delts', 'side-delts': 'Side Delts', 'rear-delts': 'Rear Delts',
-  lats: 'Lats', traps: 'Traps', biceps: 'Biceps', triceps: 'Triceps',
-  forearms: 'Forearms', quads: 'Quads', adductors: 'Adductors',
-  hamstrings: 'Hamstrings', glutes: 'Glutes', calves: 'Calves',
-  abs: 'Abs', obliques: 'Obliques',
+  tipCount?: number
+  onNextTip?: () => void
 }
 
 /**
- * Format prescribed sets as compact subtitle: "3 x 12" or "3 sets x 12 reps".
- * For varying reps: "3 sets: 12, 10, 8"
+ * Format prescribed sets as compact directive: "3 sets of 12 reps"
+ * For varying reps: "3 sets: 12, 10, 8 reps"
  */
-function formatPrescriptionSubtitle(prescribedSets: PrescribedSet[]): string {
+function formatPrescriptionDirective(prescribedSets: PrescribedSet[]): string {
   if (prescribedSets.length === 0) return 'No sets prescribed'
 
   const repsValues = prescribedSets.map(s => {
@@ -58,25 +51,50 @@ function formatPrescriptionSubtitle(prescribedSets: PrescribedSet[]): string {
   const count = prescribedSets.length
 
   if (allSame) {
-    return `${count} sets of ${repsValues[0]} repetitions`
+    return `${count} sets of ${repsValues[0]} reps`
   }
 
-  return `${count} sets: ${repsValues.join(', ')} repetitions`
+  return `${count} sets: ${repsValues.join(', ')} reps`
 }
 
 /**
  * Single-scroll follow-along view. No tabs — all content flows top to bottom:
- * title block, exercise image (crossfade), instructions, coaching tip.
+ * title block, "What To Do" card, exercise image, instructions, coaching tip.
  */
 export default function FollowAlongTabs({
   exercise,
   prescribedSets,
   tip,
+  tipCount = 0,
+  onNextTip,
 }: FollowAlongViewProps) {
-  const subtitle = formatPrescriptionSubtitle(prescribedSets)
-  const primaryMuscles = exercise.exerciseDefinition?.primaryFAUs
-    ?.map(fau => FAU_DISPLAY_NAMES[fau] || fau.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()))
+  const directive = formatPrescriptionDirective(prescribedSets)
   const imageUrls = exercise.exerciseDefinition?.imageUrls || []
+
+  // Pulse animation — fires twice on exercise screen load
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [pulseKey, setPulseKey] = useState(exercise.id)
+
+  useEffect(() => {
+    setPulseKey(exercise.id)
+  }, [exercise.id])
+
+  useEffect(() => {
+    const el = cardRef.current
+    if (!el) return
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (prefersReduced) return
+
+    el.classList.remove('wtd-pulse')
+    // Force reflow so re-adding the class restarts the animation
+    void el.offsetWidth
+    el.classList.add('wtd-pulse')
+
+    const cleanup = () => el.classList.remove('wtd-pulse')
+    el.addEventListener('animationend', cleanup, { once: true })
+    return () => el.removeEventListener('animationend', cleanup)
+  }, [pulseKey])
 
   // Track whether content is scrollable and not fully scrolled
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -97,19 +115,37 @@ export default function FollowAlongTabs({
     <div className="flex flex-col h-full min-h-0">
       <div className="relative flex-1 min-h-0">
         <div ref={scrollRef} onScroll={checkScroll} className="h-full overflow-y-auto">
-        {/* Title block */}
+        {/* Title block — exercise name only */}
         <div className="bg-card border-b border-border px-4 py-4 text-center">
-          <h2 className="text-xl font-bold text-foreground uppercase tracking-wider doom-heading">
+          <h2 className="text-[18px] font-semibold text-foreground uppercase tracking-wider doom-heading">
             {exercise.name}
           </h2>
-          <p className="text-base text-primary font-semibold mt-1">
-            {subtitle}
-          </p>
-          {primaryMuscles && primaryMuscles.length > 0 && (
-            <p className="text-xs text-muted-foreground uppercase tracking-widest mt-1.5">
-              {primaryMuscles.join(' \u00b7 ')}
-            </p>
-          )}
+        </div>
+
+        {/* "What To Do" prescription card */}
+        <div className="px-4 pt-4">
+          <div
+            ref={cardRef}
+            className="wtd-card px-[14px] py-[14px]"
+            style={{
+              backgroundColor: 'color-mix(in srgb, var(--primary) 8%, transparent)',
+              boxShadow: [
+                'inset 0 1px 0 color-mix(in srgb, var(--primary) 30%, transparent)',
+                'inset 0 -1px 0 rgba(0,0,0,0.30)',
+                'inset 0 0 0 1px color-mix(in srgb, var(--primary) 25%, transparent)',
+              ].join(', '),
+            }}
+          >
+            <span
+              className="block text-[11px] font-medium uppercase tracking-[0.12em]"
+              style={{ color: 'var(--primary)' }}
+            >
+              What to do
+            </span>
+            <span className="block text-[22px] font-medium text-foreground leading-[1.1] mt-0.5">
+              {directive}
+            </span>
+          </div>
         </div>
 
         {/* Exercise demonstration */}
@@ -135,7 +171,11 @@ export default function FollowAlongTabs({
         {/* Coaching tip */}
         {tip && (
           <div className="px-4 pt-4 pb-4">
-            <BeginnerTipCard tip={tip} />
+            <BeginnerTipCard
+              tip={tip}
+              tipCount={tipCount}
+              onNextTip={onNextTip}
+            />
           </div>
         )}
         </div>


### PR DESCRIPTION
## Summary
- **"What To Do" card**: Replaces the subtle prescription subtitle with a prominent directive card between the title block and exercise demo image. Uses dimensional styling (inset shadows, primary-tinted background) consistent with the rest timer. Pulses twice on exercise load to draw the eye, respects `prefers-reduced-motion`.
- **Title block simplified**: Removed muscle group indicator and prescription subtitle — now just the exercise name, centered.
- **Tip carousel navigation**: Added a faded-edge chevron button on the right side of the BeginnerTipCard for manual click-through. Auto-rotation on logger events still works as before.

## Test plan
- [ ] Open follow-along mode and verify the "WHAT TO DO" card appears between title and demo image
- [ ] Navigate between exercises and confirm the pulse fires on each exercise change
- [ ] Enable `prefers-reduced-motion` and verify no pulse animation plays
- [ ] Tap the chevron on the tip card to cycle through tips manually
- [ ] Verify tips still auto-rotate on exercise navigation
- [ ] Check that ExerciseDisplayTabs (logger mode) tip card renders without navigation controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)