### PR TITLE
chore(deps): upgrade lucide-react 0.577.0 -> 1.16.0

### DIFF
--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -1,12 +1,28 @@
 'use client'
 
-import { ArrowDown, ArrowUp, Check, CheckCheck, ExternalLink, Github, MessageSquarePlus, Tag } from 'lucide-react'
+import { ArrowDown, ArrowUp, Check, CheckCheck, ExternalLink, MessageSquarePlus, Tag } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { SegmentedControl } from '@/components/ui/SegmentedControl'
 import type { FeedbackStatus } from '@/types/feedback'
 import { POST_SESSION_REFINEMENTS } from '@/types/feedback'
+
+// GitHub brand icon was removed in lucide-react v1; inline SVG keeps the GitHub logo recognizable.
+function Github({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1-.02-1.96-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.24 3.34.95.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11.04 11.04 0 015.79 0c2.2-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.69.41.35.78 1.05.78 2.11 0 1.52-.01 2.75-.01 3.13 0 .3.21.67.8.55C20.21 21.38 23.5 17.07 23.5 12 23.5 5.65 18.35.5 12 .5z" />
+    </svg>
+  )
+}
 
 interface FeedbackItem {
   id: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "bcrypt": "^6.0.0",
         "better-auth": "^1.4.19",
         "bullmq": "^5.76.2",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.16.0",
         "minio": "^8.0.7",
         "next": "16.2.6",
         "pg": "^8.20.0",
@@ -12613,9 +12613,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bcrypt": "^6.0.0",
     "better-auth": "^1.4.19",
     "bullmq": "^5.76.2",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.16.0",
     "minio": "^8.0.7",
     "next": "16.2.6",
     "pg": "^8.20.0",


### PR DESCRIPTION
## Summary
- Bumps `lucide-react` from `0.577.0` to `1.16.0`.
- v1 removed the `Github` brand icon (along with other brand marks). Replaced the single import in the admin feedback page with a small inline GitHub SVG so issue links keep the recognizable mark.
- No other icons used in this codebase were affected by the v1 release.

## Updated packages
| Package | Old | New |
| --- | --- | --- |
| lucide-react | 0.577.0 | 1.16.0 |

## Breaking changes addressed
- `Github` icon no longer exported by `lucide-react` -> replaced with inline SVG component in `app/(app)/admin/feedback/page.tsx`.

## Verification
- [x] `npm run type-check` -> pass
- [x] `doppler run -- npm run build` -> pass
- [ ] `npm run lint` -> not run as part of this PR (pre-existing lint errors unrelated to dependency change exist in `components/workout-logging/FollowAlongTabs.tsx` and `hooks/usePwaPrompt.ts`)
- [ ] Test suite not run in this PR (purely an icon swap; manual verification of admin feedback page recommended post-merge)

## Test plan
- [ ] Visit `/admin/feedback` after merge and confirm the GitHub icon renders on items with `githubIssueUrl`.
- [ ] Spot-check a few other pages using lucide icons to confirm no visual regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)