### PR TITLE
fix: assign Beginner Free Weights and Cables for dumbbell/cable beginners

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -7,7 +7,7 @@ import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
 
 const PROGRAM_MAP: Record<string, string> = {
   machines: 'Machine Starter',
-  free_weights_cables: 'Nothing But Cables*',
+  free_weights_cables: 'Beginner Free Weights and Cables',
 }
 
 interface OnboardingRequest {


### PR DESCRIPTION
## Summary
- Replace placeholder "Nothing But Cables*" with "Beginner Free Weights and Cables" in the onboarding program mapping for users who select the free weights & cables equipment preference

## Test plan
- [ ] New beginner user selecting "Free weights & cables" gets "Beginner Free Weights and Cables" auto-assigned
- [ ] Machine path still assigns Machine Starter (unchanged)
- [ ] "I'm not sure" still defaults to machines (unchanged)
- [ ] Cloned program appears on Training page with Week 1 Day 1 ready

Fixes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)