### PR TITLE
Suppress intensity tracking in follow-along mode

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -205,7 +205,8 @@ export default function SettingsPage() {
               </fieldset>
             </div>
 
-            {/* Intensity Tracking Toggle */}
+            {/* Intensity Tracking Toggle — hidden in follow-along mode */}
+            {loggingMode !== 'follow_along' && (
             <div>
               <div className="flex items-center justify-between">
                 <div>
@@ -285,6 +286,7 @@ export default function SettingsPage() {
                 </div>
               </div>
             </div>
+            )}
 
             {/* Workout Mode */}
             <div>

--- a/hooks/useIntensityAccess.ts
+++ b/hooks/useIntensityAccess.ts
@@ -4,11 +4,14 @@ import { useUserSettings } from '@/hooks/useUserSettings'
  * Returns whether the current user has intensity features (RIR/RPE) enabled.
  * All users can toggle this on/off in Settings. Beginners start with it off,
  * experienced users get it auto-enabled during onboarding.
+ *
+ * Follow-along mode forces intensity off regardless of the saved setting.
  */
 export function useIntensityAccess() {
   const { settings, isLoading } = useUserSettings()
 
-  const hasAccess = settings?.intensityEnabled ?? false
+  const isFollowAlong = settings?.loggingMode === 'follow_along'
+  const hasAccess = isFollowAlong ? false : (settings?.intensityEnabled ?? false)
 
   return { hasAccess, isLoading }
 }


### PR DESCRIPTION
## Summary
- Hide intensity toggle and RPE/RIR type selector in Settings when `loggingMode === 'follow_along'`
- Force `useIntensityAccess` to return `hasAccess: false` when in follow-along mode, suppressing the "Intensity tracker is on" message in the logger
- Switching back to standard mode re-exposes intensity controls with saved preferences intact

## Test plan
- [ ] Switch to follow-along mode in Settings — intensity toggle and RPE/RIR selector should disappear
- [ ] Open the exercise logger in follow-along mode — no "Intensity tracker is on" message
- [ ] Switch back to standard (Log Sets) mode — intensity toggle reappears with previous setting
- [ ] Verify intensity tracking works normally in standard mode

Fixes #624

Generated with [Claude Code](https://claude.com/claude-code)