### PR TITLE
Broaden waiver language beyond Colorado-specific references

### DIFF
--- a/lib/constants/waiver.ts
+++ b/lib/constants/waiver.ts
@@ -5,7 +5,7 @@
  * will force existing users to re-accept before they can proceed.
  */
 
-export const CURRENT_WAIVER_VERSION = '1.0'
+export const CURRENT_WAIVER_VERSION = '1.1'
 
 export const WAIVER_TEXT = `
 ASSUMPTION OF RISK AND RELEASE OF LIABILITY
@@ -24,5 +24,5 @@ Voluntary Participation. Your use of the App is entirely voluntary. No one is re
 
 Age Requirement. You confirm that you are at least 18 years of age, or have the consent of a parent or legal guardian.
 
-Governing Law. This agreement is governed by the laws of the State of Colorado.
+Governing Law. This agreement is governed by the laws of the state or jurisdiction in which you reside, to the extent applicable. Any dispute arising under this agreement shall be resolved in accordance with the laws of that jurisdiction.
 `.trim()


### PR DESCRIPTION
## Summary
- Replace Colorado-specific governing law clause with jurisdiction-agnostic language
- Bump `CURRENT_WAIVER_VERSION` from `1.0` to `1.1` so existing users are prompted to re-accept
- No code logic changes — content/legal copy only

## Changes
- `lib/constants/waiver.ts`: Updated "Governing Law" section to reference the user's state of residence instead of Colorado specifically. Bumped version constant.

## Test plan
- [ ] Verify waiver text renders correctly on the waiver acceptance screen
- [ ] Verify existing users are prompted to re-accept (version bump triggers re-acceptance per #507)
- [ ] Review legal language for broad enforceability

Fixes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)