### PR TITLE
fix(training): spinner while restoring draft workout (#765)

### DIFF
--- a/app/api/workouts/[workoutId]/metadata/route.ts
+++ b/app/api/workouts/[workoutId]/metadata/route.ts
@@ -102,6 +102,7 @@ export async function GET(
     // When resuming a draft, find the first exercise with incomplete sets
     let resumeExerciseIndex = 0
     let exerciseCount: number
+    let targetExerciseId: string | null = null
     if (completionId && completionStatus === 'draft') {
       // Fetch all exercises (ordered) and logged set counts in parallel
       const [allExercises, loggedSetCounts] = await Promise.all([
@@ -136,6 +137,8 @@ export async function GET(
           resumeExerciseIndex = i
         }
       }
+
+      targetExerciseId = allExercises[resumeExerciseIndex]?.id ?? null
     } else {
       // Non-draft: just count exercises
       exerciseCount = await prisma.exercise.count({
@@ -143,13 +146,19 @@ export async function GET(
       })
     }
 
-    // Fetch the target exercise (first incomplete for drafts, first overall otherwise)
-    const targetExercise = await prisma.exercise.findFirst({
-      where: { OR: whereConditions, userId: user.id },
-      orderBy: { order: 'asc' },
-      skip: resumeExerciseIndex,
-      select: exerciseSelect,
-    })
+    // Fetch the target exercise. For drafts we already know the id from the
+    // ordered list above — use findUnique to avoid a redundant offset scan.
+    const targetExercise = targetExerciseId
+      ? await prisma.exercise.findUnique({
+          where: { id: targetExerciseId },
+          select: exerciseSelect,
+        })
+      : await prisma.exercise.findFirst({
+          where: { OR: whereConditions, userId: user.id },
+          orderBy: { order: 'asc' },
+          skip: resumeExerciseIndex,
+          select: exerciseSelect,
+        })
 
     // Fetch history for the target exercise
     let targetExerciseHistory = null

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CheckCircle } from 'lucide-react'
+import { CheckCircle, Loader2 } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState, useTransition } from 'react'
 import ExerciseLoggingModal from '@/components/ExerciseLoggingModal'
@@ -562,6 +562,22 @@ export default function StrengthWeekView({
       {/* Recent History */}
       {historyCount > 0 && (
         <WorkoutHistoryList count={historyCount} compact />
+      )}
+
+      {/* Fullscreen loading overlay shown while a workout is being restored
+          (e.g. ?resume= from QuickActionSheet) before the modal can open. */}
+      {isLoadingWorkout && !workoutMetadata && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="Restoring workout"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background/80 backdrop-blur-sm"
+        >
+          <Loader2 className="w-10 h-10 text-primary animate-spin" />
+          <p className="mt-4 text-sm font-semibold uppercase tracking-wider text-foreground">
+            {resumeWorkoutId ? 'Restoring workout…' : 'Loading workout…'}
+          </p>
+        </div>
       )}
 
       {/* Logging Modal - uses progressive loading */}


### PR DESCRIPTION
## Summary
- Adds a fullscreen loading overlay (Loader2 spinner + label) while `/api/workouts/[workoutId]/metadata` is being fetched. This covers the `?resume=` flow from Quick Actions, where the user was previously left staring at the training page for a few seconds with no indication that anything was happening.
- Small efficiency win in the metadata route: for draft resumes we already know the target exercise id from the ordered list used to pick the resume index, so we now `findUnique` by id instead of doing a second `findFirst` with a SQL offset scan.

Fixes #765

## Test plan
- [ ] Tap an in-progress workout from Quick Actions → spinner appears immediately on `/training`, then the logging modal opens
- [ ] Tap a workout card from the training page → existing per-card spinner still works (no double UI)
- [ ] Confirm draft resume still lands on the first incomplete exercise
- [ ] `npm run type-check` passes (no new errors)