### PR TITLE
feat: extract LoggedSetList for logged sets above input area (#727)

### DIFF
--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -11,6 +11,7 @@ import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/types/workout'
 import DrawerContextBanner from './DrawerContextBanner'
 import ExerciseInfoContent from './ExerciseInfoContent'
+import LoggedSetList from './LoggedSetList'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -144,6 +145,13 @@ export default function ExerciseDisplayTabs({
           totalSets={totalSets}
           prescribed={prescribedSummary}
         />
+        {!isInputExpanded && (
+          <LoggedSetList
+            loggedSets={loggedSets}
+            onDeleteSet={onDeleteSet}
+            showIntensity={showIntensity}
+          />
+        )}
         <div className="px-4 flex-1 flex flex-col gap-2">
           {loggingForm}
           {!isInputExpanded && (

--- a/components/workout-logging/LoggedSetList.tsx
+++ b/components/workout-logging/LoggedSetList.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { AlertCircle, Trash2 } from 'lucide-react'
+import type { LoggedSet } from '@/types/workout'
+
+interface LoggedSetListProps {
+  loggedSets: LoggedSet[]
+  onDeleteSet: (setNumber: number) => void
+  showIntensity?: boolean
+}
+
+/**
+ * Format the intensity cell for a logged set.
+ *
+ * Returns `null` when intensity is hidden or untracked so the caller can
+ * render an empty placeholder span (keeps the row layout stable across sets
+ * with and without intensity values).
+ */
+function formatIntensity(
+  set: { rpe: number | null; rir: number | null },
+  showIntensity: boolean,
+): string | null {
+  if (!showIntensity) return null
+  if (set.rir !== null) return `RIR ${set.rir}`
+  if (set.rpe !== null) return `RPE ${set.rpe}`
+  return null
+}
+
+/**
+ * Format the weight cell. Bodyweight (`weight === 0`) renders without a unit
+ * so it reads as a noun rather than a measurement. Otherwise the numeric
+ * value is paired with the stored unit (e.g. `135 lb`).
+ */
+function formatWeight(weight: number, weightUnit: string): string {
+  if (weight === 0) return 'Bodyweight'
+  return `${weight} ${weightUnit}`
+}
+
+/**
+ * Tabular list of previously logged sets for the current exercise. Sits above
+ * the input area on the LOG SETS tab so "what I've done" stays distinct from
+ * "what I'm doing right now."
+ *
+ * Returns `null` when there are no logged sets — an empty section header
+ * reads worse than no header at all.
+ */
+export default function LoggedSetList({
+  loggedSets,
+  onDeleteSet,
+  showIntensity = true,
+}: LoggedSetListProps) {
+  if (loggedSets.length === 0) return null
+
+  return (
+    <div className="px-4 pb-3">
+      <div className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-1.5">
+        Logged
+      </div>
+      <div className="border border-border bg-card divide-y divide-border/60">
+        {loggedSets.map((set) => {
+          const isFailed = set._syncStatus === 'error'
+          const isPending = set._syncStatus === 'pending'
+          const intensity = formatIntensity(set, showIntensity)
+
+          return (
+            <div
+              key={`logged-${set.exerciseId}-${set.setNumber}`}
+              className="flex items-center gap-3 px-3 py-2 text-sm tabular-nums"
+            >
+              <span className="w-6 text-muted-foreground font-bold">
+                {set.setNumber}
+              </span>
+              <span
+                className={`flex-1 font-semibold ${isFailed ? 'text-warning' : 'text-foreground'}`}
+              >
+                {set.reps} reps{' '}
+                <span className="text-muted-foreground">×</span>{' '}
+                {formatWeight(set.weight, set.weightUnit)}
+                {isPending && (
+                  <span className="ml-2 text-xs font-normal text-muted-foreground normal-case tracking-normal">
+                    saving...
+                  </span>
+                )}
+                {isFailed && (
+                  <AlertCircle
+                    aria-hidden="true"
+                    size={12}
+                    className="inline-block ml-2 -mt-0.5 text-warning"
+                  />
+                )}
+              </span>
+              {intensity ? (
+                <span className="text-xs text-muted-foreground font-semibold uppercase tracking-wider">
+                  {intensity}
+                </span>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              <button
+                type="button"
+                onClick={() => onDeleteSet(set.setNumber)}
+                className="p-1 text-muted-foreground/60 hover:text-error doom-focus-ring"
+                aria-label={`Delete set ${set.setNumber}`}
+              >
+                <Trash2 size={14} strokeWidth={2} />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/workout-logging/SetList.tsx
+++ b/components/workout-logging/SetList.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { AlertCircle, Check, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import type { LoggedSet } from '@/types/workout'
 import RestStopwatch from './RestStopwatch'
@@ -33,7 +32,12 @@ interface SetListProps {
   prescribedSets: PrescribedSet[]
   loggedSets: LoggedSet[]
   exerciseHistory: ExerciseHistory | null
-  onDeleteSet: (setNumber: number) => void
+  /**
+   * @deprecated Logged-set deletion now lives on `<LoggedSetList>`. Kept for
+   * backwards compatibility with callers that still wire it through; this
+   * component no longer renders the delete affordance.
+   */
+  onDeleteSet?: (setNumber: number) => void
   exerciseId?: string
   showIntensity?: boolean
 }
@@ -62,11 +66,16 @@ function isUniformPrescription(sets: PrescribedSet[]): boolean {
   )
 }
 
+/**
+ * Prescribed-set rendering for the LOG SETS tab. Logged sets now render in a
+ * dedicated `<LoggedSetList>` above the input area (#727). This component
+ * keeps the prescribed-set view + rest timer + history strip in their
+ * existing slot below the input.
+ */
 export default function SetList({
   prescribedSets,
   loggedSets,
   exerciseHistory,
-  onDeleteSet,
   exerciseId,
   showIntensity = true,
 }: SetListProps) {
@@ -85,34 +94,6 @@ export default function SetList({
     }
     prevLogCountRef.current = loggedSets.length
   }, [loggedSets.length])
-
-  // Track which set was just logged for the flash animation
-  const prevExerciseRef = useRef(exerciseId)
-  const prevCountRef = useRef(loggedSets.length)
-  const [flashSetNumber, setFlashSetNumber] = useState<number | null>(null)
-
-  useEffect(() => {
-    const count = loggedSets.length
-
-    if (exerciseId !== prevExerciseRef.current) {
-      prevExerciseRef.current = exerciseId
-      prevCountRef.current = count
-      const frame = requestAnimationFrame(() => setFlashSetNumber(null))
-      return () => cancelAnimationFrame(frame)
-    }
-
-    if (count > prevCountRef.current) {
-      const newest = loggedSets[count - 1]
-      const frame = requestAnimationFrame(() => setFlashSetNumber(newest.setNumber))
-      const flashOffTimer = setTimeout(() => setFlashSetNumber(null), 650)
-      prevCountRef.current = count
-      return () => {
-        cancelAnimationFrame(frame)
-        clearTimeout(flashOffTimer)
-      }
-    }
-    prevCountRef.current = count
-  }, [loggedSets, exerciseId])
 
   // Collapsed summary: show when no sets logged and prescription is uniform
   const showCollapsedSummary = loggedSets.length === 0 && isUniformPrescription(prescribedSets) && prescribedSets.length > 1
@@ -148,57 +129,9 @@ export default function SetList({
         </div>
       )}
 
-      {/* Per-row view: logged + rest timer + prescribed */}
+      {/* Rest timer + prescribed rows */}
       {!showCollapsedSummary && (
         <div>
-          {/* Logged sets */}
-          {loggedSets.map((set) => {
-            const isFailed = set._syncStatus === 'error'
-            const isPending = set._syncStatus === 'pending'
-            return (
-              <div
-                key={`logged-${set.exerciseId}-${set.setNumber}`}
-                className={`px-2.5 py-3 ${flashSetNumber === set.setNumber ? 'doom-set-logged' : ''}`}
-                style={{
-                  backgroundColor: 'color-mix(in srgb, var(--success) 8%, transparent)',
-                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.30)',
-                }}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-start gap-2 flex-1 min-w-0">
-                    {/* State indicator — filled circle */}
-                    <span className="flex-shrink-0 mt-0.5 w-[22px] h-[22px] flex items-center justify-center" style={{ backgroundColor: isFailed ? 'var(--warning)' : 'var(--success)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), inset 0 -1px 0 rgba(0,0,0,0.20)' }}>
-                      {isFailed ? (
-                        <AlertCircle size={12} className="text-white" />
-                      ) : (
-                        <Check size={12} className="text-white" strokeWidth={3} />
-                      )}
-                    </span>
-                    <div className="min-w-0">
-                      <span className="block text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                        Set {set.setNumber}
-                      </span>
-                      <span className={`block text-base font-bold ${isFailed ? 'text-warning' : 'text-foreground'}`}>
-                        {formatWeight(set.weight, set.weightUnit)} × {set.reps}
-                        {showIntensity && formatIntensity(set) ? ` · ${formatIntensity(set)}` : ''}
-                      </span>
-                      {isPending && <span className="text-xs text-muted-foreground">saving...</span>}
-                    </div>
-                  </div>
-                  {/* Delete — hidden by default, visible on hover */}
-                  <button
-                    type="button"
-                    onClick={() => onDeleteSet(set.setNumber)}
-                    className="opacity-0 hover:opacity-100 focus:opacity-100 text-muted-foreground/30 hover:text-error p-1 transition-all doom-focus-ring"
-                    aria-label={`Delete set ${set.setNumber}`}
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                </div>
-              </div>
-            )
-          })}
-
           {/* Rest timer card — between logged and prescribed */}
           {loggedSets.length > 0 && remainingSets.length > 0 && (
             <RestStopwatch


### PR DESCRIPTION
## Summary

Extracts the logged-set rendering from `SetList.tsx` into a new presentational
`<LoggedSetList>` component placed above the input area on the LOG SETS tab,
matching the canonical logger reference (`feat/reference-mockups`).

The separation makes the logger noticeably more readable mid-workout:
\"what I've done\" sits above \"what I'm doing right now,\" and prescribed sets
remain in `SetList` beneath the input.

## Changes

- **New** `components/workout-logging/LoggedSetList.tsx` — tabular row per
  logged set: set number (left), \`reps × weight\` (center, \`flex-1\`),
  intensity (right), delete trash (trailing). All numerics use
  \`tabular-nums\`. Returns \`null\` when \`loggedSets.length === 0\`.
- **Updated** `components/workout-logging/SetList.tsx` — removes the
  logged-set rendering block; keeps history strip, \"Sets\" header,
  prescribed-set rows, and rest-stopwatch placement. \`onDeleteSet\` prop
  marked deprecated for backwards compatibility.
- **Updated** `components/workout-logging/ExerciseDisplayTabs.tsx` — wires
  \`<LoggedSetList>\` above the \`loggingForm\` (only when input is not
  expanded), so the row order is now: DrawerContextBanner → LoggedSetList →
  input → SetList (prescribed-only) → MessageCard.

## Notes on acceptance items

- **Delete confirmation:** retained the existing pattern in
  `ExerciseLoggingModal.handleDeleteSet` — confirms only when deleting the
  *last* logged set for an exercise (\"if you delete this, the exercise will
  be cleared\"). Mid-list deletions are immediate. Matches prior behavior; if
  this needs to expand to every delete, that's a separate follow-up.
- **Tap-on-row to edit:** skipped per ticket's explicit nice-to-have caveat.
  The bottom-bar chevrons remain the primary \"edit previous set\" affordance
  per #710.
- **Sync-status preserved:** failed (\`_syncStatus === 'error'\`) sets show in
  warning color with an inline \`AlertCircle\`. Pending sets show a small
  \"saving...\" label. Subtler than the old filled-circle indicators since the
  reference's tabular row had no room for them; the color shift and inline
  glyph carry the signal.

## Test plan

- [ ] Open a workout in progress; verify a \"LOGGED\" tabular block appears
      above the REPS/WEIGHT/RIR controls once a set is logged
- [ ] Verify the block is hidden entirely before any sets are logged
- [ ] Delete a logged set via the trash; verify confirmation only fires for
      the last-remaining set
- [ ] Verify rest stopwatch still appears between logged and prescribed sets
      in the SetList region beneath the input
- [ ] Toggle a theme via \`/dev/theme-validator\`; verify token roles
      (\`border\`, \`bg-card\`, \`text-error\`) read correctly
- [ ] Confirm row layout stays stable when some sets have intensity values
      and others don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)