### PR TITLE
fix: stop sync-exercise-data from overwriting curated programs

### DIFF
--- a/scripts/sync-exercise-data.ts
+++ b/scripts/sync-exercise-data.ts
@@ -308,8 +308,14 @@ function resolveExerciseIds(
   return { resolved: data, missing }
 }
 
+const updatePrograms = process.argv.includes('--update-programs')
+
 async function syncCommunityPrograms(programs: CuratedMeta[]) {
-  console.log('Step 3: Syncing community programs...')
+  if (updatePrograms) {
+    console.log('Step 3: Syncing community programs (--update-programs: will overwrite existing)...')
+  } else {
+    console.log('Step 3: Syncing community programs...')
+  }
 
   // Build name → id lookup
   const allDefs = await prisma.exerciseDefinition.findMany({
@@ -319,6 +325,7 @@ async function syncCommunityPrograms(programs: CuratedMeta[]) {
 
   let created = 0
   let updated = 0
+  let skipped = 0
 
   // Check which snapshot files exist
   const availableSnapshots = new Set(readdirSync(SNAPSHOT_DIR))
@@ -377,19 +384,26 @@ async function syncCommunityPrograms(programs: CuratedMeta[]) {
     })
 
     if (existing) {
-      await prisma.communityProgram.update({
-        where: { id: existing.id },
-        data,
-      })
-      updated++
+      if (updatePrograms) {
+        await prisma.communityProgram.update({
+          where: { id: existing.id },
+          data,
+        })
+        console.log(`  UPDATED: ${data.name}`)
+        updated++
+      } else {
+        console.log(`  SKIP (exists): ${data.name}`)
+        skipped++
+      }
+      continue
     } else {
       await prisma.communityProgram.create({ data })
       created++
     }
   }
 
-  console.log(`  Created: ${created}, Updated: ${updated}`)
-  return { created, updated }
+  console.log(`  Created: ${created}, Updated: ${updated}, Skipped: ${skipped}`)
+  return { created, updated, skipped }
 }
 
 // ── Step 4: Verify ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `syncCommunityPrograms()` unconditionally overwrote existing curated community programs on every deploy, reverting manual production edits
- Changed default behavior to skip existing programs (matching the pattern in seed-community-programs.ts)
- Added `--update-programs` flag for intentional overwrites when needed

Fixes #664

## Changes
- `scripts/sync-exercise-data.ts`: Updated `syncCommunityPrograms()` to skip existing programs by default, with opt-in `--update-programs` flag for overwrites

## Test plan
- [ ] Run sync script against a test DB with existing community programs — verify they are NOT overwritten
- [ ] Run with `--update-programs` flag — verify they ARE overwritten
- [ ] Run against a DB missing a program — verify it gets created
- [ ] Exercise definition sync (steps 1-2) is unaffected (no code changes to those steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)