### PR TITLE
fix(ux): make follow-along switch-to-logging banner read as tappable

### DIFF
--- a/components/workout-logging/FollowAlongHeader.tsx
+++ b/components/workout-logging/FollowAlongHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { X } from 'lucide-react'
+import { ChevronRight, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
 interface FollowAlongHeaderProps {
@@ -97,11 +97,15 @@ export default function FollowAlongHeader({
           <button
             type="button"
             onClick={handleBannerTap}
-            className={`w-full text-center text-sm text-secondary-foreground/80 pb-2 transition-opacity duration-500 ${
+            className={`w-full pb-2 px-4 text-sm text-secondary-foreground/90 hover:text-secondary-foreground hover:bg-black/5 active:bg-black/10 cursor-pointer transition-all duration-500 doom-focus-ring flex items-center justify-center gap-1.5 ${
               bannerFading ? 'opacity-0' : 'opacity-100'
             }`}
           >
-            Ready to track weights? Tap here to switch to logging.
+            <span>
+              Ready to track weights?{' '}
+              <span className="font-semibold underline underline-offset-2">Switch to logging</span>
+            </span>
+            <ChevronRight size={16} strokeWidth={2.5} aria-hidden="true" />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds a trailing `ChevronRight` glyph, underlines "Switch to logging", and applies hover/active background tint + focus ring on the brown follow-along header banner so the tap affordance is unambiguous.
- Reworded copy to lead with the question; the chevron and underline carry the call-to-action visually.
- Cursor changes to pointer on desktop hover (button default + explicit `cursor-pointer`).

## Test plan
- [ ] In follow-along mode, the banner under the progress bar shows `Ready to track weights? Switch to logging ›` with the second phrase underlined and a chevron at the end
- [ ] Hovering on desktop shows pointer + slight background tint
- [ ] Tapping/pressing on touch shows a brief active tint, then opens the confirm dialog
- [ ] Banner still fades out after 15s and accepts focus ring on keyboard nav

Fixes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)