### PR TITLE
fix: auto-expand first workout for beginner users

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -119,12 +119,19 @@ export default function StrengthWeekView({
   const [modalMode, setModalMode] = useState<ModalMode>(null)
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
   const [workoutMetadata, setWorkoutMetadata] = useState<WorkoutMetadata | null>(null)
-  // Auto-expand first workout when arriving from onboarding (?expand=first)
+  // Auto-expand first workout for beginners with no workout history or via ?expand=first
   const shouldExpandFirst = searchParams.get('expand') === 'first'
   const firstWorkoutId = week.workouts.length > 0 ? week.workouts[0].id : null
   const [expandedWorkoutId, setExpandedWorkoutId] = useState<string | null>(
     shouldExpandFirst && firstWorkoutId ? firstWorkoutId : null
   )
+  // Expand first workout once settings load for beginners with no history
+  const isBeginnerFirstVisit = historyCount === 0 && !settingsLoading && settings?.loggingMode !== 'full'
+  useEffect(() => {
+    if (isBeginnerFirstVisit && firstWorkoutId && !expandedWorkoutId) {
+      setExpandedWorkoutId(firstWorkoutId)
+    }
+  }, [isBeginnerFirstVisit, firstWorkoutId, expandedWorkoutId])
   const [isLoadingWorkout, setIsLoadingWorkout] = useState(false)
   const [modalKey, setModalKey] = useState(0)
   const [showCompletionModal, setShowCompletionModal] = useState(false)
@@ -479,6 +486,7 @@ export default function StrengthWeekView({
             onSkip={handleSkipWorkout}
             onUnskip={handleUnskipWorkout}
             onLog={handleOpenLogging}
+            hideSkip={isBeginnerFirstVisit && workout.id === firstWorkoutId}
           />
         ))}
 

--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -26,6 +26,7 @@ type Props = {
   onSkip: (workoutId: string) => void
   onUnskip: (workoutId: string) => void
   onLog: (workoutId: string) => void
+  hideSkip?: boolean
 }
 
 export default function WorkoutCard({
@@ -38,6 +39,7 @@ export default function WorkoutCard({
   onSkip,
   onUnskip,
   onLog,
+  hideSkip = false,
 }: Props) {
   const latestCompletion = workout.completions[0]
   const isCompleted = latestCompletion?.status === 'completed'
@@ -157,7 +159,7 @@ export default function WorkoutCard({
             <Play size={16} />
             {isDraft ? 'Continue Workout' : 'Start Workout'}
           </button>
-          {!latestCompletion && (
+          {!latestCompletion && !hideSkip && (
             <button
               type="button"
               onClick={() => onSkip(workout.id)}


### PR DESCRIPTION
## Summary

- Auto-expand the first workout card for beginner users (follow-along mode) with zero completed workouts, showing the Start Workout button immediately
- Hide the Skip button on that first workout to reduce decision fatigue for new users
- Works on page refresh (not just the `?expand=first` onboarding redirect)
- Experienced users (full logging mode) are unaffected — they see the default collapsed view

## Test plan

- [ ] Create a new beginner user, complete onboarding — first workout should be expanded with Start Workout visible, no Skip button
- [ ] Refresh the training page — first workout should still be expanded (persists via historyCount check, not just query param)
- [ ] Complete a workout — on next visit, workouts should no longer auto-expand
- [ ] Create an experienced user — first workout should NOT auto-expand
- [ ] Verify Skip button still works on non-first workouts for beginners

🤖 Generated with [Claude Code](https://claude.com/claude-code)