### PR TITLE
Remove misleading Info tab tip from carousel

### DIFF
--- a/lib/data/tip-library.ts
+++ b/lib/data/tip-library.ts
@@ -29,11 +29,6 @@ export const TIP_LIBRARY: Tip[] = [
     tier: 'beginner',
   },
   {
-    id: 'info-tab',
-    text: "Not sure how an exercise works? Tap the INFO tab to see which muscles it targets and how to set up.",
-    tier: 'beginner',
-  },
-  {
     id: 'skip-exercise',
     text: "Not comfortable with an exercise? Go ahead and skip to the next. You don't need to log everything.",
     tier: 'beginner',


### PR DESCRIPTION
## Summary
- Removes the `info-tab` tip from `lib/data/tip-library.ts` that directed users to a non-existent INFO tab
- The new follow-along mode (#577) condenses exercise info into a single screen with no tabs, making this tip misleading

## Test plan
- [ ] Verify tip carousel no longer shows the Info tab tip
- [ ] Verify remaining tips still display correctly

Fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)