### PR TITLE
fix: preserve week descriptions during program/week duplication

### DIFF
--- a/app/api/weeks/[weekId]/duplicate/route.ts
+++ b/app/api/weeks/[weekId]/duplicate/route.ts
@@ -63,6 +63,8 @@ export async function POST(
     const newWeek = await prisma.week.create({
       data: {
         weekNumber: newWeekNumber,
+        name: originalWeek.name,
+        description: originalWeek.description,
         programId: originalWeek.programId,
         userId: user.id,
       }

--- a/lib/db/batch-insert.ts
+++ b/lib/db/batch-insert.ts
@@ -7,6 +7,8 @@ import { validateWorkoutLimit } from '@/lib/validation/workout-limits'
  */
 export type WeekData = {
   weekNumber: number
+  name?: string | null
+  description?: string | null
   workouts: Array<{
     name: string
     dayNumber: number
@@ -176,10 +178,10 @@ export async function batchInsertWeek(
   // Pre-generate week ID
   const weekId = createId()
 
-  // 1. INSERT Week
+  // 1. INSERT Week (include name and description if present)
   await tx.$executeRaw(Prisma.sql`
-    INSERT INTO "Week" (id, "weekNumber", "programId", "userId")
-    VALUES (${weekId}, ${week.weekNumber}, ${programId}, ${userId})
+    INSERT INTO "Week" (id, "weekNumber", name, description, "programId", "userId")
+    VALUES (${weekId}, ${week.weekNumber}, ${week.name || null}, ${week.description || null}, ${programId}, ${userId})
   `)
 
   // 2. Insert all content


### PR DESCRIPTION
## Summary
- `lib/db/batch-insert.ts` `batchInsertWeek()` was silently dropping `name` and `description` columns when inserting weeks via raw SQL — the INSERT only included `id`, `weekNumber`, `programId`, `userId`
- `app/api/weeks/[weekId]/duplicate/route.ts` also omitted `name` and `description` when creating the duplicated week shell
- This caused week descriptions (e.g., beginner guidance like "This is an introductory week...") to disappear after duplicating a program or week
- Note: the community program clone worker (`cloud-functions/clone-program/src/batch-insert.ts`) already handled description correctly — this only affected the in-app duplication paths

## Test plan
- [ ] Clone a curated program (e.g., Machine Starter) that has week descriptions
- [ ] Verify week descriptions appear on the Training page below the week header
- [ ] Duplicate the program via the program actions menu
- [ ] Verify the duplicated program also has week descriptions on the Training page
- [ ] Duplicate a week and verify the new week retains the description

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)