### PR TITLE
Themed safe-area inset on logger footers

### DIFF
--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -485,7 +485,10 @@ export default function AdHocLoggerView({
         {!hasExercises && (
           <div
             className="bg-secondary px-4 py-3 flex-shrink-0"
-            style={{ boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)' }}
+            style={{
+              boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)',
+              paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom, 0px))',
+            }}
           >
             <button
               type="button"

--- a/components/workout-logging/ExerciseActionsFooter.tsx
+++ b/components/workout-logging/ExerciseActionsFooter.tsx
@@ -40,7 +40,10 @@ export default function ExerciseActionsFooter({
   return (
     <div
       className="bg-secondary px-4 py-3 flex-shrink-0"
-      style={{ boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)' }}
+      style={{
+        boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)',
+        paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom, 0px))',
+      }}
     >
       <div className="flex items-center gap-2.5">
         <button

--- a/components/workout-logging/FollowAlongFooter.tsx
+++ b/components/workout-logging/FollowAlongFooter.tsx
@@ -26,7 +26,10 @@ export default function FollowAlongFooter({
   return (
     <div
       className="flex-shrink-0 bg-secondary px-4 py-3 flex gap-2.5"
-      style={{ boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)' }}
+      style={{
+        boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.25)',
+        paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom, 0px))',
+      }}
     >
       <Button
         variant="secondary"


### PR DESCRIPTION
## Summary
- Move bottom `env(safe-area-inset-bottom)` from the white modal container onto the secondary-colored footers so the iOS home-indicator gap matches the footer theme instead of showing as blank white space.
- Applied to `FollowAlongFooter`, `ExerciseActionsFooter` (used by the structured logger and the ad-hoc logger), and the AdHoc empty-state add-exercise footer.

## Test plan
- [ ] Open a structured workout on iOS PWA in follow-along mode → home indicator clears the Next Exercise button and the gap is themed (orange/secondary).
- [ ] Same workout in full logging mode → same behavior on the Log Set footer.
- [ ] Open an ad-hoc / freestyle workout with no exercises yet → Add Exercise footer has themed bottom inset; after adding an exercise the shared ExerciseActionsFooter shows the same.
- [ ] On desktop / non-PWA the inset resolves to 0 and the footers render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)