### PR TITLE
Logger quick-actions menu: reusable, themed, with adhoc swap/delete

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle, Info, LogOut, Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react'
+import { AlertTriangle, Info, Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Button } from '@/components/ui/Button'
@@ -17,12 +17,12 @@ import { clientLogger } from '@/lib/client-logger'
 import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
 import { formatPrescribedSummary } from '@/lib/format/prescribed-summary'
 import type { LoggedSet } from '@/types/workout'
-import type { ActionItem } from './ActionsMenu'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
 import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from './workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from './workout-logging/ExerciseLoggingHeader'
 import ExerciseNavigation from './workout-logging/ExerciseNavigation'
+import type { QuickAction } from './workout-logging/ExerciseQuickActionsMenu'
 import ExitWorkoutConfirm from './workout-logging/ExitWorkoutConfirm'
 import FollowAlongFooter from './workout-logging/FollowAlongFooter'
 import FollowAlongHeader from './workout-logging/FollowAlongHeader'
@@ -555,9 +555,15 @@ export default function ExerciseLoggingModal({
                 { label: 'Edit this exercise', icon: Pencil, onClick: handleEditExercise },
                 { label: 'Add an exercise', icon: Plus, onClick: handleAddExercise },
                 { label: 'Swap this exercise', icon: RefreshCw, onClick: handleReplaceExercise },
-                { label: 'Delete this exercise', icon: Trash2, onClick: handleDeleteExercise, variant: 'danger' as const, requiresConfirmation: true, confirmationMessage: `Are you sure you want to delete "${currentExercise?.name || 'this exercise'}"?` },
-                { label: 'Exit workout', icon: LogOut, onClick: handleExitWorkout, variant: 'danger' as const },
-              ] satisfies ActionItem[]}
+                {
+                  label: 'Delete this exercise',
+                  icon: Trash2,
+                  onClick: handleDeleteExercise,
+                  variant: 'danger',
+                  requiresConfirmation: true,
+                  confirmationMessage: `Are you sure you want to delete "${currentExercise?.name || 'this exercise'}"?`,
+                },
+              ] satisfies QuickAction[]}
             />
           )}
 

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import * as Toast from '@radix-ui/react-toast'
-import { AlertCircle, CheckCircle2, X } from 'lucide-react'
+import { AlertCircle, AlertTriangle, CheckCircle2, X } from 'lucide-react'
 import { createContext, type ReactNode, useContext, useState } from 'react'
 
-type ToastType = 'success' | 'error'
+type ToastType = 'success' | 'error' | 'warning'
 
 type ToastMessage = {
   id: string
@@ -16,6 +16,7 @@ type ToastMessage = {
 type ToastContextType = {
   success: (title: string, description?: string) => void
   error: (title: string, description?: string) => void
+  warning: (title: string, description?: string) => void
 }
 
 const ToastContext = createContext<ToastContextType | null>(null)
@@ -41,12 +42,16 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     addToast('error', title, description)
   }
 
+  const warning = (title: string, description?: string) => {
+    addToast('warning', title, description)
+  }
+
   const removeToast = (id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }
 
   return (
-    <ToastContext.Provider value={{ success, error }}>
+    <ToastContext.Provider value={{ success, error, warning }}>
       <Toast.Provider swipeDirection="right">
         {children}
         {toasts.map((toast) => (
@@ -59,12 +64,16 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             className={`fixed bottom-4 left-4 right-4 sm:left-auto sm:right-4 z-[100] sm:w-full sm:max-w-sm p-4 rounded-lg shadow-lg border animate-in slide-in-from-bottom-5 ${
               toast.type === 'success'
                 ? 'bg-success text-success-foreground border-success'
-                : 'bg-error text-error-foreground border-error'
+                : toast.type === 'warning'
+                  ? 'bg-warning text-warning-foreground border-warning'
+                  : 'bg-error text-error-foreground border-error'
             }`}
           >
             <div className="flex items-start gap-3">
               {toast.type === 'success' ? (
                 <CheckCircle2 className="w-5 h-5 flex-shrink-0 mt-0.5" />
+              ) : toast.type === 'warning' ? (
+                <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
               ) : (
                 <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
               )}

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -526,7 +526,6 @@ export default function AdHocLoggerView({
           startedAt={startedAt}
           onCompleteWorkout={handleRequestComplete}
           onClose={handleClose}
-          onAddExercise={hasExercises ? () => setPickerMode({ kind: 'add' }) : undefined}
           menuActions={
             hasExercises && currentExercise
               ? ([

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Plus, Sparkles } from 'lucide-react'
+import { Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -23,6 +23,7 @@ import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from '@/components/workout-logging/ExerciseLoggingHeader'
+import type { QuickAction } from '@/components/workout-logging/ExerciseQuickActionsMenu'
 import ExitWorkoutConfirm from '@/components/workout-logging/ExitWorkoutConfirm'
 import SetLoggingForm, {
   type ExpandedInput,
@@ -110,8 +111,10 @@ export default function AdHocLoggerView({
   const [currentIndex, setCurrentIndex] = useState(0)
   const [currentSet, setCurrentSet] = useState(EMPTY_SET)
   const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
-  const [isPickerOpen, setIsPickerOpen] = useState(false)
+  const [pickerMode, setPickerMode] = useState<PickerMode | null>(null)
   const [isAdding, setIsAdding] = useState(false)
+  const [isSwapping, setIsSwapping] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [isLoggingSet, setIsLoggingSet] = useState(false)
   const [isCompleting, setIsCompleting] = useState(false)
   const [isConfirmingComplete, setIsConfirmingComplete] = useState(false)
@@ -239,7 +242,7 @@ export default function AdHocLoggerView({
         // any pending input expansion.
         setCurrentSet(EMPTY_SET)
         setExpandedInput(null)
-        setIsPickerOpen(false)
+        setPickerMode(null)
       } catch (err) {
         clientLogger.error('Failed to add exercises:', err)
       } finally {
@@ -248,6 +251,90 @@ export default function AdHocLoggerView({
     },
     [completionId, isAdding]
   )
+
+  const handleSwapExercise = useCallback(
+    async (definitions: ExerciseDefinition[]) => {
+      const target = exercises[currentIndex]
+      const replacement = definitions[0]
+      if (!target || !replacement || isSwapping) return
+      setIsSwapping(true)
+      try {
+        const res = await fetch(`/api/exercises/${target.id}/replace`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            newExerciseDefinitionId: replacement.id,
+            applyToFuture: false,
+          }),
+        })
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}))
+          clientLogger.error('Failed to swap exercise:', err)
+          return
+        }
+        const data = await res.json()
+        const updated = data.exercises?.[0]
+        if (!updated) return
+        setExercises((prev) =>
+          prev.map((ex, i) =>
+            i === currentIndex
+              ? {
+                  ...ex,
+                  name: updated.name,
+                  exerciseDefinition: {
+                    primaryFAUs: updated.exerciseDefinition.primaryFAUs,
+                    secondaryFAUs: updated.exerciseDefinition.secondaryFAUs,
+                    equipment: updated.exerciseDefinition.equipment,
+                    instructions: updated.exerciseDefinition.instructions ?? undefined,
+                    imageUrls: updated.exerciseDefinition.imageUrls,
+                  },
+                }
+              : ex
+          )
+        )
+        // Reset input so the new exercise's history can pre-fill.
+        setCurrentSet(EMPTY_SET)
+        setExpandedInput(null)
+        setPickerMode(null)
+      } catch (err) {
+        clientLogger.error('Failed to swap exercise:', err)
+      } finally {
+        setIsSwapping(false)
+      }
+    },
+    [currentIndex, exercises, isSwapping]
+  )
+
+  const handleDeleteExercise = useCallback(async () => {
+    const target = exercises[currentIndex]
+    if (!target || isDeleting) return
+    setIsDeleting(true)
+    try {
+      const res = await fetch(`/api/exercises/${target.id}/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ applyToFuture: false }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        clientLogger.error('Failed to delete exercise:', err)
+        return
+      }
+      setLoggedSets((prev) => prev.filter((s) => s.exerciseId !== target.id))
+      setExercises((prev) => {
+        const next = prev.filter((ex) => ex.id !== target.id)
+        // Keep currentIndex in range; bias toward the previous exercise.
+        setCurrentIndex((idx) => Math.max(0, Math.min(idx, next.length - 1)))
+        return next
+      })
+      setCurrentSet(EMPTY_SET)
+      setExpandedInput(null)
+    } catch (err) {
+      clientLogger.error('Failed to delete exercise:', err)
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [currentIndex, exercises, isDeleting])
 
   const handleLogSet = useCallback(async () => {
     if (!currentExercise || isLoggingSet) return
@@ -439,8 +526,32 @@ export default function AdHocLoggerView({
           startedAt={startedAt}
           onCompleteWorkout={handleRequestComplete}
           onClose={handleClose}
-          onAddExercise={hasExercises ? () => setIsPickerOpen(true) : undefined}
-          menuActions={[]}
+          onAddExercise={hasExercises ? () => setPickerMode({ kind: 'add' }) : undefined}
+          menuActions={
+            hasExercises && currentExercise
+              ? ([
+                  {
+                    label: 'Add an exercise',
+                    icon: Plus,
+                    onClick: () => setPickerMode({ kind: 'add' }),
+                  },
+                  {
+                    label: 'Swap this exercise',
+                    icon: RefreshCw,
+                    onClick: () =>
+                      setPickerMode({ kind: 'swap', replacingName: currentExercise.name }),
+                  },
+                  {
+                    label: 'Delete this exercise',
+                    icon: Trash2,
+                    onClick: handleDeleteExercise,
+                    variant: 'danger',
+                    requiresConfirmation: true,
+                    confirmationMessage: `Are you sure you want to delete "${currentExercise.name}"? Any sets you've logged for it will be removed.`,
+                  },
+                ] satisfies QuickAction[])
+              : []
+          }
         />
 
         <div
@@ -517,7 +628,7 @@ export default function AdHocLoggerView({
           >
             <button
               type="button"
-              onClick={() => setIsPickerOpen(true)}
+              onClick={() => setPickerMode({ kind: 'add' })}
               className="w-full h-11 bg-primary text-primary-foreground text-sm font-medium uppercase tracking-widest transition-all doom-focus-ring inline-flex items-center justify-center gap-2"
               style={{
                 boxShadow:
@@ -531,11 +642,12 @@ export default function AdHocLoggerView({
         )}
       </div>
 
-      {isPickerOpen && (
+      {pickerMode && (
         <ExercisePickerModal
-          onClose={() => setIsPickerOpen(false)}
-          onConfirm={handleAddExercises}
-          isAdding={isAdding}
+          mode={pickerMode}
+          onClose={() => setPickerMode(null)}
+          onConfirm={pickerMode.kind === 'add' ? handleAddExercises : handleSwapExercise}
+          isBusy={pickerMode.kind === 'add' ? isAdding : isSwapping}
         />
       )}
       {showExitConfirm && (
@@ -608,20 +720,27 @@ function EmptyState() {
   )
 }
 
+type PickerMode =
+  | { kind: 'add' }
+  | { kind: 'swap'; replacingName: string }
+
 function ExercisePickerModal({
+  mode,
   onClose,
   onConfirm,
-  isAdding,
+  isBusy,
 }: {
+  mode: PickerMode
   onClose: () => void
   onConfirm: (defs: ExerciseDefinition[]) => void
-  isAdding: boolean
+  isBusy: boolean
 }) {
-  // Preserve selection order so exercises are inserted the way the user picked them.
+  const isAdd = mode.kind === 'add'
+  // Multi-select state used only in add mode.
   const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
   const selectedIds = new Set(selectedDefs.map((d) => d.id))
 
-  const handleToggle = useCallback((def: ExerciseDefinition) => {
+  const handleAddToggle = useCallback((def: ExerciseDefinition) => {
     setSelectedDefs((prev) =>
       prev.some((d) => d.id === def.id)
         ? prev.filter((d) => d.id !== def.id)
@@ -629,7 +748,19 @@ function ExercisePickerModal({
     )
   }, [])
 
+  const handleSwapSelect = useCallback(
+    (def: ExerciseDefinition) => {
+      if (isBusy) return
+      onConfirm([def])
+    },
+    [isBusy, onConfirm]
+  )
+
   const count = selectedDefs.length
+  const title = isAdd ? 'Search Exercises' : 'Swap Exercise'
+  const description = isAdd
+    ? 'Pick one or more to add to your workout'
+    : `Pick a replacement for ${mode.kind === 'swap' ? mode.replacingName : ''}`
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
@@ -642,10 +773,10 @@ function ExercisePickerModal({
           <div className="flex items-center justify-between">
             <div className="flex-1">
               <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
-                Search Exercises
+                {title}
               </DialogTitle>
               <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
-                Pick one or more to add to your workout
+                {description}
               </DialogDescription>
             </div>
           </div>
@@ -653,26 +784,28 @@ function ExercisePickerModal({
 
         <DialogBody className="flex-1 min-h-0">
           <ExerciseSearchInterface
-            onExerciseSelect={handleToggle}
-            selectedIds={selectedIds}
+            onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
+            selectedIds={isAdd ? selectedIds : undefined}
             preloadExercises
           />
         </DialogBody>
 
         <DialogFooter className="border-t border-border bg-card py-2">
           <div className="flex items-center justify-end gap-2 w-full">
-            <Button variant="secondary" onClick={onClose} doom disabled={isAdding}>
+            <Button variant="secondary" onClick={onClose} doom disabled={isBusy}>
               Cancel
             </Button>
-            <Button
-              variant="primary"
-              onClick={() => onConfirm(selectedDefs)}
-              disabled={count === 0 || isAdding}
-              loading={isAdding}
-              doom
-            >
-              {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
-            </Button>
+            {isAdd && (
+              <Button
+                variant="primary"
+                onClick={() => onConfirm(selectedDefs)}
+                disabled={count === 0 || isBusy}
+                loading={isBusy}
+                doom
+              >
+                {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
+              </Button>
+            )}
           </div>
         </DialogFooter>
       </DialogContent>

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -8,6 +8,7 @@ import {
   type ExerciseDefinition,
   ExerciseSearchInterface,
 } from '@/components/exercise-selection/ExerciseSearchInterface'
+import { useToast } from '@/components/ToastProvider'
 import { Button } from '@/components/ui/Button'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import {
@@ -20,7 +21,6 @@ import {
   DialogTitle,
 } from '@/components/ui/radix/dialog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
-import { useToast } from '@/components/ToastProvider'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from '@/components/workout-logging/ExerciseLoggingHeader'

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
 } from '@/components/ui/radix/dialog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
+import { useToast } from '@/components/ToastProvider'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from '@/components/workout-logging/ExerciseLoggingHeader'
@@ -92,6 +93,7 @@ export default function AdHocLoggerView({
   initialLoggedSets,
 }: Props) {
   const router = useRouter()
+  const toast = useToast()
   const { hasAccess: hasIntensityAccess } = useIntensityAccess()
 
   const [exercises, setExercises] = useState<AdHocExercise[]>(initialExercises)
@@ -416,12 +418,18 @@ export default function AdHocLoggerView({
   )
 
   // Header check icon → confirmation modal (matches programmed logger).
-  // If no sets have been logged, the workout can't be completed at all, so
-  // bail out silently rather than opening the modal.
+  // If no sets have been logged, nudge the user to log something first
+  // instead of silently doing nothing.
   const handleRequestComplete = useCallback(() => {
-    if (loggedSets.length === 0) return
+    if (loggedSets.length === 0) {
+      toast.warning(
+        'Log a set first',
+        'Add at least one set before completing the workout.'
+      )
+      return
+    }
     setIsConfirmingComplete(true)
-  }, [loggedSets.length])
+  }, [loggedSets.length, toast])
 
   const handleCompleteWorkout = useCallback(async () => {
     if (isCompleting || loggedSets.length === 0) return

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -2,8 +2,10 @@
 
 import { Check, Plus, X } from 'lucide-react'
 import { useMemo } from 'react'
-import ActionsMenu, { type ActionItem } from '@/components/ActionsMenu'
 import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
+import ExerciseQuickActionsMenu, {
+  type QuickAction,
+} from './ExerciseQuickActionsMenu'
 
 interface ExerciseLoggingHeaderProps {
   currentExerciseIndex: number
@@ -13,7 +15,7 @@ interface ExerciseLoggingHeaderProps {
   onCompleteWorkout: () => void
   onClose: () => void
   onAddExercise?: () => void
-  menuActions: ActionItem[]
+  menuActions: QuickAction[]
   modeToggle?: React.ReactNode
 }
 
@@ -92,11 +94,9 @@ export default function ExerciseLoggingHeader({
         {/* Right: action icons */}
         <div className="flex items-center justify-end gap-3.5">
           {menuActions.length > 0 && (
-            <ActionsMenu
+            <ExerciseQuickActionsMenu
               actions={menuActions}
-              size="sm"
-              variant="ghost"
-              className="text-secondary-foreground/80 hover:text-secondary-foreground"
+              triggerClassName="text-secondary-foreground/80 hover:text-secondary-foreground"
             />
           )}
           {onAddExercise && (

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -94,7 +94,7 @@ export default function ExerciseLoggingHeader({
           {menuActions.length > 0 && (
             <ExerciseQuickActionsMenu
               actions={menuActions}
-              triggerClassName="text-secondary-foreground/80 hover:text-secondary-foreground"
+              triggerClassName="text-accent hover:text-accent/80"
             />
           )}
           <button

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Check, Plus, X } from 'lucide-react'
+import { Check, X } from 'lucide-react'
 import { useMemo } from 'react'
 import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
 import ExerciseQuickActionsMenu, {
@@ -14,7 +14,6 @@ interface ExerciseLoggingHeaderProps {
   startedAt?: string | null
   onCompleteWorkout: () => void
   onClose: () => void
-  onAddExercise?: () => void
   menuActions: QuickAction[]
   modeToggle?: React.ReactNode
 }
@@ -61,7 +60,6 @@ export default function ExerciseLoggingHeader({
   startedAt,
   onCompleteWorkout,
   onClose,
-  onAddExercise,
   menuActions,
   modeToggle,
 }: ExerciseLoggingHeaderProps) {
@@ -98,16 +96,6 @@ export default function ExerciseLoggingHeader({
               actions={menuActions}
               triggerClassName="text-secondary-foreground/80 hover:text-secondary-foreground"
             />
-          )}
-          {onAddExercise && (
-            <button
-              type="button"
-              onClick={onAddExercise}
-              className="p-1 text-secondary-foreground/80 hover:text-secondary-foreground transition-colors doom-focus-ring"
-              aria-label="Add exercise"
-            >
-              <Plus size={20} strokeWidth={2.5} />
-            </button>
           )}
           <button
             type="button"

--- a/components/workout-logging/ExerciseQuickActionsMenu.tsx
+++ b/components/workout-logging/ExerciseQuickActionsMenu.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { AlertTriangle, Pencil } from 'lucide-react'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export type QuickAction = {
+  label: string
+  icon: React.ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
+  onClick: () => void
+  disabled?: boolean
+  variant?: 'default' | 'danger'
+  requiresConfirmation?: boolean
+  confirmationMessage?: string
+}
+
+type ExerciseQuickActionsMenuProps = {
+  actions: QuickAction[]
+  /** Optional override for the trigger icon. Defaults to a pencil. */
+  triggerIcon?: React.ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
+  /** Optional menu heading rendered above the action list. */
+  heading?: string
+  /** Optional override for the trigger button's accessible label. */
+  triggerAriaLabel?: string
+  /** Tailwind classes to merge into the trigger button (color/state, etc). */
+  triggerClassName?: string
+}
+
+export default function ExerciseQuickActionsMenu({
+  actions,
+  triggerIcon: TriggerIcon = Pencil,
+  heading = 'Edit Workout',
+  triggerAriaLabel = 'Edit workout',
+  triggerClassName = '',
+}: ExerciseQuickActionsMenuProps) {
+  const [confirming, setConfirming] = useState<QuickAction | null>(null)
+
+  const handleClick = (action: QuickAction) => {
+    if (action.disabled) return
+    if (action.requiresConfirmation) {
+      setConfirming(action)
+    } else {
+      action.onClick()
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label={triggerAriaLabel}
+            className={`p-1 transition-colors doom-focus-ring ${triggerClassName}`}
+          >
+            <TriggerIcon size={20} strokeWidth={2.5} />
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            sideOffset={8}
+            align="end"
+            collisionPadding={12}
+            className="z-[80] min-w-[260px] bg-card border-2 border-primary doom-corners shadow-[0_8px_32px_rgba(0,0,0,0.4)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          >
+            {heading && (
+              <div className="px-4 py-2.5 border-b-2 border-border bg-primary/10">
+                <span className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                  {heading}
+                </span>
+              </div>
+            )}
+
+            <div className="py-1">
+              {actions.map((action, index) => {
+                const Icon = action.icon
+                const isDanger = action.variant === 'danger'
+                return (
+                  <DropdownMenu.Item
+                    key={`${action.label}-${index}`}
+                    onSelect={(e) => {
+                      // Keep menu open until our handler decides (confirmation flow).
+                      e.preventDefault()
+                      handleClick(action)
+                    }}
+                    disabled={action.disabled}
+                    className={`min-h-[52px] px-4 py-3 flex items-center gap-3 cursor-pointer outline-none transition-colors text-base font-medium tracking-wide ${
+                      action.disabled
+                        ? 'opacity-50 cursor-not-allowed'
+                        : isDanger
+                          ? 'text-error data-[highlighted]:bg-error/10'
+                          : 'text-foreground data-[highlighted]:bg-primary/10'
+                    }`}
+                  >
+                    <Icon
+                      size={20}
+                      strokeWidth={2.25}
+                      className={`flex-shrink-0 ${isDanger ? 'text-error' : 'text-primary'}`}
+                    />
+                    <span className="flex-1">{action.label}</span>
+                  </DropdownMenu.Item>
+                )
+              })}
+            </div>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+
+      {confirming && typeof document !== 'undefined' && createPortal(
+        <div
+          style={{ position: 'fixed', inset: 0, zIndex: 100 }}
+          className="backdrop-blur-md bg-black/50 flex items-center justify-center p-4"
+        >
+          <div className="bg-card border-2 border-border p-6 text-center max-w-sm w-full shadow-xl doom-corners">
+            <div className="text-warning mb-4 flex justify-center">
+              <AlertTriangle size={48} strokeWidth={2} />
+            </div>
+            <h3 className="text-lg font-bold text-foreground mb-2 uppercase tracking-wider">
+              Confirm Action
+            </h3>
+            <p className="text-sm text-muted-foreground mb-6">
+              {confirming.confirmationMessage || 'Are you sure you want to proceed?'}
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setConfirming(null)}
+                className="flex-1 px-4 py-2.5 bg-muted text-foreground hover:bg-secondary transition-colors font-semibold uppercase tracking-wide border-2 border-border"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  confirming.onClick()
+                  setConfirming(null)
+                }}
+                className={`flex-1 px-4 py-2.5 transition-colors font-semibold uppercase tracking-wide border-2 ${
+                  confirming.variant === 'danger'
+                    ? 'bg-error text-error-foreground hover:bg-error-hover border-error'
+                    : 'bg-primary text-primary-foreground hover:bg-primary-hover border-primary-active'
+                }`}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
+  )
+}

--- a/components/workout-logging/ExerciseQuickActionsMenu.tsx
+++ b/components/workout-logging/ExerciseQuickActionsMenu.tsx
@@ -80,11 +80,7 @@ export default function ExerciseQuickActionsMenu({
                 return (
                   <DropdownMenu.Item
                     key={`${action.label}-${index}`}
-                    onSelect={(e) => {
-                      // Keep menu open until our handler decides (confirmation flow).
-                      e.preventDefault()
-                      handleClick(action)
-                    }}
+                    onSelect={() => handleClick(action)}
                     disabled={action.disabled}
                     className={`min-h-[52px] px-4 py-3 flex items-center gap-3 cursor-pointer outline-none transition-colors text-base font-medium tracking-wide ${
                       action.disabled


### PR DESCRIPTION
## Summary

- New reusable `ExerciseQuickActionsMenu` component (Radix DropdownMenu) replaces the cramped 3-dot `ActionsMenu` in the logger header. Pencil trigger in the accent theme color, 52px-min items, doom-themed border, "Edit Workout" heading, danger styling for destructive actions, built-in confirmation flow.
- Action list is fully configurable per-logger via a `QuickAction[]` prop.
- Regular logger drops the "Exit workout" entry — the X icon already handles it.
- Ad-hoc logger gains **Add / Swap / Delete** entries (no Edit, no Exit). Standalone `+` plus icon removed from the header now that the menu's Add covers it.
- Ad-hoc swap reuses the existing exercise picker in a new single-select mode (`Pick a replacement for X`); delete uses the menu's confirm modal. Both hit the existing `/api/exercises/[id]/replace` and `/delete` endpoints with `applyToFuture:false` (those endpoints already handle one-off exercises, so no new API surface).
- `ToastProvider` gains a `warning` type (orange `--warning` theme token, `AlertTriangle` icon) so soft nudges don't have to use error red.
- Ad-hoc check-icon now shows a warning toast when no sets are logged instead of silently doing nothing.

## Test plan

- [ ] Regular logger: pencil opens menu with Edit / Add / Swap / Delete (no Exit). Each item closes the menu on tap; Delete shows a confirm modal.
- [ ] Ad-hoc logger: pencil opens menu with Add / Swap / Delete. No standalone plus icon.
- [ ] Ad-hoc Swap: pick a new exercise → the current adhoc exercise's name updates, history pre-fill resets, logged sets so far are preserved on the same exercise record.
- [ ] Ad-hoc Delete: confirms, removes the exercise + its logged sets, current-index bumps to a neighbor.
- [ ] Ad-hoc check icon with zero logged sets → orange warning toast, no completion modal.
- [ ] Ad-hoc check icon with ≥1 logged set → completion modal opens as before.
- [ ] Pencil trigger uses the accent (gold) color and is visible against the brown header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)