### PR TITLE
fix: beta UI polish and cleanup

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -81,7 +81,7 @@ export default function SettingsPage() {
       <div className="max-w-md md:max-w-2xl mx-auto space-y-6">
         <h1 className="text-xl font-bold">Settings</h1>
 
-        {isLoading ? (
+        {isLoading || !settings ? (
           <div className="text-sm text-muted-foreground">Loading...</div>
         ) : (
           <>

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Save, Shield, Sun } from 'lucide-react'
+import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
 import { useThemePreference } from '@/hooks/useThemePreference'
 import { useUserSettings } from '@/hooks/useUserSettings'
@@ -25,9 +25,8 @@ export default function SettingsPage() {
   const [intensityEnabled, setIntensityEnabled] = useState(false)
   const [intensityRating, setIntensityRating] = useState<'rpe' | 'rir'>('rir')
   const [loggingMode, setLoggingMode] = useState<'full' | 'follow_along'>('full')
-  const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [saved, setSaved] = useState(false)
+  const initializedRef = useRef(false)
   const [connectedAccounts, setConnectedAccounts] = useState<ConnectedAccounts | null>(null)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   const [showPasswordChange, setShowPasswordChange] = useState(false)
@@ -44,6 +43,8 @@ export default function SettingsPage() {
       setIntensityEnabled(settings.intensityEnabled)
       setIntensityRating(settings.defaultIntensityRating)
       setLoggingMode(settings.loggingMode || 'full')
+      // Mark initialized after first settings load so auto-save doesn't fire on mount
+      setTimeout(() => { initializedRef.current = true }, 0)
     }
   }, [settings])
 
@@ -56,33 +57,24 @@ export default function SettingsPage() {
       .catch(() => {})
   }, [])
 
-  const handleSave = async () => {
-    setIsSaving(true)
+  // Auto-save when any setting changes (debounced to avoid rapid-fire requests)
+  useEffect(() => {
+    if (!initializedRef.current) return
     setError(null)
-    setSaved(false)
 
-    try {
-      await updateSettings({
+    const timeout = setTimeout(() => {
+      updateSettings({
         defaultWeightUnit: weightUnit,
         intensityEnabled,
         ...(intensityEnabled ? { defaultIntensityRating: intensityRating } : {}),
         loggingMode,
+      }).catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to save settings')
       })
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save settings')
-    } finally {
-      setIsSaving(false)
-    }
-  }
+    }, 300)
 
-  const isDirty =
-    settings &&
-    (weightUnit !== settings.defaultWeightUnit ||
-      intensityEnabled !== settings.intensityEnabled ||
-      (intensityEnabled && intensityRating !== settings.defaultIntensityRating) ||
-      loggingMode !== (settings.loggingMode || 'full'))
+    return () => clearTimeout(timeout)
+  }, [weightUnit, intensityEnabled, intensityRating, loggingMode, updateSettings])
 
   return (
     <div className="bg-background px-4 sm:px-6 py-8">
@@ -168,126 +160,6 @@ export default function SettingsPage() {
                 </div>
             </div>
 
-            {/* Weight Unit */}
-            <div>
-              <span
-                id="weight-unit-label"
-                className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
-              >
-                Default Weight Unit
-              </span>
-              <fieldset
-                className="flex gap-2"
-                aria-labelledby="weight-unit-label"
-              >
-                <button
-                  type="button"
-                  onClick={() => setWeightUnit('lbs')}
-                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    weightUnit === 'lbs'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
-                  }`}
-                >
-                  LBS
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setWeightUnit('kg')}
-                  className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    weightUnit === 'kg'
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted text-foreground border-border hover:bg-secondary'
-                  }`}
-                >
-                  KG
-                </button>
-              </fieldset>
-            </div>
-
-            {/* Intensity Tracking Toggle — hidden in follow-along mode */}
-            {loggingMode !== 'follow_along' && (
-            <div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <span className="block text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                    Intensity Tracking (RIR/RPE)
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={intensityEnabled}
-                  aria-label="Toggle intensity tracking"
-                  onClick={() => setIntensityEnabled(!intensityEnabled)}
-                  className={`relative inline-flex h-7 w-12 min-w-12 items-center rounded-full border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                    intensityEnabled
-                      ? 'border-primary bg-primary'
-                      : 'border-border bg-muted hover:border-primary'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-5 w-5 rounded-full transition-transform ${
-                      intensityEnabled
-                        ? 'translate-x-[22px] bg-primary-foreground'
-                        : 'translate-x-[2px] bg-muted-foreground'
-                    }`}
-                  />
-                </button>
-              </div>
-
-              {/* RPE/RIR Selector — animated reveal when intensity is enabled */}
-              <div
-                className={`grid transition-all duration-300 ease-in-out ${
-                  intensityEnabled
-                    ? 'grid-rows-[1fr] opacity-100'
-                    : 'grid-rows-[0fr] opacity-0'
-                }`}
-              >
-                <div className="overflow-hidden">
-                  <div className="mt-3">
-                    <span
-                      id="intensity-rating-label"
-                      className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
-                    >
-                      Default Rating Type
-                    </span>
-                    <fieldset
-                      className="flex gap-2"
-                      aria-labelledby="intensity-rating-label"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setIntensityRating('rpe')}
-                        className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                          intensityRating === 'rpe'
-                            ? 'bg-primary text-primary-foreground border-primary'
-                            : 'bg-muted text-foreground border-border hover:bg-secondary'
-                        }`}
-                      >
-                        RPE
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setIntensityRating('rir')}
-                        className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
-                          intensityRating === 'rir'
-                            ? 'bg-primary text-primary-foreground border-primary'
-                            : 'bg-muted text-foreground border-border hover:bg-secondary'
-                        }`}
-                      >
-                        RIR
-                      </button>
-                    </fieldset>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            )}
-
             {/* Workout Mode */}
             <div>
               <span
@@ -302,7 +174,7 @@ export default function SettingsPage() {
               >
                 <button
                   type="button"
-                  onClick={() => setLoggingMode('follow_along')}
+                  onClick={() => { setLoggingMode('follow_along'); setIntensityEnabled(false) }}
                   className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
                     loggingMode === 'follow_along'
                       ? 'bg-primary text-primary-foreground border-primary'
@@ -328,26 +200,102 @@ export default function SettingsPage() {
               </p>
             </div>
 
-            {/* Save Button */}
+            {/* Intensity Tracking — only visible in Log Sets mode */}
+            <div
+              className={`grid transition-all duration-300 ease-in-out ${
+                loggingMode === 'full'
+                  ? 'grid-rows-[1fr] opacity-100'
+                  : 'grid-rows-[0fr] opacity-0'
+              }`}
+            >
+              <div className="overflow-hidden">
+                <div>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <span className="block text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                        Intensity Tracking (RIR/RPE)
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={intensityEnabled}
+                      aria-label="Toggle intensity tracking"
+                      onClick={() => setIntensityEnabled(!intensityEnabled)}
+                      className={`relative inline-flex h-7 w-12 min-w-12 items-center rounded-full border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                        intensityEnabled
+                          ? 'border-primary bg-primary'
+                          : 'border-border bg-muted hover:border-primary'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-5 w-5 rounded-full transition-transform ${
+                          intensityEnabled
+                            ? 'translate-x-[22px] bg-primary-foreground'
+                            : 'translate-x-[2px] bg-muted-foreground'
+                        }`}
+                      />
+                    </button>
+                  </div>
+
+                  {/* RPE/RIR Selector — animated reveal when intensity is enabled */}
+                  <div
+                    className={`grid transition-all duration-300 ease-in-out ${
+                      intensityEnabled
+                        ? 'grid-rows-[1fr] opacity-100'
+                        : 'grid-rows-[0fr] opacity-0'
+                    }`}
+                  >
+                    <div className="overflow-hidden">
+                      <div className="mt-3">
+                        <span
+                          id="intensity-rating-label"
+                          className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider"
+                        >
+                          Default Rating Type
+                        </span>
+                        <fieldset
+                          className="flex gap-2"
+                          aria-labelledby="intensity-rating-label"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => setIntensityRating('rpe')}
+                            className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                              intensityRating === 'rpe'
+                                ? 'bg-primary text-primary-foreground border-primary'
+                                : 'bg-muted text-foreground border-border hover:bg-secondary'
+                            }`}
+                          >
+                            RPE
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setIntensityRating('rir')}
+                            className={`flex-1 px-4 py-2 border-2 font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${
+                              intensityRating === 'rir'
+                                ? 'bg-primary text-primary-foreground border-primary'
+                                : 'bg-muted text-foreground border-border hover:bg-secondary'
+                            }`}
+                          >
+                            RIR
+                          </button>
+                        </fieldset>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          RPE = Rate of Perceived Exertion, RIR = Reps in Reserve
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             {error && (
               <div className="p-3 bg-error/10 border-2 border-error text-error text-sm">
                 {error}
               </div>
             )}
-
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={isSaving || !isDirty}
-              className={`w-full md:w-auto md:min-w-[200px] px-4 py-3 border-2 font-semibold uppercase tracking-wider flex items-center justify-center gap-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 disabled:cursor-not-allowed ${
-                saved
-                  ? 'bg-success text-white border-success'
-                  : 'bg-primary text-primary-foreground border-primary hover:bg-primary-hover'
-              }`}
-            >
-              <Save size={18} />
-              {isSaving ? 'Saving...' : saved ? 'Saved' : 'Save'}
-            </button>
 
             {/* Account Section */}
             <div className="pt-4 border-t border-border space-y-4">
@@ -372,10 +320,6 @@ export default function SettingsPage() {
                   <ProviderBadge
                     name="Google"
                     connected={connectedAccounts?.providers.includes('google') ?? false}
-                  />
-                  <ProviderBadge
-                    name="Discord"
-                    connected={connectedAccounts?.providers.includes('discord') ?? false}
                   />
                 </div>
               </div>

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -27,6 +27,7 @@ export default function SettingsPage() {
   const [loggingMode, setLoggingMode] = useState<'full' | 'follow_along'>('full')
   const [error, setError] = useState<string | null>(null)
   const initializedRef = useRef(false)
+  const prevSettingsRef = useRef<typeof settings>(null)
   const [connectedAccounts, setConnectedAccounts] = useState<ConnectedAccounts | null>(null)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   const [showPasswordChange, setShowPasswordChange] = useState(false)
@@ -37,16 +38,18 @@ export default function SettingsPage() {
   const [passwordSuccess, setPasswordSuccess] = useState(false)
   const [isChangingPassword, setIsChangingPassword] = useState(false)
 
-  useEffect(() => {
-    if (settings) {
-      setWeightUnit(settings.defaultWeightUnit)
-      setIntensityEnabled(settings.intensityEnabled)
-      setIntensityRating(settings.defaultIntensityRating)
-      setLoggingMode(settings.loggingMode || 'full')
-      // Mark initialized after first settings load so auto-save doesn't fire on mount
+  // Sync local state from settings — runs during render (not after) to avoid flash
+  if (settings && settings !== prevSettingsRef.current) {
+    prevSettingsRef.current = settings
+    setWeightUnit(settings.defaultWeightUnit)
+    setIntensityEnabled(settings.intensityEnabled)
+    setIntensityRating(settings.defaultIntensityRating)
+    setLoggingMode(settings.loggingMode || 'full')
+    if (!initializedRef.current) {
+      // Use setTimeout so the auto-save effect skips this render's state updates
       setTimeout(() => { initializedRef.current = true }, 0)
     }
-  }, [settings])
+  }
 
   useEffect(() => {
     fetch('/api/settings/connected-accounts')

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -482,6 +482,20 @@ function EquipmentScreen({
 // --- Screen 3: Consolidated Info ---
 
 function InfoScreen({ onFinish }: { onFinish: () => void }) {
+  const [showFade, setShowFade] = useState(true)
+
+  useEffect(() => {
+    function handleScroll() {
+      const scrollBottom = window.innerHeight + window.scrollY
+      const docHeight = document.documentElement.scrollHeight
+      // Hide fade when within 40px of the bottom
+      setShowFade(docHeight - scrollBottom > 40)
+    }
+    handleScroll()
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
   return (
     <>
       <h1 className="text-[32px] font-semibold text-foreground mb-9">
@@ -519,6 +533,22 @@ function InfoScreen({ onFinish }: { onFinish: () => void }) {
       >
         LET&apos;S GO
       </button>
+
+      {/* Scroll fade indicator — hints there's more content below */}
+      <div
+        aria-hidden
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 64,
+          background: 'linear-gradient(to bottom, transparent, var(--background))',
+          pointerEvents: 'none',
+          opacity: showFade ? 1 : 0,
+          transition: 'opacity 0.3s ease',
+        }}
+      />
     </>
   )
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -17,7 +17,6 @@ import {
 export default function SignupPage() {
   const _router = useRouter()
   const [email, setEmail] = useState('')
-  const [displayName, setDisplayName] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -52,30 +51,16 @@ export default function SignupPage() {
     setLoading(true)
 
     try {
-      const trimmedName = displayName.trim()
       const { error } = await signUp.email({
         email,
         password,
-        name: trimmedName || email.split('@')[0],
+        name: email.split('@')[0],
       })
 
       if (error) {
         setError(error.message || 'Could not create account')
         setLoading(false)
         return
-      }
-
-      // Save display name to UserSettings if provided (non-blocking)
-      if (trimmedName) {
-        try {
-          await fetch('/api/settings', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ displayName: trimmedName }),
-          })
-        } catch {
-          // Non-blocking — user can set display name later in Settings
-        }
       }
 
       // BetterAuth signs in immediately after signup.
@@ -126,20 +111,6 @@ export default function SignupPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                 placeholder="you@example.com"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="displayName" className="block text-sm font-medium text-foreground">
-                Display name
-              </label>
-              <input
-                id="displayName"
-                type="text"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 bg-white border border-input rounded-md shadow-sm text-gray-900 placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                placeholder="Optional"
               />
             </div>
 

--- a/app/waiver/page.tsx
+++ b/app/waiver/page.tsx
@@ -64,7 +64,7 @@ export default function WaiverPage() {
           type="button"
           onClick={handleAccept}
           disabled={accepting}
-          className="w-full h-11 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50 doom-focus-ring"
+          className="w-full h-12 bg-primary text-sm font-medium uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary-hover active:bg-primary-active disabled:opacity-50 doom-focus-ring"
           style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)' }}
         >
           {accepting ? 'Submitting...' : 'I Agree'}

--- a/components/community/CommunityProgramCard.tsx
+++ b/components/community/CommunityProgramCard.tsx
@@ -141,8 +141,8 @@ export default function CommunityProgramCard({
               </span>
             )}
 
-            {/* Goal Badges (show first 3) */}
-            {program.goals.slice(0, 3).map((goal) => (
+            {/* Goal Badges (show first 3 that have labels) */}
+            {program.goals.filter((g) => GOAL_LABELS[g]).slice(0, 3).map((goal) => (
               <span
                 key={goal}
                 className="px-2 py-1 bg-primary/10 text-primary text-xs font-bold uppercase tracking-wider border border-primary/30"
@@ -151,9 +151,9 @@ export default function CommunityProgramCard({
               </span>
             ))}
 
-            {program.goals.length > 3 && (
+            {program.goals.filter((g) => GOAL_LABELS[g]).length > 3 && (
               <span className="px-2 py-1 bg-muted text-muted-foreground text-xs font-bold uppercase tracking-wider">
-                +{program.goals.length - 3} more
+                +{program.goals.filter((g) => GOAL_LABELS[g]).length - 3} more
               </span>
             )}
           </div>

--- a/components/community/CommunityProgramCard.tsx
+++ b/components/community/CommunityProgramCard.tsx
@@ -44,6 +44,7 @@ export default function CommunityProgramCard({
   const [showUnpublishDialog, setShowUnpublishDialog] = useState(false)
   const [showLimitModal, setShowLimitModal] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [descExpanded, setDescExpanded] = useState(false)
 
   const isAuthor = program.authorUserId === currentUserId
 
@@ -126,10 +127,22 @@ export default function CommunityProgramCard({
           </div>
         </div>
 
-        {/* Description */}
-        <p className="text-sm text-foreground/80 mb-4 line-clamp-3 break-words">
-          {program.description}
-        </p>
+        {/* Description — tap to expand */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            setDescExpanded((v) => !v)
+          }}
+          className="text-sm text-foreground/80 mb-4 break-words text-left w-full"
+        >
+          <span className={descExpanded ? '' : 'line-clamp-3'}>
+            {program.description}
+          </span>
+          {!descExpanded && program.description.length > 120 && (
+            <span className="text-primary text-xs font-semibold uppercase tracking-wider ml-1">more</span>
+          )}
+        </button>
 
         {/* Metadata Badges */}
         {(program.level || program.goals.length > 0) && (

--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -127,14 +127,7 @@ export default function CommunityProgramsView({
     <div>
         {/* Filter Buttons */}
         <div className="sticky top-0 bg-background z-10 pb-4">
-          <div className="flex flex-wrap gap-2">
-            <span className="px-4 py-2 bg-primary text-primary-foreground doom-button-3d font-semibold text-sm sm:text-base uppercase tracking-wider">
-              All ({communityPrograms.length})
-            </span>
-          </div>
-
-          {/* Additional Filters - Compact Popovers */}
-          <div className="mt-4 flex flex-wrap gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             {/* Level Filter Popover */}
             <Popover>
               <PopoverTrigger asChild>

--- a/components/ui/ExerciseImageCrossfade.tsx
+++ b/components/ui/ExerciseImageCrossfade.tsx
@@ -11,8 +11,6 @@ interface ExerciseImageCrossfadeProps {
   holdDuration?: number
   /** Crossfade transition duration in ms. Default 300. */
   fadeDuration?: number
-  /** Optional label override. Default uses "Exercise demonstration" */
-  label?: string
 }
 
 const POSITION_LABELS = ['START', 'FINISH'] as const
@@ -26,7 +24,6 @@ export default function ExerciseImageCrossfade({
   exerciseName,
   holdDuration = 1200,
   fadeDuration = 300,
-  label,
 }: ExerciseImageCrossfadeProps) {
   const [activeIndex, setActiveIndex] = useState(0)
   const [paused, setPaused] = useState(false)
@@ -72,11 +69,6 @@ export default function ExerciseImageCrossfade({
             More images to come
           </p>
         </div>
-        {label && (
-          <div className="border-t border-border px-3 py-1.5 bg-card">
-            <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{label}</p>
-          </div>
-        )}
       </div>
     )
   }
@@ -94,11 +86,6 @@ export default function ExerciseImageCrossfade({
             sizes="(max-width: 640px) 100vw, 600px"
           />
         </div>
-        {label && (
-          <div className="border-t border-border px-3 py-1.5 bg-card">
-            <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{label}</p>
-          </div>
-        )}
       </div>
     )
   }
@@ -169,10 +156,7 @@ export default function ExerciseImageCrossfade({
           </span>
         )}
       </button>
-      <div className="border-t border-border px-3 py-1.5 bg-card flex items-center justify-between">
-        <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-          {label || 'Exercise demonstration'}
-        </p>
+      <div className="border-t border-border px-3 py-1.5 bg-card flex items-center justify-end">
         {/* Dot indicators for current position */}
         <div className="flex gap-1.5">
           {POSITION_LABELS.map((pos, i) => (


### PR DESCRIPTION
## Summary
- Add scroll fade indicator on onboarding tips screen for below-fold content
- Bump waiver accept button to 48px touch target
- Remove "Exercise Demonstration" label (keep position dot indicators)
- Remove display name field from signup (unused, settable later)
- Settings: auto-save on change with 300ms debounce, remove save button
- Settings: hide intensity tracking in follow-along mode, hide lbs/kg and Discord badge
- Browse programs: filter out empty goal badges, remove "All" button, add tap-to-expand descriptions

## Test plan
- [x] Onboarding tips screen: verify fade gradient appears at bottom and disappears when scrolled to end
- [x] Waiver page: verify "I Agree" button has adequate touch target height
- [x] Signup page: verify no display name field, account creates successfully
- [x] Settings: toggle workout mode and verify intensity hides/shows with animation
- [ ] Settings: change a setting and verify it saves without a save button
- [ ] Browse programs: verify no blank badge placeholders next to level badge
- [ ] Browse programs: tap a truncated description to expand, tap again to collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)