### PR TITLE
Hide week description when training message is shown

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -487,10 +487,10 @@ export default function StrengthWeekView({
             ) : undefined
           }
         />
-        {week.description && (
+        {week.description && !trainingMessage && (
           <div className="mt-3 px-1">
-            <p className="text-base text-muted-foreground leading-relaxed">
-              {week.description}
+            <p className="text-lg text-muted-foreground leading-relaxed">
+              <span className="font-bold">Week Overview:</span> {week.description}
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Week description and contextual training messages no longer compete on the training tab — the message takes precedence, and the description reappears once the message is dismissed.
- Restyled the week description to match the message card (`text-lg`, `leading-relaxed`) and prefixed it with a bold **Week Overview:** label.

## Test plan
- [ ] With an active training message visible, confirm the week description is hidden.
- [ ] Dismiss the message and confirm the week description appears with the new styling and "Week Overview:" prefix.
- [ ] With no message present, the week description still renders as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)