### PR TITLE
Fix workout day-row title truncation on Training page

### DIFF
--- a/components/workout/WorkoutCard.tsx
+++ b/components/workout/WorkoutCard.tsx
@@ -96,11 +96,11 @@ export default function WorkoutCard({
         aria-expanded={hasActions ? expanded : undefined}
         className={`w-full text-left border-l-4 ${borderColor} ${stateClass} px-4 py-3 transition-all ${isInteractive ? 'hover:bg-muted/50 active:bg-muted/70 cursor-pointer' : 'cursor-default'} disabled:opacity-60 doom-focus-ring`}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-start gap-3">
           {/* Content */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-0.5">
-              <h3 className={`text-lg font-bold text-foreground doom-heading truncate ${isSkipped ? 'line-through opacity-60' : ''}`}>
+              <h3 className={`text-lg font-bold text-foreground doom-heading break-words ${isSkipped ? 'line-through opacity-60' : ''}`}>
                 DAY {workout.dayNumber}: {workout.name}
               </h3>
             </div>
@@ -117,8 +117,8 @@ export default function WorkoutCard({
             </div>
           </div>
 
-          {/* Status badge + chevron */}
-          <div className="flex items-center gap-2 shrink-0">
+          {/* Status badge + chevron — top-aligned to first line of title */}
+          <div className="flex items-center gap-2 shrink-0 min-h-7">
             {isCompleted && (
               <span className="doom-badge doom-badge-completed">
                 <Check size={12} />


### PR DESCRIPTION
## Summary
- Remove `truncate` from workout day-row titles so they wrap to multiple lines instead of mid-word ellipsizing at mobile widths
- Switch outer row flex from `items-center` to `items-start` so the right-side status badge + chevron stay aligned to the first line when the title wraps
- Add `min-h-7` on the indicator column so single-line rows preserve their existing vertical rhythm

Fixes #700

## Test plan
- [ ] At 360px viewport, verify `DAY 1: MACHINE WORKOUT` and similarly long titles wrap to a second line without ellipsizing
- [ ] Confirm the completed-check badge and chevron remain visually anchored to the first line of the title
- [ ] Skipped, completed, draft, and pending states all render cleanly
- [ ] Three-line user-named workouts wrap without overlap
- [ ] Desktop layout unaffected

Generated with [Claude Code](https://claude.com/claude-code)