### PR TITLE
feat(rollup): post-workout stats rollup with embedded feedback

### DIFF
--- a/__tests__/api/workout-rollup.test.ts
+++ b/__tests__/api/workout-rollup.test.ts
@@ -1,12 +1,12 @@
 import type { PrismaClient } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 import { getTestDatabase } from '@/lib/test/database'
 import {
   createCompleteTestScenario,
   createTestUser,
   createTestWorkoutCompletion,
 } from '@/lib/test/factories'
-import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 
 async function addLoggedSets(
   prisma: PrismaClient,

--- a/__tests__/api/workout-rollup.test.ts
+++ b/__tests__/api/workout-rollup.test.ts
@@ -1,0 +1,217 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import {
+  createCompleteTestScenario,
+  createTestUser,
+  createTestWorkoutCompletion,
+} from '@/lib/test/factories'
+import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
+
+async function addLoggedSets(
+  prisma: PrismaClient,
+  completionId: string,
+  exerciseId: string,
+  userId: string,
+  sets: Array<{ setNumber: number; reps: number; weight: number; isWarmup?: boolean }>
+) {
+  await prisma.loggedSet.createMany({
+    data: sets.map((s) => ({
+      completionId,
+      exerciseId,
+      userId,
+      setNumber: s.setNumber,
+      reps: s.reps,
+      weight: s.weight,
+      weightUnit: 'lbs',
+      isWarmup: s.isWarmup ?? false,
+    })),
+  })
+}
+
+describe('computeWorkoutRollup', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('returns null for unknown completion', async () => {
+    const result = await computeWorkoutRollup(prisma, 'does-not-exist', userId)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for completion owned by a different user', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+    const other = await createTestUser()
+    const result = await computeWorkoutRollup(prisma, scenario.completion.id, other.id)
+    expect(result).toBeNull()
+  })
+
+  it('excludes warmup sets from totals', async () => {
+    const { completion, exercise } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+
+    await addLoggedSets(prisma, completion.id, exercise.id, userId, [
+      { setNumber: 1, reps: 10, weight: 45, isWarmup: true },
+      { setNumber: 2, reps: 5, weight: 185 },
+      { setNumber: 3, reps: 5, weight: 185 },
+    ])
+
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup).not.toBeNull()
+    expect(rollup!.workingSetCount).toBe(2)
+    expect(rollup!.totalReps).toBe(10)
+    expect(rollup!.totalVolumeLbs).toBe(1850)
+    expect(rollup!.exerciseCount).toBe(1)
+    expect(rollup!.isMinimal).toBe(false)
+  })
+
+  it('returns minimal rollup when all sets are warmups (no working sets)', async () => {
+    const { completion, exercise } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+    await addLoggedSets(prisma, completion.id, exercise.id, userId, [
+      { setNumber: 1, reps: 10, weight: 45, isWarmup: true },
+    ])
+
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup!.isMinimal).toBe(true)
+    expect(rollup!.workingSetCount).toBe(0)
+    expect(rollup!.exercises).toHaveLength(0)
+    expect(rollup!.lifetimeWorkoutCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('returns minimal rollup with zero sets (Follow Along)', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup!.isMinimal).toBe(true)
+    expect(rollup!.workingSetCount).toBe(0)
+  })
+
+  it('handles bodyweight exercises (weight=0) without dragging volume down', async () => {
+    const { completion, exercise } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+
+    await addLoggedSets(prisma, completion.id, exercise.id, userId, [
+      { setNumber: 1, reps: 12, weight: 0 },
+      { setNumber: 2, reps: 10, weight: 0 },
+      { setNumber: 3, reps: 8, weight: 0 },
+    ])
+
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup!.exercises).toHaveLength(1)
+    expect(rollup!.exercises[0].isBodyweight).toBe(true)
+    expect(rollup!.exercises[0].volumeLbs).toBe(0)
+    expect(rollup!.exercises[0].reps).toBe(30)
+    expect(rollup!.totalVolumeLbs).toBe(0)
+    expect(rollup!.totalReps).toBe(30)
+    expect(rollup!.hasBodyweightOnlyExercises).toBe(true)
+  })
+
+  it('computes duration from startedAt/completedAt', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+    const startedAt = new Date(completion.completedAt.getTime() - 45 * 60 * 1000)
+    await prisma.workoutCompletion.update({
+      where: { id: completion.id },
+      data: { startedAt },
+    })
+
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup!.durationSeconds).toBe(45 * 60)
+  })
+
+  it('returns null duration when startedAt is missing', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+    const rollup = await computeWorkoutRollup(prisma, completion.id, userId)
+    expect(rollup!.durationSeconds).toBeNull()
+  })
+
+  it('counts lifetime workouts and last-7-day workouts', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+
+    // 2 older completions outside 7-day window
+    const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    for (let i = 0; i < 2; i++) {
+      const c = await createTestWorkoutCompletion(
+        prisma,
+        scenario.workout.id,
+        userId,
+        'completed'
+      )
+      await prisma.workoutCompletion.update({
+        where: { id: c.id },
+        data: { completedAt: oldDate },
+      })
+    }
+
+    // 1 recent completion inside 7-day window (other than the scenario one)
+    await createTestWorkoutCompletion(prisma, scenario.workout.id, userId, 'completed')
+
+    const rollup = await computeWorkoutRollup(prisma, scenario.completion.id, userId)
+    expect(rollup!.lifetimeWorkoutCount).toBe(4)
+    expect(rollup!.workoutsLast7Days).toBe(2)
+  })
+
+  it('surfaces vs-last-time per exercise', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 0,
+      status: 'completed',
+    })
+
+    // Previous completion: same exercise, lower volume
+    const previous = await createTestWorkoutCompletion(
+      prisma,
+      scenario.workout.id,
+      userId,
+      'completed'
+    )
+    const previousDate = new Date(scenario.completion.completedAt.getTime() - 7 * 24 * 60 * 60 * 1000)
+    await prisma.workoutCompletion.update({
+      where: { id: previous.id },
+      data: { completedAt: previousDate },
+    })
+    await addLoggedSets(prisma, previous.id, scenario.exercise.id, userId, [
+      { setNumber: 1, reps: 5, weight: 135 },
+      { setNumber: 2, reps: 5, weight: 135 },
+    ])
+
+    // Current completion: higher volume
+    await addLoggedSets(prisma, scenario.completion.id, scenario.exercise.id, userId, [
+      { setNumber: 1, reps: 5, weight: 155 },
+      { setNumber: 2, reps: 5, weight: 155 },
+    ])
+
+    const rollup = await computeWorkoutRollup(prisma, scenario.completion.id, userId)
+    const ex = rollup!.exercises[0]
+    expect(ex.vsLastTime).not.toBeNull()
+    expect(ex.vsLastTime!.previousVolumeLbs).toBe(1350)
+    expect(ex.vsLastTime!.previousTopSet).toEqual({ weight: 135, reps: 5 })
+    expect(ex.topSet).toEqual({ weight: 155, reps: 5 })
+  })
+})

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db'
 import { recordEvent } from '@/lib/events'
 import { logger } from '@/lib/logger'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 
 type LoggedSetInput = {
   exerciseId: string
@@ -162,6 +163,16 @@ export async function POST(
 
     recordEvent(user.id, 'workout_completed', { workoutId })
 
+    let rollup = null
+    try {
+      rollup = await computeWorkoutRollup(prisma, completion.id, user.id)
+    } catch (rollupErr) {
+      logger.error(
+        { error: rollupErr, completionId: completion.id, context: 'workout-complete' },
+        'Failed to compute rollup; returning completion without it'
+      )
+    }
+
     return NextResponse.json({
       success: true,
       completion: {
@@ -169,6 +180,7 @@ export async function POST(
         completedAt: completion.completedAt,
         status: completion.status,
       },
+      rollup,
     })
   } catch (error) {
     if (error instanceof Error && error.message === 'ALREADY_COMPLETED') {

--- a/app/api/workouts/adhoc/[completionId]/complete/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/complete/route.ts
@@ -5,6 +5,7 @@ import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
 import { recordEvent } from '@/lib/events'
 import { logger } from '@/lib/logger'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 
 export async function POST(
   _request: NextRequest,
@@ -55,7 +56,17 @@ export async function POST(
       'Ad-hoc workout completed'
     )
 
-    return NextResponse.json({ success: true, completion })
+    let rollup = null
+    try {
+      rollup = await computeWorkoutRollup(prisma, completion.id, user.id)
+    } catch (rollupErr) {
+      logger.error(
+        { error: rollupErr, completionId: completion.id, context: 'adhoc-complete' },
+        'Failed to compute rollup; returning completion without it'
+      )
+    }
+
+    return NextResponse.json({ success: true, completion, rollup })
   } catch (err) {
     logger.error(
       { error: err, context: 'adhoc-complete' },

--- a/app/api/workouts/completions/[completionId]/rollup/route.ts
+++ b/app/api/workouts/completions/[completionId]/rollup/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const rollup = await computeWorkoutRollup(prisma, completionId, user.id)
+    if (!rollup) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ rollup })
+  } catch (err) {
+    logger.error({ error: err, context: 'workout-rollup' }, 'Failed to compute rollup')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -51,7 +51,7 @@ type Props = {
   onMessageSeen?: (messageId: string) => void
   onMessageDismissed?: (messageId: string) => void
   loggingMode?: 'full' | 'follow_along'
-  onComplete: () => Promise<void>
+  onComplete: (result?: { completionId: string; rollup: import('@/lib/stats/workout-rollup').WorkoutRollup | null }) => Promise<void>
   onRefresh?: () => Promise<void>
 }
 
@@ -419,9 +419,9 @@ export default function ExerciseLoggingModal({
     try {
       // Pass fallback sets if any per-set writes failed
       const fallback = failedSetCount > 0 ? loggedSets : undefined
-      await completeDraft(workoutId, fallback)
+      const result = await completeDraft(workoutId, fallback)
       clearCache()
-      await onComplete()
+      await onComplete(result)
       // Do not call onClose() here — onComplete() already closes the modal
       // via handleCloseModal(true) with router.refresh() inside startTransition.
       // Calling onClose() again triggers a second router.refresh() outside
@@ -444,9 +444,9 @@ export default function ExerciseLoggingModal({
   const handleGuidedComplete = async () => {
     setIsSubmitting(true)
     try {
-      await completeDraft(workoutId, undefined, true)
+      const result = await completeDraft(workoutId, undefined, true)
       clearCache()
-      await onComplete()
+      await onComplete(result)
     } catch (error) {
       clientLogger.error('Error completing guided workout:', error)
       setIsSubmitting(false)

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -4,8 +4,8 @@ import { CheckCircle } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState, useTransition } from 'react'
 import ExerciseLoggingModal from '@/components/ExerciseLoggingModal'
-import { PostSessionFeedback } from '@/components/features/training/PostSessionFeedback'
 import { PwaInstallPrompt } from '@/components/features/training/PwaInstallPrompt'
+import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
 import { ProgramCompletionModal } from '@/components/ProgramCompletionModal'
 import type { MessageData } from '@/components/ui/MessageCard'
 import { MessageCard } from '@/components/ui/MessageCard'
@@ -17,7 +17,7 @@ import { usePwaPrompt } from '@/hooks/usePwaPrompt'
 import { useUserSettings } from '@/hooks/useUserSettings'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
-import { POST_SESSION_COOLDOWN } from '@/types/feedback'
+import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 
 type Workout = {
   id: string
@@ -113,7 +113,7 @@ export default function StrengthWeekView({
   const router = useRouter()
   const searchParams = useSearchParams()
   const { activeDraft, refreshDraft, clearDraft } = useDraftWorkout()
-  const { settings, isLoading: settingsLoading, refetch: refetchSettings, updateSettings } = useUserSettings()
+  const { settings, isLoading: settingsLoading, updateSettings } = useUserSettings()
   const [isPending, startTransition] = useTransition()
   const [updatingWorkoutId, setUpdatingWorkoutId] = useState<string | null>(null)
   const [skippingWorkout, setSkippingWorkout] = useState<string | null>(null)
@@ -140,10 +140,11 @@ export default function StrengthWeekView({
   const [showCompletionModal, setShowCompletionModal] = useState(false)
   const [isRestarting, setIsRestarting] = useState(false)
   const [isProgramComplete, setIsProgramComplete] = useState(false)
-  const [showPostSession, setShowPostSession] = useState(false)
   const [pendingProgramCompletionCheck, setPendingProgramCompletionCheck] = useState(false)
   const [pendingPwaCheck, setPendingPwaCheck] = useState(false)
   const [wasFirstWorkout, setWasFirstWorkout] = useState(false)
+  const [rollup, setRollup] = useState<WorkoutRollup | null>(null)
+  const [showRollup, setShowRollup] = useState(false)
 
   // PWA install prompt — capture beforeinstallprompt early for Android
   const { deferredPrompt } = useBeforeInstallPrompt()
@@ -344,58 +345,54 @@ export default function StrengthWeekView({
     }
   }
 
-  // Completion is handled inside ExerciseLoggingModal now (per-set writes + status flip)
-  const handleCompleteWorkout = async () => {
+  // Completion is handled inside ExerciseLoggingModal now (per-set writes + status flip).
+  // After the rollup modal closes we chain into the PWA prompt (first workout only) and
+  // then the program completion check.
+  const runPostCompletionFlow = useCallback(async () => {
+    if (wasFirstWorkout) {
+      triggerAfterWorkout(1)
+      setWasFirstWorkout(false)
+      setPendingPwaCheck(true)
+      setPendingProgramCompletionCheck(true)
+      return
+    }
+    await checkProgramCompletion(true)
+  }, [wasFirstWorkout, triggerAfterWorkout, checkProgramCompletion])
+
+  const handleCompleteWorkout = async (
+    result?: { completionId: string; rollup: WorkoutRollup | null }
+  ) => {
     // Capture before router.refresh() updates the prop
     if (historyCount === 0) setWasFirstWorkout(true)
 
     handleCloseModal(true)
 
-    // Check if we should show the post-session feedback prompt
-    const shouldPrompt = settings
-      && (settings.postSessionPromptCount % POST_SESSION_COOLDOWN === 0)
-    if (shouldPrompt) {
-      setShowPostSession(true)
-      setPendingProgramCompletionCheck(true)
-      // Bump the prompt counter immediately so skip/send both count
-      updateSettings({
-        postSessionPromptCount: (settings.postSessionPromptCount ?? 0) + 1,
-        lastPostSessionPromptAt: new Date().toISOString(),
-      }).then(() => refetchSettings()).catch(() => {})
-    } else {
-      // Increment counter even when not showing to keep cadence
-      if (settings) {
-        updateSettings({
-          postSessionPromptCount: (settings.postSessionPromptCount ?? 0) + 1,
-        }).then(() => refetchSettings()).catch(() => {})
-      }
-      await checkProgramCompletion(true)
+    if (result?.rollup) {
+      setRollup(result.rollup)
+      setShowRollup(true)
+      // PWA + program completion deferred until rollup closes
+      return
     }
+
+    await runPostCompletionFlow()
   }
 
-  const handlePostSessionClose = async () => {
-    setShowPostSession(false)
-    // After post-session feedback, try showing PWA prompt (first workout trigger)
-    // Use wasFirstWorkout flag because router.refresh() updates historyCount before this runs
-    if (wasFirstWorkout) {
-      triggerAfterWorkout(1)
-      setWasFirstWorkout(false)
-    }
-    // If PWA prompt will show, defer program completion check to after it closes
-    // We check this on next render via the showPwaPrompt state
-    if (pendingProgramCompletionCheck) {
-      setPendingPwaCheck(true)
-    }
+  const handleRollupClose = async () => {
+    setShowRollup(false)
+    setRollup(null)
+    await runPostCompletionFlow()
   }
 
-  // When post-session closes but PWA prompt doesn't show, run deferred checks
+  // When PWA prompt closes (or never showed) run deferred program completion check
   useEffect(() => {
-    if (pendingPwaCheck && !showPwaPrompt && !showPostSession) {
+    if (pendingPwaCheck && !showPwaPrompt) {
       setPendingPwaCheck(false)
-      setPendingProgramCompletionCheck(false)
-      checkProgramCompletion(true)
+      if (pendingProgramCompletionCheck) {
+        setPendingProgramCompletionCheck(false)
+        checkProgramCompletion(true)
+      }
     }
-  }, [pendingPwaCheck, showPwaPrompt, showPostSession, checkProgramCompletion])
+  }, [pendingPwaCheck, showPwaPrompt, pendingProgramCompletionCheck, checkProgramCompletion])
 
   const handlePwaPromptClose = async () => {
     await handlePwaClose()
@@ -603,10 +600,11 @@ export default function StrengthWeekView({
         />
       )}
 
-      {/* Post-Session Feedback */}
-      <PostSessionFeedback
-        open={showPostSession}
-        onClose={handlePostSessionClose}
+      {/* Workout Rollup */}
+      <WorkoutRollupModal
+        open={showRollup}
+        rollup={rollup}
+        onClose={handleRollupClose}
       />
 
       {/* PWA Install Prompt */}

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -30,6 +30,8 @@ import SetLoggingForm, {
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import { clientLogger } from '@/lib/client-logger'
+import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
+import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
 
 export type AdHocExercise = {
@@ -121,6 +123,8 @@ export default function AdHocLoggerView({
   >(new Map())
   const [historyLoadingIds, setHistoryLoadingIds] = useState<Set<string>>(new Set())
   const [showExitConfirm, setShowExitConfirm] = useState(false)
+  const [rollup, setRollup] = useState<WorkoutRollup | null>(null)
+  const [showRollup, setShowRollup] = useState(false)
   // Tracks which exercises we've already pre-filled from history this session,
   // so user typing isn't clobbered when history arrives later.
   const prefilledFromHistoryIds = useRef<Set<string>>(new Set())
@@ -349,6 +353,15 @@ export default function AdHocLoggerView({
         setIsCompleting(false)
         return
       }
+      const data = (await res.json().catch(() => ({}))) as {
+        rollup?: WorkoutRollup | null
+      }
+      setIsConfirmingComplete(false)
+      if (data.rollup) {
+        setRollup(data.rollup)
+        setShowRollup(true)
+        return
+      }
       router.push('/training')
       router.refresh()
     } catch (err) {
@@ -356,6 +369,13 @@ export default function AdHocLoggerView({
       setIsCompleting(false)
     }
   }, [isCompleting, loggedSets.length, completionId, router])
+
+  const handleRollupClose = useCallback(() => {
+    setShowRollup(false)
+    setRollup(null)
+    router.push('/training')
+    router.refresh()
+  }, [router])
 
   const handleExitSaveAsDraft = useCallback(() => {
     setShowExitConfirm(false)
@@ -590,6 +610,11 @@ export default function AdHocLoggerView({
           </div>,
           document.body
         )}
+      <WorkoutRollupModal
+        open={showRollup}
+        rollup={rollup}
+        onClose={handleRollupClose}
+      />
     </>
   )
 }

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -8,6 +8,7 @@ import {
   type ExerciseDefinition,
   ExerciseSearchInterface,
 } from '@/components/exercise-selection/ExerciseSearchInterface'
+import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
 import { Button } from '@/components/ui/Button'
 import { LoadingFrog } from '@/components/ui/loading-frog'
 import {
@@ -30,7 +31,6 @@ import SetLoggingForm, {
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import { clientLogger } from '@/lib/client-logger'
-import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
 

--- a/components/features/training/WorkoutRollupModal.tsx
+++ b/components/features/training/WorkoutRollupModal.tsx
@@ -1,0 +1,545 @@
+'use client'
+
+import { ChevronLeft, MessageSquarePlus, TrendingDown, TrendingUp, X } from 'lucide-react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { clientLogger } from '@/lib/client-logger'
+import type { RollupExercise, WorkoutRollup } from '@/lib/stats/workout-rollup'
+import { POST_SESSION_REFINEMENTS } from '@/types/feedback'
+
+interface WorkoutRollupModalProps {
+  open: boolean
+  rollup: WorkoutRollup | null
+  onClose: () => void
+}
+
+type View = 'stats' | 'feedback'
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = seconds % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s.toString().padStart(2, '0')}s`
+  return `${s}s`
+}
+
+function formatVolume(lbs: number): string {
+  if (lbs >= 10_000) return `${(lbs / 1000).toFixed(1)}k`
+  return Math.round(lbs).toLocaleString()
+}
+
+function formatWeight(weight: number): string {
+  return Number.isInteger(weight) ? weight.toString() : weight.toFixed(1)
+}
+
+function ExerciseRow({ ex }: { ex: RollupExercise }) {
+  const vs = ex.vsLastTime
+  let trend: 'up' | 'down' | 'flat' | null = null
+  let trendLabel = ''
+
+  if (vs && !ex.isBodyweight && vs.previousVolumeLbs > 0) {
+    const delta = ex.volumeLbs - vs.previousVolumeLbs
+    const pct = Math.round((delta / vs.previousVolumeLbs) * 100)
+    if (pct > 0) {
+      trend = 'up'
+      trendLabel = `+${pct}% vs last`
+    } else if (pct < 0) {
+      trend = 'down'
+      trendLabel = `${pct}% vs last`
+    } else {
+      trend = 'flat'
+      trendLabel = 'same as last'
+    }
+  } else if (vs && ex.isBodyweight) {
+    const prevReps = vs.previousTopSet?.reps ?? 0
+    if (prevReps && ex.reps !== prevReps) {
+      const delta = ex.reps - prevReps
+      trend = delta > 0 ? 'up' : 'down'
+      trendLabel = `${delta > 0 ? '+' : ''}${delta} reps vs last`
+    }
+  }
+
+  return (
+    <div className="py-3 border-b border-border/60 last:border-b-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-semibold text-foreground text-base truncate">{ex.name}</div>
+        {ex.topSet && !ex.isBodyweight && (
+          <div className="text-sm text-muted-foreground whitespace-nowrap tabular-nums">
+            top {formatWeight(ex.topSet.weight)} × {ex.topSet.reps}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-3 mt-1.5 text-sm tabular-nums">
+        <span className="text-muted-foreground">
+          {ex.workingSets} set{ex.workingSets !== 1 ? 's' : ''} · {ex.reps} rep{ex.reps !== 1 ? 's' : ''}
+          {!ex.isBodyweight && (
+            <>
+              {' · '}
+              <span className="text-foreground font-semibold">{formatVolume(ex.volumeLbs)} lbs</span>
+            </>
+          )}
+        </span>
+        {trend && (
+          <span
+            className={`flex items-center gap-1 font-semibold uppercase tracking-wider text-sm ${
+              trend === 'up' ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            {trend === 'up' && <TrendingUp className="w-3.5 h-3.5" />}
+            {trend === 'down' && <TrendingDown className="w-3.5 h-3.5" />}
+            {trendLabel}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+type Tile = { label: string; value: string; tone?: 'default' | 'hero' }
+
+function StatTile({ label, value, tone = 'default' }: Tile) {
+  const isHero = tone === 'hero'
+  return (
+    <div
+      className={`border-2 border-border bg-muted flex flex-col items-center justify-center ${
+        isHero ? 'p-4 col-span-2' : 'p-3'
+      }`}
+    >
+      <div
+        className={`font-bold text-foreground doom-heading tabular-nums ${
+          isHero ? 'text-3xl' : 'text-2xl'
+        }`}
+      >
+        {value}
+      </div>
+      <div className="text-sm uppercase tracking-wider text-muted-foreground mt-1.5">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+export function WorkoutRollupModal({ open, rollup, onClose }: WorkoutRollupModalProps) {
+  const [view, setView] = useState<View>('stats')
+  const [rating, setRating] = useState<number | null>(null)
+  const [selectedRefinements, setSelectedRefinements] = useState<string[]>([])
+  const [message, setMessage] = useState('')
+  const [scope, setScope] = useState<'app' | 'workout'>('app')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const [showBottomFade, setShowBottomFade] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setView('stats')
+      setRating(null)
+      setSelectedRefinements([])
+      setMessage('')
+      setScope('app')
+      setSubmitting(false)
+      setSubmitted(false)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const original = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = original
+    }
+  }, [open])
+
+  // Show a bottom fade when there's more scrollable content below the fold.
+  // Re-measure on view change, content change, scroll, and viewport resize.
+  useLayoutEffect(() => {
+    if (!open) return
+    const el = scrollRef.current
+    if (!el) return
+
+    const measure = () => {
+      const more = el.scrollHeight - el.scrollTop - el.clientHeight > 4
+      setShowBottomFade(more)
+    }
+
+    measure()
+    el.addEventListener('scroll', measure, { passive: true })
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    window.addEventListener('resize', measure)
+    return () => {
+      el.removeEventListener('scroll', measure)
+      ro.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [open, view, submitted, rating, scope])
+
+  if (!open || !rollup) return null
+
+  // Build stat tiles. Hero is volume if non-zero, else total reps (bodyweight day).
+  const heroTile: Tile | null = (() => {
+    if (rollup.isMinimal) return null
+    if (rollup.totalVolumeLbs > 0) {
+      return { label: 'Volume (lbs)', value: formatVolume(rollup.totalVolumeLbs), tone: 'hero' }
+    }
+    if (rollup.totalReps > 0) {
+      return { label: 'Total Reps', value: rollup.totalReps.toLocaleString(), tone: 'hero' }
+    }
+    return null
+  })()
+
+  const secondaryTiles: Tile[] = []
+  if (!rollup.isMinimal) {
+    if (rollup.totalVolumeLbs > 0) {
+      // Volume was the hero; reps still earns a secondary tile.
+      secondaryTiles.push({ label: 'Reps', value: rollup.totalReps.toLocaleString() })
+    }
+    secondaryTiles.push({ label: 'Working Sets', value: rollup.workingSetCount.toString() })
+    secondaryTiles.push({ label: 'Exercises', value: rollup.exerciseCount.toString() })
+    if (rollup.durationSeconds !== null) {
+      secondaryTiles.push({ label: 'Duration', value: formatDuration(rollup.durationSeconds) })
+    }
+  }
+
+  const toggleRefinement = (value: string) => {
+    setSelectedRefinements((prev) =>
+      prev.includes(value) ? prev.filter((r) => r !== value) : [...prev, value]
+    )
+  }
+
+  const submitFeedback = async (
+    ratingValue: number,
+    refinements: string[] = [],
+    comment = ''
+  ) => {
+    setSubmitting(true)
+    try {
+      const properties: Record<string, string> = {
+        completionId: rollup.completionId,
+        scope,
+      }
+      if (scope === 'workout' && rollup.workoutId) {
+        properties.workoutId = rollup.workoutId
+        if (rollup.workoutName) properties.workoutName = rollup.workoutName
+      }
+
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          category: 'post_session',
+          rating: ratingValue,
+          refinements,
+          message: comment.trim() || undefined,
+          pageUrl: window.location.pathname,
+          userAgent: navigator.userAgent,
+          properties,
+        }),
+      })
+      if (res.ok) {
+        setSubmitted(true)
+      } else {
+        clientLogger.error('Failed to submit post-session feedback')
+      }
+    } catch (err) {
+      clientLogger.error('Error submitting post-session feedback:', err)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleRatingTap = (value: number) => {
+    setRating(value)
+    if (value === 5 && scope === 'app') {
+      submitFeedback(value)
+    }
+  }
+
+  const handleFeedbackSubmit = () => {
+    if (!rating) return
+    submitFeedback(rating, selectedRefinements, message)
+  }
+
+  const headerTitle = view === 'stats' ? 'Workout Complete' : submitted ? 'Thanks!' : 'Quick Feedback'
+
+  return (
+    <div
+      role="button"
+      tabIndex={-1}
+      style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+      className="flex items-center justify-center backdrop-blur-md bg-black/40 dark:bg-black/60 p-4"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === 'Escape') onClose() }}
+      aria-label="Close workout summary"
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: presentation wrapper stops click propagation */}
+      <div
+        role="presentation"
+        style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.3)', maxHeight: 'calc(100dvh - 2rem)' }}
+        className="relative w-full max-w-md bg-card border-2 border-border doom-corners doom-noise flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="shrink-0 px-4 py-3 border-b-2 border-border flex items-center justify-between gap-2">
+          {view === 'feedback' && !submitted ? (
+            <button
+              type="button"
+              onClick={() => setView('stats')}
+              className="h-9 w-9 flex items-center justify-center border-2 border-border bg-muted hover:bg-secondary/10 transition-colors focus:outline-none doom-focus-ring"
+              aria-label="Back to summary"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+          ) : (
+            <span className="w-9" aria-hidden />
+          )}
+          <h2 className="flex-1 text-base font-bold text-foreground doom-heading uppercase tracking-[0.15em] text-center">
+            {headerTitle}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 w-9 flex items-center justify-center border-2 border-border bg-muted hover:bg-secondary/10 transition-colors focus:outline-none doom-focus-ring"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Scrollable body with bottom fade when content overflows */}
+        <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
+          {view === 'stats' && (
+            <div className="px-5 py-5 space-y-5">
+              {/* Compact meta row: lifetime + 7-day count */}
+              <div className="flex items-stretch justify-between gap-3 text-foreground border-b-2 border-border/50 pb-4">
+                <div className="flex-1">
+                  <div className="text-sm uppercase tracking-wider text-muted-foreground">
+                    Workout
+                  </div>
+                  <div className="text-3xl font-bold doom-heading tabular-nums leading-none mt-1">
+                    #{rollup.lifetimeWorkoutCount}
+                  </div>
+                </div>
+                <div className="w-px bg-border/60" aria-hidden />
+                <div className="flex-1 text-right">
+                  <div className="text-sm uppercase tracking-wider text-muted-foreground">
+                    Last 7 Days
+                  </div>
+                  <div className="text-3xl font-bold doom-heading tabular-nums leading-none mt-1">
+                    {rollup.workoutsLast7Days}
+                  </div>
+                </div>
+              </div>
+
+              {/* Hero stat + 2x2 secondary grid */}
+              {heroTile && (
+                <div className="grid grid-cols-2 gap-2">
+                  <StatTile {...heroTile} />
+                  {secondaryTiles.map((t) => (
+                    <StatTile key={t.label} label={t.label} value={t.value} />
+                  ))}
+                </div>
+              )}
+
+              {rollup.exercises.length > 0 && (
+                <div>
+                  <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+                    Exercises
+                  </p>
+                  <div>
+                    {rollup.exercises.map((ex) => (
+                      <ExerciseRow key={ex.exerciseDefinitionId} ex={ex} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {rollup.isMinimal && (
+                <p className="text-sm text-muted-foreground text-center py-2">
+                  Marked complete. Nice work.
+                </p>
+              )}
+            </div>
+          )}
+
+          {view === 'feedback' && submitted && (
+            <p className="px-5 py-10 text-base text-foreground text-center">
+              Thanks for the feedback.
+            </p>
+          )}
+
+          {view === 'feedback' && !submitted && (
+            <div className="px-5 py-5 space-y-5">
+              {/* Scope toggle (community-sourced workouts only) */}
+              {rollup.isCommunitySourced && rollup.workoutId && (
+                <div>
+                  <p className="text-sm font-semibold text-foreground uppercase tracking-wider mb-2">
+                    Feedback about
+                  </p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setScope('app')}
+                      className={`py-3 border-2 text-sm font-semibold uppercase tracking-wider transition-colors doom-focus-ring ${
+                        scope === 'app'
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary/10'
+                      }`}
+                    >
+                      The app
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setScope('workout')}
+                      className={`py-3 border-2 text-sm font-semibold uppercase tracking-wider transition-colors doom-focus-ring ${
+                        scope === 'workout'
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary/10'
+                      }`}
+                    >
+                      This workout
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Rating */}
+              <div>
+                <p className="text-sm font-semibold text-foreground uppercase tracking-wider mb-2">
+                  {scope === 'workout' ? 'How was this workout?' : 'How are you liking the app?'}
+                </p>
+                <div className="grid grid-cols-5 gap-1.5">
+                  {[1, 2, 3, 4, 5].map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => handleRatingTap(value)}
+                      disabled={submitting}
+                      className={`h-11 border-2 text-base font-bold tabular-nums transition-colors doom-focus-ring ${
+                        rating === value
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-muted text-foreground border-border hover:bg-secondary/10'
+                      }`}
+                    >
+                      {value}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Refinement chips: 2-column grid (app scope, rating < 5) */}
+              {scope === 'app' && rating !== null && rating < 5 && (
+                <div>
+                  <p className="text-sm font-semibold text-foreground uppercase tracking-wider mb-2">
+                    What could be better?
+                  </p>
+                  <div className="grid grid-cols-2 gap-1.5">
+                    {POST_SESSION_REFINEMENTS.map(({ value, label }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => toggleRefinement(value)}
+                        disabled={submitting}
+                        className={`px-3 py-2.5 border-2 text-sm font-semibold text-left transition-colors doom-focus-ring ${
+                          selectedRefinements.includes(value)
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-muted text-foreground border-border hover:bg-secondary/10'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Optional comment */}
+              {rating !== null && (
+                <div>
+                  <label
+                    htmlFor="rollup-feedback-comment"
+                    className="block text-sm font-semibold text-foreground mb-2 uppercase tracking-wider"
+                  >
+                    {scope === 'workout' ? 'What about it? (optional)' : 'Anything specific? (optional)'}
+                  </label>
+                  <textarea
+                    id="rollup-feedback-comment"
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    rows={3}
+                    maxLength={2000}
+                    placeholder="TYPE ANYTHING"
+                    className="w-full px-3 py-2 bg-input border-2 border-border text-foreground text-sm placeholder:text-muted-foreground placeholder:uppercase placeholder:tracking-wider placeholder:text-xs resize-none focus:outline-none focus:border-primary"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+          {/* Sticky fade pinned to the bottom of the scroll viewport. Negative margin
+              cancels its layout contribution so scrollHeight stays accurate. */}
+          <div
+            aria-hidden
+            className={`sticky bottom-0 -mt-10 h-10 pointer-events-none bg-gradient-to-t from-card to-transparent transition-opacity duration-200 ${
+              showBottomFade ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 px-4 py-3 border-t-2 border-border flex items-center gap-3">
+          {view === 'stats' && (
+            <>
+              <button
+                type="button"
+                onClick={() => setView('feedback')}
+                className="flex items-center gap-2 px-3 py-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+              >
+                <MessageSquarePlus className="w-4 h-4" />
+                Got feedback?
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="ml-auto px-6 py-3 bg-primary text-primary-foreground doom-button-3d font-bold text-base uppercase tracking-wider doom-focus-ring"
+              >
+                Done
+              </button>
+            </>
+          )}
+
+          {view === 'feedback' && !submitted && (
+            <>
+              <button
+                type="button"
+                onClick={() => setView('stats')}
+                className="px-4 py-2.5 text-sm font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors doom-focus-ring"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleFeedbackSubmit}
+                disabled={submitting || rating === null}
+                className="ml-auto px-6 py-3 bg-primary text-primary-foreground doom-button-3d font-bold text-sm uppercase tracking-wider doom-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitting ? 'Sending…' : 'Submit'}
+              </button>
+            </>
+          )}
+
+          {view === 'feedback' && submitted && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="ml-auto px-6 py-3 bg-primary text-primary-foreground doom-button-3d font-bold text-base uppercase tracking-wider doom-focus-ring"
+            >
+              Done
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/api/workout-sets.ts
+++ b/lib/api/workout-sets.ts
@@ -1,3 +1,4 @@
+import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
 
 const MAX_RETRIES = 3
@@ -125,12 +126,21 @@ export async function fetchDraft(workoutId: string): Promise<DraftResponse> {
   }
 }
 
+export type CompleteDraftResult = {
+  completionId: string
+  rollup: WorkoutRollup | null
+}
+
 export async function completeDraft(
   workoutId: string,
   fallbackSets?: LoggedSet[],
   guidedCompletion?: boolean
-): Promise<void> {
-  await fetchWithRetry<{ success: boolean }>(
+): Promise<CompleteDraftResult> {
+  const res = await fetchWithRetry<{
+    success: boolean
+    completion: { id: string }
+    rollup: WorkoutRollup | null
+  }>(
     `/api/workouts/${workoutId}/complete`,
     {
       method: 'POST',
@@ -150,6 +160,7 @@ export async function completeDraft(
       }),
     }
   )
+  return { completionId: res.completion.id, rollup: res.rollup }
 }
 
 export async function discardDraft(workoutId: string): Promise<void> {

--- a/lib/stats/workout-rollup.ts
+++ b/lib/stats/workout-rollup.ts
@@ -1,0 +1,232 @@
+import type { PrismaClient } from '@prisma/client'
+import { getBatchExercisePerformance } from '@/lib/queries/exercise-history'
+
+export type RollupExercise = {
+  exerciseDefinitionId: string
+  name: string
+  workingSets: number
+  reps: number
+  volumeLbs: number
+  isBodyweight: boolean
+  topSet: { weight: number; reps: number } | null
+  vsLastTime: {
+    previousCompletedAt: Date
+    previousVolumeLbs: number
+    previousTopSet: { weight: number; reps: number } | null
+  } | null
+}
+
+export type WorkoutRollup = {
+  completionId: string
+  isMinimal: boolean
+  durationSeconds: number | null
+  exerciseCount: number
+  workingSetCount: number
+  totalReps: number
+  totalVolumeLbs: number
+  hasBodyweightOnlyExercises: boolean
+  lifetimeWorkoutCount: number
+  workoutsLast7Days: number
+  exercises: RollupExercise[]
+  workoutId: string | null
+  workoutName: string | null
+  isCommunitySourced: boolean
+}
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+export async function computeWorkoutRollup(
+  prisma: PrismaClient,
+  completionId: string,
+  userId: string
+): Promise<WorkoutRollup | null> {
+  const completion = await prisma.workoutCompletion.findFirst({
+    where: { id: completionId, userId, status: 'completed', isArchived: false },
+    select: {
+      id: true,
+      completedAt: true,
+      startedAt: true,
+      workoutId: true,
+      name: true,
+      workout: {
+        select: {
+          name: true,
+          week: {
+            select: {
+              program: { select: { sourceCommunityProgramId: true } },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!completion) return null
+
+  const workoutName = completion.workout?.name ?? completion.name ?? null
+  const isCommunitySourced = Boolean(
+    completion.workout?.week?.program?.sourceCommunityProgramId
+  )
+
+  const loggedSets = await prisma.loggedSet.findMany({
+    where: { completionId },
+    select: {
+      reps: true,
+      weight: true,
+      isWarmup: true,
+      exercise: {
+        select: {
+          id: true,
+          name: true,
+          exerciseDefinitionId: true,
+        },
+      },
+    },
+  })
+
+  const workingSets = loggedSets.filter((s) => !s.isWarmup)
+
+  const [lifetimeWorkoutCount, workoutsLast7Days] = await Promise.all([
+    prisma.workoutCompletion.count({
+      where: { userId, status: 'completed', isArchived: false },
+    }),
+    prisma.workoutCompletion.count({
+      where: {
+        userId,
+        status: 'completed',
+        isArchived: false,
+        completedAt: { gte: new Date(Date.now() - SEVEN_DAYS_MS) },
+      },
+    }),
+  ])
+
+  const durationSeconds =
+    completion.startedAt && completion.completedAt
+      ? Math.max(
+          0,
+          Math.round(
+            (completion.completedAt.getTime() - completion.startedAt.getTime()) / 1000
+          )
+        )
+      : null
+
+  if (workingSets.length === 0) {
+    return {
+      completionId: completion.id,
+      isMinimal: true,
+      durationSeconds,
+      exerciseCount: 0,
+      workingSetCount: 0,
+      totalReps: 0,
+      totalVolumeLbs: 0,
+      hasBodyweightOnlyExercises: false,
+      lifetimeWorkoutCount,
+      workoutsLast7Days,
+      exercises: [],
+      workoutId: completion.workoutId,
+      workoutName,
+      isCommunitySourced,
+    }
+  }
+
+  type Agg = {
+    exerciseDefinitionId: string
+    name: string
+    workingSets: number
+    reps: number
+    volumeLbs: number
+    maxWeight: number
+    topSet: { weight: number; reps: number } | null
+  }
+  const byDef = new Map<string, Agg>()
+
+  for (const set of workingSets) {
+    const defId = set.exercise.exerciseDefinitionId
+    const existing = byDef.get(defId) ?? {
+      exerciseDefinitionId: defId,
+      name: set.exercise.name,
+      workingSets: 0,
+      reps: 0,
+      volumeLbs: 0,
+      maxWeight: -1,
+      topSet: null,
+    }
+    existing.workingSets += 1
+    existing.reps += set.reps
+    existing.volumeLbs += set.weight * set.reps
+    if (set.weight > existing.maxWeight) {
+      existing.maxWeight = set.weight
+      existing.topSet = { weight: set.weight, reps: set.reps }
+    }
+    byDef.set(defId, existing)
+  }
+
+  const defIds = Array.from(byDef.keys())
+  const previousMap = await getBatchExercisePerformance(
+    defIds,
+    userId,
+    completion.completedAt
+  )
+
+  const exercises: RollupExercise[] = []
+  let totalReps = 0
+  let totalVolumeLbs = 0
+  let hasBodyweightOnly = false
+
+  for (const agg of byDef.values()) {
+    const isBodyweight = agg.maxWeight <= 0
+    if (isBodyweight) hasBodyweightOnly = true
+
+    const previous = previousMap.get(agg.exerciseDefinitionId)
+    let vsLastTime: RollupExercise['vsLastTime'] = null
+    if (previous) {
+      const prevWorking = previous.sets.filter((s) => !s.isWarmup)
+      const prevVolume = prevWorking.reduce(
+        (sum, s) => sum + s.weight * s.reps,
+        0
+      )
+      let prevTop: { weight: number; reps: number } | null = null
+      for (const s of prevWorking) {
+        if (!prevTop || s.weight > prevTop.weight) {
+          prevTop = { weight: s.weight, reps: s.reps }
+        }
+      }
+      vsLastTime = {
+        previousCompletedAt: previous.completedAt,
+        previousVolumeLbs: prevVolume,
+        previousTopSet: prevTop,
+      }
+    }
+
+    exercises.push({
+      exerciseDefinitionId: agg.exerciseDefinitionId,
+      name: agg.name,
+      workingSets: agg.workingSets,
+      reps: agg.reps,
+      volumeLbs: isBodyweight ? 0 : agg.volumeLbs,
+      isBodyweight,
+      topSet: agg.topSet,
+      vsLastTime,
+    })
+
+    totalReps += agg.reps
+    if (!isBodyweight) totalVolumeLbs += agg.volumeLbs
+  }
+
+  return {
+    completionId: completion.id,
+    isMinimal: false,
+    durationSeconds,
+    exerciseCount: byDef.size,
+    workingSetCount: workingSets.length,
+    totalReps,
+    totalVolumeLbs,
+    hasBodyweightOnlyExercises: hasBodyweightOnly,
+    lifetimeWorkoutCount,
+    workoutsLast7Days,
+    exercises,
+    workoutId: completion.workoutId,
+    workoutName,
+    isCommunitySourced,
+  }
+}

--- a/lib/stats/workout-rollup.ts
+++ b/lib/stats/workout-rollup.ts
@@ -1,5 +1,4 @@
 import type { PrismaClient } from '@prisma/client'
-import { getBatchExercisePerformance } from '@/lib/queries/exercise-history'
 
 export type RollupExercise = {
   exerciseDefinitionId: string
@@ -34,6 +33,59 @@ export type WorkoutRollup = {
 }
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+type PreviousHistorySet = { weight: number; reps: number; isWarmup: boolean }
+type PreviousHistory = { completedAt: Date; sets: PreviousHistorySet[] }
+
+// Inlined so tests can pass their own PrismaClient. lib/queries/exercise-history.ts
+// uses the singleton prisma directly, which has no DATABASE_URL in CI tests.
+async function fetchPreviousExerciseHistory(
+  prisma: PrismaClient,
+  exerciseDefinitionIds: string[],
+  userId: string,
+  beforeDate: Date
+): Promise<Map<string, PreviousHistory>> {
+  if (exerciseDefinitionIds.length === 0) return new Map()
+
+  const completions = await prisma.workoutCompletion.findMany({
+    where: {
+      userId,
+      status: 'completed',
+      isArchived: false,
+      completedAt: { lt: beforeDate },
+      loggedSets: {
+        some: { exercise: { exerciseDefinitionId: { in: exerciseDefinitionIds } } },
+      },
+    },
+    orderBy: { completedAt: 'desc' },
+    take: 50,
+    select: {
+      completedAt: true,
+      loggedSets: {
+        where: { exercise: { exerciseDefinitionId: { in: exerciseDefinitionIds } } },
+        select: {
+          weight: true,
+          reps: true,
+          isWarmup: true,
+          exercise: { select: { exerciseDefinitionId: true } },
+        },
+      },
+    },
+  })
+
+  const map = new Map<string, PreviousHistory>()
+  for (const completion of completions) {
+    for (const set of completion.loggedSets) {
+      const defId = set.exercise.exerciseDefinitionId
+      if (map.has(defId)) continue
+      const setsForDef = completion.loggedSets
+        .filter((s) => s.exercise.exerciseDefinitionId === defId)
+        .map((s) => ({ weight: s.weight, reps: s.reps, isWarmup: s.isWarmup }))
+      map.set(defId, { completedAt: completion.completedAt, sets: setsForDef })
+    }
+  }
+  return map
+}
 
 export async function computeWorkoutRollup(
   prisma: PrismaClient,
@@ -162,7 +214,8 @@ export async function computeWorkoutRollup(
   }
 
   const defIds = Array.from(byDef.keys())
-  const previousMap = await getBatchExercisePerformance(
+  const previousMap = await fetchPreviousExerciseHistory(
+    prisma,
     defIds,
     userId,
     completion.completedAt


### PR DESCRIPTION
## Summary

Phase 1 of #760 — post-workout stats rollup modal with embedded feedback.

- Computes per-completion volume, reps, working sets, exercise count, duration, lifetime + 7-day workout counts, and vs-last-time deltas per exercise. Bodyweight (weight=0) contributes reps only, not volume. Follow-Along / zero-set completions get a minimal rollup with just the counters.
- New \`GET /api/workouts/completions/[id]/rollup\` and the same payload returned inline from both \`/complete\` POSTs (strength + ad-hoc) so the first view is round-trip-free.
- Feedback merged into the rollup behind a \"Got feedback?\" button so it's always reachable. The cooldown-based PostSessionFeedback popup is no longer wired up. Community-sourced workouts get a \"What about? The app / This workout\" toggle that tags the submission with \`workoutId\`.
- DOOM-themed modal: \`doom-corners\` frame, \`doom-button-3d\` primary, \`doom-noise\` paper grain, tabular numerics on every read-to-act number, uppercase Rajdhani labels per DESIGN.md.
- Sticky bottom fade indicator when content overflows the scroll viewport.

## Test plan

- [ ] Complete a strength workout → rollup shows correct volume / reps / sets / exercises / duration, lifetime + 7-day counts match
- [ ] Bodyweight-only day (pull-ups, dips) → no \"0 lbs volume\" text; rep count shown
- [ ] Follow-Along completion with no sets → minimal rollup (just the counters)
- [ ] Complete an ad-hoc workout → rollup shows before /training redirect, Done closes and navigates
- [ ] Long workout (5+ exercises) → body scrolls, bottom fade appears and disappears at end
- [ ] \"Got feedback?\" → rating 5 auto-submits on app scope; rating <5 opens refinements + comment
- [ ] Community-cloned program workout → \"The app / This workout\" toggle appears; \"This workout\" submission carries \`workoutId\` in properties
- [ ] User-authored program workout → no toggle (defaults to app scope)
- [ ] Integration tests: \`doppler run --config dev_test -- npm test workout-rollup\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)