### PR TITLE
Remove bottom safe-area padding from logger modal

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -514,7 +514,7 @@ export default function ExerciseLoggingModal({
     <>
       <div className="fixed inset-0 z-50 backdrop-blur-md bg-black/40 dark:bg-black/60 flex items-center justify-center">
         {/* Modal - Full screen on mobile, centered on desktop */}
-        <div className="bg-card w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg flex flex-col shadow-xl pb-[env(safe-area-inset-bottom)]">
+        <div className="bg-card w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg flex flex-col shadow-xl">
           {/* Header */}
           {isFollowAlong ? (
             <FollowAlongHeader


### PR DESCRIPTION
## Summary
- Drop `pb-[env(safe-area-inset-bottom)]` from the `ExerciseLoggingModal` container. The modal is full-viewport on mobile so the footer button already sits at the screen edge; the inset padding produced a visible gap below the Next Exercise / Log Set button on both follow-along and logging views.
- Bottom safe-area inset is preserved on `BottomNav` and other dialogs/modals where it's still needed.

## Test plan
- [ ] Open a workout in follow-along mode on iOS PWA — footer button sits flush with the bottom edge, no gap.
- [ ] Switch to logging mode — same.
- [ ] Verify primary tabs still have the `BottomNav` safe-area gap so nothing is cut off by the home indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)