### PR TITLE
feat: add persistent PWA install button above tab bar

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import BottomNav from '@/components/BottomNav'
 import FloatingDraftButton from '@/components/FloatingDraftButton'
 import FeedbackButton from '@/components/features/FeedbackButton'
+import { PwaInstallButton } from '@/components/features/PwaInstallButton'
 import { SessionContextTracker } from '@/components/features/SessionContextTracker'
 import { SignupCompletedTracker } from '@/components/features/SignupCompletedTracker'
 import Header from '@/components/Header'
@@ -47,6 +48,7 @@ export default async function AppLayout({
           {children}
         </div>
         <BottomNav />
+        <PwaInstallButton />
         <FeedbackButton />
       </div>
     </DraftWorkoutProvider>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2482,3 +2482,37 @@ body > [data-training-widget] {
   background: var(--muted);
   font-weight: 600;
 }
+
+/* PWA install button shimmer */
+@keyframes pwa-btn-shine {
+  0%, 85% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.pwa-install-btn {
+  overflow: hidden;
+}
+
+.pwa-install-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    105deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.25) 45%,
+    rgba(255, 255, 255, 0.35) 50%,
+    rgba(255, 255, 255, 0.25) 55%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  animation: pwa-btn-shine 8s ease-in-out 2s infinite;
+  pointer-events: none;
+}

--- a/components/features/PwaInstallButton.tsx
+++ b/components/features/PwaInstallButton.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { Download, X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { useBeforeInstallPrompt } from '@/hooks/useBeforeInstallPrompt'
+import { PwaInstallPrompt } from '@/components/features/training/PwaInstallPrompt'
+import { trackEvent } from '@/lib/analytics'
+
+const DISMISS_KEY = 'pwa-install-button-dismissed'
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false
+  return (
+    ('standalone' in navigator && (navigator as { standalone?: boolean }).standalone === true) ||
+    window.matchMedia('(display-mode: standalone)').matches
+  )
+}
+
+function isMobileDevice(): boolean {
+  if (typeof window === 'undefined') return false
+  if (process.env.NODE_ENV === 'development') {
+    const debugParam = new URLSearchParams(window.location.search).get('debugPwa')
+    if (debugParam === 'ios' || debugParam === 'android') return true
+  }
+  return /iPad|iPhone|iPod|Android/.test(navigator.userAgent)
+}
+
+export function PwaInstallButton() {
+  const [visible, setVisible] = useState(false)
+  const [showPrompt, setShowPrompt] = useState(false)
+  const { deferredPrompt } = useBeforeInstallPrompt()
+  const pathname = usePathname()
+  const isAdminPage = pathname.startsWith('/admin')
+
+  useEffect(() => {
+    if (isStandalone()) return
+    if (!isMobileDevice()) return
+    if (localStorage.getItem(DISMISS_KEY)) return
+    setVisible(true)
+  }, [])
+
+  // Listen for app install to auto-hide
+  useEffect(() => {
+    const handler = () => setVisible(false)
+    window.addEventListener('appinstalled', handler)
+    return () => window.removeEventListener('appinstalled', handler)
+  }, [])
+
+  const handleDismiss = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    localStorage.setItem(DISMISS_KEY, '1')
+    setVisible(false)
+    trackEvent('pwa_button_dismissed')
+  }, [])
+
+  const handleClick = useCallback(() => {
+    setShowPrompt(true)
+    trackEvent('pwa_button_tapped')
+  }, [])
+
+  const handlePromptClose = useCallback(() => {
+    setShowPrompt(false)
+  }, [])
+
+  const handleInstalled = useCallback(() => {
+    setShowPrompt(false)
+    setVisible(false)
+    localStorage.setItem(DISMISS_KEY, '1')
+  }, [])
+
+  if (!visible || isAdminPage) return null
+
+  return (
+    <>
+      <div
+        className="md:hidden fixed right-3 z-[39] animate-in fade-in slide-in-from-bottom-2 duration-500"
+        style={{
+          bottom: 'calc(3.75rem + env(safe-area-inset-bottom, 0px) + 10px)',
+        }}
+      >
+        <button
+          type="button"
+          onClick={handleClick}
+          className="pwa-install-btn relative flex items-center gap-1.5 pl-3 pr-2 py-2 bg-primary text-primary-foreground rounded-full shadow-lg shadow-primary/30 text-sm font-bold uppercase tracking-wider"
+          aria-label="Install app"
+        >
+          <Download className="h-3.5 w-3.5" />
+          <span>Install</span>
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={handleDismiss}
+            onKeyDown={(e) => e.key === 'Enter' && handleDismiss(e as unknown as React.MouseEvent)}
+            className="ml-0.5 p-0.5 rounded-full hover:bg-primary-foreground/20 transition-colors"
+            aria-label="Dismiss install button"
+          >
+            <X className="h-3 w-3" />
+          </span>
+        </button>
+      </div>
+
+      <PwaInstallPrompt
+        open={showPrompt}
+        onClose={handlePromptClose}
+        onInstalled={handleInstalled}
+        deferredPrompt={deferredPrompt}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a non-intrusive floating "Install" button (accent pill with download icon) positioned bottom-right above the mobile tab bar
- Visible from first signup on mobile devices; hidden on desktop, admin pages, and when app is already installed
- Tapping opens the existing PWA install assistance bottom sheet (platform-aware iOS/Android instructions)
- Dismissable via X button (persisted in localStorage); auto-hides on `appinstalled` event
- Subtle shimmer animation every 8s for discoverability without being annoying
- Supports existing `?debugPwa=ios`/`?debugPwa=android` dev override for desktop testing

## Test plan
- [ ] Visit any tab screen on mobile (or with `?debugPwa=android`) — button appears bottom-right above nav
- [ ] Tap button — install assistance popup opens
- [ ] Dismiss popup ("Maybe Later") — popup closes, button remains
- [ ] Tap X on button — button disappears permanently (survives refresh)
- [ ] Clear `pwa-install-button-dismissed` from localStorage — button returns
- [ ] Navigate to `/admin` — button hidden; navigate back — button visible
- [ ] Verify shimmer animation fires every ~8s
- [ ] In standalone/PWA mode — button never appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)