### PR TITLE
fix: intensity type selector resets to NONE on re-render

### DIFF
--- a/components/ExerciseSearchModal.tsx
+++ b/components/ExerciseSearchModal.tsx
@@ -120,33 +120,32 @@ export default function ExerciseSearchModal({
     }
   }, [effectiveExercise])
 
-  if (!isOpen) return null
+  // Memoize initialConfig to prevent the useEffect in SetConfigurationInterface
+  // from resetting exerciseIntensityType on every parent re-render
+  const initialConfig = useMemo(() => {
+    if (!editingExercise) return undefined
 
-  // Prepare initial config for editing
-  const initialConfig = editingExercise ? {
-    sets: editingExercise.prescribedSets.map(set => {
-      const firstSet = editingExercise.prescribedSets[0]
-      const intensityType = firstSet?.rpe !== null && firstSet?.rpe !== undefined ? 'RPE'
-        : firstSet?.rir !== null && firstSet?.rir !== undefined ? 'RIR'
-        : 'NONE'
+    const firstSet = editingExercise.prescribedSets[0]
+    const intensityType: 'RIR' | 'RPE' | 'NONE' =
+      firstSet?.rpe !== null && firstSet?.rpe !== undefined ? 'RPE'
+      : firstSet?.rir !== null && firstSet?.rir !== undefined ? 'RIR'
+      : 'NONE'
 
-      return {
+    return {
+      sets: editingExercise.prescribedSets.map(set => ({
         id: set.id,
         setNumber: set.setNumber,
         reps: set.reps,
         intensityValue: intensityType === 'RPE' ? (set.rpe ?? undefined)
           : intensityType === 'RIR' ? (set.rir ?? undefined)
           : undefined
-      }
-    }),
-    intensityType: (() => {
-      const firstSet = editingExercise.prescribedSets[0]
-      return firstSet?.rpe !== null && firstSet?.rpe !== undefined ? 'RPE' as const
-        : firstSet?.rir !== null && firstSet?.rir !== undefined ? 'RIR' as const
-        : 'NONE' as const
-    })(),
-    notes: editingExercise.notes || ''
-  } : undefined
+      })),
+      intensityType,
+      notes: editingExercise.notes || ''
+    }
+  }, [editingExercise])
+
+  if (!isOpen) return null
 
   return (
     <>

--- a/components/workout-logging/wizards/EditExerciseWizard.tsx
+++ b/components/workout-logging/wizards/EditExerciseWizard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { WizardDialog, type WizardStep } from '@/components/ui/radix/wizard-dialog'
 import { clientLogger } from '@/lib/client-logger'
 import type { ExerciseDefinition } from '../wizard-steps/ExerciseSearchStep'
@@ -71,32 +71,32 @@ export function EditExerciseWizard({
     instructions: exercise.exerciseDefinition?.instructions,
   }
 
-  // Determine initial intensity type from prescribed sets
-  const getInitialIntensityType = (): 'RIR' | 'RPE' | 'NONE' => {
+  // Memoize initialConfig to prevent the useEffect in SetConfigurationInterface
+  // from resetting exerciseIntensityType on every parent re-render
+  const initialConfig = useMemo(() => {
     const firstSet = exercise.prescribedSets[0]
-    if (!firstSet) return 'NONE'
+    const intensityType: 'RIR' | 'RPE' | 'NONE' =
+      firstSet?.rpe !== null && firstSet?.rpe !== undefined ? 'RPE'
+      : firstSet?.rir !== null && firstSet?.rir !== undefined ? 'RIR'
+      : 'NONE'
 
-    if (firstSet.rpe !== null && firstSet.rpe !== undefined) return 'RPE'
-    if (firstSet.rir !== null && firstSet.rir !== undefined) return 'RIR'
-    return 'NONE'
-  }
-
-  const initialConfig = {
-    setCount: exercise.prescribedSets.length,
-    intensityType: getInitialIntensityType(),
-    notes: exercise.notes || '',
-    sets: exercise.prescribedSets.map((set) => ({
-      id: set.id,
-      setNumber: set.setNumber,
-      reps: set.reps,
-      intensityValue:
-        getInitialIntensityType() === 'RPE'
-          ? set.rpe ?? undefined
-          : getInitialIntensityType() === 'RIR'
-          ? set.rir ?? undefined
-          : undefined,
-    })),
-  }
+    return {
+      setCount: exercise.prescribedSets.length,
+      intensityType,
+      notes: exercise.notes || '',
+      sets: exercise.prescribedSets.map((set) => ({
+        id: set.id,
+        setNumber: set.setNumber,
+        reps: set.reps,
+        intensityValue:
+          intensityType === 'RPE'
+            ? set.rpe ?? undefined
+            : intensityType === 'RIR'
+            ? set.rir ?? undefined
+            : undefined,
+      })),
+    }
+  }, [exercise.prescribedSets, exercise.notes])
 
   // Reset wizard state when opened
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fixes intensity type dropdown resetting to NONE when editing exercises that don't have intensity prescriptions (e.g., community program clones without built-in RIR/RPE)
- Root cause: `initialConfig` objects in `EditExerciseWizard` and `ExerciseSearchModal` were recreated on every render, triggering a `useEffect` in `SetConfigurationInterface` that reset `exerciseIntensityType` back to the initial value
- Wrapped `initialConfig` in `useMemo` in both components to stabilize the object reference

## Test plan

- [ ] Open a program cloned from community that has no intensity prescriptions
- [ ] Edit an exercise in the workout logger
- [ ] Change intensity type from None to RIR or RPE — verify it stays selected
- [ ] Fill in intensity values and save — verify they persist
- [ ] Repeat in the admin panel exercise editor (ExerciseSearchModal)
- [ ] Verify exercises that already have intensity still load correctly when editing

Fixes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)