### PR TITLE
fix: remove (Community) suffix from cloned program names

### DIFF
--- a/__tests__/api/clone-worker.test.ts
+++ b/__tests__/api/clone-worker.test.ts
@@ -207,7 +207,7 @@ describe('Program Cloning via BullMQ Worker', () => {
 
       expect(clonedProgram).toBeTruthy();
       expect(clonedProgram!.copyStatus).toBe('ready');
-      expect(clonedProgram!.name).toBe('Test Strength Program (Community)');
+      expect(clonedProgram!.name).toBe('Test Strength Program');
       expect(clonedProgram!.userId).toBe(otherUserId);
       expect(clonedProgram!.isActive).toBe(false);
 

--- a/__tests__/api/community.test.ts
+++ b/__tests__/api/community.test.ts
@@ -447,7 +447,7 @@ describe('Community Programs API', () => {
       });
 
       expect(clonedProgram).toBeTruthy();
-      expect(clonedProgram!.name).toBe('Original Program (Community)');
+      expect(clonedProgram!.name).toBe('Original Program');
       expect(clonedProgram!.userId).toBe(otherUserId);
       expect(clonedProgram!.isActive).toBe(false);
       expect(clonedProgram!.isUserCreated).toBe(true);

--- a/lib/community/cloning.ts
+++ b/lib/community/cloning.ts
@@ -11,17 +11,16 @@ export interface CloneResult {
 /**
  * Generates a unique program name by checking for existing programs and auto-incrementing
  * Examples:
- * - "My Program (Community)" if no conflict
- * - "My Program (Community) (2)" if first name exists
- * - "My Program (Community) (3)" if first two exist
+ * - "My Program" if no conflict
+ * - "My Program (2)" if first name exists
+ * - "My Program (3)" if first two exist
  */
 async function generateUniqueProgramName(
   prisma: PrismaClient,
   baseName: string,
   userId: string
 ): Promise<string> {
-  const suffix = ' (Community)';
-  let candidateName = `${baseName}${suffix}`;
+  let candidateName = baseName;
 
   const checkNameExists = async (name: string): Promise<boolean> => {
     const strengthProgram = await prisma.program.findFirst({
@@ -38,7 +37,7 @@ async function generateUniqueProgramName(
 
   let counter = 2;
   while (counter < 100) {
-    candidateName = `${baseName}${suffix} (${counter})`;
+    candidateName = `${baseName} (${counter})`;
 
     const exists = await checkNameExists(candidateName);
 
@@ -49,7 +48,7 @@ async function generateUniqueProgramName(
     counter++;
   }
 
-  return `${baseName}${suffix} (${Date.now()})`;
+  return `${baseName} (${Date.now()})`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removes the `(Community)` suffix from cloned community program names
- Cloned programs now keep the original name (e.g., "Machine Starter" instead of "Machine Starter (Community)")
- Deduplication logic preserved: second clone gets "(2)" suffix if name already exists

## Test plan
- [ ] Clone a community program — name should match the original without "(Community)"
- [ ] Clone the same program twice — second should get "(2)" suffix
- [ ] Existing programs with "(Community)" in the name are unaffected

Fixes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)