### PR TITLE
fix: /go/ironworks QR landing page crash and auth redirect

### DIFF
--- a/app/go/[gymSlug]/page.tsx
+++ b/app/go/[gymSlug]/page.tsx
@@ -1,23 +1,22 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { use, useEffect } from 'react'
+import { Suspense, use, useEffect } from 'react'
 import { trackEvent } from '@/lib/analytics'
+import { useSession } from '@/lib/auth-client'
 import type { QrMode } from '@/lib/signup-attribution'
 import { setAttribution } from '@/lib/signup-attribution'
 
 const VALID_MODES: QrMode[] = ['beginner', 'experienced']
 
-export default function GoPage({
-  params,
-}: {
-  params: Promise<{ gymSlug: string }>
-}) {
-  const { gymSlug } = use(params)
+function GoPageInner({ gymSlug }: { gymSlug: string }) {
   const searchParams = useSearchParams()
   const router = useRouter()
+  const { data: session, isPending } = useSession()
 
   useEffect(() => {
+    if (isPending) return
+
     const rawMode = searchParams.get('mode')
     const mode = rawMode && VALID_MODES.includes(rawMode as QrMode)
       ? (rawMode as QrMode)
@@ -26,12 +25,33 @@ export default function GoPage({
     setAttribution({ source: 'qr', gymSlug, mode })
     trackEvent('qr_landing_viewed', { gymSlug, mode: mode ?? null })
 
-    router.replace('/signup')
-  }, [gymSlug, searchParams, router])
+    // Authenticated users go straight to training; unauthenticated go to signup
+    router.replace(session ? '/training' : '/signup')
+  }, [gymSlug, searchParams, router, session, isPending])
 
   return (
     <div className="flex min-h-[100dvh] items-center justify-center bg-background">
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
     </div>
+  )
+}
+
+export default function GoPage({
+  params,
+}: {
+  params: Promise<{ gymSlug: string }>
+}) {
+  const { gymSlug } = use(params)
+
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[100dvh] items-center justify-center bg-background">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
+        </div>
+      }
+    >
+      <GoPageInner gymSlug={gymSlug} />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- **Missing Suspense boundary**: `useSearchParams()` in the `/go/[gymSlug]` page lacked a `<Suspense>` wrapper, causing an SSR crash ("This page couldn't load") in production for unauthenticated users
- **Auth redirect loop**: Authenticated users were sent to `/signup`, which middleware bounced back to `/` -> `/training`. Now auth'd users go directly to `/training` after attribution is set.
- Extracted inner component (`GoPageInner`) following the same pattern used in `/login` and other pages that use `useSearchParams()`

## Test plan
- [ ] Visit `/go/ironworks` as unauthenticated user — should briefly show spinner then redirect to `/signup`
- [ ] Visit `/go/ironworks?mode=beginner` as unauthenticated user — should redirect to `/signup` with attribution set
- [ ] Visit `/go/ironworks` as authenticated user — should redirect to `/training` (not bounced through `/signup`)
- [ ] Verify `sessionStorage` has `ripit:signup-attribution` set after visiting `/go/ironworks`

Fixes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)