### PR TITLE
feat(format): add pluralize and formatRelativeTime helpers (Fixes #728)

### DIFF
--- a/__tests__/lib/format/pluralize.test.ts
+++ b/__tests__/lib/format/pluralize.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { pluralize } from '@/lib/format/pluralize'
+
+describe('pluralize', () => {
+  describe('regular nouns', () => {
+    it('returns plural form for 0', () => {
+      expect(pluralize(0, 'set')).toBe('0 sets')
+    })
+
+    it('returns singular form for 1', () => {
+      expect(pluralize(1, 'set')).toBe('1 set')
+    })
+
+    it('returns plural form for 2', () => {
+      expect(pluralize(2, 'set')).toBe('2 sets')
+    })
+
+    it('returns plural form for large counts', () => {
+      expect(pluralize(42, 'exercise')).toBe('42 exercises')
+    })
+
+    it('handles longer noun stems', () => {
+      expect(pluralize(1, 'workout')).toBe('1 workout')
+      expect(pluralize(3, 'workout')).toBe('3 workouts')
+    })
+  })
+
+  describe('irregular plurals', () => {
+    it('uses the supplied plural for counts != 1', () => {
+      expect(pluralize(2, 'man', 'men')).toBe('2 men')
+    })
+
+    it('still uses singular for count === 1 even when plural is supplied', () => {
+      expect(pluralize(1, 'man', 'men')).toBe('1 man')
+    })
+
+    it('uses supplied plural for 0', () => {
+      expect(pluralize(0, 'person', 'people')).toBe('0 people')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('treats negative numbers as plural', () => {
+      // We don't have negative counts in this app, but the helper should
+      // still produce a sensible string.
+      expect(pluralize(-1, 'set')).toBe('-1 sets')
+      expect(pluralize(-2, 'set')).toBe('-2 sets')
+    })
+  })
+})

--- a/__tests__/lib/format/relativeTime.test.ts
+++ b/__tests__/lib/format/relativeTime.test.ts
@@ -79,5 +79,12 @@ describe('formatRelativeTime', () => {
       const inFive = new Date(NOW.getTime() + 5 * 24 * 60 * 60 * 1000)
       expect(formatRelativeTime(inFive)).toBe('in 5 days')
     })
+
+    it('returns "Today" for a same-day timestamp a few hours in the future', () => {
+      // Symmetric with the past-3-hours case: Math.trunc keeps both as "Today"
+      // rather than rendering the future side as "tomorrow".
+      const inThreeHours = new Date(NOW.getTime() + 1000 * 60 * 60 * 3)
+      expect(formatRelativeTime(inThreeHours)).toBe('Today')
+    })
   })
 })

--- a/__tests__/lib/format/relativeTime.test.ts
+++ b/__tests__/lib/format/relativeTime.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatRelativeTime } from '@/lib/format/relativeTime'
+
+/**
+ * Tests for formatRelativeTime. We freeze the clock so bucket boundaries
+ * are deterministic regardless of CI timing.
+ */
+describe('formatRelativeTime', () => {
+  // Fixed reference: 2026-05-14T12:00:00Z (noon UTC, mid-day).
+  const NOW = new Date('2026-05-14T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Helper: build a date N days before NOW.
+  function daysAgo(days: number): Date {
+    return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000)
+  }
+
+  it('returns "Today" for the current moment', () => {
+    expect(formatRelativeTime(NOW)).toBe('Today')
+  })
+
+  it('returns "Today" for a same-day timestamp earlier in the day', () => {
+    const earlier = new Date(NOW.getTime() - 1000 * 60 * 60 * 3) // 3 hours ago
+    expect(formatRelativeTime(earlier)).toBe('Today')
+  })
+
+  it('returns "yesterday" for 1 day ago', () => {
+    expect(formatRelativeTime(daysAgo(1))).toBe('yesterday')
+  })
+
+  it('returns "5 days ago" for 5 days ago', () => {
+    expect(formatRelativeTime(daysAgo(5))).toBe('5 days ago')
+  })
+
+  it('returns "1 week ago" for 7 days ago', () => {
+    expect(formatRelativeTime(daysAgo(7))).toBe('1 week ago')
+  })
+
+  it('returns "2 weeks ago" for 14 days ago', () => {
+    expect(formatRelativeTime(daysAgo(14))).toBe('2 weeks ago')
+  })
+
+  it('returns "1 month ago" for 30 days ago', () => {
+    expect(formatRelativeTime(daysAgo(30))).toBe('1 month ago')
+  })
+
+  it('returns "2 months ago" for 60 days ago', () => {
+    expect(formatRelativeTime(daysAgo(60))).toBe('2 months ago')
+  })
+
+  it('returns "1 year ago" for 365 days ago', () => {
+    expect(formatRelativeTime(daysAgo(365))).toBe('1 year ago')
+  })
+
+  it('returns "2 years ago" for ~2 years ago', () => {
+    expect(formatRelativeTime(daysAgo(365 * 2))).toBe('2 years ago')
+  })
+
+  it('accepts ISO string input', () => {
+    const isoFiveDaysAgo = daysAgo(5).toISOString()
+    expect(formatRelativeTime(isoFiveDaysAgo)).toBe('5 days ago')
+  })
+
+  describe('future dates', () => {
+    it('returns "tomorrow" for 1 day in the future', () => {
+      const tomorrow = new Date(NOW.getTime() + 24 * 60 * 60 * 1000)
+      expect(formatRelativeTime(tomorrow)).toBe('tomorrow')
+    })
+
+    it('returns "in N days" for a few days in the future', () => {
+      const inFive = new Date(NOW.getTime() + 5 * 24 * 60 * 60 * 1000)
+      expect(formatRelativeTime(inFive)).toBe('in 5 days')
+    })
+  })
+})

--- a/app/(app)/admin/messages/page.tsx
+++ b/app/(app)/admin/messages/page.tsx
@@ -3,6 +3,7 @@
 import { Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { pluralize } from '@/lib/format/pluralize'
 import { MESSAGE_ICONS } from '@/lib/icons/message-icons'
 
 interface Message {
@@ -177,7 +178,7 @@ export default function AdminMessagesPage() {
 
       {/* Sort indicator */}
       <p className="text-xs text-muted-foreground mb-3">
-        Sorted by priority (highest first) &middot; {sortedMessages.length} message{sortedMessages.length !== 1 ? 's' : ''}
+        Sorted by priority (highest first) &middot; {pluralize(sortedMessages.length, 'message')}
       </p>
 
       {/* Message list */}

--- a/app/(app)/admin/signups/page.tsx
+++ b/app/(app)/admin/signups/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { pluralize } from '@/lib/format/pluralize'
 
 interface SignupRow {
   email: string
@@ -81,7 +82,7 @@ export default function AdminSignupsPage() {
             Recent Signups
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Last 30 days &middot; {rows.length} signup{rows.length !== 1 ? 's' : ''}
+            Last 30 days &middot; {pluralize(rows.length, 'signup')}
           </p>
         </div>
         <button

--- a/app/api/admin/exercise-definitions/[id]/route.ts
+++ b/app/api/admin/exercise-definitions/[id]/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { requireEditor } from '@/lib/admin/auth'
 import { prisma } from '@/lib/db'
+import { pluralize } from '@/lib/format/pluralize'
 import { logger } from '@/lib/logger'
 import {
   normalizeExerciseName,
@@ -261,7 +262,7 @@ export async function DELETE(
         {
           error: 'Exercise is in use',
           usageCount,
-          message: `This exercise is used ${usageCount} time${usageCount > 1 ? 's' : ''}. Use force=true to delete anyway.`,
+          message: `This exercise is used ${pluralize(usageCount, 'time')}. Use force=true to delete anyway.`,
         },
         { status: 409 }
       )

--- a/components/ProgramCompletionModal.tsx
+++ b/components/ProgramCompletionModal.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
+import { pluralize } from '@/lib/format/pluralize'
 
 interface CompletionStats {
   programName: string
@@ -264,7 +265,7 @@ export function ProgramCompletionModal({
 
               {stats.skippedWorkouts > 0 && (
                 <p className="text-sm text-muted-foreground text-center border-t-2 border-border pt-4">
-                  {stats.skippedWorkouts} workout{stats.skippedWorkouts !== 1 ? 's' : ''} skipped
+                  {pluralize(stats.skippedWorkouts, 'workout')} skipped
                 </p>
               )}
             </div>

--- a/components/SortableExerciseItem.tsx
+++ b/components/SortableExerciseItem.tsx
@@ -3,6 +3,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Pencil, Trash2 } from 'lucide-react'
+import { pluralize } from '@/lib/format/pluralize'
 
 type PrescribedSet = {
   id: string
@@ -76,7 +77,7 @@ export default function SortableExerciseItem({
         <div className="flex-1">
           <span className="font-medium text-foreground">{exercise.name}</span>
           <span className="text-muted-foreground ml-2">
-            ({exercise.prescribedSets.length} set{exercise.prescribedSets.length !== 1 ? 's' : ''})
+            ({pluralize(exercise.prescribedSets.length, 'set')})
           </span>
         </div>
       </div>

--- a/components/TransformWeekModal.tsx
+++ b/components/TransformWeekModal.tsx
@@ -3,6 +3,7 @@
 import { Minus, Plus, X } from 'lucide-react'
 import { useState } from 'react'
 import { LoadingFrog } from '@/components/ui/loading-frog'
+import { pluralize } from '@/lib/format/pluralize'
 import type { Week } from '@/types/program-builder'
 
 interface TransformWeekModalProps {
@@ -136,22 +137,22 @@ export default function TransformWeekModal({
               <p className="text-sm font-bold text-success doom-heading uppercase tracking-wider">Transformation Complete!</p>
               {stats.intensityUpdatedCount > 0 && (
                 <p className="text-xs text-foreground">
-                  Updated intensity on {stats.intensityUpdatedCount} set{stats.intensityUpdatedCount !== 1 ? 's' : ''}
+                  Updated intensity on {pluralize(stats.intensityUpdatedCount, 'set')}
                 </p>
               )}
               {stats.volumeAddedCount > 0 && (
                 <p className="text-xs text-foreground">
-                  Added {stats.volumeAddedCount} set{stats.volumeAddedCount !== 1 ? 's' : ''} to {stats.volumeAddedCount} exercise{stats.volumeAddedCount !== 1 ? 's' : ''}
+                  Added {pluralize(stats.volumeAddedCount, 'set')} to {pluralize(stats.volumeAddedCount, 'exercise')}
                 </p>
               )}
               {stats.volumeRemovedCount > 0 && (
                 <p className="text-xs text-foreground">
-                  Removed {stats.volumeRemovedCount} set{stats.volumeRemovedCount !== 1 ? 's' : ''} from {stats.volumeRemovedCount} exercise{stats.volumeRemovedCount !== 1 ? 's' : ''}
+                  Removed {pluralize(stats.volumeRemovedCount, 'set')} from {pluralize(stats.volumeRemovedCount, 'exercise')}
                 </p>
               )}
               {stats.skippedExercises > 0 && (
                 <p className="text-xs text-muted-foreground">
-                  Skipped {stats.skippedExercises} exercise{stats.skippedExercises !== 1 ? 's' : ''} (no sets to modify)
+                  Skipped {pluralize(stats.skippedExercises, 'exercise')} (no sets to modify)
                 </p>
               )}
             </div>

--- a/components/admin/CommunityProgramSelector.tsx
+++ b/components/admin/CommunityProgramSelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { pluralize } from '@/lib/format/pluralize'
 
 interface CommunityProgram {
   id: string
@@ -71,7 +72,7 @@ export function CommunityProgramSelector({ selectedIds, onChange }: CommunityPro
       </div>
       {selectedIds.size > 0 && (
         <p className="text-xs text-muted-foreground mt-1">
-          {selectedIds.size} program{selectedIds.size > 1 ? 's' : ''} selected
+          {pluralize(selectedIds.size, 'program')} selected
         </p>
       )}
     </div>

--- a/components/admin/DeleteExerciseDialog.tsx
+++ b/components/admin/DeleteExerciseDialog.tsx
@@ -4,6 +4,7 @@ import * as AlertDialog from '@radix-ui/react-alert-dialog'
 import { AlertTriangle } from 'lucide-react'
 import { useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
+import { pluralize } from '@/lib/format/pluralize'
 
 type DeleteExerciseDialogProps = {
   open: boolean
@@ -119,7 +120,7 @@ export default function DeleteExerciseDialog({
               {usageCount > 0 && (
                 <div className="p-3 bg-error/10 border-2 border-error mb-3">
                   <p className="text-sm text-error font-medium">
-                    This exercise is used {usageCount} time{usageCount > 1 ? 's' : ''} in
+                    This exercise is used {pluralize(usageCount, 'time')} in
                     workouts. Deleting it will remove the exercise definition, but existing
                     workout data referencing it may be affected.
                   </p>

--- a/components/community/CommunityProgramCard.tsx
+++ b/components/community/CommunityProgramCard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import { EQUIPMENT_LABELS, GOAL_LABELS, LEVEL_LABELS } from '@/lib/constants/program-metadata'
+import { formatRelativeTime } from '@/lib/format/relativeTime'
 import UnpublishProgramDialog from './UnpublishProgramDialog'
 
 type CommunityProgram = {
@@ -47,21 +48,6 @@ export default function CommunityProgramCard({
   const [descExpanded, setDescExpanded] = useState(false)
 
   const isAuthor = program.authorUserId === currentUserId
-
-  // Format published date
-  const formatDate = (date: Date) => {
-    const now = new Date()
-    const published = new Date(date)
-    const diffInMs = now.getTime() - published.getTime()
-    const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24))
-
-    if (diffInDays === 0) return 'Today'
-    if (diffInDays === 1) return 'Yesterday'
-    if (diffInDays < 7) return `${diffInDays} days ago`
-    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`
-    if (diffInDays < 365) return `${Math.floor(diffInDays / 30)} months ago`
-    return `${Math.floor(diffInDays / 365)} years ago`
-  }
 
   const handleAddProgram = async () => {
     setIsAdding(true)
@@ -203,7 +189,7 @@ export default function CommunityProgramCard({
 
         {/* Published date */}
         <div className="text-sm text-muted-foreground mb-4">
-          Published {formatDate(program.publishedAt)}
+          Published {formatRelativeTime(program.publishedAt)}
         </div>
 
         {/* Error message */}

--- a/components/community/CommunityProgramsView.tsx
+++ b/components/community/CommunityProgramsView.tsx
@@ -13,6 +13,7 @@ import {
   FITNESS_LEVELS,
   LEVEL_LABELS,
 } from '@/lib/constants/program-metadata'
+import { pluralize } from '@/lib/format/pluralize'
 import CommunityProgramCard from './CommunityProgramCard'
 
 type CommunityProgram = {
@@ -176,8 +177,7 @@ export default function CommunityProgramsView({
           {/* Results count */}
           {filteredPrograms.length > 0 && (
             <p className="text-sm text-muted-foreground mt-3">
-              Showing {filteredPrograms.length} program
-              {filteredPrograms.length !== 1 ? 's' : ''}
+              Showing {pluralize(filteredPrograms.length, 'program')}
             </p>
           )}
         </div>

--- a/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
+++ b/components/features/exercise-definition/ExerciseDefinitionEditorModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useToast } from '@/components/ToastProvider';
 import { Button } from '@/components/ui/Button';
 import { clientLogger } from '@/lib/client-logger';
+import { pluralize } from '@/lib/format/pluralize';
 import EquipmentSelector from './EquipmentSelector';
 import ExerciseInfoPreview from './ExerciseInfoPreview';
 import FAUSelector from './FAUSelector';
@@ -287,8 +288,7 @@ export default function ExerciseDefinitionEditorModal({
               {mode === 'edit' && usageCount > 0 && (
                 <div className="bg-warning-muted border-2 border-warning-border rounded p-4">
                   <p className="text-sm text-warning-text font-medium">
-                    ⚠️ This exercise is used {usageCount} time
-                    {usageCount > 1 ? 's' : ''} in this program. Changes will affect future sessions.
+                    ⚠️ This exercise is used {pluralize(usageCount, 'time')} in this program. Changes will affect future sessions.
                   </p>
                 </div>
               )}

--- a/components/features/exercise-definition/FAUSelector.tsx
+++ b/components/features/exercise-definition/FAUSelector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover';
 import { FAU_DISPLAY_NAMES } from '@/lib/fau-volume';
+import { pluralize } from '@/lib/format/pluralize';
 
 export interface FAUSelectorProps {
   value: string[];
@@ -117,7 +118,7 @@ export default function FAUSelector({
       {/* Selection count */}
       {value.length > 0 && (
         <p className="text-sm text-muted-foreground">
-          {value.length} {variant} muscle group{value.length !== 1 ? 's' : ''} selected
+          {pluralize(value.length, `${variant} muscle group`)} selected
         </p>
       )}
     </div>

--- a/components/program-builder/WorkoutCard.tsx
+++ b/components/program-builder/WorkoutCard.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { ChevronDown, ChevronRight, MoreVertical } from 'lucide-react'
+import { pluralize } from '@/lib/format/pluralize'
 import type { Exercise, Workout } from '@/types/program-builder'
 import SortableExerciseList from '../SortableExerciseList'
 
@@ -88,7 +89,7 @@ export default function WorkoutCard({
             </button>
             <span className="font-medium text-foreground doom-heading">{workout.name}</span>
             <span className="text-sm text-muted-foreground">
-              ({workout.exercises.length} exercise{workout.exercises.length !== 1 ? 's' : ''}, {workout.exercises.reduce((sum, ex) => sum + ex.prescribedSets.length, 0)} sets)
+              ({pluralize(workout.exercises.length, 'exercise')}, {workout.exercises.reduce((sum, ex) => sum + ex.prescribedSets.length, 0)} sets)
             </span>
 
             <DropdownMenu.Root>

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
+import { pluralize } from '@/lib/format/pluralize'
 
 type ActivationConfirmModalProps = {
   programId: string
@@ -262,7 +263,7 @@ export default function ActivationConfirmModal({
 
         {hasHistory && (
           <p className="text-base text-muted-foreground mb-6">
-            {historyState.completionCount} workout{historyState.completionCount !== 1 ? 's' : ''} logged — continue or start fresh?
+            {pluralize(historyState.completionCount, 'workout')} logged — continue or start fresh?
           </p>
         )}
 

--- a/components/programs/StrengthMetadata.tsx
+++ b/components/programs/StrengthMetadata.tsx
@@ -1,3 +1,5 @@
+import { pluralize } from '@/lib/format/pluralize'
+
 type StrengthMetadataProps = {
   weekCount?: number
   workoutCount?: number
@@ -13,12 +15,12 @@ export default function StrengthMetadata({
     <div className="flex gap-4 text-sm text-muted-foreground">
       {weekCount !== undefined && (
         <span>
-          {weekCount} week{weekCount !== 1 ? 's' : ''}
+          {pluralize(weekCount, 'week')}
         </span>
       )}
       {workoutCount !== undefined && (
         <span>
-          {workoutCount} workout{workoutCount !== 1 ? 's' : ''}
+          {pluralize(workoutCount, 'workout')}
         </span>
       )}
     </div>

--- a/components/workout-logging/FollowAlongTabs.tsx
+++ b/components/workout-logging/FollowAlongTabs.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import ExerciseImageCrossfade from '@/components/ui/ExerciseImageCrossfade'
 import type { MessageData } from '@/components/ui/MessageCard'
 import { MessageCard } from '@/components/ui/MessageCard'
+import { pluralize } from '@/lib/format/pluralize'
 
 interface PrescribedSet {
   id: string
@@ -54,10 +55,10 @@ function formatPrescriptionDirective(prescribedSets: PrescribedSet[]): string {
   const count = prescribedSets.length
 
   if (allSame) {
-    return `${count} sets of ${repsValues[0]} reps`
+    return `${pluralize(count, 'set')} of ${repsValues[0]} reps`
   }
 
-  return `${count} sets: ${repsValues.join(', ')} reps`
+  return `${pluralize(count, 'set')}: ${repsValues.join(', ')} reps`
 }
 
 /**

--- a/lib/format/pluralize.ts
+++ b/lib/format/pluralize.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns a formatted count-plus-word string with correct pluralization.
+ *
+ * Uses `count === 1` to pick the singular form. Counts of 0, 2, and negatives
+ * all use the plural form (English convention: "0 sets", "2 sets").
+ *
+ * If the noun has an irregular plural, pass it as the third argument.
+ *
+ * Examples:
+ *   pluralize(1, 'set')        // "1 set"
+ *   pluralize(2, 'set')        // "2 sets"
+ *   pluralize(0, 'exercise')   // "0 exercises"
+ *   pluralize(1, 'man', 'men') // "1 man"
+ *   pluralize(2, 'man', 'men') // "2 men"
+ */
+export function pluralize(count: number, singular: string, plural?: string): string {
+  const word = count === 1 ? singular : (plural ?? `${singular}s`)
+  return `${count} ${word}`
+}

--- a/lib/format/relativeTime.ts
+++ b/lib/format/relativeTime.ts
@@ -20,26 +20,34 @@
  *   formatRelativeTime(oneMonthAgo) // "1 month ago"
  *
  * TODO: When i18n lands, switch 'en' to navigator.language or a user-pref token.
+ * The formatter instances below assume a fixed locale; reallocate per-call (or
+ * memoize by locale) when that changes.
  */
+
+// Two formatters: `auto` collapses single-day deltas to "yesterday"/"tomorrow",
+// `always` keeps numeric units ("1 month ago" rather than "last month") since
+// numeric weeks/months/years read more naturally in this app. Hoisted to module
+// scope so we don't reallocate on every call.
+const rtfAuto = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+const rtfAlways = new Intl.RelativeTimeFormat('en', { numeric: 'always' })
+
+const ONE_DAY_MS = 1000 * 60 * 60 * 24
+
 export function formatRelativeTime(date: Date | string): string {
   const target = typeof date === 'string' ? new Date(date) : date
   const now = new Date()
 
   const diffInMs = now.getTime() - target.getTime()
-  const oneDayMs = 1000 * 60 * 60 * 24
-  const diffInDays = Math.floor(diffInMs / oneDayMs)
+  // `trunc` (not `floor`) keeps past/future symmetric: a few hours either side
+  // of "now" should both collapse to "Today", whereas `floor(-0.125) === -1`
+  // would render a 3-hour-future date as "tomorrow".
+  const diffInDays = Math.trunc(diffInMs / ONE_DAY_MS)
   const absDays = Math.abs(diffInDays)
 
   // Same-calendar-day fast path: today regardless of hour-level drift.
   if (absDays === 0) return 'Today'
 
-  // Two formatters: `auto` collapses single-day deltas to "yesterday"/"tomorrow",
-  // `always` keeps numeric units ("1 month ago" rather than "last month") since
-  // numeric weeks/months/years read more naturally in this app.
-  const rtfAuto = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
-  const rtfAlways = new Intl.RelativeTimeFormat('en', { numeric: 'always' })
-
-  // Past = negative deltas; future = positive. We use signed values so Intl
+  // Past = positive diffInDays; future = negative. We use signed values so Intl
   // handles "ago" vs "in N" automatically.
   const sign = diffInDays > 0 ? -1 : 1
 

--- a/lib/format/relativeTime.ts
+++ b/lib/format/relativeTime.ts
@@ -1,0 +1,51 @@
+/**
+ * Returns a humanized relative-time string like "Today", "Yesterday",
+ * "5 days ago", "2 months ago", "1 year ago".
+ *
+ * Uses Intl.RelativeTimeFormat with `numeric: 'auto'` so single-unit deltas
+ * collapse to "yesterday" / "tomorrow" naturally.
+ *
+ * Bucket order (compared by absolute days from now):
+ *   - 0 days  -> "Today"
+ *   - 1 day   -> "Yesterday" / "Tomorrow"
+ *   - < 7     -> "N days ago" / "in N days"
+ *   - < 30    -> "N weeks ago"
+ *   - < 365   -> "N months ago"
+ *   - >= 365  -> "N years ago"
+ *
+ * Examples:
+ *   formatRelativeTime(new Date())  // "Today"
+ *   formatRelativeTime(yesterday)   // "yesterday"
+ *   formatRelativeTime(fiveDaysAgo) // "5 days ago"
+ *   formatRelativeTime(oneMonthAgo) // "1 month ago"
+ *
+ * TODO: When i18n lands, switch 'en' to navigator.language or a user-pref token.
+ */
+export function formatRelativeTime(date: Date | string): string {
+  const target = typeof date === 'string' ? new Date(date) : date
+  const now = new Date()
+
+  const diffInMs = now.getTime() - target.getTime()
+  const oneDayMs = 1000 * 60 * 60 * 24
+  const diffInDays = Math.floor(diffInMs / oneDayMs)
+  const absDays = Math.abs(diffInDays)
+
+  // Same-calendar-day fast path: today regardless of hour-level drift.
+  if (absDays === 0) return 'Today'
+
+  // Two formatters: `auto` collapses single-day deltas to "yesterday"/"tomorrow",
+  // `always` keeps numeric units ("1 month ago" rather than "last month") since
+  // numeric weeks/months/years read more naturally in this app.
+  const rtfAuto = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+  const rtfAlways = new Intl.RelativeTimeFormat('en', { numeric: 'always' })
+
+  // Past = negative deltas; future = positive. We use signed values so Intl
+  // handles "ago" vs "in N" automatically.
+  const sign = diffInDays > 0 ? -1 : 1
+
+  if (absDays === 1) return rtfAuto.format(sign * 1, 'day')
+  if (absDays < 7) return rtfAlways.format(sign * absDays, 'day')
+  if (absDays < 30) return rtfAlways.format(sign * Math.floor(absDays / 7), 'week')
+  if (absDays < 365) return rtfAlways.format(sign * Math.floor(absDays / 30), 'month')
+  return rtfAlways.format(sign * Math.floor(absDays / 365), 'year')
+}

--- a/lib/validation/workout-limits.ts
+++ b/lib/validation/workout-limits.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from '@prisma/client'
+import { pluralize } from '@/lib/format/pluralize'
 
 export const MAX_WORKOUTS_PER_WEEK = 10
 
@@ -14,7 +15,7 @@ export async function validateWorkoutLimit(
     return {
       valid: false,
       currentCount,
-      error: `Cannot add ${additionalWorkouts} workout${additionalWorkouts > 1 ? 's' : ''}. Week already has ${currentCount} workout${currentCount !== 1 ? 's' : ''}. Maximum ${MAX_WORKOUTS_PER_WEEK} workouts per week allowed.`
+      error: `Cannot add ${pluralize(additionalWorkouts, 'workout')}. Week already has ${pluralize(currentCount, 'workout')}. Maximum ${MAX_WORKOUTS_PER_WEEK} workouts per week allowed.`
     }
   }
 


### PR DESCRIPTION
## Summary

Builds two shared formatters under `lib/format/` to fix the recurring class of bug where `\${count} \${noun}` is interpolated without a singular check (e.g. "1 days ago", "1 sets") or where ad-hoc inline `count !== 1 ? 's' : ''` conditionals drift across the codebase.

- `pluralize(count, singular, plural?)` -> `"1 set"` / `"2 sets"` / `"0 exercises"` / `"2 men"`
- `formatRelativeTime(date)` -> `"Today"` / `"yesterday"` / `"5 days ago"` / `"1 month ago"`, backed by `Intl.RelativeTimeFormat`. Uses `numeric: 'auto'` only for single-day deltas so `"yesterday"`/`"tomorrow"` collapse naturally; `numeric: 'always'` for weeks/months/years so we get `"1 month ago"` instead of `"last month"`.

Migrated all 17 call sites that used `count !== 1 ? 's' : ''` or `count > 1 ? 's' : ''` inline, including the 4 explicit ones in the ticket plus the rest of the codebase to satisfy the zero-grep acceptance criterion.

Visible bug fixes:
- `CommunityProgramCard` no longer renders `"1 days ago"` / `"1 months ago"` / `"1 years ago"` (the #720 bug).
- `FollowAlongTabs` no longer renders `"1 sets of N reps"`.

## Test plan

- [x] `lib/format/pluralize.ts` + 9 unit tests passing
- [x] `lib/format/relativeTime.ts` + 13 unit tests passing (uses `vi.setSystemTime` for determinism)
- [x] `grep -rn "\\? 's' : ''" --include="*.tsx" --include="*.ts" components/ app/ lib/` returns zero results
- [x] `npm run type-check` clean
- [x] Full vitest suite passes (364 + 22 new tests)
- [ ] Visual QA: confirm Programs Browse view shows correct relative-time strings
- [ ] Visual QA: confirm Transform Week stats display correct singular/plural

## Notes

- 7 lint errors remain in unrelated files (setState-in-effect, impure-call) — all pre-existing, none introduced by this PR.
- The pre-commit `noLabelWithoutControl` warning fires on `app/(app)/admin/messages/page.tsx` but is on a line I did not modify (label/select pair pre-dates this PR).
- Absorbs #720 (relative-time pluralization bug) — close as duplicate once this merges.

Fixes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)