### PR TITLE
feat(ux): wire first-run TipAnnotation into Training page (#702)

### DIFF
--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -501,6 +501,7 @@ export default function StrengthWeekView({
           <MessageCard
             message={trainingMessage}
             variant="training_tab"
+            isFirstRun={historyCount === 0}
             onDismiss={async (messageId) => {
               try {
                 const current = settings?.dismissedMessageIds

--- a/components/ui/MessageCard.tsx
+++ b/components/ui/MessageCard.tsx
@@ -40,6 +40,13 @@ interface MessageCardProps {
   onNextTip?: () => void
   onDismiss?: (messageId: string) => void
   onSeen?: (messageId: string) => void
+  /**
+   * When true, renders with the field-guide first-run treatment
+   * (TIP sticker, frog ornament, paper-grain overlay). Use only for
+   * brand-new users who have not yet completed any workouts —
+   * see DESIGN.md §1 The Adult-Newcomer Rule.
+   */
+  isFirstRun?: boolean
 }
 
 export function MessageCard({
@@ -49,6 +56,7 @@ export function MessageCard({
   onNextTip,
   onDismiss,
   onSeen,
+  isFirstRun = false,
 }: MessageCardProps) {
   const seenRef = useRef(false)
   const slides = getSlides(message)
@@ -126,6 +134,7 @@ export function MessageCard({
 
   return (
     <TipAnnotation
+      variant={isFirstRun ? 'first-run' : 'default'}
       icon={<Icon aria-hidden="true" size={16} strokeWidth={1.8} />}
       overlay={
         <>


### PR DESCRIPTION
## Summary
- Plumbs `variant='first-run'` through `MessageCard` -> `TipAnnotation` when the user has not yet completed any workouts (`historyCount === 0`).
- Established users keep the default dashed-border tip — frog stays in field-guide chrome only (DESIGN.md §1 The Adult-Newcomer Rule).
- Primitive already shipped in PR #734; this is the wiring follow-up.

## Predicate choice
Used user-state (`historyCount === 0`) instead of an InAppMessage column. Reasons:
- `historyCount === 0` is already the canonical first-visit signal in this component (see `isBeginnerFirstVisit`).
- No schema change needed; admin can author the first-run message via the existing `maxWorkouts: 0` targeting and it will pick up the Field Guide chrome automatically.
- Mid-program tips (any workout completed) never get the frog, regardless of authoring.

## Test plan
- [ ] Fresh test user on `/training` shows TIP sticker + frog + paper-grain on the context message.
- [ ] After completing one workout, the next tip renders in default (no sticker, no frog) variant.
- [ ] `/dev/theme-validator` first-run variant renders correctly in light + dark theme groups (frog asset swap).

Fixes #702