### PR TITLE
feat(adhoc): desktop workout button + properly sized ad-hoc logger

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,13 @@
 'use client'
 
-import { Settings } from 'lucide-react'
+import { Dumbbell, Settings } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useState } from 'react'
+import QuickActionSheet from '@/components/QuickActionSheet'
 import { ThemeSelector } from '@/components/ThemeSelector'
+import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
 
 type Props = {
   userEmail: string
@@ -12,6 +15,8 @@ type Props = {
 
 export default function Header({ userEmail }: Props) {
   const pathname = usePathname()
+  const { activeDraft } = useDraftWorkout()
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   const NAV_LINKS = [
     { href: '/training', label: 'Training' },
@@ -20,6 +25,7 @@ export default function Header({ userEmail }: Props) {
   ] as const
 
   return (
+    <>
     <nav
       className="hidden md:block bg-card border-b border-border"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
@@ -59,6 +65,33 @@ export default function Header({ userEmail }: Props) {
 
           {/* Right: Desktop Menu */}
           <div className="flex items-center space-x-4">
+            <button
+              type="button"
+              onClick={() => setSheetOpen(true)}
+              aria-label={
+                activeDraft
+                  ? `Resume draft workout: ${activeDraft.workoutName}`
+                  : 'Start a workout'
+              }
+              className="relative inline-flex items-center gap-2 px-4 h-9 bg-accent text-accent-foreground transition-transform active:translate-y-[2px] doom-focus-ring overflow-hidden"
+              style={{
+                boxShadow:
+                  '0 4px 0 var(--accent-hover), 0 6px 10px rgba(0,0,0,0.30), inset 0 2px 0 rgba(255,255,255,0.45), inset 0 -1px 0 rgba(0,0,0,0.15)',
+              }}
+            >
+              {activeDraft && (
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-0 pointer-events-none"
+                  style={{ animation: 'doom-pulse 2s ease-in-out infinite' }}
+                />
+              )}
+              {activeDraft && <span aria-hidden="true" className="chip-gold-shine" />}
+              <Dumbbell size={16} strokeWidth={2.75} className="relative" />
+              <span className="relative text-xs font-black uppercase tracking-[0.1em]">
+                Workout
+              </span>
+            </button>
             <ThemeSelector />
             <Link
               href="/settings"
@@ -80,5 +113,7 @@ export default function Header({ userEmail }: Props) {
         </div>
       </div>
     </nav>
+    <QuickActionSheet open={sheetOpen} onOpenChange={setSheetOpen} />
+    </>
   )
 }

--- a/components/QuickActionSheet.tsx
+++ b/components/QuickActionSheet.tsx
@@ -30,12 +30,10 @@ type Props = {
   onOpenChange: (open: boolean) => void
 }
 
-// Bottom-anchored sheet sitting above the h-14 mobile bottom nav, with a small
-// breathing gap so the nav's gold action chip doesn't kiss the panel border.
-const NAV_OFFSET_PX = 56 + 8
-const SHEET_BOTTOM_STYLE = {
-  bottom: `calc(env(safe-area-inset-bottom, 0px) + ${NAV_OFFSET_PX}px)`,
-}
+// Bottom-anchored on mobile (above h-14 nav with a breathing gap so the gold
+// chip doesn't kiss the panel); centered on desktop where there's no bottom nav.
+const MOBILE_BOTTOM = 'bottom-[calc(env(safe-area-inset-bottom,0px)+64px)]'
+const DESKTOP_CENTER = 'md:bottom-auto md:top-1/2 md:-translate-y-1/2'
 
 export default function QuickActionSheet({ open, onOpenChange }: Props) {
   const router = useRouter()
@@ -195,15 +193,7 @@ export default function QuickActionSheet({ open, onOpenChange }: Props) {
         />
         <DialogPrimitive.Content
           aria-describedby={undefined}
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom data-[state=open]:duration-200 data-[state=closed]:duration-150"
-          style={{
-            position: 'fixed',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: 'min(96vw, 28rem)',
-            zIndex: 51,
-            ...SHEET_BOTTOM_STYLE,
-          }}
+          className={`fixed left-1/2 -translate-x-1/2 z-[51] w-[min(96vw,28rem)] ${MOBILE_BOTTOM} ${DESKTOP_CENTER} data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=open]:fade-in-0 md:data-[state=closed]:fade-out-0 data-[state=open]:duration-200 data-[state=closed]:duration-150`}
         >
           <div
             className="bg-card border border-border doom-corners"

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -432,7 +432,10 @@ export default function AdHocLoggerView({
 
   return (
     <>
-      <div className="fixed inset-0 bg-background flex flex-col" style={{ zIndex: 50 }}>
+      <div
+        className="fixed inset-0 z-50 flex items-stretch justify-center sm:items-center sm:backdrop-blur-md sm:bg-black/40 sm:dark:bg-black/60"
+      >
+        <div className="bg-background w-full h-[100dvh] sm:h-[85vh] sm:max-h-[85vh] sm:max-w-2xl sm:border-2 sm:border-border sm:rounded-lg sm:shadow-xl flex flex-col overflow-hidden">
         <ExerciseLoggingHeader
           currentExerciseIndex={hasExercises ? currentIndex : 0}
           totalExercises={Math.max(1, exercises.length)}
@@ -529,6 +532,7 @@ export default function AdHocLoggerView({
             </button>
           </div>
         )}
+        </div>
       </div>
 
       {isPickerOpen && (


### PR DESCRIPTION
## Summary
- Add a prominent gold **Workout** chip to the desktop `Header` (mirrors mobile chip styling — accent fill, 3D shadow, draft pulse + shine when a draft exists). Opens the existing `QuickActionSheet`.
- Make `QuickActionSheet` responsive: bottom-anchored above the mobile nav as before, vertically centered on desktop (`md+`), with fade-in instead of slide-up at desktop widths.
- Constrain `AdHocLoggerView` on desktop: backdrop + centered `max-w-2xl` / `h-[85vh]` card, matching `ExerciseLoggingModal`. Mobile remains edge-to-edge.

Previously the ad-hoc workout flow had no entry point at desktop widths and the logger spanned the entire viewport.

## Test plan
- [ ] On desktop, click the gold **Workout** chip in the header — `QuickActionSheet` opens centered.
- [ ] Start a freestyle workout — `AdHocLoggerView` opens as a centered modal sized like the regular workout logger.
- [ ] Resume an in-progress draft from the desktop Workout chip.
- [ ] On mobile, bottom-nav Workout chip and sheet behavior unchanged.
- [ ] Ad-hoc logger on mobile still goes full-bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)