### PR TITLE
feat: gym-parameterized signup with dual QR mode support

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { clearAttribution, getAttribution } from '@/lib/signup-attribution'
 
 type Step = 'loading' | 'experience' | 'equipment' | 'info' | 'completing'
 
@@ -52,27 +53,6 @@ export default function OnboardingPage() {
     setFadeKey(k => k + 1)
     setStep(next)
   }, [])
-
-  useEffect(() => {
-    async function check() {
-      try {
-        const res = await fetch('/api/settings')
-        if (!res.ok) {
-          changeStep('experience')
-          return
-        }
-        const data = await res.json()
-        if (data.settings?.onboardingCompleted) {
-          router.replace('/')
-          return
-        }
-        changeStep('experience')
-      } catch {
-        changeStep('experience')
-      }
-    }
-    check()
-  }, [router, changeStep])
 
   const completeOnboarding = useCallback(async (
     level: ExperienceLevel,
@@ -161,6 +141,41 @@ export default function OnboardingPage() {
     }
   }, [changeStep])
 
+  useEffect(() => {
+    async function check() {
+      try {
+        const res = await fetch('/api/settings')
+        if (!res.ok) {
+          applyQrMode()
+          return
+        }
+        const data = await res.json()
+        if (data.settings?.onboardingCompleted) {
+          router.replace('/')
+          return
+        }
+        applyQrMode()
+      } catch {
+        applyQrMode()
+      }
+    }
+
+    function applyQrMode() {
+      const attribution = getAttribution()
+      clearAttribution()
+      if (attribution.mode === 'experienced') {
+        completeOnboarding('experienced')
+      } else if (attribution.mode === 'beginner') {
+        setExperienceLevel('beginner')
+        changeStep('equipment')
+      } else {
+        changeStep('experience')
+      }
+    }
+
+    check()
+  }, [router, changeStep, completeOnboarding])
+
   const handleExperienceSelect = (level: ExperienceLevel) => {
     setSelectedCard(level)
     setExperienceLevel(level)
@@ -187,7 +202,11 @@ export default function OnboardingPage() {
 
   const handleBack = () => {
     if (step === 'equipment') {
-      changeStep('experience')
+      // If QR mode pre-selected beginner, don't go back to experience
+      const attribution = getAttribution()
+      if (attribution.mode !== 'beginner') {
+        changeStep('experience')
+      }
     } else if (step === 'info') {
       changeStep('equipment')
     }
@@ -198,13 +217,14 @@ export default function OnboardingPage() {
   }
 
   // --- Progress bar math ---
-  const totalSegments = 3
-  const currentSegment =
-    step === 'experience' ? 0 :
-    step === 'equipment' ? 1 :
-    step === 'info' ? 2 : 0
+  // QR beginner mode skips experience step: 2 segments instead of 3
+  const qrBeginner = getAttribution().mode === 'beginner'
+  const totalSegments = qrBeginner ? 2 : 3
+  const currentSegment = qrBeginner
+    ? (step === 'equipment' ? 0 : step === 'info' ? 1 : 0)
+    : (step === 'experience' ? 0 : step === 'equipment' ? 1 : step === 'info' ? 2 : 0)
 
-  const canGoBack = step === 'equipment' || step === 'info'
+  const canGoBack = (step === 'equipment' && !qrBeginner) || step === 'info'
 
   // --- Loading ---
   if (step === 'loading') {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -10,7 +10,6 @@ import { Button } from '@/components/ui/Button'
 import { flushEvents, trackEvent } from '@/lib/analytics'
 import { signUp } from '@/lib/auth-client'
 import {
-  clearAttribution,
   getAttribution,
   resolveSource,
 } from '@/lib/signup-attribution'
@@ -47,6 +46,7 @@ export default function SignupPage() {
     const source = resolveSource('email', attribution)
     const startedProps: Record<string, unknown> = { source, method: 'email' }
     if (attribution.gymSlug) startedProps.gymSlug = attribution.gymSlug
+    if (attribution.mode) startedProps.mode = attribution.mode
     trackEvent('signup_started', startedProps)
 
     setLoading(true)
@@ -86,8 +86,9 @@ export default function SignupPage() {
         method: 'email',
       }
       if (attribution.gymSlug) completedProps.gymSlug = attribution.gymSlug
+      if (attribution.mode) completedProps.mode = attribution.mode
       trackEvent('signup_completed', completedProps)
-      clearAttribution()
+      // Don't clear attribution here — onboarding reads mode from it
       await flushEvents(true)
       window.location.href = '/onboarding'
     } catch {

--- a/app/go/[gymSlug]/page.tsx
+++ b/app/go/[gymSlug]/page.tsx
@@ -1,63 +1,37 @@
 'use client'
 
-import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { use, useEffect } from 'react'
-import { AuthPageHeader } from '@/components/features/auth/AuthPageHeader'
-import { Button } from '@/components/ui/Button'
 import { trackEvent } from '@/lib/analytics'
+import type { QrMode } from '@/lib/signup-attribution'
 import { setAttribution } from '@/lib/signup-attribution'
 
-interface QrLandingPageProps {
-  params: Promise<{ gymSlug: string }>
-}
+const VALID_MODES: QrMode[] = ['beginner', 'experienced']
 
-/**
- * QR landing page rendered when a user scans a gym-specific QR code.
- *
- * - Stores `{source: 'qr', gymSlug}` in sessionStorage so signup attribution
- *   carries through to /signup (and through OAuth round-trips).
- * - Fires `qr_landing_viewed` for the QR-funnel dashboard.
- *
- * The `signup_started` event fires later when the user clicks the primary CTA.
- */
-export default function QrLandingPage({ params }: QrLandingPageProps) {
+export default function GoPage({
+  params,
+}: {
+  params: Promise<{ gymSlug: string }>
+}) {
   const { gymSlug } = use(params)
+  const searchParams = useSearchParams()
+  const router = useRouter()
 
   useEffect(() => {
-    if (!gymSlug) return
-    setAttribution({ source: 'qr', gymSlug })
-    trackEvent('qr_landing_viewed', { gymSlug })
-  }, [gymSlug])
+    const rawMode = searchParams.get('mode')
+    const mode = rawMode && VALID_MODES.includes(rawMode as QrMode)
+      ? (rawMode as QrMode)
+      : undefined
+
+    setAttribution({ source: 'qr', gymSlug, mode })
+    trackEvent('qr_landing_viewed', { gymSlug, mode: mode ?? null })
+
+    router.replace('/signup')
+  }, [gymSlug, searchParams, router])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <div className="max-w-md w-full space-y-8 p-6 sm:p-8 bg-card rounded-lg shadow-lg border border-border">
-        <AuthPageHeader subtitle="A flexible strength tracker — built for the gym, no fluff." />
-
-        <div className="space-y-4 text-center">
-          <p className="text-sm text-muted-foreground">
-            You scanned a code from{' '}
-            <span className="font-semibold text-foreground">{gymSlug}</span>.
-            Create your free account to start logging workouts.
-          </p>
-
-          <Link href="/signup" className="block">
-            <Button variant="primary" doom className="w-full">
-              Create free account
-            </Button>
-          </Link>
-
-          <p className="text-center text-sm text-muted-foreground">
-            Already have an account?{' '}
-            <Link
-              href="/login"
-              className="font-medium text-primary hover:text-primary-hover"
-            >
-              Sign in
-            </Link>
-          </p>
-        </div>
-      </div>
+    <div className="flex min-h-[100dvh] items-center justify-center bg-background">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
     </div>
   )
 }

--- a/lib/auth/middleware.ts
+++ b/lib/auth/middleware.ts
@@ -25,6 +25,7 @@ export async function updateSession(request: NextRequest) {
       !pathname.startsWith('/forgot-password') &&
       !pathname.startsWith('/reset-password') &&
       !pathname.startsWith('/auth/complete-profile') &&
+      !pathname.startsWith('/go') &&
       !pathname.startsWith('/waiver') &&
       !pathname.startsWith('/_next') &&
       !pathname.startsWith('/api')) {

--- a/lib/signup-attribution.ts
+++ b/lib/signup-attribution.ts
@@ -20,9 +20,12 @@
 export type SignupSource = 'qr' | 'organic' | 'oauth'
 export type SignupMethod = 'email' | 'google' | 'discord'
 
+export type QrMode = 'beginner' | 'experienced'
+
 export interface SignupAttribution {
   source: SignupSource
   gymSlug?: string
+  mode?: QrMode
 }
 
 export interface PendingOAuthSignup {


### PR DESCRIPTION
## Summary
- Add `?mode=beginner|experienced` query param support to `/go/[gymSlug]` QR landing route
- Beginner mode skips the experience question and starts onboarding at equipment selection (2-step progress bar)
- Experienced mode skips onboarding entirely — completes with intensity enabled and redirects to Programs
- Mode persists through signup → waiver → onboarding via sessionStorage attribution (cleared after onboarding reads it)
- `qr_landing_viewed`, `signup_started`, and `signup_completed` events all carry `mode`

Closes #473

## Test plan
- [x] Visit `/go/ironworks?mode=beginner` → signup → verify onboarding starts at equipment selection (no experience question)
- [x] Visit `/go/ironworks?mode=experienced` → signup → verify onboarding auto-completes and redirects to Programs
- [ ] Visit `/go/ironworks` (no mode) → signup → verify standard onboarding with experience question
- [x] Verify sessionStorage `ripit:signup-attribution` contains `mode` after hitting `/go/` URL
- [x] Verify attribution is cleared after onboarding consumes it
- [ ] Check DevTools Network for `qr_landing_viewed` and `signup_completed` events carrying correct `mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)