### PR TITLE
fix: re-style START/FINISH position label as chrome, not button (#724)

### DIFF
--- a/components/ui/ExerciseImageCrossfade.tsx
+++ b/components/ui/ExerciseImageCrossfade.tsx
@@ -180,8 +180,15 @@ export default function ExerciseImageCrossfade({
           />
         ))}
 
-        {/* Position label pill */}
-        <span className="absolute bottom-3 left-3 px-2.5 py-1 text-xs font-bold uppercase tracking-wider text-primary bg-background/80 border border-primary">
+        {/* Position label sticker — chrome, not a button */}
+        <span
+          className="absolute bottom-3 left-3 uppercase font-semibold text-muted-foreground bg-card/85 pointer-events-none"
+          style={{
+            fontSize: '0.65rem',
+            letterSpacing: '0.1em',
+            padding: '2px 8px',
+          }}
+        >
           {POSITION_LABELS[activeIndex]}
         </span>
 


### PR DESCRIPTION
## Summary

Re-styles the START/FINISH corner label on the follow-along exercise photo so it no longer reads as a tappable button.

Before: emerald border + emerald uppercase Rajdhani text — same vocabulary as a primary outline button. Users saw it as a third tappable action alongside Next Exercise and the header Finish check.

After (option (a) from the issue): muted-foreground text on a warm card/85 background, no border, smaller font (0.65rem), tighter 2px/8px padding. Reads as a margin sticker. Set `pointer-events-none` since the parent button already owns pause/resume.

## Changes

- `components/ui/ExerciseImageCrossfade.tsx` — restyle the position label pill (crossfade branch only; the reduced-motion stacked-label branch was left alone since it doesn't sit overlaid on the photo as a faux-button).

## Acceptance

- [x] START/FINISH label no longer reads as a button (no emerald border, no primary color)
- [x] Position dot indicators at bottom-right of the photo still update on crossfade (unchanged)
- [x] No regression on Info-tab embed in `ExerciseInfoContent.tsx` (same component, change is purely visual)
- [x] Uses token roles (`--color-muted-foreground`, `--color-card`) — works across all twelve themes

## Test plan

- [ ] Visually verify on follow-along mode that the label reads as chrome, not a button
- [ ] Verify in a dark-mode theme that the label is still legible
- [ ] Verify the photo crossfade still pauses/resumes on tap (parent button intact, label pointer-events-none)

Fixes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)