### PR TITLE
fix: reset logger tab when swiping to exercise without notes

### DIFF
--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -96,6 +96,7 @@ export default function ExerciseDisplayTabs({
 
   // When the exercise changes, reset to "log-sets" if the current tab is
   // unavailable on the new exercise (e.g. "notes" tab when there are no notes).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: exercise.id is intentional — re-evaluate tab availability on exercise switch
   useEffect(() => {
     if (activeTab === 'notes' && !hasNotes) {
       setActiveTab('log-sets')

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Check, Sparkles } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import type { MessageData } from '@/components/ui/MessageCard'
 import { MessageCard } from '@/components/ui/MessageCard'

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { Check, Sparkles } from 'lucide-react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import type { MessageData } from '@/components/ui/MessageCard'
@@ -91,9 +92,18 @@ export default function ExerciseDisplayTabs({
   onMessageDismissed,
 }: ExerciseDisplayTabsProps) {
   const hasNotes = !!exercise.notes
+  const [activeTab, setActiveTab] = useState('log-sets')
+
+  // When the exercise changes, reset to "log-sets" if the current tab is
+  // unavailable on the new exercise (e.g. "notes" tab when there are no notes).
+  useEffect(() => {
+    if (activeTab === 'notes' && !hasNotes) {
+      setActiveTab('log-sets')
+    }
+  }, [exercise.id, hasNotes, activeTab])
 
   return (
-    <Tabs defaultValue="log-sets" className="w-full h-full flex flex-col">
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full h-full flex flex-col">
       <TabsList className="flex-shrink-0 sticky top-0 z-10 overflow-hidden">
         <TabsTrigger value="log-sets" className="flex-1">
           <span>Log Sets</span>


### PR DESCRIPTION
## Summary
- When on the notes tab and swiping to an exercise without notes, the logger content appeared empty (no tab selected)
- Convert `ExerciseDisplayTabs` from uncontrolled to controlled Radix Tabs so the active tab resets to "log-sets" when the new exercise has no notes
- If the swiped-to exercise has notes, the notes tab stays selected

## Root Cause
`ExerciseDisplayTabs` used `<Tabs defaultValue="log-sets">` (uncontrolled). Radix kept internal state as "notes" even after the exercise changed and the notes tab/content stopped rendering, resulting in empty content.

## Fix
- Added `useState` to track `activeTab` and converted to controlled `<Tabs value={activeTab} onValueChange={setActiveTab}>`
- Added `useEffect` that resets to "log-sets" when `exercise.id` changes and the new exercise has no notes

## Test plan
- [x] Open workout logger on an exercise with notes
- [x] Switch to the Notes tab
- [x] Swipe to an adjacent exercise that has no notes — should auto-switch to Log Sets tab
- [x] Swipe to an exercise that has notes — should stay on Notes tab
- [x] Verify all tabs (Log Sets, Info, Notes, History) work normally without regressions

Note: No automated test — this project uses API integration tests only (Testcontainers); no React component test infrastructure exists.

Fixes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)