### PR TITLE
chore(lint): mechanical cleanup on recently changed files

### DIFF
--- a/components/QuickActionSheet.tsx
+++ b/components/QuickActionSheet.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useToast } from '@/components/ToastProvider'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import {
   discardAdHocWorkout,
   startFreestyleWorkout,
@@ -21,7 +22,6 @@ import { FetchError, fetchJsonWithRetry } from '@/lib/api/fetch'
 import { discardDraft } from '@/lib/api/workout-sets'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
-import { useUserSettings } from '@/hooks/useUserSettings'
 
 type NextWorkout = {
   workoutId: string

--- a/components/features/PwaInstallButton.tsx
+++ b/components/features/PwaInstallButton.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Download, X } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
-import { useBeforeInstallPrompt } from '@/hooks/useBeforeInstallPrompt'
+import { useCallback, useEffect, useState } from 'react'
 import { PwaInstallPrompt } from '@/components/features/training/PwaInstallPrompt'
+import { useBeforeInstallPrompt } from '@/hooks/useBeforeInstallPrompt'
 import { trackEvent } from '@/lib/analytics'
 
 const DISMISS_KEY = 'pwa-install-button-dismissed'

--- a/components/features/training/PwaInstallPrompt.tsx
+++ b/components/features/training/PwaInstallPrompt.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Share, Plus, MoreVertical } from 'lucide-react'
+import { MoreVertical, Plus, Share } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import type { BeforeInstallPromptEvent } from '@/hooks/useBeforeInstallPrompt'
 import { trackEvent } from '@/lib/analytics'

--- a/hooks/usePwaPrompt.ts
+++ b/hooks/usePwaPrompt.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { UserSettings } from '@/hooks/useUserSettings'
 
 const DAYS_BEFORE_REPROMPT = 14

--- a/lib/format/prescribed-summary.ts
+++ b/lib/format/prescribed-summary.ts
@@ -70,7 +70,7 @@ export function formatPrescribedSummary(
   if (!repsLabel) return ''
 
   const intensity = showIntensity ? formatIntensity(set) : null
-  const weight = set.weight && set.weight.trim() ? set.weight.trim() : null
+  const weight = set.weight?.trim() ? set.weight.trim() : null
 
   if (weight && intensity) return `${repsLabel} @ ${weight}, ${intensity}`
   if (weight) return `${repsLabel} @ ${weight}`


### PR DESCRIPTION
## Summary
- Auto-organized imports in three recently-changed components (`QuickActionSheet`, `PwaInstallButton`, `PwaInstallPrompt`)
- Removed unused `useEffect` import from `usePwaPrompt`
- Replaced `set.weight && set.weight.trim()` with `set.weight?.trim()` in `formatPrescribedSummary`

No behavior change — all Biome-FIXABLE issues on files touched in the last 7 days.

## Deferred follow-ups
- #784 — a11y label-without-control violations in admin forms (low)
- #785 — PwaInstallPrompt interactive div + untitled svg + img element (medium)
- #786 — useExhaustiveDependencies warnings on three components (low)

## Test plan
- [x] `npm run type-check` passes
- [x] `npx biome check` on touched files reports no remaining issues for the targeted rules
- [ ] CI green