### PR TITLE
docs: clarify admin rate limiting for read vs write endpoints

### DIFF
--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -62,12 +62,14 @@ if (rl.response) return rl.response
 return withRateLimitHeaders(NextResponse.json({ ok: true }), rl)
 ```
 
-For **admin** routes, prefer the `requireEditor({ rateLimit: true })` helper — it combines editor role check and rate limiting in one call:
+For **admin write** routes (`POST`/`PATCH`/`DELETE`), prefer the `requireEditor({ rateLimit: true })` helper — it combines editor role check and rate limiting in one call:
 
 ```ts
 const auth = await requireEditor({ rateLimit: true })
 if (auth.response) return auth.response
 ```
+
+Admin **read** routes (`GET`) use `requireEditor()` without the `rateLimit` flag — read endpoints are excluded from rate limiting per the policy above.
 
 For **pre-auth** or **auth-sensitive** routes, key by IP rather than user id:
 


### PR DESCRIPTION
## Summary

- Updated `docs/RATE_LIMITING.md` to clarify that `requireEditor({ rateLimit: true })` applies only to admin **write** endpoints (`POST`/`PATCH`/`DELETE`), while admin **read** endpoints (`GET`) use plain `requireEditor()` without rate limiting.

## What triggered this update

PR #669 (CSV export) and the admin rate-limit refactor removed `{ rateLimit: true }` from all admin GET handlers. The rate limiting doc's example implied all admin routes should pass `{ rateLimit: true }`, which no longer matches the codebase.

## What was stale

- `docs/RATE_LIMITING.md` line 65: said "For **admin** routes" — now says "For **admin write** routes" with a note that GETs are excluded.

## What was NOT updated (and why)

- **Schema additions** (`startedAt` on WorkoutCompletion, PWA fields on UserSettings): CLAUDE.md lists tables by purpose, not by column. No update needed.
- **sync-exercise-data removal from deploy pipeline**: No docs referenced the deploy-time sync step.
- **New features** (PWA install prompt, CSV export): Discoverable from code; no existing docs to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)