### PR TITLE
fix: increase logger progress segment contrast (#708)

### DIFF
--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -33,10 +33,10 @@ function ProgressIndicator({ current, total }: { current: number; total: number 
             style={{
               backgroundColor: exerciseIndex <= current
                 ? 'var(--primary)'
-                : 'rgba(0,0,0,0.25)',
+                : 'color-mix(in srgb, var(--secondary-foreground) 40%, transparent)',
               boxShadow: exerciseIndex <= current
                 ? undefined
-                : 'inset 0 1px 0 rgba(0,0,0,0.20)',
+                : 'inset 0 0 0 1px color-mix(in srgb, var(--secondary-foreground) 15%, transparent)',
             }}
           />
         )


### PR DESCRIPTION
## Summary
- Logger top-bar progress segments were dark-brown (`rgba(0,0,0,0.25)`) on a barrel-brown `bg-secondary` header — incomplete cells nearly disappeared.
- Switch unfilled segments to `color-mix(in srgb, var(--secondary-foreground) 40%, transparent)` so the track reads as a light sandy/cream tint against the brown bar. Completed segments remain `var(--primary)`.
- Replace the inset top-only black shadow with a 1px inner cream-tint outline so adjacent unfilled segments read as distinct cells.

Token roles only — no hex values — so contrast holds across all DOOM theme variants.

## Test plan
- [ ] Open the logger on a multi-exercise workout (e.g. 5 exercises) on light brown theme — verify both filled emerald/orange and unfilled cream segments are clearly visible at arm's length
- [ ] Toggle dark mode and other themes (cyan/etc.) — segments remain visible
- [ ] Verify single-row (≤5) and double-row (>5) layouts both render correctly

Fixes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)