### PR TITLE
Remove premium gate from intensity, add intro tip, fix bugs

### DIFF
--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -52,8 +52,8 @@ describe('useRestTimer', () => {
       { initialProps: { count: 3 } }
     )
 
-    // Timer not running initially (all prescribed sets already logged)
-    expect(result.current.isRunning).toBe(false)
+    // Timer running on mount when sets already logged
+    expect(result.current.isRunning).toBe(true)
 
     // Log extra set 4
     rerender({ count: 4 })
@@ -100,9 +100,10 @@ describe('useRestTimer', () => {
       { initialProps: { count: 1, exId: 'ex-1' } }
     )
 
-    expect(result.current.isRunning).toBe(false) // Initial mount, no increase
+    // Timer running on mount when sets already logged
+    expect(result.current.isRunning).toBe(true)
 
-    // Switch exercise
+    // Switch exercise — timer resets
     rerender({ count: 0, exId: 'ex-2' })
     expect(result.current.isRunning).toBe(false)
     expect(result.current.elapsed).toBe(0)

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Heart, KeyRound, Lock, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -64,7 +64,7 @@ export default function SettingsPage() {
     try {
       await updateSettings({
         defaultWeightUnit: weightUnit,
-        ...(isAdmin ? { intensityEnabled } : {}),
+        intensityEnabled,
         ...(intensityEnabled ? { defaultIntensityRating: intensityRating } : {}),
         loggingMode,
       })
@@ -80,7 +80,7 @@ export default function SettingsPage() {
   const isDirty =
     settings &&
     (weightUnit !== settings.defaultWeightUnit ||
-      (isAdmin && intensityEnabled !== settings.intensityEnabled) ||
+      intensityEnabled !== settings.intensityEnabled ||
       (intensityEnabled && intensityRating !== settings.defaultIntensityRating) ||
       loggingMode !== (settings.loggingMode || 'full'))
 
@@ -212,26 +212,17 @@ export default function SettingsPage() {
                   <span className="block text-sm font-semibold text-muted-foreground uppercase tracking-wider">
                     Intensity Tracking (RIR/RPE)
                   </span>
-                  {!isAdmin && (
-                    <span className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-                      <Lock size={12} />
-                      Premium Feature Coming Soon
-                    </span>
-                  )}
                 </div>
                 <button
                   type="button"
                   role="switch"
                   aria-checked={intensityEnabled}
                   aria-label="Toggle intensity tracking"
-                  disabled={!isAdmin}
                   onClick={() => setIntensityEnabled(!intensityEnabled)}
                   className={`relative inline-flex h-7 w-12 min-w-12 items-center rounded-full border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    !isAdmin
-                      ? 'border-border bg-muted cursor-not-allowed opacity-50'
-                      : intensityEnabled
-                        ? 'border-primary bg-primary'
-                        : 'border-border bg-muted hover:border-primary'
+                    intensityEnabled
+                      ? 'border-primary bg-primary'
+                      : 'border-border bg-muted hover:border-primary'
                   }`}
                 >
                   <span

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -58,6 +58,9 @@ export async function POST(request: NextRequest) {
       settingsUpdate.equipmentPreference = equipmentPreference || 'machines'
       settingsUpdate.dismissedPrimer = true // they saw it during onboarding
       settingsUpdate.loggingMode = 'follow_along'
+    } else if (experienceLevel === 'experienced') {
+      settingsUpdate.intensityEnabled = true
+      settingsUpdate.defaultIntensityRating = 'rir'
     }
 
     await prisma.userSettings.upsert({

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -176,7 +176,7 @@ export default function ExerciseLoggingModal({
     (s) => s.setNumber === nextSetNumber
   )
 
-  // Premium intensity gate: admins always have access, others need intensityEnabled
+  // Intensity preference check: user has it enabled in settings
   const { hasAccess: hasIntensityAccess } = useIntensityAccess()
 
   // Check if current exercise has any prescribed RPE/RIR (gated by premium)

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { AlertTriangle, LogOut, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { AlertTriangle, Info, LogOut, Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { useImagePrefetch } from '@/hooks/useImagePrefetch'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import { type Exercise, type ExerciseHistory, useProgressiveExercises } from '@/hooks/useProgressiveExercises'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import { useWorkoutDraft } from '@/hooks/useWorkoutDraft'
@@ -178,8 +179,30 @@ export default function ExerciseLoggingModal({
 
   // Intensity preference check: user has it enabled in settings
   const { hasAccess: hasIntensityAccess } = useIntensityAccess()
+  const { settings, updateSettings } = useUserSettings()
 
-  // Check if current exercise has any prescribed RPE/RIR (gated by premium)
+  // One-time intensity intro tip
+  const completedTours: string[] = useMemo(() => {
+    try { return JSON.parse(settings?.completedTours || '[]') } catch { return [] }
+  }, [settings?.completedTours])
+  const showIntensityIntro = hasIntensityAccess && !completedTours.includes('intensity-intro')
+  const [intensityIntroDismissed, setIntensityIntroDismissed] = useState(false)
+  const showIntensityBubble = showIntensityIntro && !intensityIntroDismissed
+
+  const dismissIntensityIntro = useCallback(() => {
+    setIntensityIntroDismissed(true)
+    const updated = [...completedTours, 'intensity-intro']
+    updateSettings({ completedTours: JSON.stringify(updated) }).catch(() => {})
+  }, [completedTours, updateSettings])
+
+  // Auto-dismiss intensity intro after 15 seconds
+  useEffect(() => {
+    if (!showIntensityBubble) return
+    const timer = setTimeout(dismissIntensityIntro, 15000)
+    return () => clearTimeout(timer)
+  }, [showIntensityBubble, dismissIntensityIntro])
+
+  // Check if current exercise has any prescribed RPE/RIR
   const hasRpe = hasIntensityAccess && currentPrescribedSets.some((s) => s.rpe !== null)
   const hasRir = hasIntensityAccess && currentPrescribedSets.some((s) => s.rir !== null)
 
@@ -526,6 +549,24 @@ export default function ExerciseLoggingModal({
                 <div className="h-8 bg-muted animate-pulse" />
               </div>
             )
+          )}
+
+          {/* One-time intensity intro bubble */}
+          {showIntensityBubble && (
+            <div className="mx-4 mt-2 mb-1 px-3 py-3 bg-primary/10 border-2 border-primary/30 flex items-start gap-2.5">
+              <Info size={18} className="text-primary flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-foreground flex-1">
+                Intensity tracking is on. You&apos;ll see <strong>RIR</strong> (Reps in Reserve) or <strong>RPE</strong> (Rate of Perceived Exertion) fields on your sets. You can change or disable this in Settings.
+              </p>
+              <button
+                type="button"
+                onClick={dismissIntensityIntro}
+                className="text-muted-foreground hover:text-foreground flex-shrink-0 mt-0.5"
+                aria-label="Dismiss intensity tip"
+              >
+                <X size={16} />
+              </button>
+            </div>
           )}
 
           {/* Content area with tabs — swipeable */}

--- a/components/SetDefinitionModal.tsx
+++ b/components/SetDefinitionModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Lock, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { useState } from 'react'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 
@@ -184,23 +184,16 @@ function SetDefinitionForm({
             <label htmlFor="intensity-type" className="block text-sm font-medium text-foreground mb-2">
               Intensity Type
             </label>
-            {hasIntensityAccess ? (
-              <select
-                id="intensity-type"
-                value={exerciseIntensityType}
-                onChange={(e) => handleIntensityTypeChange(e.target.value as 'RIR' | 'RPE' | 'NONE')}
-                className="w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-muted text-foreground"
-              >
-                <option value="NONE">None</option>
-                <option value="RIR">RIR (Reps in Reserve)</option>
-                <option value="RPE">RPE (Rate of Perceived Exertion)</option>
-              </select>
-            ) : (
-              <div className="w-full px-3 py-2 border border-input rounded-lg bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
-                <Lock size={14} />
-                <span className="text-sm">Premium Feature Coming Soon</span>
-              </div>
-            )}
+            <select
+              id="intensity-type"
+              value={exerciseIntensityType}
+              onChange={(e) => handleIntensityTypeChange(e.target.value as 'RIR' | 'RPE' | 'NONE')}
+              className="w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-muted text-foreground"
+            >
+              <option value="NONE">None</option>
+              <option value="RIR">RIR (Reps in Reserve)</option>
+              <option value="RPE">RPE (Rate of Perceived Exertion)</option>
+            </select>
           </div>
         </div>
 

--- a/components/TransformWeekModal.tsx
+++ b/components/TransformWeekModal.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { Lock, Minus, Plus, X } from 'lucide-react'
+import { Minus, Plus, X } from 'lucide-react'
 import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
-import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import type { Week } from '@/types/program-builder'
 
 interface TransformWeekModalProps {
@@ -28,7 +27,6 @@ export default function TransformWeekModal({
   weekNumber,
   onTransform
 }: TransformWeekModalProps) {
-  const { hasAccess: hasIntensityAccess } = useIntensityAccess()
   const [intensityDirection, setIntensityDirection] = useState<'MORE' | 'LESS' | 'NONE'>('NONE')
   const [intensityMagnitude, setIntensityMagnitude] = useState<number>(1)
   const [volumeAdjustment, setVolumeAdjustment] = useState<number>(0)
@@ -170,78 +168,69 @@ export default function TransformWeekModal({
           <div className="space-y-3">
             <h3 className="text-sm font-bold text-foreground doom-heading uppercase tracking-wider">Adjust Intensity</h3>
 
-            {!hasIntensityAccess ? (
-              <div className="px-3 py-2.5 border-2 border-border bg-muted text-muted-foreground opacity-60 flex items-center gap-2">
-                <Lock size={14} />
-                <span className="text-sm">Premium Feature Coming Soon</span>
-              </div>
-            ) : (
-              <>
-                {/* Intensity Direction Selection */}
-                <div className="flex gap-2">
-                  <button type="button"
-                    onClick={() => setIntensityDirection('NONE')}
-                    disabled={isSubmitting || stats !== null}
-                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                      intensityDirection === 'NONE'
-                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                    } disabled:opacity-50`}
-                  >
-                    None
-                  </button>
-                  <button type="button"
-                    onClick={() => setIntensityDirection('MORE')}
-                    disabled={isSubmitting || stats !== null}
-                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                      intensityDirection === 'MORE'
-                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                    } disabled:opacity-50`}
-                  >
-                    More
-                  </button>
-                  <button type="button"
-                    onClick={() => setIntensityDirection('LESS')}
-                    disabled={isSubmitting || stats !== null}
-                    className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
-                      intensityDirection === 'LESS'
-                        ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
-                        : 'bg-muted text-foreground border-border hover:bg-muted/80'
-                    } disabled:opacity-50`}
-                  >
-                    Less
-                  </button>
-                </div>
+            {/* Intensity Direction Selection */}
+            <div className="flex gap-2">
+              <button type="button"
+                onClick={() => setIntensityDirection('NONE')}
+                disabled={isSubmitting || stats !== null}
+                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                  intensityDirection === 'NONE'
+                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                } disabled:opacity-50`}
+              >
+                None
+              </button>
+              <button type="button"
+                onClick={() => setIntensityDirection('MORE')}
+                disabled={isSubmitting || stats !== null}
+                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                  intensityDirection === 'MORE'
+                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                } disabled:opacity-50`}
+              >
+                More
+              </button>
+              <button type="button"
+                onClick={() => setIntensityDirection('LESS')}
+                disabled={isSubmitting || stats !== null}
+                className={`flex-1 px-3 py-2 text-xs font-semibold uppercase tracking-wider border-2 transition-colors doom-focus-ring ${
+                  intensityDirection === 'LESS'
+                    ? 'bg-primary text-primary-foreground border-primary doom-button-3d'
+                    : 'bg-muted text-foreground border-border hover:bg-muted/80'
+                } disabled:opacity-50`}
+              >
+                Less
+              </button>
+            </div>
 
-                {/* Intensity Magnitude Stepper */}
-                {intensityDirection !== 'NONE' && (
-                  <div className="flex items-center gap-3">
-                    <button type="button"
-                      onClick={decrementMagnitude}
-                      disabled={isSubmitting || stats !== null || intensityMagnitude <= 1}
-                      className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
-                    >
-                      <Minus size={16} />
-                    </button>
-                    <div className="flex-1 text-center">
-                      <div className="text-3xl font-bold text-foreground doom-heading">
-                        {intensityDirection === 'MORE' ? '+' : '-'}{intensityMagnitude}
-                      </div>
-                      <div className="text-xs text-muted-foreground uppercase tracking-wide">
-                        Intensity adjustment
-                      </div>
-                    </div>
-                    <button type="button"
-                      onClick={incrementMagnitude}
-                      disabled={isSubmitting || stats !== null || intensityMagnitude >= 5}
-                      className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
-                    >
-                      <Plus size={16} />
-                    </button>
+            {/* Intensity Magnitude Stepper */}
+            {intensityDirection !== 'NONE' && (
+              <div className="flex items-center gap-3">
+                <button type="button"
+                  onClick={decrementMagnitude}
+                  disabled={isSubmitting || stats !== null || intensityMagnitude <= 1}
+                  className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
+                >
+                  <Minus size={16} />
+                </button>
+                <div className="flex-1 text-center">
+                  <div className="text-3xl font-bold text-foreground doom-heading">
+                    {intensityDirection === 'MORE' ? '+' : '-'}{intensityMagnitude}
                   </div>
-                )}
-              </>
+                  <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                    Intensity adjustment
+                  </div>
+                </div>
+                <button type="button"
+                  onClick={incrementMagnitude}
+                  disabled={isSubmitting || stats !== null || intensityMagnitude >= 5}
+                  className="p-2 bg-muted border-2 border-border hover:bg-muted/80 disabled:opacity-50 doom-button-3d doom-focus-ring"
+                >
+                  <Plus size={16} />
+                </button>
+              </div>
             )}
           </div>
 

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -98,13 +98,17 @@ export function SetConfigurationInterface({
   const [duplicatingSetId, setDuplicatingSetId] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<Tab>('sets')
 
-  // Update intensity type when settings load (only for new exercises, not when editing)
+  // Update intensity type when settings load
   useEffect(() => {
     if (!hasIntensityAccess) {
       setExerciseIntensityType('NONE')
       return
     }
-    if (!initialConfig && settings?.defaultIntensityRating) {
+    if (initialConfig) {
+      // Editing: apply the initialConfig intensity type once access is confirmed
+      setExerciseIntensityType(initialConfig.intensityType)
+    } else if (settings?.defaultIntensityRating) {
+      // New exercise: use the user's default
       const newIntensityType = settings.defaultIntensityRating === 'rpe'
         ? 'RPE'
         : settings.defaultIntensityRating === 'rir'

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Lock, Plus, Trash } from 'lucide-react'
+import { Plus, Trash } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
@@ -65,7 +65,7 @@ export function SetConfigurationInterface({
   const { settings } = useUserSettings()
   const { hasAccess: hasIntensityAccess } = useIntensityAccess()
 
-  // Determine default intensity type (forced to NONE for non-premium users)
+  // Determine default intensity type based on user preference
   const getDefaultIntensityType = (): 'RIR' | 'RPE' | 'NONE' => {
     if (!hasIntensityAccess) return 'NONE'
     if (initialConfig) return initialConfig.intensityType
@@ -282,23 +282,16 @@ export function SetConfigurationInterface({
               <label htmlFor="exercise-intensity-type" className="block text-sm font-bold text-muted-foreground mb-1.5 uppercase tracking-wider">
                 INTENSITY TYPE
               </label>
-              {hasIntensityAccess ? (
-                <select
-                  id="exercise-intensity-type"
-                  value={exerciseIntensityType}
-                  onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
-                  className="w-full px-3 py-2.5 border border-border focus:outline-none focus:border-primary bg-card text-foreground text-base"
-                >
-                  <option value="NONE">None</option>
-                  <option value="RIR">RIR (Reps in Reserve)</option>
-                  <option value="RPE">RPE (Rate of Perceived Exertion)</option>
-                </select>
-              ) : (
-                <div className="w-full px-3 py-2.5 border border-border bg-card text-muted-foreground opacity-60 flex items-center gap-2">
-                  <Lock size={14} />
-                  <span className="text-sm">Premium Feature Coming Soon</span>
-                </div>
-              )}
+              <select
+                id="exercise-intensity-type"
+                value={exerciseIntensityType}
+                onChange={(e) => setExerciseIntensityType(e.target.value as 'RIR' | 'RPE' | 'NONE')}
+                className="w-full px-3 py-2.5 border border-border focus:outline-none focus:border-primary bg-card text-foreground text-base"
+              >
+                <option value="NONE">None</option>
+                <option value="RIR">RIR (Reps in Reserve)</option>
+                <option value="RPE">RPE (Rate of Perceived Exertion)</option>
+              </select>
             </div>
 
             {/* Individual Set Configuration - Table Layout */}

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -116,6 +116,30 @@ export function IntensitySelector({
           </button>
         </div>
       </div>
+
+      {/* Info blurb */}
+      <div className="mt-3 p-3.5 border border-dashed border-border/40 bg-muted/35 flex items-start gap-2.5">
+        <svg
+          aria-hidden="true"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          className="shrink-0 mt-[5px] stroke-muted-foreground"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M9 18h6" />
+          <path d="M10 22h4" />
+          <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5C8.35 12.26 8.82 13.02 9 14" />
+        </svg>
+        <span className="text-sm leading-relaxed text-muted-foreground">
+          {type === 'rir'
+            ? 'Reps in Reserve: How many more reps you think you could have done after stopping your set.'
+            : 'Rate of Perceived Exertion: How hard did the last set feel?'}
+        </span>
+      </div>
     </div>
   )
 }

--- a/hooks/useIntensityAccess.ts
+++ b/hooks/useIntensityAccess.ts
@@ -1,9 +1,9 @@
 import { useUserSettings } from '@/hooks/useUserSettings'
 
 /**
- * Returns whether the current user has access to intensity features (RIR/RPE).
- * Access requires intensityEnabled in settings. Admins can toggle this on/off
- * in settings — admin role grants the ability to toggle, not automatic access.
+ * Returns whether the current user has intensity features (RIR/RPE) enabled.
+ * All users can toggle this on/off in Settings. Beginners start with it off,
+ * experienced users get it auto-enabled during onboarding.
  */
 export function useIntensityAccess() {
   const { settings, isLoading } = useUserSettings()

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -15,9 +15,10 @@ export function useRestTimer(
   loggedSetCount: number,
   exerciseId: string
 ) {
+  // Start running immediately if we mount with sets already logged
   const [elapsed, setElapsed] = useState(0)
-  const [isRunning, setIsRunning] = useState(false)
-  const startRef = useRef<number | null>(null)
+  const [isRunning, setIsRunning] = useState(loggedSetCount > 0)
+  const startRef = useRef<number | null>(loggedSetCount > 0 ? Date.now() : null)
   const prevExerciseRef = useRef(exerciseId)
   const prevCountRef = useRef(loggedSetCount)
 


### PR DESCRIPTION
## Summary
- Remove premium gate from intensity (RIR/RPE) — all users can toggle it on/off in Settings (no lock icon, no "Coming Soon" text)
- Experienced users get `intensityEnabled: true` + `defaultIntensityRating: 'rir'` auto-set during onboarding
- Add one-time intensity intro bubble in the logger (auto-dismisses after 15s, persisted via `completedTours`)
- Add lightbulb-styled RIR/RPE info blurbs below the intensity pickers in the logger
- Fix rest timer not appearing after logging the first set
- Fix exercise editor not showing the correct intensity type when editing

## Test plan
- [ ] Toggle intensity on/off in Settings as a non-admin user
- [ ] Complete onboarding as experienced user — verify intensity auto-enabled with RIR default
- [ ] Complete onboarding as beginner — verify intensity stays disabled
- [ ] Open logger with intensity enabled for first time — verify intro bubble appears and auto-dismisses
- [ ] Reopen logger — verify intro bubble does not reappear
- [ ] Log first set — verify rest timer appears
- [ ] Edit an exercise with RIR/RPE prescribed — verify intensity type shows correctly in editor
- [ ] No "Premium Feature Coming Soon" text anywhere in the app

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)