### PR TITLE
feat(adhoc): schema + API for freestyle workouts (PR 1/2 of #738)

### DIFF
--- a/__tests__/api/adhoc.test.ts
+++ b/__tests__/api/adhoc.test.ts
@@ -1,0 +1,425 @@
+import type { PrismaClient, WorkoutCompletion } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import {
+  createCompleteTestScenario,
+  createTestExerciseDefinition,
+  createTestUser,
+} from '@/lib/test/factories'
+
+// Simulation helpers — mirror the API logic in app/api/workouts/adhoc/*
+// without going through Next.js HTTP. Keep these tight; route handlers
+// own auth + rate-limiting + logging, which is out of scope here.
+
+type SimResult<T> =
+  | { ok: true; status: 200; data: T }
+  | { ok: false; status: 400 | 403 | 404 | 409 | 422; error: string }
+
+const DATE_FMT = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+async function simulateCreateAdHoc(
+  prisma: PrismaClient,
+  userId: string,
+  now: Date = new Date()
+): Promise<SimResult<{ completion: WorkoutCompletion }>> {
+  const existing = await prisma.workoutCompletion.findFirst({
+    where: { userId, status: 'draft', isArchived: false },
+  })
+  if (existing) {
+    return { ok: false, status: 409, error: 'DRAFT_EXISTS' }
+  }
+
+  const completion = await prisma.workoutCompletion.create({
+    data: {
+      workoutId: null,
+      userId,
+      status: 'draft',
+      isAdHoc: true,
+      name: `Open Workout — ${DATE_FMT.format(now)}`,
+      startedAt: now,
+      completedAt: now,
+    },
+  })
+  return { ok: true, status: 200, data: { completion } }
+}
+
+async function simulateAddExercise(
+  prisma: PrismaClient,
+  completionId: string,
+  userId: string,
+  exerciseDefinitionId: string
+): Promise<SimResult<{ exerciseId: string; order: number }>> {
+  const completion = await prisma.workoutCompletion.findUnique({
+    where: { id: completionId },
+  })
+  if (!completion) return { ok: false, status: 404, error: 'Workout not found' }
+  if (completion.userId !== userId)
+    return { ok: false, status: 403, error: 'Unauthorized' }
+  if (!completion.isAdHoc)
+    return { ok: false, status: 400, error: 'Not an ad-hoc workout' }
+  if (completion.status !== 'draft')
+    return { ok: false, status: 400, error: 'Cannot add exercises to a completed workout' }
+
+  const exerciseDefinition = await prisma.exerciseDefinition.findUnique({
+    where: { id: exerciseDefinitionId },
+  })
+  if (!exerciseDefinition)
+    return { ok: false, status: 404, error: 'Exercise definition not found' }
+
+  const existingExercises = await prisma.exercise.findMany({
+    where: { workoutCompletionId: completionId },
+    select: { order: true },
+  })
+  const nextOrder = Math.max(0, ...existingExercises.map((e) => e.order)) + 1
+
+  const exercise = await prisma.exercise.create({
+    data: {
+      name: exerciseDefinition.name,
+      exerciseDefinitionId,
+      order: nextOrder,
+      workoutId: null,
+      isOneOff: true,
+      workoutCompletionId: completionId,
+      userId,
+    },
+  })
+  return { ok: true, status: 200, data: { exerciseId: exercise.id, order: nextOrder } }
+}
+
+async function simulateLogSet(
+  prisma: PrismaClient,
+  completionId: string,
+  userId: string,
+  set: {
+    exerciseId: string
+    setNumber: number
+    reps: number
+    weight: number
+    weightUnit: string
+    rpe?: number | null
+    rir?: number | null
+  }
+): Promise<SimResult<{ setId: string }>> {
+  const completion = await prisma.workoutCompletion.findUnique({
+    where: { id: completionId },
+  })
+  if (!completion) return { ok: false, status: 404, error: 'Workout not found' }
+  if (completion.userId !== userId) return { ok: false, status: 403, error: 'Unauthorized' }
+  if (!completion.isAdHoc) return { ok: false, status: 400, error: 'Not an ad-hoc workout' }
+  if (completion.status !== 'draft')
+    return { ok: false, status: 400, error: 'Cannot log sets on a completed workout' }
+
+  const exercise = await prisma.exercise.findUnique({
+    where: { id: set.exerciseId },
+    select: { workoutCompletionId: true },
+  })
+  if (!exercise || exercise.workoutCompletionId !== completionId)
+    return { ok: false, status: 422, error: 'Exercise not found in this workout' }
+
+  const loggedSet = await prisma.loggedSet.upsert({
+    where: {
+      completionId_exerciseId_setNumber: {
+        completionId,
+        exerciseId: set.exerciseId,
+        setNumber: set.setNumber,
+      },
+    },
+    update: {
+      reps: set.reps,
+      weight: set.weight,
+      weightUnit: set.weightUnit,
+      rpe: set.rpe ?? null,
+      rir: set.rir ?? null,
+    },
+    create: {
+      completionId,
+      exerciseId: set.exerciseId,
+      userId,
+      setNumber: set.setNumber,
+      reps: set.reps,
+      weight: set.weight,
+      weightUnit: set.weightUnit,
+      rpe: set.rpe ?? null,
+      rir: set.rir ?? null,
+    },
+  })
+  return { ok: true, status: 200, data: { setId: loggedSet.id } }
+}
+
+async function simulateComplete(
+  prisma: PrismaClient,
+  completionId: string,
+  userId: string
+): Promise<SimResult<{ status: string }>> {
+  const completion = await prisma.workoutCompletion.findUnique({
+    where: { id: completionId },
+  })
+  if (!completion) return { ok: false, status: 404, error: 'Workout not found' }
+  if (completion.userId !== userId) return { ok: false, status: 403, error: 'Unauthorized' }
+  if (!completion.isAdHoc) return { ok: false, status: 400, error: 'Not an ad-hoc workout' }
+  if (completion.status === 'completed')
+    return { ok: false, status: 400, error: 'Workout already completed' }
+
+  const setCount = await prisma.loggedSet.count({ where: { completionId } })
+  if (setCount === 0)
+    return { ok: false, status: 400, error: 'Log at least one set before completing.' }
+
+  const updated = await prisma.workoutCompletion.update({
+    where: { id: completionId },
+    data: { status: 'completed', completedAt: new Date() },
+  })
+  return { ok: true, status: 200, data: { status: updated.status } }
+}
+
+describe('Ad-hoc Workout API', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  describe('Full lifecycle', () => {
+    it('creates, adds exercises, logs sets, and completes', async () => {
+      const exerciseDef = await createTestExerciseDefinition(prisma, {
+        name: 'Ad-hoc Bench Press',
+      })
+
+      // Create
+      const created = await simulateCreateAdHoc(prisma, userId)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+      const completionId = created.data.completion.id
+
+      expect(created.data.completion.workoutId).toBeNull()
+      expect(created.data.completion.isAdHoc).toBe(true)
+      expect(created.data.completion.name).toMatch(/^Open Workout — /)
+      expect(created.data.completion.status).toBe('draft')
+
+      // Add exercise
+      const added = await simulateAddExercise(prisma, completionId, userId, exerciseDef.id)
+      expect(added.ok).toBe(true)
+      if (!added.ok) return
+      const exerciseId = added.data.exerciseId
+
+      const exerciseRow = await prisma.exercise.findUnique({ where: { id: exerciseId } })
+      expect(exerciseRow?.workoutId).toBeNull()
+      expect(exerciseRow?.isOneOff).toBe(true)
+      expect(exerciseRow?.workoutCompletionId).toBe(completionId)
+
+      // Log three sets
+      for (let i = 1; i <= 3; i++) {
+        const result = await simulateLogSet(prisma, completionId, userId, {
+          exerciseId,
+          setNumber: i,
+          reps: 5,
+          weight: 135 + i * 5,
+          weightUnit: 'lbs',
+          rir: 2,
+        })
+        expect(result.ok).toBe(true)
+      }
+
+      // Complete
+      const completed = await simulateComplete(prisma, completionId, userId)
+      expect(completed.ok).toBe(true)
+      if (!completed.ok) return
+      expect(completed.data.status).toBe('completed')
+
+      const finalCompletion = await prisma.workoutCompletion.findUnique({
+        where: { id: completionId },
+        include: { loggedSets: true, exercises: true },
+      })
+      expect(finalCompletion?.status).toBe('completed')
+      expect(finalCompletion?.loggedSets).toHaveLength(3)
+      expect(finalCompletion?.exercises).toHaveLength(1)
+    })
+
+    it('supports multiple exercises in one ad-hoc session', async () => {
+      const def1 = await createTestExerciseDefinition(prisma, { name: 'Squat' })
+      const def2 = await createTestExerciseDefinition(prisma, { name: 'Deadlift' })
+
+      const created = await simulateCreateAdHoc(prisma, userId)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+      const completionId = created.data.completion.id
+
+      const added1 = await simulateAddExercise(prisma, completionId, userId, def1.id)
+      const added2 = await simulateAddExercise(prisma, completionId, userId, def2.id)
+      expect(added1.ok && added2.ok).toBe(true)
+      if (!added1.ok || !added2.ok) return
+
+      expect(added1.data.order).toBe(1)
+      expect(added2.data.order).toBe(2)
+    })
+  })
+
+  describe('Validation + auth', () => {
+    it('blocks creating a new ad-hoc when a draft already exists', async () => {
+      const first = await simulateCreateAdHoc(prisma, userId)
+      expect(first.ok).toBe(true)
+
+      const second = await simulateCreateAdHoc(prisma, userId)
+      expect(second.ok).toBe(false)
+      if (second.ok) return
+      expect(second.status).toBe(409)
+      expect(second.error).toBe('DRAFT_EXISTS')
+    })
+
+    it('blocks creating an ad-hoc when a programmed draft exists', async () => {
+      // Build a programmed scenario with a draft completion
+      await createCompleteTestScenario(prisma, userId, { status: 'draft' })
+
+      const result = await simulateCreateAdHoc(prisma, userId)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(409)
+    })
+
+    it("rejects adding an exercise to another user's ad-hoc", async () => {
+      const otherUser = await createTestUser()
+      const created = await simulateCreateAdHoc(prisma, otherUser.id)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+
+      const exerciseDef = await createTestExerciseDefinition(prisma, { name: 'Curl' })
+      const result = await simulateAddExercise(
+        prisma,
+        created.data.completion.id,
+        userId,
+        exerciseDef.id
+      )
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(403)
+    })
+
+    it('rejects logging sets after completion', async () => {
+      const exerciseDef = await createTestExerciseDefinition(prisma, { name: 'Row' })
+      const created = await simulateCreateAdHoc(prisma, userId)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+      const completionId = created.data.completion.id
+
+      const added = await simulateAddExercise(prisma, completionId, userId, exerciseDef.id)
+      expect(added.ok).toBe(true)
+      if (!added.ok) return
+
+      await simulateLogSet(prisma, completionId, userId, {
+        exerciseId: added.data.exerciseId,
+        setNumber: 1,
+        reps: 8,
+        weight: 100,
+        weightUnit: 'lbs',
+      })
+
+      const completed = await simulateComplete(prisma, completionId, userId)
+      expect(completed.ok).toBe(true)
+
+      const secondAttempt = await simulateLogSet(prisma, completionId, userId, {
+        exerciseId: added.data.exerciseId,
+        setNumber: 2,
+        reps: 8,
+        weight: 105,
+        weightUnit: 'lbs',
+      })
+      expect(secondAttempt.ok).toBe(false)
+      if (secondAttempt.ok) return
+      expect(secondAttempt.status).toBe(400)
+    })
+
+    it('rejects completing with no logged sets', async () => {
+      const created = await simulateCreateAdHoc(prisma, userId)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+
+      const result = await simulateComplete(prisma, created.data.completion.id, userId)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(400)
+      expect(result.error).toContain('Log at least one set')
+    })
+  })
+
+  describe('History + active-draft surfacing', () => {
+    it('lists ad-hoc completions alongside programmed completions', async () => {
+      // Programmed completion
+      const scenario = await createCompleteTestScenario(prisma, userId, {
+        loggedSetCount: 2,
+        status: 'completed',
+      })
+      expect(scenario.workout).toBeDefined()
+
+      // Ad-hoc completion
+      const exerciseDef = await createTestExerciseDefinition(prisma, { name: 'Pulldown' })
+      const created = await simulateCreateAdHoc(prisma, userId)
+      if (!created.ok) throw new Error('Failed to create ad-hoc')
+      const adHocId = created.data.completion.id
+      const added = await simulateAddExercise(prisma, adHocId, userId, exerciseDef.id)
+      if (!added.ok) throw new Error('Failed to add exercise')
+      await simulateLogSet(prisma, adHocId, userId, {
+        exerciseId: added.data.exerciseId,
+        setNumber: 1,
+        reps: 10,
+        weight: 80,
+        weightUnit: 'lbs',
+      })
+      await simulateComplete(prisma, adHocId, userId)
+
+      // Mirror /api/workouts/history select shape — must include null workout
+      const completions = await prisma.workoutCompletion.findMany({
+        where: { userId, status: { in: ['completed', 'draft'] } },
+        orderBy: { completedAt: 'desc' },
+        select: {
+          id: true,
+          status: true,
+          isAdHoc: true,
+          name: true,
+          workout: {
+            select: { id: true, name: true, week: { select: { program: { select: { name: true } } } } },
+          },
+        },
+      })
+
+      expect(completions).toHaveLength(2)
+      const adHocRow = completions.find((c) => c.id === adHocId)
+      expect(adHocRow).toBeDefined()
+      expect(adHocRow?.isAdHoc).toBe(true)
+      expect(adHocRow?.workout).toBeNull()
+      expect(adHocRow?.name).toMatch(/^Open Workout — /)
+
+      const programmedRow = completions.find((c) => c.id !== adHocId)
+      expect(programmedRow?.isAdHoc).toBe(false)
+      expect(programmedRow?.workout).not.toBeNull()
+    })
+
+    it('returns ad-hoc draft from active-draft lookup with name fallback', async () => {
+      const created = await simulateCreateAdHoc(prisma, userId)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+
+      // Mirror /api/workouts/active-draft logic
+      const draft = await prisma.workoutCompletion.findFirst({
+        where: { userId, status: 'draft', isArchived: false },
+        orderBy: { completedAt: 'desc' },
+        include: { workout: { select: { name: true } } },
+      })
+
+      expect(draft).not.toBeNull()
+      expect(draft?.isAdHoc).toBe(true)
+      expect(draft?.workoutId).toBeNull()
+      expect(draft?.workout).toBeNull()
+      const resolvedName = draft?.workout?.name ?? draft?.name ?? 'Open Workout'
+      expect(resolvedName).toMatch(/^Open Workout — /)
+    })
+  })
+})

--- a/app/api/workouts/active-draft/route.ts
+++ b/app/api/workouts/active-draft/route.ts
@@ -35,7 +35,8 @@ export async function GET() {
       draft: {
         completionId: draft.id,
         workoutId: draft.workoutId,
-        workoutName: draft.workout.name,
+        workoutName: draft.workout?.name ?? draft.name ?? 'Open Workout',
+        isAdHoc: draft.isAdHoc,
       },
     })
   } catch (err) {

--- a/app/api/workouts/adhoc/[completionId]/complete/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/complete/route.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
+import { recordEvent } from '@/lib/events'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
+
+    const lookup = await findAdHocCompletion(completionId, user.id)
+    if (!lookup.ok) {
+      return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+    }
+
+    if (lookup.completion.status === 'completed') {
+      return NextResponse.json(
+        { error: 'Workout already completed' },
+        { status: 400 }
+      )
+    }
+
+    // Require at least one logged set so we don't persist empty ad-hoc sessions.
+    const setCount = await prisma.loggedSet.count({ where: { completionId } })
+    if (setCount === 0) {
+      return NextResponse.json(
+        { error: 'Log at least one set before completing.' },
+        { status: 400 }
+      )
+    }
+
+    const completion = await prisma.workoutCompletion.update({
+      where: { id: completionId },
+      data: { status: 'completed', completedAt: new Date() },
+      select: { id: true, completedAt: true, status: true },
+    })
+
+    recordEvent(user.id, 'adhoc_workout_completed', { completionId })
+
+    logger.info(
+      { userId: user.id, completionId, setCount },
+      'Ad-hoc workout completed'
+    )
+
+    return NextResponse.json({ success: true, completion })
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'adhoc-complete' },
+      'Error completing ad-hoc workout'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/workouts/adhoc/[completionId]/exercises/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/exercises/route.ts
@@ -1,0 +1,106 @@
+import type { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+
+type AddAdHocExerciseRequest = {
+  exerciseDefinitionId: string
+  notes?: string
+}
+
+const exerciseInclude = {
+  prescribedSets: { orderBy: { setNumber: 'asc' as const } },
+  exerciseDefinition: {
+    select: {
+      id: true,
+      name: true,
+      primaryFAUs: true,
+      secondaryFAUs: true,
+      equipment: true,
+      instructions: true,
+    },
+  },
+} satisfies Prisma.ExerciseInclude
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
+
+    const body = (await request.json()) as AddAdHocExerciseRequest
+    const { exerciseDefinitionId, notes } = body
+
+    if (!exerciseDefinitionId) {
+      return NextResponse.json(
+        { error: 'Exercise definition ID is required' },
+        { status: 400 }
+      )
+    }
+
+    const lookup = await findAdHocCompletion(completionId, user.id)
+    if (!lookup.ok) {
+      return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+    }
+
+    if (lookup.completion.status !== 'draft') {
+      return NextResponse.json(
+        { error: 'Cannot add exercises to a completed workout' },
+        { status: 400 }
+      )
+    }
+
+    const exerciseDefinition = await prisma.exerciseDefinition.findUnique({
+      where: { id: exerciseDefinitionId },
+      select: { id: true, name: true },
+    })
+
+    if (!exerciseDefinition) {
+      return NextResponse.json(
+        { error: 'Exercise definition not found' },
+        { status: 404 }
+      )
+    }
+
+    // Order is unique-within-completion; compute next from existing rows.
+    const existingExercises = await prisma.exercise.findMany({
+      where: { workoutCompletionId: completionId },
+      select: { order: true },
+    })
+    const nextOrder = Math.max(0, ...existingExercises.map((e) => e.order)) + 1
+
+    const exercise = await prisma.exercise.create({
+      data: {
+        name: exerciseDefinition.name,
+        exerciseDefinitionId,
+        order: nextOrder,
+        workoutId: null,
+        isOneOff: true,
+        workoutCompletionId: completionId,
+        notes: notes || null,
+        userId: user.id,
+      },
+      include: exerciseInclude,
+    })
+
+    return NextResponse.json({ success: true, exercise })
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'adhoc-exercise-add' },
+      'Failed to add exercise to ad-hoc workout'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/workouts/adhoc/[completionId]/sets/[setId]/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/sets/[setId]/route.ts
@@ -6,10 +6,10 @@ import { checkRateLimit, setLoggingLimiter } from '@/lib/rate-limit'
 
 export async function DELETE(
   _request: NextRequest,
-  { params }: { params: Promise<{ workoutId: string; setId: string }> }
+  { params }: { params: Promise<{ completionId: string; setId: string }> }
 ) {
   try {
-    const { workoutId, setId } = await params
+    const { completionId, setId } = await params
 
     const { user, error } = await getCurrentUser()
     if (error || !user) {
@@ -19,47 +19,40 @@ export async function DELETE(
     const limited = await checkRateLimit(setLoggingLimiter, user.id)
     if (limited) return limited
 
-    // Find the set and verify ownership through the completion -> workout -> program chain
     const loggedSet = await prisma.loggedSet.findUnique({
       where: { id: setId },
-      include: {
-        completion: {
-          include: {
-            workout: {
-              include: { week: { include: { program: { select: { userId: true } } } } },
-            },
-          },
-        },
-      },
+      include: { completion: true },
     })
 
     if (!loggedSet) {
       return NextResponse.json({ error: 'Set not found' }, { status: 404 })
     }
-
-    // This is the programmed-workout deletion path; ad-hoc sets are deleted
-    // via /api/workouts/adhoc/[completionId]/sets/[setId].
-    if (!loggedSet.completion.workout) {
-      return NextResponse.json({ error: 'Set does not belong to this workout' }, { status: 400 })
-    }
-
-    if (loggedSet.completion.workout.week.program.userId !== user.id) {
+    if (loggedSet.completion.userId !== user.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
-
-    if (loggedSet.completion.workoutId !== workoutId) {
-      return NextResponse.json({ error: 'Set does not belong to this workout' }, { status: 400 })
+    if (loggedSet.completionId !== completionId) {
+      return NextResponse.json(
+        { error: 'Set does not belong to this workout' },
+        { status: 400 }
+      )
     }
-
+    if (!loggedSet.completion.isAdHoc) {
+      return NextResponse.json(
+        { error: 'Not an ad-hoc workout' },
+        { status: 400 }
+      )
+    }
     if (loggedSet.completion.status !== 'draft') {
-      return NextResponse.json({ error: 'Cannot delete sets from a completed workout' }, { status: 400 })
+      return NextResponse.json(
+        { error: 'Cannot delete sets from a completed workout' },
+        { status: 400 }
+      )
     }
 
-    // Delete the set and renumber remaining sets for the same exercise
+    // Delete + renumber remaining sets for this exercise to stay sequential.
     const result = await prisma.$transaction(async (tx) => {
       await tx.loggedSet.delete({ where: { id: setId } })
 
-      // Renumber remaining sets for this exercise to keep sequential
       const remainingSets = await tx.loggedSet.findMany({
         where: {
           completionId: loggedSet.completionId,
@@ -69,15 +62,14 @@ export async function DELETE(
       })
 
       const renumbered: Array<{ id: string; setNumber: number }> = []
-
       for (let i = 0; i < remainingSets.length; i++) {
-        const expectedSetNumber = i + 1
-        if (remainingSets[i].setNumber !== expectedSetNumber) {
+        const expected = i + 1
+        if (remainingSets[i].setNumber !== expected) {
           await tx.loggedSet.update({
             where: { id: remainingSets[i].id },
-            data: { setNumber: expectedSetNumber },
+            data: { setNumber: expected },
           })
-          renumbered.push({ id: remainingSets[i].id, setNumber: expectedSetNumber })
+          renumbered.push({ id: remainingSets[i].id, setNumber: expected })
         }
       }
 
@@ -85,8 +77,11 @@ export async function DELETE(
     })
 
     return NextResponse.json({ success: true, renumbered: result.renumbered })
-  } catch (error) {
-    logger.error({ error, context: 'draft-sets-delete' }, 'Error deleting draft set')
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'adhoc-sets-delete' },
+      'Error deleting set from ad-hoc workout'
+    )
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/app/api/workouts/adhoc/[completionId]/sets/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/sets/route.ts
@@ -1,0 +1,119 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, setLoggingLimiter } from '@/lib/rate-limit'
+
+type SetInput = {
+  exerciseId: string
+  setNumber: number
+  reps: number
+  weight: number
+  weightUnit: string
+  rpe: number | null
+  rir: number | null
+  isWarmup?: boolean
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(setLoggingLimiter, user.id)
+    if (limited) return limited
+
+    const set = (await request.json()) as SetInput
+
+    if (
+      !set.exerciseId ||
+      typeof set.setNumber !== 'number' ||
+      typeof set.reps !== 'number'
+    ) {
+      return NextResponse.json({ error: 'Invalid set data' }, { status: 422 })
+    }
+
+    const lookup = await findAdHocCompletion(completionId, user.id)
+    if (!lookup.ok) {
+      return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+    }
+    if (lookup.completion.status !== 'draft') {
+      return NextResponse.json(
+        { error: 'Cannot log sets on a completed workout' },
+        { status: 400 }
+      )
+    }
+
+    // Verify the exercise belongs to this ad-hoc completion.
+    const exercise = await prisma.exercise.findUnique({
+      where: { id: set.exerciseId },
+      select: { workoutCompletionId: true },
+    })
+    if (!exercise || exercise.workoutCompletionId !== completionId) {
+      return NextResponse.json(
+        { error: 'Exercise not found in this workout' },
+        { status: 422 }
+      )
+    }
+
+    const loggedSet = await prisma.loggedSet.upsert({
+      where: {
+        completionId_exerciseId_setNumber: {
+          completionId,
+          exerciseId: set.exerciseId,
+          setNumber: set.setNumber,
+        },
+      },
+      update: {
+        reps: set.reps,
+        weight: set.weight,
+        weightUnit: set.weightUnit,
+        rpe: set.rpe,
+        rir: set.rir,
+        isWarmup: set.isWarmup ?? false,
+      },
+      create: {
+        completionId,
+        exerciseId: set.exerciseId,
+        userId: user.id,
+        setNumber: set.setNumber,
+        reps: set.reps,
+        weight: set.weight,
+        weightUnit: set.weightUnit,
+        rpe: set.rpe,
+        rir: set.rir,
+        isWarmup: set.isWarmup ?? false,
+      },
+    })
+
+    return NextResponse.json({
+      success: true,
+      set: {
+        id: loggedSet.id,
+        exerciseId: loggedSet.exerciseId,
+        setNumber: loggedSet.setNumber,
+        reps: loggedSet.reps,
+        weight: loggedSet.weight,
+        weightUnit: loggedSet.weightUnit,
+        rpe: loggedSet.rpe,
+        rir: loggedSet.rir,
+        isWarmup: loggedSet.isWarmup,
+      },
+      completionId,
+    })
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'adhoc-sets-create' },
+      'Error logging set on ad-hoc workout'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/workouts/adhoc/route.ts
+++ b/app/api/workouts/adhoc/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+
+const DATE_FMT = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+function defaultAdHocName(now: Date = new Date()): string {
+  return `Open Workout — ${DATE_FMT.format(now)}`
+}
+
+export async function POST() {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
+
+    // One active draft at a time — block if a draft already exists (programmed or ad-hoc).
+    const existingDraft = await prisma.workoutCompletion.findFirst({
+      where: { userId: user.id, status: 'draft', isArchived: false },
+      select: { id: true, isAdHoc: true, name: true, workout: { select: { name: true } } },
+    })
+
+    if (existingDraft) {
+      return NextResponse.json(
+        {
+          error: 'DRAFT_EXISTS',
+          message: 'Finish your current workout before starting a new one.',
+          draft: {
+            completionId: existingDraft.id,
+            isAdHoc: existingDraft.isAdHoc,
+            name: existingDraft.name ?? existingDraft.workout?.name ?? null,
+          },
+        },
+        { status: 409 }
+      )
+    }
+
+    const now = new Date()
+    const completion = await prisma.workoutCompletion.create({
+      data: {
+        workoutId: null,
+        userId: user.id,
+        status: 'draft',
+        isAdHoc: true,
+        name: defaultAdHocName(now),
+        startedAt: now,
+        completedAt: now,
+      },
+      select: { id: true, name: true, startedAt: true },
+    })
+
+    logger.info(
+      { userId: user.id, completionId: completion.id },
+      'Ad-hoc workout started'
+    )
+
+    return NextResponse.json({
+      completion: {
+        id: completion.id,
+        name: completion.name,
+        startedAt: completion.startedAt,
+      },
+    })
+  } catch (err) {
+    logger.error({ error: err, context: 'adhoc-create' }, 'Failed to create ad-hoc workout')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/workouts/history/route.ts
+++ b/app/api/workouts/history/route.ts
@@ -28,6 +28,8 @@ export async function GET(request: NextRequest) {
         id: true,
         status: true,
         completedAt: true,
+        isAdHoc: true,
+        name: true,
         workout: {
           select: {
             id: true,

--- a/components/FloatingDraftButton.tsx
+++ b/components/FloatingDraftButton.tsx
@@ -8,7 +8,9 @@ export default function FloatingDraftButton() {
   const { activeDraft } = useDraftWorkout()
   const router = useRouter()
 
-  if (!activeDraft) return null
+  // Hidden for ad-hoc drafts; the bottom-nav action button (PR2) is the home
+  // for that pulse + resume affordance. Programmed drafts still render here.
+  if (!activeDraft || activeDraft.workoutId === null) return null
 
   return (
     <button

--- a/components/WorkoutHistoryList.tsx
+++ b/components/WorkoutHistoryList.tsx
@@ -25,6 +25,8 @@ type WorkoutCompletion = {
   id: string
   completedAt: Date
   status: string
+  isAdHoc: boolean
+  name: string | null
   workout: {
     id: string
     name: string
@@ -33,7 +35,7 @@ type WorkoutCompletion = {
         name: string
       }
     }
-  }
+  } | null
   loggedSets: LoggedSet[]
   _count: {
     loggedSets: number
@@ -176,11 +178,13 @@ export default function WorkoutHistoryList({ count, compact = false }: Props) {
                 })}
               </p>
               <h3 className="text-lg font-bold text-foreground doom-heading mb-1">
-                {completion.workout.name}
+                {completion.workout?.name ?? completion.name ?? 'Open Workout'}
               </h3>
-              <p className="text-sm text-muted-foreground">
-                {completion.workout.week.program.name}
-              </p>
+              {completion.workout && (
+                <p className="text-sm text-muted-foreground">
+                  {completion.workout.week.program.name}
+                </p>
+              )}
             </div>
             <div className="ml-4">
               {isItemCompleted && (
@@ -229,14 +233,16 @@ export default function WorkoutHistoryList({ count, compact = false }: Props) {
                 </div>
               )
             })}
-            <div className="pt-2">
-              <Link
-                href={`/programs/${completion.workout.id}`}
-                className="text-sm text-primary hover:text-primary-hover font-medium"
-              >
-                View Full Workout →
-              </Link>
-            </div>
+            {completion.workout && (
+              <div className="pt-2">
+                <Link
+                  href={`/programs/${completion.workout.id}`}
+                  className="text-sm text-primary hover:text-primary-hover font-medium"
+                >
+                  View Full Workout →
+                </Link>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/lib/contexts/DraftWorkoutContext.tsx
+++ b/lib/contexts/DraftWorkoutContext.tsx
@@ -12,8 +12,9 @@ import { clientLogger } from '@/lib/client-logger'
 
 type ActiveDraft = {
   completionId: string
-  workoutId: string
+  workoutId: string | null
   workoutName: string
+  isAdHoc: boolean
 }
 
 type DraftWorkoutContextValue = {

--- a/lib/db/adhoc-completion.ts
+++ b/lib/db/adhoc-completion.ts
@@ -1,0 +1,34 @@
+import type { PrismaClient, WorkoutCompletion } from '@prisma/client'
+import { prisma as defaultPrisma } from '@/lib/db'
+
+type Tx = PrismaClient | Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
+
+export type AdHocCompletionLookupResult =
+  | { ok: true; completion: WorkoutCompletion }
+  | { ok: false; status: 404 | 403 | 400; error: string }
+
+/**
+ * Look up an ad-hoc WorkoutCompletion by id and verify it belongs to the
+ * given user. Returns a structured result so callers can map to the
+ * appropriate HTTP status without scattering ownership checks.
+ */
+export async function findAdHocCompletion(
+  completionId: string,
+  userId: string,
+  client: Tx = defaultPrisma
+): Promise<AdHocCompletionLookupResult> {
+  const completion = await client.workoutCompletion.findUnique({
+    where: { id: completionId },
+  })
+
+  if (!completion) {
+    return { ok: false, status: 404, error: 'Workout not found' }
+  }
+  if (completion.userId !== userId) {
+    return { ok: false, status: 403, error: 'Unauthorized' }
+  }
+  if (!completion.isAdHoc) {
+    return { ok: false, status: 400, error: 'Not an ad-hoc workout' }
+  }
+  return { ok: true, completion }
+}

--- a/lib/queries/exercise-history.ts
+++ b/lib/queries/exercise-history.ts
@@ -55,6 +55,7 @@ export async function getBatchExercisePerformance(
     take: 50, // Limit to recent workouts - sufficient for finding last performance
     select: {
       completedAt: true,
+      name: true,
       workout: { select: { name: true } },
       loggedSets: {
         where: {
@@ -103,7 +104,7 @@ export async function getBatchExercisePerformance(
 
         historyMap.set(defId, {
           completedAt: completion.completedAt,
-          workoutName: completion.workout.name,
+          workoutName: completion.workout?.name ?? completion.name ?? 'Open Workout',
           sets: exerciseSets
         });
       }
@@ -157,7 +158,7 @@ export async function getLastExercisePerformance(
 
   return {
     completedAt: lastCompletion.completedAt,
-    workoutName: lastCompletion.workout.name,
+    workoutName: lastCompletion.workout?.name ?? lastCompletion.name ?? 'Open Workout',
     sets: lastCompletion.loggedSets.map(set => ({
       setNumber: set.setNumber,
       reps: set.reps,

--- a/prisma/migrations/20260514211653_workout_completion_adhoc/migration.sql
+++ b/prisma/migrations/20260514211653_workout_completion_adhoc/migration.sql
@@ -1,0 +1,9 @@
+-- Ad-hoc workout support: completions can exist without a programmed Workout parent.
+-- See issue #695 / #738.
+
+ALTER TABLE "WorkoutCompletion" ALTER COLUMN "workoutId" DROP NOT NULL;
+ALTER TABLE "WorkoutCompletion" ADD COLUMN "isAdHoc" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "WorkoutCompletion" ADD COLUMN "name" TEXT;
+
+CREATE INDEX "WorkoutCompletion_userId_isAdHoc_status_idx"
+  ON "WorkoutCompletion" ("userId", "isAdHoc", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,7 +140,7 @@ model PrescribedSet {
 
 model WorkoutCompletion {
   id          String      @id @default(cuid())
-  workoutId   String
+  workoutId   String?
   userId      String
   completedAt DateTime    @default(now())
   startedAt   DateTime?
@@ -148,15 +148,18 @@ model WorkoutCompletion {
   notes       String?
   isArchived  Boolean     @default(false)
   cycleNumber Int         @default(1)
+  isAdHoc     Boolean     @default(false)
+  name        String?
   exercises   Exercise[]
   loggedSets  LoggedSet[]
-  workout     Workout     @relation(fields: [workoutId], references: [id], onDelete: Cascade)
+  workout     Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)
 
   @@index([workoutId, userId])
   @@index([userId, completedAt])
   @@index([userId, status, completedAt])
   @@index([userId, isArchived])
   @@index([workoutId, userId, isArchived])
+  @@index([userId, isAdHoc, status])
 }
 
 model LoggedSet {


### PR DESCRIPTION
Foundation half of #738 (implementation issue for #695 ad-hoc workouts). UI lands in PR 2.

## What's in

### Schema
- `WorkoutCompletion.workoutId` → nullable so completions can exist without a programmed parent
- New columns: `isAdHoc Boolean @default(false)`, `name String?`
- New index: `[userId, isAdHoc, status]` for the active-draft + history lookups
- Migration `20260514211653_workout_completion_adhoc` — additive, non-destructive

### New routes — `/api/workouts/adhoc/*`
| Verb + path | Purpose |
|---|---|
| `POST /api/workouts/adhoc` | Create draft completion. 409 + `DRAFT_EXISTS` if any draft already exists (programmed or ad-hoc) — the one-active-draft rule the UI relies on. |
| `POST /api/workouts/adhoc/[completionId]/exercises` | Add an exercise (no prescribed sets) |
| `POST /api/workouts/adhoc/[completionId]/sets` | Upsert a logged set |
| `DELETE /api/workouts/adhoc/[completionId]/sets/[setId]` | Delete + renumber sequential set numbers |
| `POST /api/workouts/adhoc/[completionId]/complete` | Finish. Rejects with 400 if zero sets logged. |

Shared lookup helper: `lib/db/adhoc-completion.ts::findAdHocCompletion()`.

### Null-safety on existing surfaces

Touched the spots that assumed `completion.workout` was always present:

- `app/api/workouts/active-draft` — falls back to `completion.name` when no workout; includes `isAdHoc` flag in the payload
- `app/api/workouts/history` — selects `isAdHoc` + `name`
- `lib/queries/exercise-history.ts` — two fallbacks for `workoutName` resolution
- `app/api/workouts/[workoutId]/draft/sets/[setId]` — rejects ad-hoc set ids cleanly (the dedicated ad-hoc DELETE route owns those)
- `components/WorkoutHistoryList.tsx` — types + render guards for null workout (no "View Full Workout" link for ad-hoc)
- `lib/contexts/DraftWorkoutContext.tsx` — `workoutId` now `string | null`, adds `isAdHoc`
- `components/FloatingDraftButton.tsx` — defensively hides for ad-hoc drafts (component goes away entirely in PR 2)

## Out of scope (PR 2 territory)

- Bottom-nav center action button + Quick Action sheet
- `<ExerciseLoggingModal>` ad-hoc mode (skip set-config, force `full` logging, `Set N` header)
- Removing `FloatingDraftButton` + its `app/(app)/layout.tsx` mount
- Wiring `Continue your program` to next-workout resolution

## Coordination

- `<DrawerContextBanner>` (#726) needs optional `totalSets` + `prescribed` props — coordinated via https://github.com/aptx-health/ripit-fitness/issues/726#issuecomment-4454754371
- `FloatingDraftButton` removal is deferred to PR 2 to keep PR 1 surface-minimal; the defensive null-guard prevents broken navigation in the interim window

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test adhoc` — full lifecycle, multi-exercise, draft-collision (programmed + ad-hoc), cross-user auth rejection, post-completion lock-out, empty-completion rejection, mixed-history listing, active-draft name fallback
- [ ] Staging soak: programmed workouts unchanged (regression check)
- [ ] Staging soak: `/api/workouts/active-draft` continues to surface programmed drafts correctly

## Migration safety

Additive, non-destructive — no data backfill needed. Existing rows keep `workoutId NOT NULL` semantics in practice (they all have a `workoutId`). The constraint relaxation is forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)