### PR TITLE
style: fix biome lint violations in recently changed files

### DIFF
--- a/app/(app)/admin/messages/[id]/edit/page.tsx
+++ b/app/(app)/admin/messages/[id]/edit/page.tsx
@@ -11,7 +11,7 @@ export default function EditMessagePage() {
   const [message, setMessage] = useState<MessageFormData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
+  const [refreshKey, _refresh] = useReducer((x: number) => x + 1, 0)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey triggers re-fetch intentionally
   useEffect(() => {

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
     }
 
     const workoutCount = parseInt(workoutCountStr, 10)
-    if (isNaN(workoutCount) || workoutCount < 0) {
+    if (Number.isNaN(workoutCount) || workoutCount < 0) {
       return NextResponse.json({ error: 'workoutCount must be a non-negative integer' }, { status: 400 })
     }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Rajdhani } from "next/font/google";
 import "./globals.css";
-import { ToastProvider } from "@/components/ToastProvider";
 import { ThemeInitializer } from "@/components/ThemeInitializer";
+import { ToastProvider } from "@/components/ToastProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/components/ui/MessageMarkdown.tsx
+++ b/components/ui/MessageMarkdown.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import type { Components } from 'react-markdown'
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import { MESSAGE_ICONS } from '@/lib/icons/message-icons'

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useMemo } from 'react'
 import { Check, X } from 'lucide-react'
+import { useMemo } from 'react'
 import ActionsMenu, { type ActionItem } from '@/components/ActionsMenu'
 import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
 

--- a/scripts/sync-exercise-data.ts
+++ b/scripts/sync-exercise-data.ts
@@ -395,7 +395,6 @@ async function syncCommunityPrograms(programs: CuratedMeta[]) {
         console.log(`  SKIP (exists): ${data.name}`)
         skipped++
       }
-      continue
     } else {
       await prisma.communityProgram.create({ data })
       created++


### PR DESCRIPTION
## Summary
- Remove unused `Components` type import from `MessageMarkdown.tsx`
- Replace global `isNaN()` with `Number.isNaN()` in messages API route
- Fix import ordering in `app/layout.tsx` and `ExerciseLoggingHeader.tsx`
- Prefix unused `refresh` dispatch with underscore in edit message page
- Remove useless `continue` in `sync-exercise-data.ts` script

All fixes are mechanical biome lint violations with zero behavior change.

## Verification
- type-check: pass
- biome lint on changed files: pass (0 errors, 0 warnings)
- Pre-commit hooks: pass

## Deferred follow-ups
- #676 — MessageEditor: 15+ noLabelWithoutControl lint violations (low)
- #677 — MessageCard: unused variant prop and exhaustive deps warning (low)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` passes on all changed files
- [x] Pre-commit hooks pass
- [ ] No test run needed — mechanical lint fixes only (per established convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)