### PR TITLE
fix: stop onboarding screen shake on mobile PWA

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { clearAttribution, getAttribution } from '@/lib/signup-attribution'
 
 type Step = 'loading' | 'experience' | 'equipment' | 'info' | 'completing'
@@ -357,7 +357,7 @@ export default function OnboardingPage() {
 
 function Shell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] flex-col bg-background">
+    <div className="flex min-h-screen min-h-[100svh] flex-col bg-background">
       {children}
     </div>
   )
@@ -372,19 +372,8 @@ function FadeIn({
   className?: string
   style?: React.CSSProperties
 }) {
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    el.style.animation = 'none'
-    void el.offsetHeight
-    el.style.animation = ''
-  }, [])
-
   return (
     <div
-      ref={ref}
       className={className}
       style={{ animation: 'onboarding-fade-in 0.4s ease-out both', ...style }}
     >


### PR DESCRIPTION
## Summary
- Replace `100dvh` with `100svh` (+ `100vh` fallback) in the onboarding shell to prevent viewport height oscillation during initial PWA page load
- Remove forced-reflow animation restart hack in `FadeIn` — redundant since `key={fadeKey}` already causes full remount, and the `offsetHeight` reflow amplified the viewport oscillation

## Context
New users on mobile PWAs see the experience and equipment onboarding screens shake/jump vertically by a few pixels on initial load. The `dvh` unit reactively recalculates as the browser resolves safe area insets (`viewport-fit: cover` + `black-translucent`), and the `justify-center` flex layout amplifies even sub-pixel changes. Going back to these screens doesn't reproduce it because the viewport has already stabilized.

## Test plan
- [ ] Open onboarding flow in iOS PWA (standalone) — experience and equipment screens should not shake
- [ ] Open onboarding flow in Android PWA — same check
- [ ] Verify fade-in animation still plays on step transitions
- [ ] Verify back button between steps still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)