### PR TITLE
fix(tests): eliminate CI flake from concurrent prisma generate

### DIFF
--- a/__tests__/api/clone-worker.test.ts
+++ b/__tests__/api/clone-worker.test.ts
@@ -7,7 +7,7 @@ import { type Job, Queue, QueueEvents, Worker } from 'bullmq';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { cloneCommunityProgram } from '@/lib/community/cloning';
 import { publishProgramToCommunity } from '@/lib/community/publishing';
-import type { ProgramCloneJob } from '@/lib/queue/clone-jobs';
+import { closeCloneJobsQueue, type ProgramCloneJob } from '@/lib/queue/clone-jobs';
 import { getTestDatabase } from '@/lib/test/database';
 import {
   createTestPrescribedSets,
@@ -79,6 +79,7 @@ describe('Program Cloning via BullMQ Worker', () => {
     await testWorker.close();
     await queueEvents.close();
     await queue.close();
+    await closeCloneJobsQueue();
     await stopRedisContainer();
   }, 10000);
 

--- a/lib/queue/clone-jobs.ts
+++ b/lib/queue/clone-jobs.ts
@@ -40,6 +40,17 @@ function getQueue(): Queue {
 }
 
 /**
+ * Closes the lazily-created singleton Queue and its Redis connection.
+ * Intended for test teardown — production never needs to call this.
+ */
+export async function closeCloneJobsQueue(): Promise<void> {
+  if (queue) {
+    await queue.close()
+    queue = null
+  }
+}
+
+/**
  * Publishes a program clone job to the BullMQ queue.
  * The worker picks this up and processes the clone.
  */

--- a/lib/test/database.ts
+++ b/lib/test/database.ts
@@ -46,7 +46,7 @@ export class TestDatabase {
 
       // Push schema to get fresh test database (faster than migrations for testing)
       console.log('🔄 Pushing Prisma schema to test database...')
-      execSync('npx prisma db push --force-reset', {
+      execSync('npx prisma db push --force-reset --skip-generate', {
         stdio: 'pipe',
         env: {
           ...process.env,


### PR DESCRIPTION
## Summary
- **Root cause of intermittent CI failures**: `lib/test/database.ts` ran `npx prisma db push` in every test worker. `db push` also runs `prisma generate` by default, so parallel vitest workers were concurrently overwriting `node_modules/.prisma/client/` while other workers' `@prisma/client` was loading from it — surfacing as `Cannot find module '.prisma/client/default'` in a random test file (e.g. workout-history.test.ts in [run 26009947950 attempt 1](https://github.com/aptx-health/ripit-fitness/actions/runs/26009947950/job/76448530430)). CI already runs `prisma generate` once before tests, so adding `--skip-generate` removes the race.
- **Secondary fix**: `lib/queue/clone-jobs.ts` holds a lazy singleton BullMQ `Queue` that's never closed. `clone-worker.test.ts` exercises the publish path, so its Redis connection outlived the testcontainer at teardown — a latent fragility. Added `closeCloneJobsQueue()` and call it in `afterAll` before `stopRedisContainer()`.

## Test plan
- [x] Full suite passes locally (`39 files / 421 passed | 3 skipped`, exit 0)
- [x] `clone-worker.test.ts` exits 0 across 5 consecutive runs
- [x] CI passes on first attempt (validates the prisma race fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)