### PR TITLE
fix: add doom-button-3d to Next Exercise and Complete Workout buttons

### DIFF
--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -113,7 +113,7 @@ export default function SetLoggingForm({
             <button
               type="button"
               onClick={onCompleteWorkout}
-              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-focus-ring"
+              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-button-3d doom-focus-ring"
             >
               Complete Workout
             </button>
@@ -121,7 +121,7 @@ export default function SetLoggingForm({
             <button
               type="button"
               onClick={onNextExercise}
-              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-focus-ring"
+              className="flex-1 py-2.5 bg-primary text-primary-foreground text-sm font-bold uppercase tracking-wider transition-all hover:bg-primary/90 doom-button-3d doom-focus-ring"
             >
               Next Exercise
             </button>


### PR DESCRIPTION
## Summary
- Added `doom-button-3d` class to the **Next Exercise** and **Complete Workout** buttons in the "All prescribed sets logged!" banner of `SetLoggingForm`
- These buttons now match the **Extra Sets** button's 3D styling (raised shadow, hover glow, press animation)

## Test plan
- [x] Complete all prescribed sets for an exercise in the logger
- [x] Verify the "Next Exercise" button has the 3D raised effect matching "Extra Sets"
- [x] Verify the "Complete Workout" button (on last exercise) also has the 3D effect
- [x] Confirm hover glow and press-down animation work on desktop
- [x] Confirm buttons look correct in both light and dark mode

Fixes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)