### PR TITLE
feat(logger): remove redundant exercise name header above tabs

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -22,7 +22,6 @@ import ExerciseDefinitionEditorModal from './features/exercise-definition/Exerci
 import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from './workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from './workout-logging/ExerciseLoggingHeader'
-import ExerciseNavigation from './workout-logging/ExerciseNavigation'
 import type { QuickAction } from './workout-logging/ExerciseQuickActionsMenu'
 import ExitWorkoutConfirm from './workout-logging/ExitWorkoutConfirm'
 import FollowAlongFooter from './workout-logging/FollowAlongFooter'
@@ -572,24 +571,6 @@ export default function ExerciseLoggingModal({
                 },
               ] satisfies QuickAction[]}
             />
-          )}
-
-          {/* Exercise title — hidden in follow-along (title block shows name) */}
-          {!isFollowAlong && (
-            currentExercise ? (
-              <ExerciseNavigation
-                currentExercise={currentExercise}
-                currentExerciseIndex={currentIndex}
-                totalExercises={totalExercises}
-                onPrevious={handlePreviousExercise}
-                onNext={handleNextExercise}
-                hideChevrons
-              />
-            ) : (
-              <div className="px-4 py-3 border-b border-border">
-                <div className="h-8 bg-muted animate-pulse" />
-              </div>
-            )
           )}
 
           {/* One-time intensity intro bubble */}

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -26,6 +26,7 @@ interface Exercise {
   id: string
   name: string
   notes: string | null
+  exerciseGroup?: string | null
   exerciseDefinition?: {
     primaryFAUs: string[]
     secondaryFAUs: string[]
@@ -70,6 +71,22 @@ interface ExerciseDisplayTabsProps {
   totalSets?: number
   /** Pre-formatted prescription summary for the current set. Omit to drop the line. */
   prescribedSummary?: string
+}
+
+function ExerciseTabTitle({ exercise }: { exercise: Exercise }) {
+  const supersetLabel = exercise.exerciseGroup ?? null
+  return (
+    <div className="pt-3 pb-2 mb-3 border-b border-border/60 -mx-4 px-4">
+      {supersetLabel && (
+        <span className="inline-block px-2 py-0.5 text-xs font-bold uppercase tracking-wider text-accent border border-accent mb-1">
+          Superset {supersetLabel}
+        </span>
+      )}
+      <h2 className="text-xl font-bold text-foreground doom-heading truncate">
+        {exercise.name.toUpperCase()}
+      </h2>
+    </div>
+  )
 }
 
 // Loading skeleton for history tab
@@ -171,6 +188,7 @@ export default function ExerciseDisplayTabs({
       </TabsContent>
 
       <TabsContent value="info" className="flex-1 overflow-y-auto px-4">
+        <ExerciseTabTitle exercise={exercise} />
         <ExerciseInfoContent
           exerciseName={exercise.name}
           exerciseDefinition={exercise.exerciseDefinition}
@@ -179,6 +197,7 @@ export default function ExerciseDisplayTabs({
 
       {hasNotes && (
         <TabsContent value="notes" className="flex-1 overflow-y-auto px-4">
+          <ExerciseTabTitle exercise={exercise} />
           <div className="space-y-6">
             <div>
               <h4 className="text-lg sm:text-xl font-semibold text-foreground mb-3">Notes</h4>
@@ -191,6 +210,7 @@ export default function ExerciseDisplayTabs({
       )}
 
       <TabsContent value="history" className="flex-1 overflow-y-auto px-4">
+        <ExerciseTabTitle exercise={exercise} />
         {historyState === 'loading' || historyState === 'pending' ? (
           <HistoryLoadingSkeleton />
         ) : historyState === 'error' ? (


### PR DESCRIPTION
## Summary
- Removed the `ExerciseNavigation` title block that rendered above the tabs in the regular logger — the exercise name was already shown in `DrawerContextBanner` on the Log Sets tab.
- Added a compact title (name + superset badge) at the top of the Info, Notes, and History tab panels so users still know which exercise they're viewing on non-logging tabs.
- Ad-hoc logger inherits this automatically via the shared `ExerciseDisplayTabs`.

## Test plan
- [ ] Open regular logger → confirm no duplicate name above tabs, name still visible on Log Sets via DrawerContextBanner.
- [ ] Switch to Info tab → exercise name visible at top.
- [ ] Switch to History tab → exercise name visible at top.
- [ ] Exercise with notes → Notes tab shows name at top.
- [ ] Superset exercise → superset badge appears above name on Info/Notes/History.
- [ ] Open ad-hoc logger → same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)