### PR TITLE
fix: /go/ironworks SSR crash from useSession during SSR

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -223,7 +223,7 @@ jobs:
             "$IMAGE" \
             sh -c "node scripts/sync-exercise-data.cjs"
 
-      - name: Smoke test — app boots and responds
+      - name: Smoke test — boot app
         run: |
           # Start the app in the background
           docker run --rm -d \
@@ -253,15 +253,9 @@ jobs:
             sleep 1
           done
 
-          # Verify response
-          HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/)
-          echo "HTTP status: $HTTP_STATUS"
+      - name: Smoke test — SSR routes render without errors
+        run: ./scripts/smoke-test-ssr.sh http://localhost:3000
 
-          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 500 ]; then
-            echo "Unexpected HTTP status $HTTP_STATUS"
-            docker logs smoke-app
-            docker stop smoke-app || true
-            exit 1
-          fi
-
-          docker stop smoke-app
+      - name: Stop smoke-test container
+        if: always()
+        run: docker stop smoke-app || true

--- a/app/go/[gymSlug]/page.tsx
+++ b/app/go/[gymSlug]/page.tsx
@@ -3,7 +3,6 @@
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense, use, useEffect } from 'react'
 import { trackEvent } from '@/lib/analytics'
-import { useSession } from '@/lib/auth-client'
 import type { QrMode } from '@/lib/signup-attribution'
 import { setAttribution } from '@/lib/signup-attribution'
 
@@ -12,11 +11,8 @@ const VALID_MODES: QrMode[] = ['beginner', 'experienced']
 function GoPageInner({ gymSlug }: { gymSlug: string }) {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const { data: session, isPending } = useSession()
 
   useEffect(() => {
-    if (isPending) return
-
     const rawMode = searchParams.get('mode')
     const mode = rawMode && VALID_MODES.includes(rawMode as QrMode)
       ? (rawMode as QrMode)
@@ -25,9 +21,10 @@ function GoPageInner({ gymSlug }: { gymSlug: string }) {
     setAttribution({ source: 'qr', gymSlug, mode })
     trackEvent('qr_landing_viewed', { gymSlug, mode: mode ?? null })
 
-    // Authenticated users go straight to training; unauthenticated go to signup
-    router.replace(session ? '/training' : '/signup')
-  }, [gymSlug, searchParams, router, session, isPending])
+    // Always redirect to /signup — middleware handles authenticated users
+    // by redirecting them to / (which lands on /training)
+    router.replace('/signup')
+  }, [gymSlug, searchParams, router])
 
   return (
     <div className="flex min-h-[100dvh] items-center justify-center bg-background">

--- a/scripts/smoke-test-ssr.sh
+++ b/scripts/smoke-test-ssr.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# smoke-test-ssr.sh — Verify key routes render without SSR errors.
+#
+# Next.js embeds SSR errors as <template data-msg="..."> tags in the HTML
+# when it falls back to client rendering. In production this fallback often
+# fails entirely, showing "This page couldn't load." This script catches
+# those errors before they reach users.
+#
+# Usage:
+#   ./scripts/smoke-test-ssr.sh                        # default: http://localhost:3000
+#   ./scripts/smoke-test-ssr.sh http://localhost:3099   # custom base URL
+#
+# The app must already be running when you invoke this script.
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+
+# Routes to check. These are public or redirect-safe routes that can be
+# fetched without an auth cookie. Add new public pages here as they ship.
+ROUTES=(
+  "/"
+  "/login"
+  "/signup"
+  "/forgot-password"
+  "/go/ironworks"
+  "/go/ironworks?mode=beginner"
+  "/go/ironworks?mode=experienced"
+  "/waiver"
+)
+
+FAILED=0
+PASSED=0
+
+for route in "${ROUTES[@]}"; do
+  url="${BASE_URL}${route}"
+
+  # Fetch the page (-L follows redirects, -s silent, -S show errors)
+  HTTP_CODE=$(curl -s -o /tmp/ssr-smoke-body -w '%{http_code}' -L "$url" 2>/dev/null || echo "000")
+
+  # Check for 5xx
+  if [ "$HTTP_CODE" -ge 500 ] 2>/dev/null; then
+    echo "FAIL [${HTTP_CODE}] ${route} — server error"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # Check for connection failures
+  if [ "$HTTP_CODE" = "000" ]; then
+    echo "FAIL [---] ${route} — connection refused"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # Check for SSR error markers in the HTML body.
+  # Next.js injects <template data-msg="..."> when SSR crashes and the
+  # framework falls back to client-side rendering. These are invisible
+  # to the user in dev but often cause full-page errors in production.
+  if grep -q 'data-msg=' /tmp/ssr-smoke-body 2>/dev/null; then
+    MSG=$(grep -o 'data-msg="[^"]*"' /tmp/ssr-smoke-body | head -1)
+    echo "FAIL [${HTTP_CODE}] ${route} — SSR error: ${MSG}"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  echo "  OK [${HTTP_CODE}] ${route}"
+  PASSED=$((PASSED + 1))
+done
+
+rm -f /tmp/ssr-smoke-body
+
+echo ""
+echo "SSR smoke test: ${PASSED} passed, ${FAILED} failed"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Removes `useSession()` from the `/go/[gymSlug]` page — better-auth's `useStore` calls `useRef` on a null React dispatcher during SSR, crashing the page
- The session check was unnecessary: middleware already redirects authenticated users away from `/signup`
- Follow-up to #628 which fixed the Suspense boundary but introduced the SSR crash

## Root cause
`better-auth/react`'s `useSession` hook uses an internal `useStore` that calls `useRef` during server-side rendering. In the SSR environment the React dispatcher is null, so it throws `Cannot read properties of null (reading 'useRef')`. This triggers `global-error.tsx` which renders "This page couldn't load."

## Test plan
- [x] `curl localhost:3099/go/ironworks` returns 200 with no `data-msg` error template in HTML
- [x] `/go/ironworks?mode=beginner` and `?mode=experienced` both return 200
- [ ] Verify on staging after deploy: unauthenticated users see spinner then redirect to `/signup`
- [ ] Verify on staging: authenticated users see spinner then redirect to `/signup` -> middleware -> `/`

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)