### PR TITLE
Adhoc logger: matching search styling, multi-add, and header Add button

### DIFF
--- a/app/api/workouts/adhoc/[completionId]/exercises/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/exercises/route.ts
@@ -7,7 +7,8 @@ import { logger } from '@/lib/logger'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 
 type AddAdHocExerciseRequest = {
-  exerciseDefinitionId: string
+  exerciseDefinitionId?: string
+  exerciseDefinitionIds?: string[]
   notes?: string
 }
 
@@ -41,11 +42,24 @@ export async function POST(
     if (limited) return limited
 
     const body = (await request.json()) as AddAdHocExerciseRequest
-    const { exerciseDefinitionId, notes } = body
+    const { exerciseDefinitionId, exerciseDefinitionIds, notes } = body
 
-    if (!exerciseDefinitionId) {
+    const ids = exerciseDefinitionIds && exerciseDefinitionIds.length > 0
+      ? exerciseDefinitionIds
+      : exerciseDefinitionId
+        ? [exerciseDefinitionId]
+        : []
+
+    if (ids.length === 0) {
       return NextResponse.json(
         { error: 'Exercise definition ID is required' },
+        { status: 400 }
+      )
+    }
+
+    if (ids.length > 20) {
+      return NextResponse.json(
+        { error: 'Cannot add more than 20 exercises at once' },
         { status: 400 }
       )
     }
@@ -62,40 +76,54 @@ export async function POST(
       )
     }
 
-    const exerciseDefinition = await prisma.exerciseDefinition.findUnique({
-      where: { id: exerciseDefinitionId },
+    const definitions = await prisma.exerciseDefinition.findMany({
+      where: { id: { in: ids } },
       select: { id: true, name: true },
     })
 
-    if (!exerciseDefinition) {
+    if (definitions.length !== ids.length) {
       return NextResponse.json(
-        { error: 'Exercise definition not found' },
+        { error: 'One or more exercise definitions not found' },
         { status: 404 }
       )
     }
+
+    // Preserve client-supplied insertion order.
+    const definitionsById = new Map(definitions.map((d) => [d.id, d]))
+    const ordered = ids.map((id) => definitionsById.get(id)!)
 
     // Order is unique-within-completion; compute next from existing rows.
     const existingExercises = await prisma.exercise.findMany({
       where: { workoutCompletionId: completionId },
       select: { order: true },
     })
-    const nextOrder = Math.max(0, ...existingExercises.map((e) => e.order)) + 1
+    const baseOrder = Math.max(0, ...existingExercises.map((e) => e.order))
 
-    const exercise = await prisma.exercise.create({
-      data: {
-        name: exerciseDefinition.name,
-        exerciseDefinitionId,
-        order: nextOrder,
-        workoutId: null,
-        isOneOff: true,
-        workoutCompletionId: completionId,
-        notes: notes || null,
-        userId: user.id,
-      },
-      include: exerciseInclude,
+    const created = await prisma.$transaction(
+      ordered.map((def, idx) =>
+        prisma.exercise.create({
+          data: {
+            name: def.name,
+            exerciseDefinitionId: def.id,
+            order: baseOrder + idx + 1,
+            workoutId: null,
+            isOneOff: true,
+            workoutCompletionId: completionId,
+            notes: notes || null,
+            userId: user.id,
+          },
+          include: exerciseInclude,
+        })
+      )
+    )
+
+    // Backwards-compatible response: keep `exercise` for single-add callers,
+    // always include `exercises` array for batch callers.
+    return NextResponse.json({
+      success: true,
+      exercise: created[0],
+      exercises: created,
     })
-
-    return NextResponse.json({ success: true, exercise })
   } catch (err) {
     logger.error(
       { error: err, context: 'adhoc-exercise-add' },

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -9,6 +9,7 @@ import {
   ExerciseSearchInterface,
 } from '@/components/exercise-selection/ExerciseSearchInterface'
 import { Button } from '@/components/ui/Button'
+import { LoadingFrog } from '@/components/ui/loading-frog'
 import {
   Dialog,
   DialogBody,
@@ -18,7 +19,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/radix/dialog'
-import { LoadingFrog } from '@/components/ui/loading-frog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
@@ -439,6 +439,7 @@ export default function AdHocLoggerView({
           startedAt={startedAt}
           onCompleteWorkout={handleRequestComplete}
           onClose={handleClose}
+          onAddExercise={hasExercises ? () => setIsPickerOpen(true) : undefined}
           menuActions={[]}
         />
 
@@ -503,7 +504,6 @@ export default function AdHocLoggerView({
             onLogSet={handleLogSet}
             onPrevious={() => goToExercise(currentIndex - 1)}
             onNext={() => goToExercise(currentIndex + 1)}
-            onAddExercise={() => setIsPickerOpen(true)}
           />
         )}
 

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Plus, Sparkles, X } from 'lucide-react'
+import { Plus, Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -9,6 +9,15 @@ import {
   ExerciseSearchInterface,
 } from '@/components/exercise-selection/ExerciseSearchInterface'
 import { Button } from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/radix/dialog'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
@@ -177,46 +186,62 @@ export default function AdHocLoggerView({
     currentSet.weight,
   ])
 
-  const handleAddExercise = useCallback(
-    async (definition: ExerciseDefinition) => {
-      if (isAdding) return
+  const handleAddExercises = useCallback(
+    async (definitions: ExerciseDefinition[]) => {
+      if (isAdding || definitions.length === 0) return
       setIsAdding(true)
       try {
         const res = await fetch(`/api/workouts/adhoc/${completionId}/exercises`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ exerciseDefinitionId: definition.id }),
+          body: JSON.stringify({
+            exerciseDefinitionIds: definitions.map((d) => d.id),
+          }),
         })
         if (!res.ok) {
           const err = await res.json().catch(() => ({}))
-          clientLogger.error('Failed to add exercise:', err)
+          clientLogger.error('Failed to add exercises:', err)
           return
         }
         const data = await res.json()
-        const newExercise: AdHocExercise = {
-          id: data.exercise.id,
-          name: data.exercise.name,
-          notes: data.exercise.notes ?? null,
-          exerciseDefinition: {
-            primaryFAUs: data.exercise.exerciseDefinition.primaryFAUs,
-            secondaryFAUs: data.exercise.exerciseDefinition.secondaryFAUs,
-            equipment: data.exercise.exerciseDefinition.equipment,
-            instructions: data.exercise.exerciseDefinition.instructions ?? undefined,
-            imageUrls: data.exercise.exerciseDefinition.imageUrls,
-          },
-        }
+        const created: AdHocExercise[] = (data.exercises ?? [data.exercise]).map(
+          (e: {
+            id: string
+            name: string
+            notes: string | null
+            exerciseDefinition: {
+              primaryFAUs: string[]
+              secondaryFAUs: string[]
+              equipment: string[]
+              instructions?: string | null
+              imageUrls?: string[]
+            }
+          }) => ({
+            id: e.id,
+            name: e.name,
+            notes: e.notes ?? null,
+            exerciseDefinition: {
+              primaryFAUs: e.exerciseDefinition.primaryFAUs,
+              secondaryFAUs: e.exerciseDefinition.secondaryFAUs,
+              equipment: e.exerciseDefinition.equipment,
+              instructions: e.exerciseDefinition.instructions ?? undefined,
+              imageUrls: e.exerciseDefinition.imageUrls,
+            },
+          })
+        )
         setExercises((prev) => {
-          const next = [...prev, newExercise]
-          setCurrentIndex(next.length - 1)
+          const next = [...prev, ...created]
+          // Focus the first newly-added exercise so the user can start logging.
+          setCurrentIndex(prev.length)
           return next
         })
-        // New exercise — clear input so history pre-fill can run, and reset
+        // New exercise(s) — clear input so history pre-fill can run, and reset
         // any pending input expansion.
         setCurrentSet(EMPTY_SET)
         setExpandedInput(null)
         setIsPickerOpen(false)
       } catch (err) {
-        clientLogger.error('Failed to add exercise:', err)
+        clientLogger.error('Failed to add exercises:', err)
       } finally {
         setIsAdding(false)
       }
@@ -509,7 +534,8 @@ export default function AdHocLoggerView({
       {isPickerOpen && (
         <ExercisePickerModal
           onClose={() => setIsPickerOpen(false)}
-          onSelect={handleAddExercise}
+          onConfirm={handleAddExercises}
+          isAdding={isAdding}
         />
       )}
       {showExitConfirm && (
@@ -584,41 +610,72 @@ function EmptyState() {
 
 function ExercisePickerModal({
   onClose,
-  onSelect,
+  onConfirm,
+  isAdding,
 }: {
   onClose: () => void
-  onSelect: (def: ExerciseDefinition) => void
+  onConfirm: (defs: ExerciseDefinition[]) => void
+  isAdding: boolean
 }) {
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-  if (!mounted) return null
+  // Preserve selection order so exercises are inserted the way the user picked them.
+  const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
+  const selectedIds = new Set(selectedDefs.map((d) => d.id))
 
-  return createPortal(
-    <div
-      style={{ position: 'fixed', inset: 0, zIndex: 80 }}
-      className="bg-background flex flex-col"
-    >
-      <div
-        className="bg-secondary text-secondary-foreground px-4 py-3 flex items-center justify-between flex-shrink-0"
-        style={{ paddingTop: 'calc(0.75rem + env(safe-area-inset-top, 0px))' }}
+  const handleToggle = useCallback((def: ExerciseDefinition) => {
+    setSelectedDefs((prev) =>
+      prev.some((d) => d.id === def.id)
+        ? prev.filter((d) => d.id !== def.id)
+        : [...prev, def]
+    )
+  }, [])
+
+  const count = selectedDefs.length
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        showClose={false}
+        fullScreenMobile={true}
+        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
       >
-        <button
-          type="button"
-          onClick={onClose}
-          className="p-1 doom-focus-ring"
-          aria-label="Cancel"
-        >
-          <X size={20} />
-        </button>
-        <span className="text-sm font-bold uppercase tracking-wider">Pick exercise</span>
-        <span className="w-7" />
-      </div>
-      <div className="flex-1 overflow-y-auto">
-        <ExerciseSearchInterface onExerciseSelect={onSelect} preloadExercises />
-      </div>
-    </div>,
-    document.body
+        <DialogHeader className="border-b border-border bg-primary py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
+                Search Exercises
+              </DialogTitle>
+              <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
+                Pick one or more to add to your workout
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <DialogBody className="flex-1 min-h-0">
+          <ExerciseSearchInterface
+            onExerciseSelect={handleToggle}
+            selectedIds={selectedIds}
+            preloadExercises
+          />
+        </DialogBody>
+
+        <DialogFooter className="border-t border-border bg-card py-2">
+          <div className="flex items-center justify-end gap-2 w-full">
+            <Button variant="secondary" onClick={onClose} doom disabled={isAdding}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => onConfirm(selectedDefs)}
+              disabled={count === 0 || isAdding}
+              loading={isAdding}
+              doom
+            >
+              {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -309,20 +309,18 @@ export function ExerciseSearchInterface({
               return (
               <div
                 key={exercise.id}
-                role={isMultiSelect ? 'button' : undefined}
-                tabIndex={isMultiSelect ? 0 : undefined}
-                aria-pressed={isMultiSelect ? !!isSelected : undefined}
-                onClick={isMultiSelect ? () => onExerciseSelect(exercise) : undefined}
-                onKeyDown={
-                  isMultiSelect
-                    ? (e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault()
-                          onExerciseSelect(exercise)
-                        }
-                      }
-                    : undefined
-                }
+                {...(isMultiSelect && {
+                  role: 'button',
+                  tabIndex: 0,
+                  'aria-pressed': !!isSelected,
+                  onClick: () => onExerciseSelect(exercise),
+                  onKeyDown: (e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onExerciseSelect(exercise)
+                    }
+                  },
+                })}
                 className={`border-2 p-4 transition-all bg-card ${
                   isSelected
                     ? 'border-primary bg-primary/10 shadow-[0_0_20px_rgba(var(--primary-rgb),0.35)]'

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -309,7 +309,20 @@ export function ExerciseSearchInterface({
               return (
               <div
                 key={exercise.id}
+                role={isMultiSelect ? 'button' : undefined}
+                tabIndex={isMultiSelect ? 0 : undefined}
+                aria-pressed={isMultiSelect ? !!isSelected : undefined}
                 onClick={isMultiSelect ? () => onExerciseSelect(exercise) : undefined}
+                onKeyDown={
+                  isMultiSelect
+                    ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          onExerciseSelect(exercise)
+                        }
+                      }
+                    : undefined
+                }
                 className={`border-2 p-4 transition-all bg-card ${
                   isSelected
                     ? 'border-primary bg-primary/10 shadow-[0_0_20px_rgba(var(--primary-rgb),0.35)]'

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Filter, Search } from 'lucide-react'
+import { Check, Filter, Search } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
 import { clientLogger } from '@/lib/client-logger'
@@ -27,6 +27,12 @@ interface ExerciseSearchInterfaceProps {
   preloadExercises?: boolean
   onCreateExercise?: (searchQuery: string) => void
   onEditExercise?: (exercise: ExerciseDefinition) => void
+  /**
+   * When provided, the picker switches to multi-select mode: cards highlight
+   * when their id is in the set, and clicking a card (or its button) toggles
+   * selection via onExerciseSelect rather than emitting once and closing.
+   */
+  selectedIds?: Set<string>
 }
 
 const ALL_FAUS = [
@@ -85,8 +91,10 @@ export function ExerciseSearchInterface({
   initialQuery = '',
   preloadExercises = false,
   onCreateExercise,
-  onEditExercise
+  onEditExercise,
+  selectedIds,
 }: ExerciseSearchInterfaceProps) {
+  const isMultiSelect = selectedIds !== undefined
   const [searchQuery, setSearchQuery] = useState(initialQuery)
   const [selectedFAU, setSelectedFAU] = useState<string | null>(null)
   const [selectedEquipment, setSelectedEquipment] = useState<string | null>(null)
@@ -296,10 +304,17 @@ export function ExerciseSearchInterface({
           </div>
         ) : (
           <div className="grid gap-3">
-            {exercises.map((exercise) => (
+            {exercises.map((exercise) => {
+              const isSelected = isMultiSelect && selectedIds?.has(exercise.id)
+              return (
               <div
                 key={exercise.id}
-                className="border-2 border-border p-4 hover:border-primary transition-all hover:shadow-[0_0_20px_rgba(var(--primary-rgb),0.2)] bg-card"
+                onClick={isMultiSelect ? () => onExerciseSelect(exercise) : undefined}
+                className={`border-2 p-4 transition-all bg-card ${
+                  isSelected
+                    ? 'border-primary bg-primary/10 shadow-[0_0_20px_rgba(var(--primary-rgb),0.35)]'
+                    : 'border-border hover:border-primary hover:shadow-[0_0_20px_rgba(var(--primary-rgb),0.2)]'
+                } ${isMultiSelect ? 'cursor-pointer' : ''}`}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1">
@@ -338,15 +353,26 @@ export function ExerciseSearchInterface({
                       </button>
                     )}
                     <button type="button"
-                      onClick={() => onExerciseSelect(exercise)}
-                      className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary-hover font-bold uppercase tracking-wider text-sm border-2 border-primary-active shadow-[0_3px_0_var(--primary-active),0_5px_8px_rgba(0,0,0,0.4)] hover:shadow-[0_3px_0_var(--primary-active),0_0_20px_rgba(var(--primary-rgb),0.6)] active:translate-y-[3px] active:shadow-[0_0_0_var(--primary-active),0_2px_4px_rgba(0,0,0,0.4)] transition-all"
+                      onClick={(e) => { e.stopPropagation(); onExerciseSelect(exercise) }}
+                      aria-pressed={isMultiSelect ? !!isSelected : undefined}
+                      className={
+                        isSelected
+                          ? 'px-4 py-2 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-sm border-2 border-primary-active flex items-center gap-1.5'
+                          : 'px-4 py-2 bg-primary text-primary-foreground hover:bg-primary-hover font-bold uppercase tracking-wider text-sm border-2 border-primary-active shadow-[0_3px_0_var(--primary-active),0_5px_8px_rgba(0,0,0,0.4)] hover:shadow-[0_3px_0_var(--primary-active),0_0_20px_rgba(var(--primary-rgb),0.6)] active:translate-y-[3px] active:shadow-[0_0_0_var(--primary-active),0_2px_4px_rgba(0,0,0,0.4)] transition-all'
+                      }
                     >
-                      Select
+                      {isSelected ? (
+                        <>
+                          <Check size={16} strokeWidth={3} />
+                          Added
+                        </>
+                      ) : isMultiSelect ? 'Add' : 'Select'}
                     </button>
                   </div>
                 </div>
               </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </div>

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Check, X } from 'lucide-react'
+import { Check, Plus, X } from 'lucide-react'
 import { useMemo } from 'react'
 import ActionsMenu, { type ActionItem } from '@/components/ActionsMenu'
 import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
@@ -12,6 +12,7 @@ interface ExerciseLoggingHeaderProps {
   startedAt?: string | null
   onCompleteWorkout: () => void
   onClose: () => void
+  onAddExercise?: () => void
   menuActions: ActionItem[]
   modeToggle?: React.ReactNode
 }
@@ -58,6 +59,7 @@ export default function ExerciseLoggingHeader({
   startedAt,
   onCompleteWorkout,
   onClose,
+  onAddExercise,
   menuActions,
   modeToggle,
 }: ExerciseLoggingHeaderProps) {
@@ -96,6 +98,16 @@ export default function ExerciseLoggingHeader({
               variant="ghost"
               className="text-secondary-foreground/80 hover:text-secondary-foreground"
             />
+          )}
+          {onAddExercise && (
+            <button
+              type="button"
+              onClick={onAddExercise}
+              className="p-1 text-secondary-foreground/80 hover:text-secondary-foreground transition-colors doom-focus-ring"
+              aria-label="Add exercise"
+            >
+              <Plus size={20} strokeWidth={2.5} />
+            </button>
           )}
           <button
             type="button"


### PR DESCRIPTION
## Summary

- Ad-hoc exercise picker now uses the same `Dialog`/Header/Footer chrome as the regular logger's `AddExerciseWizard` — the `SEARCH EXERCISES` header and footer Cancel/primary buttons line up across both flows.
- New **multi-select** mode in `ExerciseSearchInterface` (opt-in via `selectedIds` prop). Selected cards highlight with a primary tint + checkmark; cards are tappable in multi mode. Footer shows `Cancel` + `Add all (N)` and preserves selection order on insert.
- Backend `POST /api/workouts/adhoc/[id]/exercises` accepts either `exerciseDefinitionId` (legacy) or `exerciseDefinitionIds: string[]`, inserting in a single transaction (cap 20). Order is computed once from the existing max.
- Moved the big bottom-right `+ ADD` button into the top header as a plus icon. Reason: the green ADD competed with `LOG SET N` for the eye when the latter is the primary action. The header Add is opt-in via a new `onAddExercise` prop, so program/template loggers are unaffected.

## Test plan

- [x] Open an ad-hoc workout, tap the new `+` icon in the header — picker opens with matching header/footer chrome
- [x] Select multiple exercises, confirm `Add all (N)` reflects the count and inserts them in the order picked
- [x] Single-select Add still works (one exercise selected → `Add 1 exercise`)
- [x] Cancel from picker doesn't add anything
- [x] LOG SET N is now the only primary action in the footer; the chevron prev/next still work
- [x] Empty state (no exercises yet) still shows the big "Add Exercise" CTA
- [x] Regular workout logger (program-based) is unchanged — no plus icon in header, picker UX intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)