### PR TITLE
docs: add InAppMessage to CLAUDE.md data model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Program
 - **PrescribedSet**: Template/plan (what program prescribes)
 - **LoggedSet**: Actual performance (what user logged)
 - **WorkoutCompletion**: Tracks completed/incomplete/abandoned workouts
+- **InAppMessage**: Admin-managed messages shown in workout UI (carousel slides, lifecycle targeting, placement rules)
 - **AppEvent**: Client-side analytics events (signup source, page views)
 
 **Important**: We store BOTH prescribed and logged sets to enable plan vs reality comparison.


### PR DESCRIPTION
## Summary

- Added `InAppMessage` to the Key Database Tables section in CLAUDE.md

## What triggered this

PR #645 (`worktree-first-ui-refinement`) and its predecessor commit added an in-app messages system with:
- New `InAppMessage` Prisma model (carousel slides, lifecycle targeting, placement rules)
- Admin CMS for message management (`app/(app)/admin/messages/`)
- User-facing message delivery API (`app/api/messages/`)
- New fields on `UserSettings` (`dismissedMessageIds`, `seenMessageIds`)

The Key Database Tables section in CLAUDE.md listed all other significant tables but was missing this new one.

## What was NOT updated (and why)

- **No new feature doc created**: The in-app messages system is discoverable from the schema, API routes, and admin UI. A dedicated feature doc would duplicate what's readable from the code.
- **Test structure listing**: CLAUDE.md lists only 2 example test files but there are 20+. This is intentionally illustrative, not exhaustive — left as-is.
- **CI smoke test changes**: `build-app.yml` now uses `scripts/smoke-test-ssr.sh` for multi-route SSR validation instead of a single HTTP status check. The CLAUDE.md CI description ("Builds app Docker image") is still accurate at the right abstraction level.
- **Deleted files** (`StickNudgeBanner`, `BeginnerTipCard`, `tip-library`): Not referenced in any docs, no cleanup needed.
- **All file paths in docs verified**: Every path referenced in CLAUDE.md still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)