### PR TITLE
fix(ux): drop redundant chevron on completed workout rows

### DIFF
--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -140,9 +140,9 @@ export default function WorkoutCard({
               <span className="p-1 text-muted-foreground">
                 {expanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
               </span>
-            ) : (
+            ) : isSkipped ? (
               <ChevronRight size={18} className="text-muted-foreground" />
-            )}
+            ) : null}
           </div>
         </div>
       </button>


### PR DESCRIPTION
## Summary
- Drop the right-chevron from completed-workout rows on the Training page; the green check chip is now the sole right-side indicator.
- In-progress (`draft`), pending, and skipped rows are unchanged — they keep their existing chevron treatment.
- Tap-target behavior is preserved (full-row button); only the visual indicator shifts.

## Motivation
Completed rows previously stacked a green check chip and a `ChevronRight`, which read as "done, but also tap to enter." Dropping the chevron removes the redundant affordance so the row clearly reads as "done."

## Diff scope
Single 2-line change in `components/workout/WorkoutCard.tsx`: the trailing chevron in the non-actionable branch now renders only when `isSkipped`, returning `null` for completed rows.

## Test plan
- [ ] Training page — completed workouts (`status === 'completed'`) show only the check chip on the right
- [ ] In-progress workouts still show the `CONTINUE` chip + chevron
- [ ] Pending workouts still show the chevron
- [ ] Skipped workouts still show `SKIPPED` text + chevron (untouched)
- [ ] Keyboard focus ring and screen-reader labels are intact (no aria changes)
- [ ] Looks correct in both light and dark mode of DOOM theme

Fixes #704