### PR TITLE
ux: strengthen week navigator chevrons (#703)

### DIFF
--- a/components/ui/WeekNavigator.tsx
+++ b/components/ui/WeekNavigator.tsx
@@ -26,17 +26,17 @@ export default function WeekNavigator({
         {/* Prev button */}
         <Link
           href={hasPrev ? `${baseUrl}?week=${currentWeek - 1}` : '#'}
-          className={`shrink-0 flex items-center justify-center w-10 h-10 rounded-full transition-colors doom-focus-ring ${
+          className={`shrink-0 flex items-center justify-center w-11 h-11 rounded-full transition-colors doom-focus-ring ${
             hasPrev
-              ? 'text-foreground hover:bg-muted/50 active:bg-muted'
-              : 'text-muted-foreground/20 pointer-events-none'
+              ? 'text-foreground hover:bg-muted/60 active:bg-muted'
+              : 'text-muted-foreground opacity-40 cursor-not-allowed pointer-events-none'
           }`}
           aria-disabled={!hasPrev}
           aria-label="Previous week"
           tabIndex={hasPrev ? 0 : -1}
           onClick={e => !hasPrev && e.preventDefault()}
         >
-          <ChevronLeft size={22} strokeWidth={1.5} />
+          <ChevronLeft size={20} strokeWidth={2.75} />
         </Link>
 
         {/* Center content */}
@@ -52,17 +52,17 @@ export default function WeekNavigator({
         {/* Next button */}
         <Link
           href={hasNext ? `${baseUrl}?week=${currentWeek + 1}` : '#'}
-          className={`shrink-0 flex items-center justify-center w-10 h-10 rounded-full transition-colors doom-focus-ring ${
+          className={`shrink-0 flex items-center justify-center w-11 h-11 rounded-full transition-colors doom-focus-ring ${
             hasNext
-              ? 'text-foreground hover:bg-muted/50 active:bg-muted'
-              : 'text-muted-foreground/20 pointer-events-none'
+              ? 'text-foreground hover:bg-muted/60 active:bg-muted'
+              : 'text-muted-foreground opacity-40 cursor-not-allowed pointer-events-none'
           }`}
           aria-disabled={!hasNext}
           aria-label="Next week"
           tabIndex={hasNext ? 0 : -1}
           onClick={e => !hasNext && e.preventDefault()}
         >
-          <ChevronRight size={22} strokeWidth={1.5} />
+          <ChevronRight size={20} strokeWidth={2.75} />
         </Link>
 
         {/* Completion indicator badge */}


### PR DESCRIPTION
## Summary

Strengthens the `<` / `>` chevrons in the Training-page week navigator so they read as confident tap targets, not lightweight text glyphs against the heavy `WEEK X OF Y` heading. Applies option **(a)** from the issue (field-guide-leaning).

### Changes (`components/ui/WeekNavigator.tsx`)

- **Glyph weight:** `strokeWidth` 1.5 → **2.75** so the chevrons hold their own next to the doom-heading
- **Glyph size:** 22px → **20px** (paired with larger tap target for ~12px halo padding, matching the spec)
- **Tap target:** `w-10 h-10` (40px) → **`w-11 h-11` (44px)** to meet the 44×44 minimum touch target
- **Disabled state:** `text-muted-foreground/20` → `text-muted-foreground opacity-40 cursor-not-allowed` so disabled is unambiguous at a glance in gym lighting (previous treatment was nearly invisible)
- **Hover background:** bumped from `bg-muted/50` → `bg-muted/60` so the warm-tan halo reads a touch stronger on hover
- `aria-label="Previous week"` / `Next week` preserved
- `doom-focus-ring` preserved for keyboard navigation

### Verification

- [x] `npm run type-check` clean
- [x] `npm run lint` — no new issues in `WeekNavigator.tsx` (pre-existing errors elsewhere in `hooks/useRestTimer.ts` etc. are unrelated)
- [x] Theme tokens only (`text-foreground`, `bg-muted`, `text-muted-foreground`) — no hardcoded colors, works in both light and dark mode of the active theme

## Test plan

- [ ] Open Training page on a multi-week program
- [ ] Confirm chevrons render heavier / more button-like next to the WEEK heading
- [ ] Confirm hover shows a circular muted-warm-tan halo on desktop
- [ ] Confirm Week 1: left chevron is clearly disabled (40% opacity + not-allowed cursor) and final week: right chevron is clearly disabled
- [ ] Confirm both buttons measure ≥ 44×44 in dev tools
- [ ] Confirm keyboard tab focus shows the `doom-focus-ring` and arrows still navigate weeks via Enter
- [ ] Confirm screen reader announces "Previous week" / "Next week"

Fixes #703