### PR TITLE
feat: add Recent Signups table to admin panel

### DIFF
--- a/app/(app)/admin/layout.tsx
+++ b/app/(app)/admin/layout.tsx
@@ -26,6 +26,7 @@ export default async function AdminLayout({
     { href: '/admin/community-programs', label: 'Programs' },
     { href: '/admin/feedback', label: 'Feedback' },
     { href: '/admin/analytics', label: 'Analytics' },
+    { href: '/admin/signups', label: 'Signups' },
   ]
 
   return (

--- a/app/(app)/admin/signups/page.tsx
+++ b/app/(app)/admin/signups/page.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+interface SignupRow {
+  email: string
+  createdAt: string
+  source: string | null
+  experienceLevel: string | null
+  firstWorkoutAt: string | null
+}
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now()
+  const then = new Date(dateStr).getTime()
+  const diffMs = now - then
+  const diffMins = Math.floor(diffMs / 60000)
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 30) return `${diffDays}d ago`
+  const diffMonths = Math.floor(diffDays / 30)
+  return `${diffMonths}mo ago`
+}
+
+export default function AdminSignupsPage() {
+  const [rows, setRows] = useState<SignupRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch('/api/admin/signups')
+      if (!res.ok) throw new Error('Failed to fetch signups')
+      const json = await res.json()
+      setRows(json.data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  if (loading) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">
+        Loading signups...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-red-400 mb-4">{error}</p>
+        <button
+          type="button"
+          onClick={() => fetchData()}
+          aria-label="Retry loading signups"
+          className="text-sm text-orange-500 hover:text-orange-400 underline"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground uppercase tracking-wider">
+            Recent Signups
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Last 30 days &middot; {rows.length} signup{rows.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => fetchData()}
+          aria-label="Refresh signups data"
+          className="text-sm text-orange-500 hover:text-orange-400 transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground">
+          No signups in the last 30 days.
+        </div>
+      ) : (
+        <div className="border border-border rounded-lg overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-card">
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Email
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Signed up
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Source
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Experience
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  First workout?
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.email}
+                  className="border-b border-border last:border-b-0 hover:bg-card/50 transition-colors"
+                >
+                  <td className="px-4 py-3 text-foreground font-medium">
+                    {row.email}
+                  </td>
+                  <td
+                    className="px-4 py-3 text-muted-foreground"
+                    title={new Date(row.createdAt).toLocaleString()}
+                  >
+                    {relativeTime(row.createdAt)}
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.source ? (
+                      <span className="inline-block px-2 py-0.5 text-xs font-medium rounded bg-card border border-border text-foreground">
+                        {row.source}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.experienceLevel ? (
+                      <span className="text-foreground">{row.experienceLevel}</span>
+                    ) : (
+                      <span className="text-muted-foreground">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <FirstWorkoutCell firstWorkoutAt={row.firstWorkoutAt} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FirstWorkoutCell({ firstWorkoutAt }: { firstWorkoutAt: string | null }) {
+  if (firstWorkoutAt === null || firstWorkoutAt === undefined) {
+    return <span className="text-muted-foreground">Not yet</span>
+  }
+
+  return (
+    <span
+      className="text-green-500 font-medium"
+      title={new Date(firstWorkoutAt).toLocaleString()}
+    >
+      Yes ({relativeTime(firstWorkoutAt)})
+    </span>
+  )
+}

--- a/app/api/admin/signups/route.ts
+++ b/app/api/admin/signups/route.ts
@@ -1,0 +1,63 @@
+import { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { requireEditor } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+const END_USER_ROLE = 'user'
+const ONLY_END_USERS = Prisma.sql`AND u.role::text = ${END_USER_ROLE}`
+
+interface SignupRow {
+  email: string
+  createdAt: Date
+  source: string | null
+  experienceLevel: string | null
+  firstWorkoutAt: Date | null
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireEditor()
+    if (auth.response) return auth.response
+
+    const daysParam = request.nextUrl.searchParams.get('days')
+    const days = daysParam ? Math.min(Math.max(Number(daysParam), 1), 365) : 30
+    const since = new Date()
+    since.setDate(since.getDate() - days)
+    since.setHours(0, 0, 0, 0)
+
+    const rows = await prisma.$queryRaw<SignupRow[]>`
+      SELECT
+        u.email,
+        u."createdAt",
+        ae.source,
+        us."experienceLevel",
+        wc."firstWorkoutAt"
+      FROM "user" u
+      LEFT JOIN LATERAL (
+        SELECT (ae_inner.properties->>'source') AS source
+        FROM "AppEvent" ae_inner
+        WHERE ae_inner."userId" = u.id
+          AND ae_inner.event = 'signup_completed'
+        ORDER BY ae_inner."createdAt" DESC
+        LIMIT 1
+      ) ae ON true
+      LEFT JOIN "UserSettings" us ON us."userId" = u.id
+      LEFT JOIN LATERAL (
+        SELECT MIN(wc_inner."completedAt") AS "firstWorkoutAt"
+        FROM "WorkoutCompletion" wc_inner
+        WHERE wc_inner."userId" = u.id
+          AND wc_inner.status = 'completed'
+      ) wc ON true
+      WHERE u."createdAt" >= ${since}
+        ${ONLY_END_USERS}
+      ORDER BY u."createdAt" DESC
+    `
+
+    return NextResponse.json({ data: rows })
+  } catch (error) {
+    logger.error({ error, context: 'admin-signups' }, 'Failed to fetch signups')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/signups/route.ts
+++ b/app/api/admin/signups/route.ts
@@ -18,11 +18,14 @@ interface SignupRow {
 
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor()
+    const auth = await requireEditor({ rateLimit: true })
     if (auth.response) return auth.response
 
     const daysParam = request.nextUrl.searchParams.get('days')
-    const days = daysParam ? Math.min(Math.max(Number(daysParam), 1), 365) : 30
+    const parsedDays = daysParam ? Number(daysParam) : NaN
+    const days = Number.isFinite(parsedDays)
+      ? Math.min(Math.max(Math.floor(parsedDays), 1), 365)
+      : 30
     const since = new Date()
     since.setDate(since.getDate() - days)
     since.setHours(0, 0, 0, 0)


### PR DESCRIPTION
## Summary
- Adds new `/admin/signups` page with a table of recent signups (last 30 days)
- Shows 5 columns: Email, Signed up (relative time), Source (from AppEvent), Experience level (from UserSettings), First workout? (from WorkoutCompletion)
- Single raw SQL query with LATERAL joins for efficient server-side data fetching
- Internal/staff accounts excluded via role-based filtering (same pattern as analytics)
- Added "Signups" link to admin navigation bar

## Test plan
- [x] Navigate to `/admin/signups` as an admin/editor user
- [x] Verify table shows recent signups with all 5 columns
- [x] Verify internal accounts (admin/editor/author roles) are excluded
- [ ] Verify "Source" shows qr/organic/oauth or dash for missing events
- [x] Verify "First workout?" shows "Yes (Xd ago)" or "Not yet"
- [x] Verify relative times display correctly with hover tooltips for exact dates
- [x] Verify non-admin users cannot access the page (redirects)
- [ ] Verify the API returns 401 for unauthenticated requests

Fixes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)