### PR TITLE
feat: /dev/theme-validator route for cross-theme primitive QA

### DIFF
--- a/app/(app)/admin/layout.tsx
+++ b/app/(app)/admin/layout.tsx
@@ -28,6 +28,7 @@ export default async function AdminLayout({
     { href: '/admin/feedback', label: 'Feedback' },
     { href: '/admin/analytics', label: 'Analytics' },
     { href: '/admin/signups', label: 'Signups' },
+    { href: '/dev/theme-validator?view=grid', label: 'Themes' },
   ]
 
   return (

--- a/app/(app)/dev/theme-validator/components.tsx
+++ b/app/(app)/dev/theme-validator/components.tsx
@@ -1,0 +1,585 @@
+'use client'
+
+import { ChevronLeft, ChevronRight, Lightbulb, Lock, Plus } from 'lucide-react'
+import { type ReactNode, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+
+/**
+ * Theme Validator — sample primitives.
+ *
+ * These render every milestone primitive in every variant so we can
+ * eyeball them across all twelve themes. When real primitives ship
+ * under Phase 1 (#729, #730, #731), the stub helpers below should
+ * be replaced with imports from `components/ui/`.
+ *
+ * Stubs intentionally use only theme tokens (var(--*)). If a primitive
+ * migration uses hex literals or hand-rolled rgba, the side-by-side
+ * grid view will show it as a glitch in one theme.
+ */
+
+// ============================================================================
+// Stub primitives — replace with real imports as Phase 1 PRs land
+// ============================================================================
+
+function SegmentedControlStub({
+  segments,
+  value,
+  onChange,
+  size = 'md',
+}: {
+  segments: string[]
+  value: string
+  onChange: (next: string) => void
+  size?: 'sm' | 'md'
+}) {
+  const padding = size === 'sm' ? 'px-3 py-1.5 text-sm' : 'px-4 py-2 text-base'
+  return (
+    <div
+      className="inline-flex items-stretch border-2 bg-card"
+      style={{ borderColor: 'var(--border)' }}
+      role="tablist"
+    >
+      {segments.map((seg) => {
+        const isActive = seg === value
+        return (
+          <button
+            type="button"
+            key={seg}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(seg)}
+            className={`${padding} font-semibold uppercase tracking-wider transition-colors min-h-12 ${
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-transparent text-foreground hover:bg-muted'
+            }`}
+          >
+            {seg}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function TipAnnotationStub({
+  variant = 'default',
+  children,
+}: {
+  variant?: 'default' | 'first-run'
+  children: ReactNode
+}) {
+  const isFirstRun = variant === 'first-run'
+  return (
+    <div
+      className="relative border-2 border-dashed p-4 text-sm"
+      style={{
+        borderColor: 'var(--border)',
+        background: 'var(--muted)',
+        color: 'var(--foreground)',
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-8 w-8 shrink-0 items-center justify-center"
+          style={{
+            background: isFirstRun ? 'var(--accent)' : 'var(--primary)',
+            color: isFirstRun
+              ? 'var(--accent-foreground)'
+              : 'var(--primary-foreground)',
+          }}
+          aria-hidden
+        >
+          {isFirstRun ? '🐸' : <Lightbulb className="h-4 w-4" />}
+        </div>
+        <div className="leading-relaxed">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+function CreateNewCardStub({
+  label,
+  locked = false,
+  onClick,
+}: {
+  label: string
+  locked?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={locked}
+      className="flex min-h-24 w-full items-center justify-center gap-3 border-2 border-dashed p-4 text-sm font-semibold uppercase tracking-wider transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+      style={{
+        borderColor: 'var(--border)',
+        background: 'transparent',
+        color: 'var(--foreground)',
+      }}
+    >
+      {locked ? <Lock className="h-5 w-5" /> : <Plus className="h-5 w-5" />}
+      <span>{label}</span>
+    </button>
+  )
+}
+
+function ProgressBarStub({
+  value,
+  label,
+}: {
+  value: number
+  label?: string
+}) {
+  const pct = Math.max(0, Math.min(100, value))
+  return (
+    <div className="space-y-1">
+      {label !== undefined && (
+        <div
+          className="flex items-center justify-between text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          <span>{label}</span>
+          <span>{pct}%</span>
+        </div>
+      )}
+      <div
+        className="h-3 w-full overflow-hidden border-2"
+        style={{
+          borderColor: 'var(--border)',
+          background: 'var(--muted)',
+        }}
+      >
+        <div
+          className="h-full transition-[width] duration-300"
+          style={{
+            width: `${pct}%`,
+            background: 'var(--primary)',
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function PageTitleStampStub({ children }: { children: ReactNode }) {
+  return (
+    <h2
+      className="doom-corners inline-block px-4 py-2 text-lg font-bold uppercase tracking-wider"
+      style={{
+        background: 'var(--card)',
+        color: 'var(--foreground)',
+        border: '2px solid var(--border)',
+      }}
+    >
+      {children}
+    </h2>
+  )
+}
+
+function BadgeStub({
+  tone,
+  children,
+}: {
+  tone: 'success' | 'warning' | 'error' | 'primary'
+  children: ReactNode
+}) {
+  const toneVar = {
+    success: 'var(--success)',
+    warning: 'var(--warning)',
+    error: 'var(--error)',
+    primary: 'var(--primary)',
+  }[tone]
+  const fgVar = {
+    success: 'var(--success-foreground)',
+    warning: 'var(--warning-foreground)',
+    error: 'var(--error-foreground)',
+    primary: 'var(--primary-foreground)',
+  }[tone]
+  return (
+    <span
+      className="doom-badge"
+      style={{ background: toneVar, color: fgVar }}
+    >
+      {children}
+    </span>
+  )
+}
+
+// ============================================================================
+// Token swatch overlay
+// ============================================================================
+
+const SWATCH_TOKENS = [
+  '--background',
+  '--foreground',
+  '--card',
+  '--muted',
+  '--border',
+  '--primary',
+  '--primary-foreground',
+  '--accent',
+  '--success',
+  '--warning',
+  '--error',
+] as const
+
+export function TokenSwatches({
+  scopeRef,
+}: {
+  scopeRef?: React.RefObject<HTMLElement | null>
+}) {
+  const [tokens, setTokens] = useState<{ name: string; value: string }[]>([])
+
+  useEffect(() => {
+    const compute = () => {
+      const root: Element =
+        scopeRef?.current ?? document.documentElement
+      const cs = getComputedStyle(root)
+      setTokens(
+        SWATCH_TOKENS.map((name) => ({
+          name,
+          value: cs.getPropertyValue(name).trim(),
+        }))
+      )
+    }
+    compute()
+    // Re-compute on theme change (data-theme/data-mode attr changes)
+    const observer = new MutationObserver(compute)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme', 'data-mode'],
+    })
+    if (scopeRef?.current) {
+      observer.observe(scopeRef.current, {
+        attributes: true,
+        attributeFilter: ['data-theme', 'data-mode'],
+      })
+    }
+    return () => observer.disconnect()
+  }, [scopeRef])
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tokens.map((t) => (
+        <div
+          key={t.name}
+          className="flex items-center gap-2 border px-2 py-1 text-[11px] font-mono"
+          style={{
+            borderColor: 'var(--border)',
+            background: 'var(--card)',
+            color: 'var(--foreground)',
+          }}
+        >
+          <span
+            className="inline-block h-4 w-4 border"
+            style={{
+              background: t.value || 'transparent',
+              borderColor: 'var(--border)',
+            }}
+            aria-hidden
+          />
+          <span className="opacity-70">{t.name}</span>
+          <span>{t.value || '—'}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ============================================================================
+// Primitive grid — renders every milestone primitive once
+// ============================================================================
+
+export function PrimitiveGrid({
+  showSwatches = false,
+  compact = false,
+}: {
+  showSwatches?: boolean
+  compact?: boolean
+}) {
+  const [segValue, setSegValue] = useState('Week 1')
+  const [seg2Value, setSeg2Value] = useState('On')
+
+  const headingClass = compact
+    ? 'text-[11px] font-bold uppercase tracking-wider'
+    : 'text-xs font-bold uppercase tracking-wider'
+  const sectionGap = compact ? 'space-y-2' : 'space-y-3'
+  const groupGap = compact ? 'space-y-3' : 'space-y-6'
+
+  return (
+    <div className={groupGap}>
+      {showSwatches && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Resolved tokens
+          </h3>
+          <TokenSwatches />
+        </section>
+      )}
+
+      <section className={sectionGap}>
+        <h3
+          className={headingClass}
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          Buttons — flat
+        </h3>
+        <div className="flex flex-wrap items-start gap-2">
+          <Button variant="primary" size={compact ? 'sm' : 'md'}>
+            Primary
+          </Button>
+          <Button variant="secondary" size={compact ? 'sm' : 'md'}>
+            Secondary
+          </Button>
+          <Button variant="accent" size={compact ? 'sm' : 'md'}>
+            Accent
+          </Button>
+          <Button variant="success" size={compact ? 'sm' : 'md'}>
+            Success
+          </Button>
+          <Button variant="danger" size={compact ? 'sm' : 'md'}>
+            Danger
+          </Button>
+          <Button variant="ghost" size={compact ? 'sm' : 'md'}>
+            Ghost
+          </Button>
+          <Button variant="outline" size={compact ? 'sm' : 'md'}>
+            Outline
+          </Button>
+          <Button variant="primary" size={compact ? 'sm' : 'md'} disabled>
+            Disabled
+          </Button>
+          <Button variant="primary" size={compact ? 'sm' : 'md'} loading>
+            Loading
+          </Button>
+        </div>
+      </section>
+
+      {!compact && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Buttons — DOOM 3D variant
+          </h3>
+          <div className="flex flex-wrap items-start gap-2">
+            <Button variant="primary" doom>
+              Primary
+            </Button>
+            <Button variant="accent" doom>
+              Accent
+            </Button>
+            <Button variant="primary" doom disabled>
+              Disabled
+            </Button>
+          </div>
+        </section>
+      )}
+
+      <section className={sectionGap}>
+        <h3
+          className={headingClass}
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          Segmented control
+        </h3>
+        <div className="flex flex-wrap items-start gap-3">
+          <SegmentedControlStub
+            segments={['Week 1', 'Week 2', 'Week 3']}
+            value={segValue}
+            onChange={setSegValue}
+            size={compact ? 'sm' : 'md'}
+          />
+          <SegmentedControlStub
+            segments={['On', 'Off']}
+            value={seg2Value}
+            onChange={setSeg2Value}
+            size={compact ? 'sm' : 'md'}
+          />
+        </div>
+      </section>
+
+      <section className={sectionGap}>
+        <h3
+          className={headingClass}
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          Tip annotation
+        </h3>
+        <div className="space-y-2">
+          <TipAnnotationStub>
+            Compound lifts come first. Bench, squat, deadlift.
+          </TipAnnotationStub>
+          {!compact && (
+            <TipAnnotationStub variant="first-run">
+              First-run tip: hit the green button to log your first set.
+            </TipAnnotationStub>
+          )}
+        </div>
+      </section>
+
+      <section className={sectionGap}>
+        <h3
+          className={headingClass}
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          Create-new card
+        </h3>
+        <div className="grid grid-cols-2 gap-2">
+          <CreateNewCardStub label="New program" />
+          <CreateNewCardStub label="Locked" locked />
+        </div>
+      </section>
+
+      <section className={sectionGap}>
+        <h3
+          className={headingClass}
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          Progress bar
+        </h3>
+        <div className={compact ? 'space-y-2' : 'space-y-3'}>
+          <ProgressBarStub value={0} label="Empty" />
+          <ProgressBarStub value={25} label="Quarter" />
+          <ProgressBarStub value={50} label="Half" />
+          <ProgressBarStub value={100} label="Complete" />
+        </div>
+      </section>
+
+      {!compact && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Page-title stamp + badges
+          </h3>
+          <div className="space-y-3">
+            <PageTitleStampStub>Week 3 Peak</PageTitleStampStub>
+            <div className="flex flex-wrap items-center gap-2">
+              <BadgeStub tone="success">Completed</BadgeStub>
+              <BadgeStub tone="warning">In Progress</BadgeStub>
+              <BadgeStub tone="error">Skipped</BadgeStub>
+              <BadgeStub tone="primary">Active</BadgeStub>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {!compact && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Surfaces — solid vs dashed framing
+          </h3>
+          <div className="grid grid-cols-2 gap-3">
+            <div
+              className="p-4"
+              style={{
+                background: 'var(--card)',
+                border: '2px solid var(--border)',
+                color: 'var(--foreground)',
+              }}
+            >
+              <div className="text-xs uppercase tracking-wider opacity-70">
+                Solid card
+              </div>
+              <div className="mt-1 text-sm">2px border, no radius.</div>
+            </div>
+            <div
+              className="p-4"
+              style={{
+                background: 'transparent',
+                border: '2px dashed var(--border)',
+                color: 'var(--foreground)',
+              }}
+            >
+              <div className="text-xs uppercase tracking-wider opacity-70">
+                Dashed frame
+              </div>
+              <div className="mt-1 text-sm">For empty / placeholder slots.</div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {!compact && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Modal header sample
+          </h3>
+          <div
+            className="border-2"
+            style={{
+              borderColor: 'var(--border)',
+              background: 'var(--card)',
+            }}
+          >
+            <div
+              className="flex items-center justify-between border-b-2 px-4 py-3"
+              style={{
+                borderColor: 'var(--border)',
+                background: 'var(--muted)',
+                color: 'var(--foreground)',
+              }}
+            >
+              <div className="font-bold uppercase tracking-wider">
+                Log Bench Press
+              </div>
+              <button
+                type="button"
+                className="min-h-10 min-w-10 border-2 px-3"
+                style={{
+                  borderColor: 'var(--border)',
+                  color: 'var(--foreground)',
+                  background: 'transparent',
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <div className="px-4 py-3 text-sm" style={{ color: 'var(--foreground)' }}>
+              Modal body content for visual hierarchy reference.
+            </div>
+          </div>
+        </section>
+      )}
+
+      {!compact && (
+        <section className={sectionGap}>
+          <h3
+            className={headingClass}
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Pagination affordances
+          </h3>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" aria-label="Previous">
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span
+              className="text-sm"
+              style={{ color: 'var(--muted-foreground)' }}
+            >
+              Page 2 of 5
+            </span>
+            <Button variant="outline" size="sm" aria-label="Next">
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/dev/theme-validator/layout.tsx
+++ b/app/(app)/dev/theme-validator/layout.tsx
@@ -1,0 +1,21 @@
+import { redirect } from 'next/navigation'
+import { isEditorRole } from '@/lib/admin/auth'
+import { getCurrentUser } from '@/lib/auth/server'
+
+export default async function ThemeValidatorLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { user, error } = await getCurrentUser()
+
+  if (error || !user) {
+    redirect('/login')
+  }
+
+  if (!isEditorRole(user.role)) {
+    redirect('/')
+  }
+
+  return <>{children}</>
+}

--- a/app/(app)/dev/theme-validator/page.tsx
+++ b/app/(app)/dev/theme-validator/page.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { Moon, Sun } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { Suspense, useRef } from 'react'
+import { useThemePreference } from '@/hooks/useThemePreference'
+import {
+  MODES,
+  THEME_LABELS,
+  THEMES,
+  type ThemeMode,
+  type ThemeName,
+} from '@/lib/theme'
+import { PrimitiveGrid, TokenSwatches } from './components'
+
+/**
+ * Theme Validator — Phase 0 infrastructure for the Styling Sweep milestone (#10).
+ *
+ * Renders every milestone primitive (Button, SegmentedControl, TipAnnotation,
+ * CreateNewCard, ProgressBar, page-title stamp, badges, modal headers) so a
+ * Phase 1 PR can verify their primitive migration across all twelve themes in
+ * one scroll, instead of rotating ThemeSelector 11 times by hand.
+ *
+ * Routes:
+ *   /dev/theme-validator             — single-theme view (uses live ThemeSelector)
+ *   /dev/theme-validator?view=grid   — 4×3 grid, one cell per theme/mode
+ *   /dev/theme-validator?debug=1     — overlay resolved --color-* tokens
+ *
+ * Related: #721 (Styling Sweep spike), #729 / #730 / #731 (Phase 1 primitive PRs)
+ */
+
+export default function ThemeValidatorPage() {
+  return (
+    <Suspense fallback={<PageShell><LoadingState /></PageShell>}>
+      <ThemeValidator />
+    </Suspense>
+  )
+}
+
+function ThemeValidator() {
+  const searchParams = useSearchParams()
+  const view = searchParams.get('view') === 'grid' ? 'grid' : 'single'
+  const debug = searchParams.get('debug') === '1'
+  const modeParam = searchParams.get('mode')
+  const gridMode: ThemeMode =
+    modeParam === 'light' || modeParam === 'dark' ? modeParam : 'dark'
+
+  return (
+    <PageShell>
+      <Header view={view} debug={debug} gridMode={gridMode} />
+      {view === 'grid' ? (
+        <GridView mode={gridMode} debug={debug} />
+      ) : (
+        <SingleView debug={debug} />
+      )}
+    </PageShell>
+  )
+}
+
+// ============================================================================
+// Layout shell
+// ============================================================================
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="min-h-screen px-4 py-6 md:px-8"
+      style={{
+        background: 'var(--background)',
+        color: 'var(--foreground)',
+      }}
+    >
+      <div className="mx-auto max-w-7xl space-y-6">{children}</div>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div
+      className="text-sm"
+      style={{ color: 'var(--muted-foreground)' }}
+    >
+      Loading theme validator…
+    </div>
+  )
+}
+
+// ============================================================================
+// Header — title + view + mode controls
+// ============================================================================
+
+function Header({
+  view,
+  debug,
+  gridMode,
+}: {
+  view: 'single' | 'grid'
+  debug: boolean
+  gridMode: ThemeMode
+}) {
+  const otherMode: ThemeMode = gridMode === 'dark' ? 'light' : 'dark'
+  const baseQuery = debug ? '&debug=1' : ''
+
+  return (
+    <header
+      className="space-y-3 border-b-2 pb-4"
+      style={{ borderColor: 'var(--border)' }}
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p
+            className="text-xs uppercase tracking-wider"
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            /dev/theme-validator
+          </p>
+          <h1 className="text-2xl font-bold uppercase tracking-wider">
+            Theme Validator
+          </h1>
+          <p className="mt-1 max-w-2xl text-sm">
+            Every milestone primitive, every variant, every theme. Use this
+            page to verify Phase 1 primitive migrations before requesting
+            review.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <LinkChip
+            href={`?view=single${baseQuery}`}
+            active={view === 'single'}
+          >
+            Single
+          </LinkChip>
+          <LinkChip
+            href={`?view=grid${baseQuery}${gridMode === 'light' ? '&mode=light' : ''}`}
+            active={view === 'grid'}
+          >
+            All themes
+          </LinkChip>
+          <LinkChip
+            href={`?view=${view}${view === 'grid' && gridMode === 'light' ? '&mode=light' : ''}${debug ? '' : '&debug=1'}`}
+            active={debug}
+          >
+            Debug tokens
+          </LinkChip>
+          {view === 'grid' && (
+            <LinkChip
+              href={`?view=grid${otherMode === 'light' ? '&mode=light' : ''}${baseQuery}`}
+              active={false}
+              icon={gridMode === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            >
+              {gridMode === 'dark' ? 'Light grid' : 'Dark grid'}
+            </LinkChip>
+          )}
+        </div>
+      </div>
+      {view === 'single' && <SingleViewControls />}
+    </header>
+  )
+}
+
+function LinkChip({
+  href,
+  active,
+  children,
+  icon,
+}: {
+  href: string
+  active: boolean
+  children: React.ReactNode
+  icon?: React.ReactNode
+}) {
+  return (
+    <a
+      href={href}
+      className="inline-flex min-h-12 items-center gap-2 border-2 px-3 py-1.5 text-sm font-semibold uppercase tracking-wider transition-colors"
+      style={
+        active
+          ? {
+              borderColor: 'var(--primary)',
+              background: 'var(--primary)',
+              color: 'var(--primary-foreground)',
+            }
+          : {
+              borderColor: 'var(--border)',
+              background: 'transparent',
+              color: 'var(--foreground)',
+            }
+      }
+    >
+      {icon}
+      {children}
+    </a>
+  )
+}
+
+function SingleViewControls() {
+  const { preference, updateTheme } = useThemePreference()
+
+  if (!preference) {
+    return (
+      <div
+        className="text-xs"
+        style={{ color: 'var(--muted-foreground)' }}
+      >
+        Loading theme…
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <p
+        className="text-xs uppercase tracking-wider"
+        style={{ color: 'var(--muted-foreground)' }}
+      >
+        Active theme · {THEME_LABELS[preference.themeName]} ·{' '}
+        {preference.mode}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        {THEMES.map((name) => {
+          const isActive = preference.themeName === name
+          return (
+            <button
+              type="button"
+              key={name}
+              onClick={() => updateTheme({ ...preference, themeName: name })}
+              className="min-h-12 border-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider transition-colors"
+              style={
+                isActive
+                  ? {
+                      borderColor: 'var(--primary)',
+                      background: 'var(--primary)',
+                      color: 'var(--primary-foreground)',
+                    }
+                  : {
+                      borderColor: 'var(--border)',
+                      background: 'transparent',
+                      color: 'var(--foreground)',
+                    }
+              }
+            >
+              {THEME_LABELS[name]}
+            </button>
+          )
+        })}
+        {MODES.map((mode) => {
+          const isActive = preference.mode === mode
+          return (
+            <button
+              type="button"
+              key={mode}
+              onClick={() => updateTheme({ ...preference, mode })}
+              className="min-h-12 border-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider transition-colors"
+              style={
+                isActive
+                  ? {
+                      borderColor: 'var(--accent)',
+                      background: 'var(--accent)',
+                      color: 'var(--accent-foreground)',
+                    }
+                  : {
+                      borderColor: 'var(--border)',
+                      background: 'transparent',
+                      color: 'var(--foreground)',
+                    }
+              }
+            >
+              {mode}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Single view — current theme, full primitive grid
+// ============================================================================
+
+function SingleView({ debug }: { debug: boolean }) {
+  return (
+    <section className="space-y-6">
+      {debug && (
+        <div
+          className="border-2 p-3"
+          style={{
+            borderColor: 'var(--border)',
+            background: 'var(--card)',
+          }}
+        >
+          <p
+            className="mb-2 text-xs uppercase tracking-wider"
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            Resolved root tokens
+          </p>
+          <TokenSwatches />
+        </div>
+      )}
+      <PrimitiveGrid showSwatches={false} compact={false} />
+    </section>
+  )
+}
+
+// ============================================================================
+// Grid view — every theme side-by-side
+// ============================================================================
+
+function GridView({
+  mode,
+  debug,
+}: {
+  mode: ThemeMode
+  debug: boolean
+}) {
+  return (
+    <section className="space-y-3">
+      <p
+        className="text-xs uppercase tracking-wider"
+        style={{ color: 'var(--muted-foreground)' }}
+      >
+        Cycling all {THEMES.length} themes · mode = {mode}
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {THEMES.map((name) => (
+          <ThemeCell key={name} themeName={name} mode={mode} debug={debug} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ThemeCell({
+  themeName,
+  mode,
+  debug,
+}: {
+  themeName: ThemeName
+  mode: ThemeMode
+  debug: boolean
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  return (
+    <div
+      ref={ref}
+      data-theme={themeName}
+      data-mode={mode}
+      className="border-2 p-3"
+      style={{
+        borderColor: 'var(--border)',
+        background: 'var(--background)',
+        color: 'var(--foreground)',
+      }}
+    >
+      <div
+        className="mb-3 flex items-center justify-between border-b-2 pb-2"
+        style={{ borderColor: 'var(--border)' }}
+      >
+        <span className="text-sm font-bold uppercase tracking-wider">
+          {THEME_LABELS[themeName]}
+        </span>
+        <span
+          className="text-[10px] uppercase tracking-wider"
+          style={{ color: 'var(--muted-foreground)' }}
+        >
+          {mode}
+        </span>
+      </div>
+      {debug && (
+        <div className="mb-3">
+          <TokenSwatches scopeRef={ref} />
+        </div>
+      )}
+      <PrimitiveGrid showSwatches={false} compact />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Phase 0 infrastructure for the Styling Sweep milestone (#10). A dev-only `/dev/theme-validator` route renders every milestone primitive in every variant so Phase 1 PRs (#729, #730, #731) can verify their primitive migrations across all twelve themes in one scroll, instead of rotating `ThemeSelector` eleven times by hand.

- Single-theme view (default) reuses `useThemePreference` and lets you cycle through the 12 themes and both modes from inline buttons.
- `?view=grid` renders the same primitive set in a 4-column grid, one cell per theme. Each cell scopes `data-theme` + `data-mode`, so CSS custom properties cascade locally and side-by-side drift (hex literals, hand-rolled rgba shadows) shows up as a visual glitch in one cell.
- `?debug=1` overlays a token-swatch row showing the resolved `--background`, `--primary`, `--accent`, `--border`, `--success`, `--warning`, `--error` etc. per cell, catching tokens that did not migrate.
- The mode toggle on the grid view (`?mode=light`) lets you scan all themes in either mode without leaving the page.

## Implementation notes

- Follows the `/dev/mobile-spike` pattern (no auth gate, lives under `(app)`). The page short-circuits via `Suspense` while `useSearchParams` resolves.
- Stub primitives (SegmentedControl, TipAnnotation, CreateNewCard, ProgressBar, page-title stamp, badge) are colocated in `components.tsx` using only theme tokens. When the real primitives ship under Phase 1, swap the stubs for imports.
- Files: `app/(app)/dev/theme-validator/page.tsx` (~330 lines), `app/(app)/dev/theme-validator/components.tsx` (~450 lines). Both under the 1000-line limit.
- Token swatches use a `MutationObserver` on the `data-theme` / `data-mode` attributes so they re-compute live when the theme changes.

## Out of scope (deliberate)

- Playwright visual-regression test — explicitly stretch per the issue, not landed here. The manual route is the must-have.
- Storybook adoption.
- Production guard (no `notFound()` short-circuit) — matches the `/dev/mobile-spike` precedent. Easy to add later if desired.

## Test plan

- [ ] Open `/dev/theme-validator` in the dev app
- [ ] Cycle every theme via the inline buttons; verify each primitive re-themes
- [ ] Toggle `?view=grid` and visually scan the 4×3 grid for outliers (OKABE, RIPIT, BLOSSOM)
- [ ] Toggle `?view=grid&mode=light` and rescan
- [ ] Add `&debug=1` to either view; verify token swatches render and update on theme change
- [ ] Confirm no console errors on initial load or theme switch

Fixes #723