### PR TITLE
fix(learn): strip duplicate article title H1 from body

### DIFF
--- a/__tests__/lib/format/article-body.test.ts
+++ b/__tests__/lib/format/article-body.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { stripDuplicateTitleHeading } from '@/lib/format/article-body'
+
+describe('stripDuplicateTitleHeading', () => {
+  it('strips a leading H1 that matches the article title', () => {
+    const body = '# Your First Week: What to Expect\n\nWelcome to the gym.'
+    const result = stripDuplicateTitleHeading(body, 'Your First Week: What to Expect')
+    expect(result).toBe('Welcome to the gym.')
+  })
+
+  it('matches case-insensitively', () => {
+    const body = '# YOUR FIRST WEEK\n\nBody text.'
+    const result = stripDuplicateTitleHeading(body, 'Your First Week')
+    expect(result).toBe('Body text.')
+  })
+
+  it('tolerates extra whitespace around the heading', () => {
+    const body = '\n\n#   Hello World   \n\nNext.'
+    const result = stripDuplicateTitleHeading(body, 'Hello World')
+    expect(result).toBe('Next.')
+  })
+
+  it('tolerates closing # tokens (`# Title #`)', () => {
+    const body = '# Hello #\n\nBody.'
+    const result = stripDuplicateTitleHeading(body, 'Hello')
+    expect(result).toBe('Body.')
+  })
+
+  it('preserves a leading H1 that does not match the title', () => {
+    const body = '# Some Other Heading\n\nBody text.'
+    const result = stripDuplicateTitleHeading(body, 'Article Title')
+    expect(result).toBe(body)
+  })
+
+  it('preserves the body when there is no leading H1', () => {
+    const body = 'Just a paragraph.\n\n## Subheading\n\nMore.'
+    const result = stripDuplicateTitleHeading(body, 'Just a paragraph.')
+    expect(result).toBe(body)
+  })
+
+  it('does not strip an H2 that happens to match', () => {
+    const body = '## Title\n\nBody.'
+    const result = stripDuplicateTitleHeading(body, 'Title')
+    expect(result).toBe(body)
+  })
+
+  it('handles empty body without throwing', () => {
+    expect(stripDuplicateTitleHeading('', 'Anything')).toBe('')
+  })
+
+  it('tolerates inline emphasis tokens in the heading', () => {
+    const body = '# *Your First Week*\n\nBody.'
+    const result = stripDuplicateTitleHeading(body, 'Your First Week')
+    expect(result).toBe('Body.')
+  })
+})

--- a/components/features/learn/ArticleDetail.tsx
+++ b/components/features/learn/ArticleDetail.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 import { clientLogger } from '@/lib/client-logger'
+import { stripDuplicateTitleHeading } from '@/lib/format/article-body'
 
 interface Tag {
   id: string
@@ -194,7 +195,7 @@ export default function ArticleDetail({
         {/* Article body - markdown */}
         <div className="prose-learn mb-12">
           <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-            {article.body}
+            {stripDuplicateTitleHeading(article.body, article.title)}
           </ReactMarkdown>
         </div>
 

--- a/lib/format/article-body.ts
+++ b/lib/format/article-body.ts
@@ -1,0 +1,50 @@
+/**
+ * Strips a leading H1 from article markdown when its text duplicates the
+ * article's `title`. The Learn article page renders the title as page chrome,
+ * so a matching H1 at the top of the body would render the title twice.
+ *
+ * Behavior:
+ * - Only the first non-empty line of the body is considered.
+ * - Match is case-insensitive and whitespace-normalized.
+ * - Trailing markdown formatting (e.g. `# Title #`) and surrounding inline
+ *   markup tokens (`*`, `_`) are tolerated.
+ * - If the leading H1 doesn't match the title, or there is no leading H1, the
+ *   body is returned unchanged.
+ */
+export function stripDuplicateTitleHeading(
+  body: string,
+  title: string,
+): string {
+  if (!body) return body
+
+  // Find the first non-empty line
+  const lines = body.split('\n')
+  let firstIdx = 0
+  while (firstIdx < lines.length && lines[firstIdx].trim() === '') {
+    firstIdx++
+  }
+  if (firstIdx >= lines.length) return body
+
+  const firstLine = lines[firstIdx]
+  // Match a Markdown ATX H1: leading `#` (not `##`), optional trailing `#`s
+  const h1Match = firstLine.match(/^\s*#\s+(.+?)\s*#*\s*$/)
+  if (!h1Match) return body
+
+  if (normalize(h1Match[1]) !== normalize(title)) return body
+
+  // Strip the H1 line plus any immediately-following blank lines
+  let nextIdx = firstIdx + 1
+  while (nextIdx < lines.length && lines[nextIdx].trim() === '') {
+    nextIdx++
+  }
+  return lines.slice(nextIdx).join('\n')
+}
+
+function normalize(s: string): string {
+  return s
+    // Strip surrounding inline emphasis tokens so `# *Title*` matches `Title`
+    .replace(/[*_`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}


### PR DESCRIPTION
## Summary

- Learn article pages were rendering the title twice: once as the uppercase Rajdhani page header, and again as a sentence-case H1 inside the markdown body.
- Add `stripDuplicateTitleHeading(body, title)` in `lib/format/article-body.ts` that drops a leading H1 from article markdown when its text matches the article title (case-insensitive, whitespace-normalized, tolerates inline emphasis tokens and trailing `#`s).
- Wire the helper into `ArticleDetail` so the page chrome remains the single source of the title, with no authoring migration needed.

Fixes #714

## Test plan

- [x] `vitest run __tests__/lib/format/article-body.test.ts` — 9 cases (matching H1 stripped, non-matching H1 preserved, no H1 untouched, H2 untouched, casing, whitespace, trailing `#`, inline emphasis, empty body)
- [x] `npm run type-check`
- [x] `eslint` on changed files
- [ ] Spot-check 3-5 existing Learn articles render with the title shown exactly once
- [ ] Verify a new article authored without a leading H1 still shows the title via the page header

🤖 Generated with [Claude Code](https://claude.com/claude-code)