### PR TITLE
fix(draft-context): refresh on navigation + window focus

### DIFF
--- a/lib/contexts/DraftWorkoutContext.tsx
+++ b/lib/contexts/DraftWorkoutContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { usePathname } from 'next/navigation'
 import {
   createContext,
   type ReactNode,
@@ -34,6 +35,7 @@ const DraftWorkoutContext = createContext<DraftWorkoutContextValue>({
 export function DraftWorkoutProvider({ children }: { children: ReactNode }) {
   const [activeDraft, setActiveDraft] = useState<ActiveDraft | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const pathname = usePathname()
 
   const fetchDraft = useCallback(async () => {
     try {
@@ -48,8 +50,21 @@ export function DraftWorkoutProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  // Refresh on mount AND on pathname change. The logger surfaces (programmed
+  // and ad-hoc) mutate draft state — save / discard / complete — and then
+  // navigate back to /training. Re-fetching on navigation propagates the
+  // server state into the context without each handler having to remember
+  // to call refreshDraft itself.
   useEffect(() => {
     fetchDraft()
+  }, [fetchDraft, pathname])
+
+  // Also refresh whenever the window regains focus, so a PWA backgrounded
+  // mid-workout and resumed later sees current state.
+  useEffect(() => {
+    const onFocus = () => fetchDraft()
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
   }, [fetchDraft])
 
   const clearDraft = useCallback(() => {

--- a/lib/contexts/DraftWorkoutContext.tsx
+++ b/lib/contexts/DraftWorkoutContext.tsx
@@ -55,6 +55,7 @@ export function DraftWorkoutProvider({ children }: { children: ReactNode }) {
   // navigate back to /training. Re-fetching on navigation propagates the
   // server state into the context without each handler having to remember
   // to call refreshDraft itself.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger, not a value used inside
   useEffect(() => {
     fetchDraft()
   }, [fetchDraft, pathname])


### PR DESCRIPTION
## Problem (reported on staging)

The bottom-nav action chip and QuickActionSheet hold stale draft state after the logger mutates it (save / discard / complete) and the user navigates back to /training:

- After exiting a workout with **Save as Draft**, the chip doesn't shine. Tapping it shows the non-draft sheet variant for ~half a second, then flashes into the draft variant once the sheet's own \`refreshDraft\` fires.
- Same after **completing or discarding** — the chip stays lit until something nudges the context.

## Root cause

`DraftWorkoutContext` only fetched once on mount. Every other surface in the app reads from this single state, so anything that changed draft state elsewhere required an explicit `refreshDraft()` call from the mutating component — which the logger surfaces don't all do, and shouldn't have to remember to.

## Fix

Two refresh triggers added in the context provider:

1. **Pathname change** — the logger surfaces all navigate to `/training` after a draft mutation. Re-fetching on `usePathname` change propagates the new server state automatically.
2. **Window focus** — catches the PWA-backgrounded-and-resumed case so a user who left the app mid-workout sees current state on return.

No per-handler updates needed in `ExerciseLoggingModal` or `AdHocLoggerView`.

## Test plan

- [ ] Start a freestyle workout, log a set, exit with **Save as Draft** → land on /training → chip should be shining immediately, no half-second flicker on first tap of the sheet
- [ ] Resume that draft, complete it → land on /training → chip should be dim immediately
- [ ] Resume that draft, discard it → chip should be dim immediately
- [ ] Same matrix for a programmed workout
- [ ] Background the PWA mid-workout, foreground it → chip + sheet reflect current draft state on resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)