### PR TITLE
feat(logger): persistent DrawerContextBanner above input area

### DIFF
--- a/__tests__/lib/format/prescribed-summary.test.ts
+++ b/__tests__/lib/format/prescribed-summary.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import { formatPrescribedSummary } from '@/lib/format/prescribed-summary'
+
+describe('formatPrescribedSummary', () => {
+  describe('reps + weight + intensity', () => {
+    it('formats reps, weight, and RIR', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '135 lb',
+          rpe: null,
+          rir: 2,
+        })
+      ).toBe('5 reps @ 135 lb, RIR 2')
+    })
+
+    it('formats reps, weight, and RPE', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '135 lb',
+          rpe: 8,
+          rir: null,
+        })
+      ).toBe('5 reps @ 135 lb, RPE 8')
+    })
+
+    it('prefers RIR over RPE when both are set', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '135 lb',
+          rpe: 8,
+          rir: 2,
+        })
+      ).toBe('5 reps @ 135 lb, RIR 2')
+    })
+  })
+
+  describe('reps only', () => {
+    it('omits both weight and intensity when neither is set', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: null,
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('5 reps')
+    })
+
+    it('uses singular "rep" for count of 1', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '1',
+          weight: null,
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('1 rep')
+    })
+  })
+
+  describe('reps + intensity, no weight', () => {
+    it('joins reps and RIR with @ when weight is absent', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: null,
+          rpe: null,
+          rir: 2,
+        })
+      ).toBe('5 reps @ RIR 2')
+    })
+
+    it('joins reps and RPE with @ when weight is absent', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '8',
+          weight: null,
+          rpe: 8,
+          rir: null,
+        })
+      ).toBe('8 reps @ RPE 8')
+    })
+  })
+
+  describe('freeform weight strings', () => {
+    it('renders percentage verbatim', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '65%',
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('5 reps @ 65%')
+    })
+
+    it('renders RPE-formatted weight verbatim', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: 'RPE 8',
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('5 reps @ RPE 8')
+    })
+
+    it('trims surrounding whitespace from weight', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '  135 lb  ',
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('5 reps @ 135 lb')
+    })
+
+    it('treats an all-whitespace weight as missing', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: '   ',
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('5 reps')
+    })
+  })
+
+  describe('rep ranges and special values', () => {
+    it('keeps a range as-is and pluralizes', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '8-12',
+          weight: '135 lb',
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('8-12 reps @ 135 lb')
+    })
+
+    it('keeps "15+" as-is and pluralizes', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '15+',
+          weight: null,
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('15+ reps')
+    })
+
+    it('renders AMRAP verbatim without trailing "reps"', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: 'AMRAP',
+          weight: '135 lb',
+          rpe: null,
+          rir: 1,
+        })
+      ).toBe('AMRAP @ 135 lb, RIR 1')
+    })
+
+    it('is case-insensitive for AMRAP', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: 'amrap',
+          weight: null,
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('AMRAP')
+    })
+  })
+
+  describe('showIntensity option', () => {
+    it('omits intensity when showIntensity is false', () => {
+      expect(
+        formatPrescribedSummary(
+          { reps: '5', weight: '135 lb', rpe: null, rir: 2 },
+          { showIntensity: false }
+        )
+      ).toBe('5 reps @ 135 lb')
+    })
+
+    it('omits intensity when showIntensity is false and there is no weight', () => {
+      expect(
+        formatPrescribedSummary(
+          { reps: '5', weight: null, rpe: null, rir: 2 },
+          { showIntensity: false }
+        )
+      ).toBe('5 reps')
+    })
+
+    it('includes intensity by default', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '5',
+          weight: null,
+          rpe: null,
+          rir: 2,
+        })
+      ).toBe('5 reps @ RIR 2')
+    })
+  })
+
+  describe('empty input', () => {
+    it('returns an empty string when reps is empty', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '',
+          weight: '135 lb',
+          rpe: null,
+          rir: 2,
+        })
+      ).toBe('')
+    })
+
+    it('returns an empty string when reps is whitespace only', () => {
+      expect(
+        formatPrescribedSummary({
+          reps: '   ',
+          weight: null,
+          rpe: null,
+          rir: null,
+        })
+      ).toBe('')
+    })
+  })
+})

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -15,6 +15,7 @@ import { useWorkoutDraft } from '@/hooks/useWorkoutDraft'
 import { completeDraft, discardDraft } from '@/lib/api/workout-sets'
 import { clientLogger } from '@/lib/client-logger'
 import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
+import { formatPrescribedSummary } from '@/lib/format/prescribed-summary'
 import type { LoggedSet } from '@/types/workout'
 import type { ActionItem } from './ActionsMenu'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
@@ -187,6 +188,23 @@ export default function ExerciseLoggingModal({
 
   // Intensity preference check: user has it enabled in settings
   const { hasAccess: hasIntensityAccess } = useIntensityAccess()
+
+  // Persistent context banner above the input area: show the prescription for
+  // the current set, and the user's position in the set sequence. When the
+  // user is past the prescribed count (extra sets) we hide "of N" so the label
+  // doesn't read "Set 5 of 4".
+  const prescribedSummary = useMemo(
+    () =>
+      prescribedSet
+        ? formatPrescribedSummary(prescribedSet, { showIntensity: hasIntensityAccess }) ||
+          undefined
+        : undefined,
+    [prescribedSet, hasIntensityAccess]
+  )
+  const totalPrescribedSets =
+    currentPrescribedSets.length > 0 && nextSetNumber <= currentPrescribedSets.length
+      ? currentPrescribedSets.length
+      : undefined
   const { settings, updateSettings } = useUserSettings()
 
   // One-time intensity intro tip
@@ -633,6 +651,9 @@ export default function ExerciseLoggingModal({
                   message={currentMessage}
                   onMessageSeen={onMessageSeen}
                   onMessageDismissed={onMessageDismissed}
+                  currentSetNumber={nextSetNumber}
+                  totalSets={totalPrescribedSets}
+                  prescribedSummary={prescribedSummary}
                   loggingForm={
                     <SetLoggingForm
                       prescribedSet={prescribedSet}

--- a/components/workout-logging/DrawerContextBanner.tsx
+++ b/components/workout-logging/DrawerContextBanner.tsx
@@ -1,0 +1,54 @@
+/**
+ * Persistent context banner shown between the segmented tab row and the input
+ * area on the LOG SETS tab of the exercise logger. Surfaces:
+ *
+ *   - The current exercise name (UPPERCASE, doom-heading)
+ *   - The user's position within the set sequence ("Set 3 of 4")
+ *   - The prescription for the current set ("Prescribed: 5 reps @ 135 lb, RIR 2")
+ *
+ * Stays visible whether the weight/RIR drawer is open or closed, so the user
+ * never loses sight of which set they are on while the input takes over.
+ *
+ * Degrades cleanly when prescription data is missing (e.g. ad-hoc / freestyle
+ * mode): `totalSets` and `prescribed` are both optional. When `totalSets` is
+ * omitted the right-side label renders as just "Set N"; when `prescribed` is
+ * omitted the prescribed line is dropped entirely (no placeholder).
+ *
+ * Read-only — no buttons, no actions. It is context, not control.
+ */
+type DrawerContextBannerProps = {
+  exerciseName: string
+  currentSet: number
+  /** Omit to render just "Set N" (e.g. ad-hoc / freestyle mode). */
+  totalSets?: number
+  /** Omit to drop the "Prescribed: ..." line entirely. */
+  prescribed?: string
+}
+
+export default function DrawerContextBanner({
+  exerciseName,
+  currentSet,
+  totalSets,
+  prescribed,
+}: DrawerContextBannerProps) {
+  const setLabel =
+    typeof totalSets === 'number' ? `Set ${currentSet} of ${totalSets}` : `Set ${currentSet}`
+
+  return (
+    <div className="px-4 pt-3 pb-2 border-b border-border/60">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-xl font-bold text-foreground doom-heading truncate">
+          {exerciseName.toUpperCase()}
+        </h2>
+        <span className="text-xs text-muted-foreground font-semibold uppercase tracking-wider tabular-nums shrink-0">
+          {setLabel}
+        </span>
+      </div>
+      {prescribed && (
+        <p className="mt-1 text-sm text-muted-foreground tabular-nums">
+          Prescribed: <span className="text-foreground">{prescribed}</span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -144,7 +144,7 @@ export default function ExerciseDisplayTabs({
           totalSets={totalSets}
           prescribed={prescribedSummary}
         />
-        <div className="px-4 flex flex-col gap-2">
+        <div className="px-4 flex-1 flex flex-col gap-2">
           {loggingForm}
           {!isInputExpanded && (
             <>

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/radix/
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/types/workout'
+import DrawerContextBanner from './DrawerContextBanner'
 import ExerciseInfoContent from './ExerciseInfoContent'
 import SetList from './SetList'
 
@@ -63,6 +64,12 @@ interface ExerciseDisplayTabsProps {
   message?: MessageData | null
   onMessageSeen?: (messageId: string) => void
   onMessageDismissed?: (messageId: string) => void
+  /** 1-indexed set number the user is currently logging. */
+  currentSetNumber: number
+  /** Total prescribed sets for the current exercise. Omit when unknown (e.g. ad-hoc mode). */
+  totalSets?: number
+  /** Pre-formatted prescription summary for the current set. Omit to drop the line. */
+  prescribedSummary?: string
 }
 
 // Loading skeleton for history tab
@@ -91,6 +98,9 @@ export default function ExerciseDisplayTabs({
   message,
   onMessageSeen,
   onMessageDismissed,
+  currentSetNumber,
+  totalSets,
+  prescribedSummary,
 }: ExerciseDisplayTabsProps) {
   const hasNotes = !!exercise.notes
   const [activeTab, setActiveTab] = useState('log-sets')
@@ -127,28 +137,36 @@ export default function ExerciseDisplayTabs({
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="log-sets" className="flex-1 overflow-y-auto px-4 flex flex-col gap-2">
-        {loggingForm}
-        {!isInputExpanded && (
-          <>
-            <SetList
-              prescribedSets={prescribedSets}
-              loggedSets={loggedSets}
-              exerciseHistory={null}
-              onDeleteSet={onDeleteSet}
-              exerciseId={exercise.id}
-              showIntensity={showIntensity}
-            />
-            {message && (
-              <MessageCard
-                message={message}
-                variant="exercise_logger"
-                onSeen={onMessageSeen}
-                onDismiss={onMessageDismissed}
+      <TabsContent value="log-sets" className="flex-1 overflow-y-auto flex flex-col">
+        <DrawerContextBanner
+          exerciseName={exercise.name}
+          currentSet={currentSetNumber}
+          totalSets={totalSets}
+          prescribed={prescribedSummary}
+        />
+        <div className="px-4 flex flex-col gap-2">
+          {loggingForm}
+          {!isInputExpanded && (
+            <>
+              <SetList
+                prescribedSets={prescribedSets}
+                loggedSets={loggedSets}
+                exerciseHistory={null}
+                onDeleteSet={onDeleteSet}
+                exerciseId={exercise.id}
+                showIntensity={showIntensity}
               />
-            )}
-          </>
-        )}
+              {message && (
+                <MessageCard
+                  message={message}
+                  variant="exercise_logger"
+                  onSeen={onMessageSeen}
+                  onDismiss={onMessageDismissed}
+                />
+              )}
+            </>
+          )}
+        </div>
       </TabsContent>
 
       <TabsContent value="info" className="flex-1 overflow-y-auto px-4">

--- a/lib/format/prescribed-summary.ts
+++ b/lib/format/prescribed-summary.ts
@@ -1,0 +1,79 @@
+import { pluralize } from './pluralize'
+
+/**
+ * Minimal shape needed to format a prescribed set summary. Mirrors the fields
+ * on `PrescribedSet` that contribute to the displayed string.
+ */
+export type PrescribedSummarySet = {
+  reps: string
+  weight: string | null
+  rpe: number | null
+  rir: number | null
+}
+
+export type PrescribedSummaryOptions = {
+  /**
+   * When false, RPE/RIR are omitted. Defaults to true.
+   * Callers should pass the user's intensity preference here so the banner
+   * matches the rest of the logger UI.
+   */
+  showIntensity?: boolean
+}
+
+/**
+ * Format the reps portion of a prescribed summary.
+ *
+ * - "5"     -> "5 reps"
+ * - "1"     -> "1 rep"
+ * - "8-12"  -> "8-12 reps"
+ * - "15+"   -> "15+ reps"
+ * - "AMRAP" -> "AMRAP"   (verbatim, no trailing word)
+ * - ""      -> ""        (caller treats this as "no summary")
+ */
+function formatReps(reps: string): string {
+  const trimmed = reps.trim()
+  if (!trimmed) return ''
+  if (trimmed.toUpperCase() === 'AMRAP') return 'AMRAP'
+  if (/^\d+$/.test(trimmed)) {
+    return pluralize(parseInt(trimmed, 10), 'rep')
+  }
+  return `${trimmed} reps`
+}
+
+function formatIntensity(set: PrescribedSummarySet): string | null {
+  if (set.rir !== null && set.rir !== undefined) return `RIR ${set.rir}`
+  if (set.rpe !== null && set.rpe !== undefined) return `RPE ${set.rpe}`
+  return null
+}
+
+/**
+ * Produce a one-line summary of a prescribed set for the persistent
+ * `<DrawerContextBanner>` (and any other read-only surface).
+ *
+ * Output shape (per spec in issue #726):
+ *
+ *   Reps + weight + intensity:     "5 reps @ 135 lb, RIR 2"
+ *   Reps + weight, no intensity:   "5 reps @ 135 lb"
+ *   Reps + intensity, no weight:   "5 reps @ RIR 2"
+ *   Reps only:                     "5 reps"
+ *   Freeform weight (verbatim):    "5 reps @ 65%"  /  "5 reps @ RPE 8"
+ *
+ * Returns an empty string if `reps` is empty — callers should treat that as
+ * "no prescription available" and omit the line entirely.
+ */
+export function formatPrescribedSummary(
+  set: PrescribedSummarySet,
+  options: PrescribedSummaryOptions = {}
+): string {
+  const { showIntensity = true } = options
+  const repsLabel = formatReps(set.reps)
+  if (!repsLabel) return ''
+
+  const intensity = showIntensity ? formatIntensity(set) : null
+  const weight = set.weight && set.weight.trim() ? set.weight.trim() : null
+
+  if (weight && intensity) return `${repsLabel} @ ${weight}, ${intensity}`
+  if (weight) return `${repsLabel} @ ${weight}`
+  if (intensity) return `${repsLabel} @ ${intensity}`
+  return repsLabel
+}


### PR DESCRIPTION
## Summary
- New `<DrawerContextBanner>` between the segmented tab row and the input area on the LOG SETS tab, surfacing exercise name, set position (`Set 3 of 4`), and prescription (`Prescribed: 5 reps @ 135 lb, RIR 2`).
- Banner stays visible whether the weight/RIR drawer is open or closed, so the user no longer has to dismiss a drawer to re-check the current set or what was prescribed.
- Banner degrades cleanly when prescription data is missing — ad-hoc mode (#695) and extra-sets territory render just `Set N` and drop the `Prescribed: ...` line entirely.

## What landed
- `components/workout-logging/DrawerContextBanner.tsx` — read-only presentational component (~40 lines). Props: `exerciseName`, `currentSet`, optional `totalSets`, optional `prescribed`.
- `lib/format/prescribed-summary.ts` — `formatPrescribedSummary(set, { showIntensity })` helper. Pluralizes via the existing `pluralize()` helper, keeps AMRAP verbatim, prefers RIR over RPE, renders freeform weight strings (`65%`, `RPE 8`) as-is. Covered by 20 unit tests in `__tests__/lib/format/prescribed-summary.test.ts`.
- Wired into `ExerciseDisplayTabs.tsx` above `loggingForm` inside `TabsContent value="log-sets"` (so the banner sits between the tabs and the input area, persists across drawer-open/closed).
- Wired into `ExerciseLoggingModal.tsx`: computes `prescribedSummary` from the current prescribed set, and passes `totalSets` only when `nextSetNumber <= totalPrescribedSets` (so extras read `Set 5`, not `Set 5 of 4`).

## Token usage
All colors via theme tokens — `text-foreground`, `text-muted-foreground`, `border-border/60`. No hex literals. `doom-heading` on the exercise title.

## Test plan
- [x] `npm run type-check` clean.
- [x] `npm run lint` — only pre-existing errors in unrelated files (`FollowAlongTabs.tsx`, `useRestTimer.ts`); none introduced by this PR.
- [x] `npx vitest run __tests__/lib/format/prescribed-summary.test.ts` — 20/20 pass.
- [ ] Manual: open the logger on a multi-set exercise; verify banner shows `Set 1 of N` with prescription; log a set and confirm it advances to `Set 2 of N`; tap weight input to open the drawer and confirm banner remains visible.
- [ ] Manual: navigate to next exercise; confirm banner updates exercise name + resets set counter.
- [ ] Manual: log past prescribed (extra sets); confirm banner shows just `Set N` (no "of M") and the `Prescribed:` line is dropped.
- [ ] Manual: long exercise name (e.g. "Barbell Romanian Deadlift With Straps") — confirm title truncates with ellipsis and the `Set X of Y` label does not wrap.
- [ ] Cross-theme spot-check (default DOOM + dark mode at minimum; full 12-theme sweep once #723 lands).

Fixes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)