### PR TITLE
feat: extract <NumberKeypad> primitive with retro LCD restyle (used by weight + reps)

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -599,7 +599,7 @@ export default function ExerciseLoggingModal({
 
           {/* Content area with tabs — swipeable */}
           <div
-            className={`flex-1 overflow-hidden pb-2 transition-transform duration-150 ease-out ${
+            className={`flex-1 overflow-hidden transition-transform duration-150 ease-out ${
               slideDirection === 'left' ? '-translate-x-4 opacity-80' :
               slideDirection === 'right' ? 'translate-x-4 opacity-80' : ''
             }`}

--- a/components/workout-logging/SetLoggingForm.tsx
+++ b/components/workout-logging/SetLoggingForm.tsx
@@ -15,7 +15,7 @@ interface PrescribedSet {
   rir: number | null
 }
 
-export type ExpandedInput = 'weight' | 'rpe' | 'rir' | null
+export type ExpandedInput = 'weight' | 'rpe' | 'rir' | 'reps' | null
 
 interface SetLoggingFormProps {
   prescribedSet: PrescribedSet | undefined
@@ -79,8 +79,9 @@ export default function SetLoggingForm({
     if (input === 'weight') valueBeforeExpand.current = currentSet.weight
     else if (input === 'rpe') valueBeforeExpand.current = currentSet.rpe
     else if (input === 'rir') valueBeforeExpand.current = currentSet.rir
+    else if (input === 'reps') valueBeforeExpand.current = currentSet.reps
     onExpandedInputChange(input)
-  }, [currentSet.weight, currentSet.rpe, currentSet.rir, onExpandedInputChange])
+  }, [currentSet.weight, currentSet.rpe, currentSet.rir, currentSet.reps, onExpandedInputChange])
 
   const handleCollapse = useCallback(() => {
     onExpandedInputChange(null)
@@ -92,6 +93,7 @@ export default function SetLoggingForm({
     if (input === 'weight') onSetChange({ ...currentSet, weight: restored })
     else if (input === 'rpe') onSetChange({ ...currentSet, rpe: restored })
     else if (input === 'rir') onSetChange({ ...currentSet, rir: restored })
+    else if (input === 'reps') onSetChange({ ...currentSet, reps: restored })
     onExpandedInputChange(null)
   }, [currentSet, onSetChange, onExpandedInputChange])
 
@@ -131,7 +133,7 @@ export default function SetLoggingForm({
     )
   }
 
-  const showReps = expandedInput === null
+  const showReps = expandedInput === null || expandedInput === 'reps'
   const showWeight = expandedInput === null || expandedInput === 'weight'
   const showIntensity = expandedInput === null || expandedInput === 'rpe' || expandedInput === 'rir'
 
@@ -144,6 +146,10 @@ export default function SetLoggingForm({
             value={currentSet.reps}
             onChange={(val) => onSetChange({ ...currentSet, reps: val })}
             placeholder={prescribedSet?.reps?.toString()}
+            isExpanded={expandedInput === 'reps'}
+            onExpand={() => handleExpand('reps')}
+            onCollapse={handleCollapse}
+            onCancel={() => handleCancel('reps')}
           />
         )}
 

--- a/components/workout-logging/inputs/NumberKeypad.tsx
+++ b/components/workout-logging/inputs/NumberKeypad.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { Delete } from 'lucide-react'
+import { useCallback, useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/Button'
+
+interface NumberKeypadProps {
+  value: string
+  onChange: (value: string) => void
+  onCollapse: () => void
+  onCancel: () => void
+  label: string
+  unit?: string
+  max?: number
+}
+
+const KEYPAD_KEYS = [
+  '1', '2', '3',
+  '4', '5', '6',
+  '7', '8', '9',
+  'CLR', '0', 'DEL',
+] as const
+
+export function NumberKeypad({
+  value,
+  onChange,
+  onCollapse,
+  onCancel,
+  label,
+  unit,
+  max = 999,
+}: NumberKeypadProps) {
+  const replaceOnNext = useRef(true)
+
+  // First keystroke after opening replaces any pre-filled value
+  useEffect(() => {
+    replaceOnNext.current = true
+  }, [])
+
+  const handleKeyPress = useCallback((key: string) => {
+    if (key === 'CLR') {
+      onChange('')
+      replaceOnNext.current = false
+      return
+    }
+
+    if (key === 'DEL') {
+      if (replaceOnNext.current) {
+        onChange('')
+        replaceOnNext.current = false
+        return
+      }
+      onChange(value.slice(0, -1))
+      return
+    }
+
+    if (replaceOnNext.current) {
+      onChange(key === '0' ? '0' : key)
+      replaceOnNext.current = false
+      return
+    }
+
+    const candidate = value + key
+    if (parseInt(candidate, 10) > max) return
+
+    if (value === '0' && key === '0') return
+    if (value === '0' && key !== '0') {
+      onChange(key)
+      return
+    }
+
+    onChange(candidate)
+  }, [value, onChange, max])
+
+  const handleDone = () => {
+    replaceOnNext.current = false
+    onCollapse()
+  }
+
+  return (
+    <div
+      className="mt-auto"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      <span className="block text-sm text-muted-foreground mb-1.5 font-bold uppercase tracking-wider">
+        {label}
+      </span>
+
+      {/* Current value display - recessed LCD screen */}
+      <div
+        className="w-full h-14 px-4 flex items-center justify-center
+          border-2 border-primary
+          text-3xl font-bold text-foreground tabular-nums bg-input"
+        style={{
+          boxShadow:
+            'inset 0 2px 3px rgba(58, 40, 23, 0.18), inset 0 0 0 1px rgba(255,255,255,0.4), 0 0 12px rgba(var(--primary-rgb), 0.25)',
+        }}
+      >
+        {value || '0'}
+        {unit && (
+          <span className="text-base font-semibold text-muted-foreground ml-2">
+            {unit}
+          </span>
+        )}
+      </div>
+
+      {/* Number keypad grid - tactile molded keys on hairline rules */}
+      <div className="grid grid-cols-3 gap-px mt-2 bg-border">
+        {KEYPAD_KEYS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => handleKeyPress(key)}
+            className={`h-14 flex items-center justify-center
+              font-bold tabular-nums transition-all duration-75
+              active:translate-y-[1px]
+              active:bg-primary active:text-primary-foreground
+              ${key === 'CLR'
+                ? 'bg-muted text-muted-foreground hover:bg-secondary-hover text-sm uppercase tracking-wider'
+                : key === 'DEL'
+                  ? 'bg-muted text-muted-foreground hover:bg-secondary-hover'
+                  : 'bg-card text-foreground text-2xl hover:bg-muted'
+              }`}
+            style={{
+              boxShadow:
+                'inset 0 1px 0 rgba(255,255,255,0.55), inset 0 -1px 0 rgba(58, 40, 23, 0.08)',
+            }}
+          >
+            {key === 'DEL' ? <Delete size={20} /> : key}
+          </button>
+        ))}
+      </div>
+
+      {/* Cancel + Done buttons */}
+      <div className="flex gap-px mt-2">
+        <Button
+          variant="secondary"
+          doom
+          onClick={onCancel}
+          aria-label={`Cancel ${label.toLowerCase()} entry`}
+          className="flex-1 h-11 text-error uppercase tracking-wider text-sm"
+        >
+          CANCEL
+        </Button>
+        <Button
+          variant="primary"
+          doom
+          onClick={handleDone}
+          className="flex-[2] h-11 uppercase tracking-wider text-sm"
+        >
+          DONE
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/workout-logging/inputs/RepsStepper.tsx
+++ b/components/workout-logging/inputs/RepsStepper.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Minus, Plus } from 'lucide-react'
+import { NumberKeypad } from './NumberKeypad'
 
 const RAISED_SHADOW = 'inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -2px 0 rgba(0,0,0,0.30), 0 1px 0 rgba(0,0,0,0.40)'
 const RECESSED_SHADOW = 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)'
@@ -9,11 +10,35 @@ interface RepsStepperProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  isExpanded?: boolean
+  onExpand?: () => void
+  onCollapse?: () => void
+  onCancel?: () => void
 }
 
-export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) {
+export function RepsStepper({
+  value,
+  onChange,
+  placeholder,
+  isExpanded = false,
+  onExpand,
+  onCollapse,
+  onCancel,
+}: RepsStepperProps) {
   const numericValue = value ? parseInt(value, 10) : 0
   const hasValue = value !== ''
+
+  if (isExpanded && onCollapse && onCancel) {
+    return (
+      <NumberKeypad
+        value={value}
+        onChange={onChange}
+        onCollapse={onCollapse}
+        onCancel={onCancel}
+        label="REPETITIONS"
+      />
+    )
+  }
 
   const handleDecrement = () => {
     if (!hasValue) return
@@ -46,9 +71,15 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
           <Minus size={24} strokeWidth={3} />
         </button>
 
-        <div
+        <button
+          type="button"
+          onClick={onExpand}
+          disabled={!onExpand}
+          aria-label="Edit reps with keypad"
           className="flex-1 min-h-[44px] flex items-center justify-center
-            text-2xl font-bold text-foreground tabular-nums min-w-[60px]"
+            text-2xl font-bold text-foreground tabular-nums min-w-[60px]
+            transition-all duration-75
+            disabled:cursor-default"
           style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: RECESSED_SHADOW }}
         >
           {hasValue ? numericValue : (
@@ -56,7 +87,7 @@ export function RepsStepper({ value, onChange, placeholder }: RepsStepperProps) 
               {placeholder || '0'}
             </span>
           )}
-        </div>
+        </button>
 
         <button
           type="button"

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -121,47 +121,55 @@ export function WeightKeypad({
       className="mt-auto"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
-      <span className="block text-sm text-muted-foreground mb-1 font-bold uppercase tracking-wider">
+      <span className="block text-sm text-muted-foreground mb-1.5 font-bold uppercase tracking-wider">
         WEIGHT ({weightUnit.toUpperCase()})
       </span>
 
-      {/* Current value display */}
+      {/* Current value display - recessed LCD screen */}
       <div
-        className="w-full h-12 px-4 flex items-center justify-center
+        className="w-full h-14 px-4 flex items-center justify-center
           border-2 border-primary
-          text-2xl font-bold text-foreground tabular-nums"
-        style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), 0 0 8px rgba(var(--primary-rgb),0.2)' }}
+          text-3xl font-bold text-foreground tabular-nums bg-input"
+        style={{
+          boxShadow:
+            'inset 0 2px 3px rgba(58, 40, 23, 0.18), inset 0 0 0 1px rgba(255,255,255,0.4), 0 0 12px rgba(var(--primary-rgb), 0.25)',
+        }}
       >
         {value || '0'}
-        <span className="text-sm font-semibold text-muted-foreground ml-2">
+        <span className="text-base font-semibold text-muted-foreground ml-2">
           {weightUnit}
         </span>
       </div>
 
-      {/* Number keypad grid */}
-      <div className="grid grid-cols-3 gap-px mt-px bg-border">
+      {/* Number keypad grid - tactile molded keys on hairline rules */}
+      <div className="grid grid-cols-3 gap-px mt-2 bg-border">
         {KEYPAD_KEYS.map((key) => (
           <button
             key={key}
             type="button"
             onClick={() => handleKeyPress(key)}
-            className={`h-11 flex items-center justify-center
-              font-bold text-lg transition-colors
+            className={`h-14 flex items-center justify-center
+              font-bold tabular-nums transition-all duration-75
+              active:translate-y-[1px]
               active:bg-primary active:text-primary-foreground
               ${key === 'CLR'
-                ? 'bg-muted text-muted-foreground hover:bg-secondary text-sm uppercase tracking-wider'
+                ? 'bg-muted text-muted-foreground hover:bg-secondary-hover text-sm uppercase tracking-wider'
                 : key === 'DEL'
-                  ? 'bg-muted text-muted-foreground hover:bg-secondary'
-                  : 'bg-card text-foreground hover:bg-secondary'
+                  ? 'bg-muted text-muted-foreground hover:bg-secondary-hover'
+                  : 'bg-card text-foreground text-2xl hover:bg-muted'
               }`}
+            style={{
+              boxShadow:
+                'inset 0 1px 0 rgba(255,255,255,0.55), inset 0 -1px 0 rgba(58, 40, 23, 0.08)',
+            }}
           >
-            {key === 'DEL' ? <Delete size={18} /> : key}
+            {key === 'DEL' ? <Delete size={20} /> : key}
           </button>
         ))}
       </div>
 
       {/* Cancel + Done buttons */}
-      <div className="flex gap-px mt-px">
+      <div className="flex gap-px mt-2">
         <Button
           variant="secondary"
           doom

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { Delete } from 'lucide-react'
-import { useCallback, useEffect, useRef } from 'react'
-import { Button } from '@/components/ui/Button'
+import { NumberKeypad } from './NumberKeypad'
 
 interface WeightKeypadProps {
   value: string
@@ -14,13 +12,6 @@ interface WeightKeypadProps {
   onCancel: () => void
 }
 
-const KEYPAD_KEYS = [
-  '1', '2', '3',
-  '4', '5', '6',
-  '7', '8', '9',
-  'CLR', '0', 'DEL',
-] as const
-
 export function WeightKeypad({
   value,
   weightUnit,
@@ -30,164 +21,38 @@ export function WeightKeypad({
   onCollapse,
   onCancel,
 }: WeightKeypadProps) {
-  const replaceOnNext = useRef(false)
-
-  // Set replaceOnNext when expanding
-  useEffect(() => {
-    if (isExpanded) {
-      replaceOnNext.current = true
-    }
-  }, [isExpanded])
-
-  const handleExpand = () => {
-    onExpand()
-  }
-
-  const handleKeyPress = useCallback((key: string) => {
-    if (key === 'CLR') {
-      onChange('')
-      replaceOnNext.current = false
-      return
-    }
-
-    if (key === 'DEL') {
-      if (replaceOnNext.current) {
-        onChange('')
-        replaceOnNext.current = false
-        return
-      }
-      const newValue = value.slice(0, -1)
-      onChange(newValue)
-      return
-    }
-
-    // Digit
-    if (replaceOnNext.current) {
-      // First keystroke replaces the pre-filled value
-      onChange(key === '0' ? '0' : key)
-      replaceOnNext.current = false
-      return
-    }
-
-    const candidate = value + key
-    const numericCandidate = parseInt(candidate, 10)
-
-    // Clamp to 0-999
-    if (numericCandidate > 999) return
-
-    // Prevent leading zeros (allow single "0")
-    if (value === '0' && key === '0') return
-    if (value === '0' && key !== '0') {
-      onChange(key)
-      return
-    }
-
-    onChange(candidate)
-  }, [value, onChange])
-
-  const handleDone = () => {
-    replaceOnNext.current = false
-    onCollapse()
-  }
-
-  // Compact view
-  if (!isExpanded) {
+  if (isExpanded) {
     return (
-      <div>
-        <span className="block text-sm text-muted-foreground mb-1 font-bold uppercase tracking-wider">
-          WEIGHT ({weightUnit.toUpperCase()})
-        </span>
-        <button
-          type="button"
-          onClick={handleExpand}
-          className="w-full h-12 px-4 flex items-center justify-center
-            text-2xl font-bold text-foreground tabular-nums
-            hover:border-primary
-            transition-all duration-75"
-          style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)' }}
-        >
-          {value || '0'}
-          <span className="text-sm font-semibold text-muted-foreground ml-2">
-            {weightUnit}
-          </span>
-        </button>
-      </div>
+      <NumberKeypad
+        value={value}
+        onChange={onChange}
+        onCollapse={onCollapse}
+        onCancel={onCancel}
+        label={`WEIGHT (${weightUnit.toUpperCase()})`}
+        unit={weightUnit}
+      />
     )
   }
 
-  // Expanded view with keypad - mt-auto pushes to bottom of flex container
   return (
-    <div
-      className="mt-auto"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-    >
-      <span className="block text-sm text-muted-foreground mb-1.5 font-bold uppercase tracking-wider">
+    <div>
+      <span className="block text-sm text-muted-foreground mb-1 font-bold uppercase tracking-wider">
         WEIGHT ({weightUnit.toUpperCase()})
       </span>
-
-      {/* Current value display - recessed LCD screen */}
-      <div
-        className="w-full h-14 px-4 flex items-center justify-center
-          border-2 border-primary
-          text-3xl font-bold text-foreground tabular-nums bg-input"
-        style={{
-          boxShadow:
-            'inset 0 2px 3px rgba(58, 40, 23, 0.18), inset 0 0 0 1px rgba(255,255,255,0.4), 0 0 12px rgba(var(--primary-rgb), 0.25)',
-        }}
+      <button
+        type="button"
+        onClick={onExpand}
+        className="w-full h-12 px-4 flex items-center justify-center
+          text-2xl font-bold text-foreground tabular-nums
+          hover:border-primary
+          transition-all duration-75"
+        style={{ backgroundColor: 'rgba(0,0,0,0.3)', boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.50), inset 0 0 0 1px rgba(254,243,199,0.06)' }}
       >
         {value || '0'}
-        <span className="text-base font-semibold text-muted-foreground ml-2">
+        <span className="text-sm font-semibold text-muted-foreground ml-2">
           {weightUnit}
         </span>
-      </div>
-
-      {/* Number keypad grid - tactile molded keys on hairline rules */}
-      <div className="grid grid-cols-3 gap-px mt-2 bg-border">
-        {KEYPAD_KEYS.map((key) => (
-          <button
-            key={key}
-            type="button"
-            onClick={() => handleKeyPress(key)}
-            className={`h-14 flex items-center justify-center
-              font-bold tabular-nums transition-all duration-75
-              active:translate-y-[1px]
-              active:bg-primary active:text-primary-foreground
-              ${key === 'CLR'
-                ? 'bg-muted text-muted-foreground hover:bg-secondary-hover text-sm uppercase tracking-wider'
-                : key === 'DEL'
-                  ? 'bg-muted text-muted-foreground hover:bg-secondary-hover'
-                  : 'bg-card text-foreground text-2xl hover:bg-muted'
-              }`}
-            style={{
-              boxShadow:
-                'inset 0 1px 0 rgba(255,255,255,0.55), inset 0 -1px 0 rgba(58, 40, 23, 0.08)',
-            }}
-          >
-            {key === 'DEL' ? <Delete size={20} /> : key}
-          </button>
-        ))}
-      </div>
-
-      {/* Cancel + Done buttons */}
-      <div className="flex gap-px mt-2">
-        <Button
-          variant="secondary"
-          doom
-          onClick={onCancel}
-          aria-label="Cancel weight entry"
-          className="flex-1 h-11 text-error uppercase tracking-wider text-sm"
-        >
-          CANCEL
-        </Button>
-        <Button
-          variant="primary"
-          doom
-          onClick={handleDone}
-          className="flex-[2] h-11 uppercase tracking-wider text-sm"
-        >
-          DONE
-        </Button>
-      </div>
+      </button>
     </div>
   )
 }

--- a/components/workout-logging/inputs/WeightKeypad.tsx
+++ b/components/workout-logging/inputs/WeightKeypad.tsx
@@ -117,7 +117,10 @@ export function WeightKeypad({
 
   // Expanded view with keypad - mt-auto pushes to bottom of flex container
   return (
-    <div className="mt-auto">
+    <div
+      className="mt-auto"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
       <span className="block text-sm text-muted-foreground mb-1 font-bold uppercase tracking-wider">
         WEIGHT ({weightUnit.toUpperCase()})
       </span>


### PR DESCRIPTION
## Summary
- Extracts the expanded keypad UI from `WeightKeypad` into a shared `NumberKeypad` primitive (label + recessed LCD display + 3x4 grid + CANCEL/DONE + safe-area). Props: `value`, `onChange`, `onCollapse`, `onCancel`, `label`, `unit?`, `max?`.
- `WeightKeypad` keeps its compact view, delegates expanded rendering to `NumberKeypad` (`label="WEIGHT (LBS|KG)"`, `unit={weightUnit}`).
- `RepsStepper` gains an expanded mode: the middle value is now a tap-to-expand button. Opens `NumberKeypad` with `label="REPETITIONS"`. The +/- buttons remain for quick adjustments. Saves many taps for higher rep counts.
- `SetLoggingForm`: extends `ExpandedInput` with `'reps'`, snapshots/restores reps on expand/cancel, hides weight + intensity while reps is expanded. Both loggers (regular `ExerciseLoggingModal` and `AdHocLoggerView`) inherit the behavior with no further plumbing.
- Restyles the keypad along the way: taller keys (h-11 -> h-14), bigger digits (text-lg -> text-2xl tabular-nums), LCD-feel display (warm-tan `bg-input` with brown-tinted inner shadow, replacing the cold dark inset), tactile press feel on each key (inset highlight + active translate-y), and breathable vertical rhythm (mt-px -> mt-2).
- Also includes the safe-area padding fix for the expanded keypad (was missing on iOS PWA) and removal of an extra `pb-2` on the regular logger content wrapper so the bottom spacing matches the ad-hoc logger.

## Test plan
- [x] Open weight entry in both loggers, verify the LCD display and tactile keys render correctly across themes.
- [x] Tap the rep count number, verify the keypad opens with "REPETITIONS" header and no unit suffix.
- [x] Confirm CANCEL restores the pre-expand value for both reps and weight.
- [x] Confirm DONE commits the entered value.
- [x] Confirm intensity (RIR/RPE) is hidden while reps is expanded.
- [x] In iOS PWA, confirm the CANCEL/DONE row clears the home indicator (safe-area inset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)