### PR TITLE
fix: remove sync-exercise-data from deploy pipeline

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -207,22 +207,6 @@ jobs:
           PGPASSWORD: postgres
         run: ./scripts/smoke-test-learn-content.sh
 
-      - name: Smoke test — sync-exercise-data (non-fatal)
-        # sync-exercise-data only updates metadata/images on existing rows and
-        # verifies production-like counts (>=275 images, etc). A fresh smoke-test
-        # DB will never hit those thresholds because the base exercises were
-        # originally seeded manually via prisma/seeds/*.sql in staging/prod
-        # (see issues #245, #250). We still run the script to catch runtime
-        # errors, but do not fail the job on verification thresholds.
-        continue-on-error: true
-        run: |
-          docker run --rm \
-            --network host \
-            -e DATABASE_URL="$DATABASE_URL" \
-            -e DIRECT_URL="$DIRECT_URL" \
-            "$IMAGE" \
-            sh -c "node scripts/sync-exercise-data.cjs"
-
       - name: Smoke test — boot app
         run: |
           # Start the app in the background

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,6 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
-# Pre-compile the exercise data sync script to plain JS so the runner
-# stage doesn't need tsx (and its fragile transitive dep tree) at runtime.
-RUN ./node_modules/.bin/esbuild scripts/sync-exercise-data.ts \
-      --bundle \
-      --platform=node \
-      --format=cjs \
-      --target=node20 \
-      --external:@prisma/client \
-      --outfile=scripts-dist/sync-exercise-data.cjs
-
 # --- Stage 3: runner ---
 FROM node:20-alpine AS runner
 WORKDIR /app
@@ -53,7 +43,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Prisma migrations + exercise data sync (for k8s init container)
+# Prisma migrations (for k8s init container)
 COPY --from=builder /app/prisma ./prisma
 # dotenv: Sentry's transitive dep c12 dynamically imports dotenv at runtime;
 # Next.js standalone output traces only the package.json stub, not the code.
@@ -63,9 +53,6 @@ RUN npm install prisma@6.19.0 dotenv --save-exact --no-audit --no-fund --ignore-
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 RUN chown -R nextjs:nodejs ./node_modules/@prisma ./node_modules/prisma
 COPY scripts/prisma-migrate.sh ./scripts/prisma-migrate.sh
-COPY --from=builder /app/scripts-dist/sync-exercise-data.cjs ./scripts/sync-exercise-data.cjs
-COPY scripts/exercise-mapping.json ./scripts/exercise-mapping.json
-COPY scripts/validated-exercise-ids.json ./scripts/validated-exercise-ids.json
 RUN chmod +x ./scripts/prisma-migrate.sh
 
 USER nextjs

--- a/scripts/prisma-migrate.sh
+++ b/scripts/prisma-migrate.sh
@@ -19,11 +19,3 @@ echo "Running migrations..."
 ./node_modules/.bin/prisma migrate deploy
 
 echo "Migration completed successfully."
-
-echo ""
-echo "=== Exercise Data Sync ==="
-echo "Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-echo "==="
-node scripts/sync-exercise-data.cjs
-
-echo "Data sync completed successfully."


### PR DESCRIPTION
## Summary
- Removed `sync-exercise-data.cjs` invocation from `prisma-migrate.sh` (init container now only runs `prisma migrate deploy`)
- Removed esbuild compilation step and COPY of sync script from `Dockerfile`
- Removed the "sync-exercise-data (non-fatal)" smoke test step from CI workflow

Exercise definitions and community programs are now fully managed through the admin panel. Running sync-exercise-data on every deploy was overwriting manual edits — confirmed as the root cause of #663.

Source files (`sync-exercise-data.ts`, snapshots, `start-postgres.sh`) are preserved for local dev seeding.

## Test plan
- [ ] Verify `prisma-migrate.sh` only runs `prisma migrate deploy`
- [ ] Verify Docker image does not contain `sync-exercise-data.cjs`
- [ ] Verify CI smoke test no longer has sync-exercise-data step
- [ ] Verify local dev seeding (`start-postgres.sh`) is unaffected

Fixes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)