### PR TITLE
Fix admin rate limiting: remove from GETs, raise write budget

### DIFF
--- a/app/api/admin/articles/[id]/route.ts
+++ b/app/api/admin/articles/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/articles/route.ts
+++ b/app/api/admin/articles/route.ts
@@ -10,7 +10,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)

--- a/app/api/admin/collections/[id]/route.ts
+++ b/app/api/admin/collections/[id]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET() {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const collections = await prisma.collection.findMany({

--- a/app/api/admin/community-programs/[id]/route.ts
+++ b/app/api/admin/community-programs/[id]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/community-programs/route.ts
+++ b/app/api/admin/community-programs/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)

--- a/app/api/admin/exercise-definitions/[id]/route.ts
+++ b/app/api/admin/exercise-definitions/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
     const user = auth.user
 

--- a/app/api/admin/exercise-definitions/route.ts
+++ b/app/api/admin/exercise-definitions/route.ts
@@ -23,7 +23,7 @@ import {
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)

--- a/app/api/admin/messages/[id]/route.ts
+++ b/app/api/admin/messages/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { id } = await params

--- a/app/api/admin/messages/route.ts
+++ b/app/api/admin/messages/route.ts
@@ -17,7 +17,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)

--- a/app/api/admin/signups/route.ts
+++ b/app/api/admin/signups/route.ts
@@ -18,7 +18,7 @@ interface SignupRow {
 
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const daysParam = request.nextUrl.searchParams.get('days')

--- a/app/api/admin/tags/route.ts
+++ b/app/api/admin/tags/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET() {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const tags = await prisma.tag.findMany({

--- a/app/api/admin/waiver/route.ts
+++ b/app/api/admin/waiver/route.ts
@@ -12,7 +12,7 @@ import { logger } from '@/lib/logger'
  */
 export async function GET(request: NextRequest) {
   try {
-    const auth = await requireEditor({ rateLimit: true })
+    const auth = await requireEditor()
     if (auth.response) return auth.response
 
     const { searchParams } = new URL(request.url)

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -9,7 +9,7 @@ Rate limiting is enforced at the API-route layer using [`rate-limiter-flexible`]
 | T0 — queue protection | `communityCloneLimiter` | 3 / 60s | userId | Protects the BullMQ clone worker from being flooded with multi-week jobs |
 | T1 — program mgmt | `programManagementLimiter` | 20 / 60s | userId | Program CRUD (create, duplicate, activate, restart) — the expensive ones enqueue or transact across many rows |
 | T2 — destructive ops | `destructiveOpLimiter` | 10 / 60s | userId | Delete/archive program, bulk `applyToFuture` exercise replace/delete |
-| T3 — admin | `adminLimiter` | 30 / 60s | userId | All `/api/admin/*` endpoints (reads + writes). Defense in depth behind editor/admin role |
+| T3 — admin | `adminLimiter` | 60 / 60s | userId | Admin write endpoints (`POST`/`PATCH`/`DELETE` under `/api/admin/*`). GETs are excluded per the read-endpoint policy below |
 | T4 — workout writes | `workoutActionLimiter` | 10 / 10s | userId | Complete, skip, clear a workout |
 | T4 — set logging | `setLoggingLimiter` | 60 / 10s | userId | Draft sync, per-set upsert, per-set delete — intentionally generous for live logging |
 | T5 — auth sensitive | `authSensitiveLimiter` | 5 / 60s | **IP** | `/api/auth/complete-profile` (bypasses BetterAuth's own limiter) |

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -113,7 +113,7 @@ export const communityCloneLimiter = lazyLimiter({ keyPrefix: 'clone', points: 3
 /**
  * Admin endpoints: 30 req / 60s per user
  */
-export const adminLimiter = lazyLimiter({ keyPrefix: 'admin', points: 30, duration: 60 })
+export const adminLimiter = lazyLimiter({ keyPrefix: 'admin', points: 60, duration: 60 })
 
 /**
  * Sensitive auth endpoints that bypass BetterAuth's built-in limiter


### PR DESCRIPTION
## Summary
- Remove rate limiting from all 13 admin GET handlers — they're behind role auth and consistent with the existing read-endpoint exemption policy in `docs/RATE_LIMITING.md`
- Raise `adminLimiter` budget from 30 to 60 req/60s so bulk content editing sessions don't trigger 429s
- Update `docs/RATE_LIMITING.md` to reflect new budget and GET exclusion

## Test plan
- [ ] Navigate admin panel pages (articles, collections, programs, exercise defs, messages, tags, signups, waiver) — no 429 errors on GETs
- [ ] Perform rapid admin writes (create/edit/delete articles, tags) — rate limiting still enforced at 60 req/60s
- [ ] Verify type-check passes cleanly

Fixes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)