### PR TITLE
fix: persist rest timer across in-app tab switches (#764)

### DIFF
--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useRestTimer } from '@/hooks/useRestTimer'
+import { __clearRestTimerCache, useRestTimer } from '@/hooks/useRestTimer'
 
 // Mock requestAnimationFrame to execute synchronously in tests
 beforeEach(() => {
@@ -8,6 +8,7 @@ beforeEach(() => {
     cb(0)
     return 0
   })
+  __clearRestTimerCache()
 })
 
 afterEach(() => {
@@ -107,6 +108,43 @@ describe('useRestTimer', () => {
     rerender({ count: 0, exId: 'ex-2' })
     expect(result.current.isRunning).toBe(false)
     expect(result.current.elapsed).toBe(0)
+  })
+
+  it('preserves elapsed time across unmount/remount (tab switch within exercise)', () => {
+    // Simulate user logs a set, switches to Info tab (unmount), waits, then
+    // switches back to Log Sets tab (remount). Timer must not reset to zero.
+    const realNow = Date.now.bind(Date)
+    const t0 = 1_700_000_000_000
+    let now = t0
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    try {
+      // Initial mount with no logged sets
+      const first = renderHook(
+        ({ count }) => useRestTimer(count, 'ex-1'),
+        { initialProps: { count: 0 } }
+      )
+
+      // Log a set — timer starts at t0
+      first.rerender({ count: 1 })
+      expect(first.result.current.isRunning).toBe(true)
+      expect(first.result.current.elapsed).toBe(0)
+
+      // 30 seconds pass while user is on the Info tab. Unmount, then remount.
+      first.unmount()
+      now = t0 + 30_000
+
+      const second = renderHook(
+        ({ count }) => useRestTimer(count, 'ex-1'),
+        { initialProps: { count: 1 } }
+      )
+
+      // Timer should still be running and show 30 seconds elapsed, not 0.
+      expect(second.result.current.isRunning).toBe(true)
+      expect(second.result.current.elapsed).toBe(30)
+    } finally {
+      vi.spyOn(Date, 'now').mockImplementation(realNow)
+    }
   })
 
   it('starts the timer when logging a set from zero', () => {

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -10,36 +10,69 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  *
  * Resets whenever a new set is logged — including extra sets beyond the
  * prescribed count and re-logged sets after deletion.
+ *
+ * Start timestamps are cached at module scope keyed by exerciseId so the timer
+ * survives in-app tab switches (e.g. Log Sets → Info → Log Sets), which would
+ * otherwise unmount this hook and lose the start time.
  */
+
+// Module-level cache: exerciseId -> { startedAt epoch ms, setCount when started }
+const timerCache = new Map<string, { startedAt: number; setCount: number }>()
+
+// Exposed for tests
+export function __clearRestTimerCache() {
+  timerCache.clear()
+}
+
 export function useRestTimer(
   loggedSetCount: number,
   exerciseId: string
 ) {
-  // Start running immediately if we mount with sets already logged
-  const [elapsed, setElapsed] = useState(0)
-  const [isRunning, setIsRunning] = useState(loggedSetCount > 0)
-  const startRef = useRef<number | null>(loggedSetCount > 0 ? Date.now() : null)
+  // Lazy initializer (runs once per mount) — recognized as side-effect-safe by react-hooks/purity.
+  const [initialStart] = useState<number | null>(() => {
+    const cached = timerCache.get(exerciseId)
+    if (cached && cached.setCount === loggedSetCount && loggedSetCount > 0) {
+      return cached.startedAt
+    }
+    if (loggedSetCount > 0) {
+      const now = Date.now()
+      timerCache.set(exerciseId, { startedAt: now, setCount: loggedSetCount })
+      return now
+    }
+    return null
+  })
+
+  const [elapsed, setElapsed] = useState(() =>
+    initialStart !== null ? Math.floor((Date.now() - initialStart) / 1000) : 0
+  )
+  const [isRunning, setIsRunning] = useState(initialStart !== null)
+  const startRef = useRef<number | null>(initialStart)
   const prevExerciseRef = useRef(exerciseId)
   const prevCountRef = useRef(loggedSetCount)
 
   // Reset when exercise changes or sets change
   useEffect(() => {
-    // Exercise changed — reset tracking
+    // Exercise changed — reset tracking (but don't clobber other exercises' caches)
     if (exerciseId !== prevExerciseRef.current) {
       prevExerciseRef.current = exerciseId
       prevCountRef.current = loggedSetCount
-      startRef.current = null
-      // Defer setState to avoid synchronous setState in useEffect
+
+      const next = timerCache.get(exerciseId)
+      const useCached =
+        next && next.setCount === loggedSetCount && loggedSetCount > 0
+      startRef.current = useCached ? next.startedAt : null
       const frame = requestAnimationFrame(() => {
-        setElapsed(0)
-        setIsRunning(false)
+        setElapsed(useCached ? Math.floor((Date.now() - next.startedAt) / 1000) : 0)
+        setIsRunning(!!useCached)
       })
       return () => cancelAnimationFrame(frame)
     }
 
     // New set logged — reset the timer
     if (loggedSetCount > prevCountRef.current) {
-      startRef.current = Date.now()
+      const now = Date.now()
+      startRef.current = now
+      timerCache.set(exerciseId, { startedAt: now, setCount: loggedSetCount })
       const frame = requestAnimationFrame(() => {
         setElapsed(0)
         setIsRunning(true)
@@ -51,6 +84,7 @@ export function useRestTimer(
     // Set deleted — if no logged sets remain, stop the timer
     if (loggedSetCount === 0 && prevCountRef.current > 0) {
       startRef.current = null
+      timerCache.delete(exerciseId)
       const frame = requestAnimationFrame(() => {
         setElapsed(0)
         setIsRunning(false)


### PR DESCRIPTION
## Summary
- Cache the rest timer's start timestamp at module scope keyed by `exerciseId` so the timer survives in-app tab switches (Log Sets → Info → Log Sets).
- Previously, Radix `TabsContent` unmounted `SetList` → `RestStopwatch` → `useRestTimer` whenever the user left the Log Sets tab, dropping the start time. On return the timer restarted at 0:00.
- Switched initial-state computation to lazy `useState` initializers, which also clears a pre-existing react-hooks/purity lint error in this file.

## Root cause
`useRestTimer` stored its start time only in a `useRef` initialized at mount. Radix Tabs unmount inactive `TabsContent` by default, so navigating away and back recreated the hook with a fresh `Date.now()` (or no start), losing the elapsed rest interval.

## Fix
- Added a module-level `Map<exerciseId, { startedAt, setCount }>` cache.
- On mount/remount, hydrate the initial start from the cache when the cached `setCount` matches the current `loggedSetCount`.
- Cache is updated when a new set is logged and cleared when all sets for that exercise are deleted.

Fixes #764

## Test plan
- [x] New unit test simulates unmount/remount after 30s — timer reports 30s elapsed, not 0.
- [x] All existing `useRestTimer` tests still pass (8/8).
- [x] `npm run type-check` clean.
- [x] `npm run lint` — no new errors; existing impure-`Date.now()` warning in this file was resolved.
- [ ] Manual: log a set on iOS Safari, switch to Info tab, wait, return — verify rest timer keeps counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)