### PR TITLE
feat(ui): split dashed-border into TipAnnotation + CreateNewCard primitives

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -280,6 +280,16 @@ The default button is the **gameboy-pressed primary**: solid emerald background,
 - **Internal Padding:** `16px 20px` baseline; `24px` for larger panels.
 - **Texture (optional):** The `doom-noise` utility overlays a low-opacity (≈3%) SVG fractal noise pattern on the surface to give the parchment its paper grain. Apply on hero panels and modal surfaces, skip on dense list items.
 
+### Dashed vs Solid Border Treatment
+
+The dashed-border idiom carries **two distinct semantics** and must not be conflated. The two patterns are visually distinct primitives and must stay that way; merging them collapses a meaningful signal the user reads at a glance.
+
+- **Dashed (1px) → field-guide tip annotation.** Reserved for small inline notes the user can read past: the "First time doing this one" empty-history note, the RIR/RPE helper at the bottom of the intensity drawer, the "Your program is ready" first-run message on the Training page. Use the `<TipAnnotation>` primitive (`components/ui/TipAnnotation.tsx`) — never hand-roll the `border border-dashed border-border/40 bg-muted/35` className. The `variant="first-run"` rendering adds a `TIP` parallelogram-clipped sticker, swaps the icon for a small inline frog ornament, and applies the `doom-noise` paper-grain overlay. Per the Adult-Newcomer Rule, the frog only appears in `first-run` — it does not propagate into the default variant.
+
+- **Solid (2px) → create-new affordance.** Reserved for empty containers that invite the user to add something: `+ CREATE NEW PROGRAM` on the Programs page, `+ ADD SET (CLONES LAST)` in the program builder. Use the `<CreateNewCard>` primitive (`components/ui/CreateNewCard.tsx`) — never hand-roll the `border-2 border-border + Plus icon + uppercase Rajdhani label` pattern. The `locked` prop swaps the icon for a `Lock` and applies `cursor-not-allowed` for premium-gated create flows.
+
+If a new pattern needs an "empty frame" treatment that is neither a tip annotation nor a create-new affordance — e.g. a "request a program" empty-state placeholder, or a drag-drop file upload zone — **propose a third primitive** rather than reusing either of the existing two. Each new register requires an explicit decision; the dashed/solid pair holds because both readings are scarce.
+
 ### Inputs
 
 - **Shape:** Sharp 0-radius. 2px sandy-brown border at rest. Warm-tan `#F5EFE6` background.

--- a/components/admin/MediaUploader.tsx
+++ b/components/admin/MediaUploader.tsx
@@ -62,13 +62,22 @@ export default function MediaUploader({ onInsert }: MediaUploaderProps) {
       <span className="block text-xs font-semibold text-muted-foreground mb-1 uppercase tracking-wider">
         Media Upload
       </span>
+      {/*
+        Drag-drop file upload zone.
+        Semantically a "create-new" affordance (empty container inviting an upload),
+        not a tip annotation — so it uses the solid-2px-border treatment shared
+        with <CreateNewCard>. Kept as raw markup rather than wrapped in the primitive
+        because the body content swaps between three states (idle / uploading / preview)
+        and the children include a hidden file input + a preview <img>.
+        See DESIGN.md §5 Components — Dashed vs Solid.
+      */}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: file upload drop zone with hidden input */}
       <div
         role="button"
         tabIndex={0}
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
-        className="border-2 border-dashed border-border p-4 text-center hover:border-primary transition-colors cursor-pointer"
+        className="border-2 border-border p-4 text-center hover:border-primary hover:bg-muted/40 transition-colors cursor-pointer"
         onClick={() => fileRef.current?.click()}
       >
         <input

--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -227,7 +227,14 @@ export default function CommunityProgramsView({
               ))}
             </div>
 
-            {/* Request a Program prompt */}
+            {/*
+              "Request a program" prompt. This is an *empty-state placeholder*
+              — not a create-new affordance and not a tip annotation. The
+              dashed border is doing a third job here: signalling "this
+              region is a placeholder, not a real card." Kept as raw markup
+              with this comment so future cleanup doesn't mis-classify it.
+              See DESIGN.md §5 Components — Dashed vs Solid.
+            */}
             <div className="border-2 border-dashed border-border bg-card/50 p-6 sm:p-8 text-center mb-8">
               <p className="text-sm sm:text-base text-muted-foreground mb-4">
                 Looking for something specific?

--- a/components/exercise-selection/SetConfigurationInterface.tsx
+++ b/components/exercise-selection/SetConfigurationInterface.tsx
@@ -2,6 +2,7 @@
 
 import { Plus, Trash } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
+import { CreateNewCard } from '@/components/ui/CreateNewCard'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useUserSettings } from '@/hooks/useUserSettings'
@@ -498,14 +499,11 @@ export function SetConfigurationInterface({
               </div>
 
               {/* Add Set Button */}
-              <button
-                type="button"
+              <CreateNewCard
                 onClick={handleAddSet}
-                className="w-full mt-2 py-2.5 border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary transition-colors flex items-center justify-center gap-2 text-base font-bold uppercase tracking-wider"
-              >
-                <Plus size={16} />
-                ADD SET (CLONES LAST)
-              </button>
+                label="ADD SET (CLONES LAST)"
+                className="mt-2"
+              />
             </div>
 
           </div>

--- a/components/programs/MyProgramsList.tsx
+++ b/components/programs/MyProgramsList.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { ChevronDown, ChevronRight, Copy, Lock, Pencil, Plus, Star, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, Copy, Lock, Pencil, Star, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useToast } from '@/components/ToastProvider'
+import { CreateNewCard } from '@/components/ui/CreateNewCard'
 import { clientLogger } from '@/lib/client-logger'
 import ActivationConfirmModal from './ActivationConfirmModal'
 
@@ -318,13 +319,7 @@ function CreateProgramRow({
   if (hasAccess) {
     return (
       <div className="space-y-1">
-        <Link
-          href="/programs/new"
-          className="flex items-center justify-center gap-2 w-full py-3 border-2 border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary transition-all text-sm font-semibold uppercase tracking-wider doom-focus-ring"
-        >
-          <Plus size={16} />
-          CREATE NEW PROGRAM
-        </Link>
+        <CreateNewCard href="/programs/new" label="CREATE NEW PROGRAM" />
         {!bypassLimit && (
           <p className="text-sm text-muted-foreground text-center">
             {programCount} of {maxPrograms} program slots used
@@ -336,14 +331,11 @@ function CreateProgramRow({
 
   return (
     <div className="space-y-1">
-      <button
-        type="button"
+      <CreateNewCard
+        label="CREATE NEW PROGRAM"
+        locked
         onClick={onPremiumGate}
-        className="flex items-center justify-center gap-2 w-full py-3 border-2 border-dashed border-border text-muted-foreground hover:text-muted-foreground/80 transition-all text-sm font-semibold uppercase tracking-wider doom-focus-ring cursor-not-allowed opacity-70"
-      >
-        <Lock size={16} />
-        CREATE NEW PROGRAM
-      </button>
+      />
       <p className="text-sm text-muted-foreground text-center">
         {programCount} of {maxPrograms} program slots used
       </p>

--- a/components/ui/CreateNewCard.tsx
+++ b/components/ui/CreateNewCard.tsx
@@ -28,6 +28,11 @@ interface CreateNewCardProps {
   href?: string
   /** Button mode — renders as a <button>. Pass either onClick OR href. */
   onClick?: () => void
+  /**
+   * Disables the card. When combined with `href`, the card falls back to
+   * `<button disabled>` (no navigation) — the inert disabled state wins over
+   * the anchor mode by design.
+   */
   disabled?: boolean
   /**
    * Locked variant — shows a Lock icon, applies cursor-not-allowed/opacity,

--- a/components/ui/CreateNewCard.tsx
+++ b/components/ui/CreateNewCard.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Lock, Plus } from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+/**
+ * Create-new affordance primitive.
+ *
+ * Renders the solid-2px-sandy-border + "+" icon + uppercase-label treatment
+ * reserved for empty containers that invite the user to add something
+ * (a new program, a new exercise, a new set). This is the *visually
+ * distinct sibling* of <TipAnnotation>:
+ *
+ *   - <TipAnnotation>: 1px dashed border → "field-guide tip"
+ *   - <CreateNewCard>: 2px solid border  → "empty frame, add something here"
+ *
+ * The two patterns must remain visually distinct. If a new pattern needs
+ * an "empty frame" treatment, propose a third primitive — don't reuse either.
+ * See DESIGN.md §5 Components — Dashed vs Solid.
+ */
+
+interface CreateNewCardProps {
+  label: string
+  /** Custom icon. Defaults to <Plus size={16} /> (or <Lock> when locked). */
+  icon?: ReactNode
+  /** Anchor mode — renders as a <Link>. Pass either href OR onClick, not both. */
+  href?: string
+  /** Button mode — renders as a <button>. Pass either onClick OR href. */
+  onClick?: () => void
+  disabled?: boolean
+  /**
+   * Locked variant — shows a Lock icon, applies cursor-not-allowed/opacity,
+   * and renders as a button (typically wired to a premium-gate handler).
+   */
+  locked?: boolean
+  /** Extra className merged into the element. */
+  className?: string
+  /** Accessible label override for icon-only contexts. Defaults to `label`. */
+  'aria-label'?: string
+}
+
+export function CreateNewCard({
+  label,
+  icon,
+  href,
+  onClick,
+  disabled = false,
+  locked = false,
+  className = '',
+  'aria-label': ariaLabel,
+}: CreateNewCardProps) {
+  const baseClass =
+    'flex items-center justify-center gap-2 w-full py-3 border-2 border-border bg-transparent text-muted-foreground transition-all text-sm font-semibold uppercase tracking-wider doom-focus-ring'
+
+  const interactiveClass = locked
+    ? 'hover:text-muted-foreground/80 cursor-not-allowed opacity-70'
+    : 'hover:bg-muted/40 hover:border-primary hover:text-foreground'
+
+  const combinedClass = [baseClass, interactiveClass, className]
+    .filter(Boolean)
+    .join(' ')
+
+  const iconNode = icon ?? (locked ? <Lock size={16} /> : <Plus size={16} />)
+
+  // Anchor mode — only when an href is given and the card isn't locked/disabled.
+  if (href && !locked && !disabled) {
+    return (
+      <Link href={href} className={combinedClass} aria-label={ariaLabel ?? label}>
+        {iconNode}
+        {label}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={combinedClass}
+      aria-label={ariaLabel ?? label}
+    >
+      {iconNode}
+      {label}
+    </button>
+  )
+}

--- a/components/ui/MessageCard.tsx
+++ b/components/ui/MessageCard.tsx
@@ -3,6 +3,7 @@
 import { ChevronRight, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { MessageMarkdown } from '@/components/ui/MessageMarkdown'
+import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import { MESSAGE_ICONS } from '@/lib/icons/message-icons'
 
 export interface MessageSlide {
@@ -75,77 +76,74 @@ export function MessageCard({
     setSlideIndex((prev) => (prev + 1) % slides.length)
   }, [slides.length])
 
-  return (
-    <div
-      role="note"
-      className="relative p-3.5 border border-dashed border-border/40 bg-muted/35"
+  const dismissButton = isDismissable ? (
+    <button
+      type="button"
+      onClick={() => onDismiss(message.id)}
+      className={`absolute p-2 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring z-10 ${
+        isCarousel ? 'top-1.5 left-1.5' : 'top-1.5 right-1.5'
+      }`}
+      aria-label="Dismiss"
     >
-      {isDismissable && (
-        <button
-          type="button"
-          onClick={() => onDismiss(message.id)}
-          className={`absolute p-2 text-muted-foreground hover:text-foreground transition-colors doom-focus-ring z-10 ${
-            isCarousel ? 'top-1.5 left-1.5' : 'top-1.5 right-1.5'
-          }`}
-          aria-label="Dismiss"
-        >
-          <X size={16} />
-        </button>
-      )}
+      <X size={16} />
+    </button>
+  ) : null
 
-      <div className={`flex items-start gap-2.5 ${isDismissable && isCarousel ? 'pl-6' : ''}`}>
-        <Icon
-          aria-hidden="true"
-          size={18}
-          strokeWidth={1.8}
-          className="shrink-0 mt-[5px] text-muted-foreground"
-        />
-        <div
-          aria-live="polite"
-          className={`text-lg leading-relaxed text-muted-foreground flex-1 ${
-            isDismissable || isCarousel ? 'pr-6' : ''
-          }`}
-        >
-          <MessageMarkdown content={currentSlide.content} />
-        </div>
-      </div>
+  const carouselOverlay = isCarousel ? (
+    <>
+      <span className="absolute bottom-1.5 left-3.5 text-[10px] text-muted-foreground/40">
+        {slideIndex + 1}/{slides.length}
+      </span>
+      <button
+        type="button"
+        onClick={goNext}
+        className="absolute right-0 top-0 bottom-0 w-10 flex items-center justify-end pr-2 doom-focus-ring"
+        style={{
+          background:
+            'linear-gradient(to right, transparent, color-mix(in srgb, var(--muted) 85%, transparent) 40%)',
+        }}
+        aria-label="Next slide"
+      >
+        <ChevronRight size={16} className="text-muted-foreground/60" />
+      </button>
+    </>
+  ) : null
 
-      {/* Carousel: right arrow + subtle counter */}
-      {isCarousel && (
+  const multiMessageNav = !isCarousel && hasMultiMessageNav ? (
+    <button
+      type="button"
+      onClick={onNextTip}
+      className="absolute right-0 top-0 bottom-0 w-10 flex items-center justify-end pr-2 doom-focus-ring"
+      style={{
+        background:
+          'linear-gradient(to right, transparent, color-mix(in srgb, var(--muted) 85%, transparent) 40%)',
+      }}
+      aria-label="Next tip"
+    >
+      <ChevronRight size={16} className="text-muted-foreground/60" />
+    </button>
+  ) : null
+
+  return (
+    <TipAnnotation
+      icon={<Icon aria-hidden="true" size={16} strokeWidth={1.8} />}
+      overlay={
         <>
-          <span className="absolute bottom-1.5 left-3.5 text-[10px] text-muted-foreground/40">
-            {slideIndex + 1}/{slides.length}
-          </span>
-          <button
-            type="button"
-            onClick={goNext}
-            className="absolute right-0 top-0 bottom-0 w-10 flex items-center justify-end pr-2 doom-focus-ring"
-            style={{
-              background:
-                'linear-gradient(to right, transparent, color-mix(in srgb, var(--muted) 85%, transparent) 40%)',
-            }}
-            aria-label="Next slide"
-          >
-            <ChevronRight size={16} className="text-muted-foreground/60" />
-          </button>
+          {dismissButton}
+          {carouselOverlay}
+          {multiMessageNav}
         </>
-      )}
-
-      {/* Multi-message navigation (logger tip rotation across different messages) */}
-      {!isCarousel && hasMultiMessageNav && (
-        <button
-          type="button"
-          onClick={onNextTip}
-          className="absolute right-0 top-0 bottom-0 w-10 flex items-center justify-end pr-2 doom-focus-ring"
-          style={{
-            background:
-              'linear-gradient(to right, transparent, color-mix(in srgb, var(--muted) 85%, transparent) 40%)',
-          }}
-          aria-label="Next tip"
-        >
-          <ChevronRight size={16} className="text-muted-foreground/60" />
-        </button>
-      )}
-    </div>
+      }
+      className={isDismissable && isCarousel ? 'pl-6' : ''}
+    >
+      <div
+        aria-live="polite"
+        className={`text-lg leading-relaxed text-muted-foreground ${
+          isDismissable || isCarousel ? 'pr-6' : ''
+        }`}
+      >
+        <MessageMarkdown content={currentSlide.content} />
+      </div>
+    </TipAnnotation>
   )
 }

--- a/components/ui/TipAnnotation.tsx
+++ b/components/ui/TipAnnotation.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { Lightbulb } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useThemeMode } from '@/hooks/useThemeMode'
+
+/**
+ * Field-guide tip annotation primitive.
+ *
+ * Renders the dashed-sandy-border + flex-icon-row treatment reserved for
+ * small inline notes the user can read past. This is the canonical
+ * dashed-border styling — solid-bordered "create-new" affordances use
+ * <CreateNewCard> instead (see DESIGN.md §5 Components — Dashed vs Solid).
+ *
+ * IMPORTANT: per The Adult-Newcomer Rule (DESIGN.md §1), the frog mascot
+ * only appears in the `variant="first-run"` rendering. Do NOT propagate
+ * the frog into the default variant or any other "tip" surface — it
+ * belongs only on empty-state-adjacent, first-time contexts.
+ */
+
+interface TipAnnotationProps {
+  children: ReactNode
+  /** Custom icon. Defaults to <Lightbulb size={16} />. Ignored when variant="first-run" (the frog ornament replaces the icon). */
+  icon?: ReactNode
+  /**
+   * - `default`: dashed border + icon + content. Use for everyday tips.
+   * - `first-run`: adds a TIP sticker overlap, swaps icon for a small inline frog ornament,
+   *   and applies the paper-grain overlay. Use only on first-time / empty-state-adjacent contexts.
+   */
+  variant?: 'default' | 'first-run'
+  /**
+   * Optional content rendered as a sibling of the icon+content row inside the wrapper.
+   * Used for absolute-positioned interactive elements (e.g. the dismiss button or
+   * carousel arrow on <MessageCard>). The wrapper is `position: relative` so children
+   * passed here can position themselves freely.
+   */
+  overlay?: ReactNode
+  /** Extra className merged into the wrapper. */
+  className?: string
+}
+
+export function TipAnnotation({
+  children,
+  icon,
+  variant = 'default',
+  overlay,
+  className = '',
+}: TipAnnotationProps) {
+  const isFirstRun = variant === 'first-run'
+  const wrapperClass = [
+    'relative p-3 border border-dashed border-border/40 bg-muted/35 flex items-start gap-2.5',
+    isFirstRun ? 'doom-noise' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div role="note" className={wrapperClass}>
+      {isFirstRun && <TipSticker />}
+      {isFirstRun ? (
+        <StillFrog className="shrink-0 mt-[1px]" />
+      ) : (
+        <span className="shrink-0 mt-[3px] text-muted-foreground inline-flex">
+          {icon ?? <Lightbulb size={16} strokeWidth={1.8} aria-hidden="true" />}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">{children}</div>
+      {overlay}
+    </div>
+  )
+}
+
+/**
+ * The "TIP" stamp sticker that overlaps the top-left of the dashed border on
+ * the first-run variant. Same parallelogram-clip shape language as <doom-badge>.
+ */
+function TipSticker() {
+  return (
+    <span
+      aria-hidden="true"
+      className="absolute -top-2 left-2 px-2 py-[2px] bg-primary text-primary-foreground font-bold leading-none z-10"
+      style={{
+        fontFamily: 'Rajdhani, sans-serif',
+        fontSize: '0.7rem',
+        letterSpacing: '0.1em',
+        textTransform: 'uppercase',
+        // Same parallelogram chamfer as .doom-badge in app/globals.css
+        clipPath: 'polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%)',
+      }}
+    >
+      Tip
+    </span>
+  )
+}
+
+/**
+ * A still (non-animated) frog ornament. Uses the first frame of the
+ * 5-frame squat sprite by clipping the backgroundSize. Mirrors the
+ * light/dark sprite selection logic in <LoadingFrog>.
+ */
+function StillFrog({ className = '' }: { className?: string }) {
+  const mode = useThemeMode()
+  const spriteUrl =
+    mode === 'light' ? '/green-frog-squat-1-light.png' : '/green-frog-squat-1.png'
+
+  return (
+    <div
+      aria-hidden="true"
+      className={className}
+      style={{
+        width: '28px',
+        height: '28px',
+        backgroundImage: `url(${spriteUrl})`,
+        // Sprite is 5 frames horizontally; show only the first.
+        backgroundSize: '140px 28px',
+        backgroundPosition: '0 0',
+        backgroundRepeat: 'no-repeat',
+      }}
+    />
+  )
+}

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -6,6 +6,7 @@ import { LoadingFrog } from '@/components/ui/loading-frog'
 import type { MessageData } from '@/components/ui/MessageCard'
 import { MessageCard } from '@/components/ui/MessageCard'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/tabs'
+import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/types/workout'
 import ExerciseInfoContent from './ExerciseInfoContent'
@@ -179,20 +180,13 @@ export default function ExerciseDisplayTabs({
           </div>
         ) : !exerciseHistory ? (
           <div className="flex items-center justify-center h-full py-12">
-            <div
-              role="note"
-              className="flex items-start gap-2.5 p-3.5 border border-dashed border-border/40 bg-muted/35"
+            <TipAnnotation
+              icon={<Sparkles aria-hidden="true" size={16} strokeWidth={1.8} />}
             >
-              <Sparkles
-                aria-hidden="true"
-                size={18}
-                className="shrink-0 mt-[5px] text-muted-foreground"
-                strokeWidth={1.8}
-              />
-              <span className="text-lg leading-relaxed text-muted-foreground">
+              <span className="text-base leading-relaxed text-muted-foreground">
                 First time doing this one. Log a set and your history starts here.
               </span>
-            </div>
+            </TipAnnotation>
           </div>
         ) : (
           <div className="space-y-4">

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -183,7 +183,7 @@ export default function ExerciseDisplayTabs({
             <TipAnnotation
               icon={<Sparkles aria-hidden="true" size={16} strokeWidth={1.8} />}
             >
-              <span className="text-base leading-relaxed text-muted-foreground">
+              <span className="text-lg leading-relaxed text-muted-foreground">
                 First time doing this one. Log a set and your history starts here.
               </span>
             </TipAnnotation>

--- a/components/workout-logging/inputs/IntensitySelector.tsx
+++ b/components/workout-logging/inputs/IntensitySelector.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import { type IntensityPreset, RIR_PRESETS, RPE_PRESETS } from '@/lib/constants/intensity-presets'
 
 interface IntensitySelectorProps {
@@ -118,28 +119,32 @@ export function IntensitySelector({
       </div>
 
       {/* Info blurb */}
-      <div className="mt-3 p-3.5 border border-dashed border-border/40 bg-muted/35 flex items-start gap-2.5">
-        <svg
-          aria-hidden="true"
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          className="shrink-0 mt-[5px] stroke-muted-foreground"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M9 18h6" />
-          <path d="M10 22h4" />
-          <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5C8.35 12.26 8.82 13.02 9 14" />
-        </svg>
+      <TipAnnotation
+        className="mt-3"
+        icon={
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M9 18h6" />
+            <path d="M10 22h4" />
+            <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5C8.35 12.26 8.82 13.02 9 14" />
+          </svg>
+        }
+      >
         <span className="text-sm leading-relaxed text-muted-foreground">
           {type === 'rir'
             ? 'Reps in Reserve: How many more reps you think you could have done after stopping your set.'
             : 'Rate of Perceived Exertion: How hard did the last set feel?'}
         </span>
-      </div>
+      </TipAnnotation>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Split the overloaded dashed-border idiom into two semantically distinct primitives so the visual signal is clear at a glance, and document the convention in `DESIGN.md §5`.

- `<TipAnnotation>` (`components/ui/TipAnnotation.tsx`) — 1px dashed border + icon + content. The field-guide tip annotation register: small inline notes the user can read past. The `variant="first-run"` rendering adds a parallelogram-clipped `TIP` sticker overlapping the top-left, swaps the icon for a still frog ornament (light/dark aware), and applies the `doom-noise` paper-grain overlay. Absorbs the scope of #702.
- `<CreateNewCard>` (`components/ui/CreateNewCard.tsx`) — 2px solid border + `+` icon + uppercase Rajdhani label. The create-new register: empty containers that invite the user to add something. Anchor / button / `locked` modes (`locked` swaps to a `Lock` icon and applies `cursor-not-allowed`).

Migrated:

- **Tip sites** → `<TipAnnotation>`: `MessageCard` (the dashed wrapper with dismiss + carousel overlays, preserved via `overlay` prop), `ExerciseDisplayTabs` first-time-history empty note, `IntensitySelector` RIR/RPE helper.
- **Create-new sites** → `<CreateNewCard>`: `MyProgramsList` (`CREATE NEW PROGRAM`, has-access + locked variants), `SetConfigurationInterface` (`ADD SET (CLONES LAST)`).
- **Audited**: `MediaUploader` drag-drop classified as create-new (solid 2px border applied, kept as raw markup since body swaps across idle/uploading/preview states); `CommunityProgramsView` request-a-program prompt classified as a third "empty-state placeholder" register, kept as raw markup with classifying comment per DESIGN.md guidance to propose a third primitive rather than reuse either of the two.

## Design rule added

`DESIGN.md §5 Components — Dashed vs Solid` documents the two-pattern split and the "propose a third primitive" guidance for any future empty-frame register. Embedded code comments in the two raw-markup sites point back to this section.

## Adult-Newcomer Rule guard

The frog ornament only appears in `<TipAnnotation variant="first-run">`. Embedded code comment in `TipAnnotation.tsx` calls this out so future agents don't propagate the frog into the default variant.

## Test plan

- [ ] Visual: `<TipAnnotation>` default (lightbulb + dashed border + muted body) still reads as a field-guide tip on the IntensitySelector RIR drawer, the "First time doing this one" empty-history note, and inside `<MessageCard>` (dismiss / carousel / next-tip overlays survive via the `overlay` prop).
- [ ] Visual: `<TipAnnotation variant="first-run">` renders the TIP sticker overlapping the top-left of the dashed border, swaps the icon for the still frog (correct sprite for light vs dark mode), and applies the paper-grain overlay. *(Note: no call site currently uses `first-run` — wiring the Training-page first-run message is a follow-up; this PR ships the primitive ready to use.)*
- [ ] Visual: `<CreateNewCard>` renders 2px solid sandy-brown border that shifts to primary-emerald on hover, on the Programs page `CREATE NEW PROGRAM` (has-access + locked) and the program-builder `ADD SET (CLONES LAST)` button.
- [ ] Visual: MediaUploader drop zone now renders with a solid 2px border (previously dashed); idle/uploading/preview state machine still works.
- [ ] Visual: Community page "request a program" prompt visually unchanged (kept as raw markup with classifying comment).
- [ ] Verify across themes (light + dark, ripit + a cold-neutral theme like doom or cyber) once `/dev/theme-validator` lands (#723). Until then, spot-check ripit-light and doom-dark.
- [ ] No regression: dashed and solid treatments are clearly distinct at a glance.
- [ ] `npm run type-check` clean.
- [ ] `npm run lint` shows no *new* errors/warnings introduced by this PR (pre-existing `react-hooks/set-state-in-effect` errors in `MessageCard`, `ExerciseDisplayTabs`, and the unused `variant` prop warning all predate this PR).
- [ ] `npm test` passes.

## Related

- Absorbs #702 (TIP sticker + frog + paper grain spec is built into `variant="first-run"`).
- Absorbs #717 (this PR *is* the dashed/solid split + DESIGN.md doc update).
- Phase 0 of the primitives sweep; lands in parallel with #729 (Button) and #730 (SegmentedControl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)