### PR TITLE
feat: add image loading skeleton in exercise logger

### DIFF
--- a/components/ui/ExerciseImageCrossfade.tsx
+++ b/components/ui/ExerciseImageCrossfade.tsx
@@ -19,6 +19,30 @@ function resolveUrl(url: string): string {
   return url.startsWith('http') ? url : `https://cdn.ripit.fit/exercise-images/${url}`
 }
 
+function ImageLoadingSkeleton() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted animate-pulse z-10">
+      <svg
+        aria-hidden="true"
+        className="w-10 h-10 text-muted-foreground/40 mb-2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+        />
+      </svg>
+      <span className="text-xs text-muted-foreground/60 uppercase tracking-wider">
+        Loading
+      </span>
+    </div>
+  )
+}
+
 export default function ExerciseImageCrossfade({
   imageUrls,
   exerciseName,
@@ -27,6 +51,7 @@ export default function ExerciseImageCrossfade({
 }: ExerciseImageCrossfadeProps) {
   const [activeIndex, setActiveIndex] = useState(0)
   const [paused, setPaused] = useState(false)
+  const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set())
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null)
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
     if (typeof window === 'undefined') return false
@@ -42,6 +67,15 @@ export default function ExerciseImageCrossfade({
 
   const resolved = imageUrls.map(resolveUrl)
   const hasAnimation = resolved.length === 2 && !prefersReducedMotion
+
+  const handleImageLoad = useCallback((url: string) => {
+    setLoadedImages(prev => {
+      if (prev.has(url)) return prev
+      const next = new Set(prev)
+      next.add(url)
+      return next
+    })
+  }, [])
 
   // Cycle between images — activeIndex is an intentional trigger to restart the timer after each transition
   // biome-ignore lint/correctness/useExhaustiveDependencies: activeIndex triggers timer restart for cycling animation
@@ -78,12 +112,14 @@ export default function ExerciseImageCrossfade({
     return (
       <div className="border-2 border-border">
         <div className="relative aspect-[4/3] bg-muted">
+          {!loadedImages.has(resolved[0]) && <ImageLoadingSkeleton />}
           <Image
             src={resolved[0]}
             alt={`${exerciseName} demonstration`}
             fill
             className="object-cover"
             sizes="(max-width: 640px) 100vw, 600px"
+            onLoad={() => handleImageLoad(resolved[0])}
           />
         </div>
       </div>
@@ -97,12 +133,14 @@ export default function ExerciseImageCrossfade({
         {resolved.map((src, i) => (
           <div key={src} className="border-2 border-border">
             <div className="relative aspect-[4/3] bg-muted">
+              {!loadedImages.has(src) && <ImageLoadingSkeleton />}
               <Image
                 src={src}
                 alt={`${exerciseName} - ${POSITION_LABELS[i].toLowerCase()} position`}
                 fill
                 className="object-cover"
                 sizes="(max-width: 640px) 100vw, 600px"
+                onLoad={() => handleImageLoad(src)}
               />
             </div>
             <div className="border-t border-border px-3 py-1.5 bg-card">
@@ -125,6 +163,7 @@ export default function ExerciseImageCrossfade({
         className="relative aspect-[4/3] w-full bg-muted cursor-pointer block"
         aria-label={paused ? 'Resume animation' : 'Pause animation'}
       >
+        {resolved.every(src => !loadedImages.has(src)) && <ImageLoadingSkeleton />}
         {resolved.map((src, i) => (
           <Image
             key={src}
@@ -137,6 +176,7 @@ export default function ExerciseImageCrossfade({
               transition: `opacity ${fadeDuration}ms ease-in-out`,
             }}
             sizes="(max-width: 640px) 100vw, 600px"
+            onLoad={() => handleImageLoad(src)}
           />
         ))}
 


### PR DESCRIPTION
## Summary
- Adds a pulsing skeleton placeholder with an image icon while exercise demonstration images load in the workout logger
- Covers all three display modes: single image, reduced-motion stacked layout, and crossfade animation
- Skeleton disappears once the image fires its `onLoad` event

## Implementation
- New `ImageLoadingSkeleton` component rendered as an absolute overlay with `animate-pulse`, `z-10`, and themed colors (`bg-muted`, `text-muted-foreground`)
- `loadedImages` Set state tracks which image URLs have finished loading via `onLoad` callbacks
- For crossfade mode, skeleton shows only when *no* images have loaded yet (hides as soon as the first loads)

## Test plan
- [x] Open workout logger with exercise that has 2 images — verify pulsing skeleton appears briefly before images render
- [x] Test on slow network (DevTools throttling) — skeleton should persist until images load
- [x] Test with single-image exercise — skeleton appears and disappears on load
- [x] Test with no-image exercise — "More images to come" text shows (unchanged)
- [x] Verify reduced-motion preference shows skeleton per image in stacked layout
- [x] Check both light and dark mode — skeleton uses theme tokens
- [x] Verify no layout shift when skeleton transitions to loaded image

Fixes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)