### PR TITLE
fix: theme toggle icon not syncing with OS preference changes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,6 +120,8 @@ export default function RootLayout({
                     } else {
                       root.classList.remove('dark');
                     }
+                    // Notify React components so theme toggle icon updates
+                    window.dispatchEvent(new Event('themechange'));
                   };
                   darkModeMediaQuery.addEventListener('change', updateMode);
                 }


### PR DESCRIPTION
## Summary
- The inline theme script updated DOM attributes when the OS color scheme changed, but didn't dispatch the `themechange` event
- React components (ThemeSelector, settings page) never re-rendered, so the Sun/Moon icon stayed stale
- Added a single `window.dispatchEvent(new Event('themechange'))` to notify the `useThemePreference` hook

## Test plan
- [ ] Clear localStorage `themePreference` key so no stored preference exists
- [ ] Toggle OS dark/light mode and verify the toggle icon updates in both header and settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)