### PR TITLE
feat(welcome): two-step post-signup screen for experienced users

### DIFF
--- a/app/(app)/admin/signups/page.tsx
+++ b/app/(app)/admin/signups/page.tsx
@@ -9,6 +9,30 @@ interface SignupRow {
   source: string | null
   experienceLevel: string | null
   firstWorkoutAt: string | null
+  signupIntent: string | null
+  welcomePath: string | null
+  welcomeMsToChoice: number | null
+}
+
+const INTENT_LABELS: Record<string, string> = {
+  new_to_apps: 'New to apps',
+  from_another_app: 'From another app',
+  returning_to_training: 'Returning to training',
+  just_curious: 'Just curious',
+}
+
+const PATH_LABELS: Record<string, string> = {
+  freestyle: 'Freestyle',
+  program: 'Program',
+  skipped: 'Skipped',
+}
+
+function formatMsToChoice(ms: number | null): string {
+  if (ms === null || ms === undefined) return ''
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  return `${Math.round(s / 60)}m`
 }
 
 function relativeTime(dateStr: string): string {
@@ -100,7 +124,9 @@ export default function AdminSignupsPage() {
           No signups in the last 30 days.
         </div>
       ) : (
-        <div className="border border-border rounded-lg overflow-x-auto">
+        <>
+          <FunnelSummary rows={rows} />
+          <div className="border border-border rounded-lg overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border bg-card">
@@ -115,6 +141,12 @@ export default function AdminSignupsPage() {
                 </th>
                 <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
                   Experience
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Intent
+                </th>
+                <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
+                  Welcome path
                 </th>
                 <th className="text-left px-4 py-3 font-semibold text-muted-foreground uppercase tracking-wider text-xs">
                   First workout?
@@ -153,15 +185,103 @@ export default function AdminSignupsPage() {
                     )}
                   </td>
                   <td className="px-4 py-3">
+                    {row.signupIntent ? (
+                      <span className="text-foreground">
+                        {INTENT_LABELS[row.signupIntent] ?? row.signupIntent}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.welcomePath ? (
+                      <span className="text-foreground">
+                        {PATH_LABELS[row.welcomePath] ?? row.welcomePath}
+                        {row.welcomeMsToChoice !== null && (
+                          <span className="text-muted-foreground ml-1">
+                            ({formatMsToChoice(row.welcomeMsToChoice)})
+                          </span>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
                     <FirstWorkoutCell firstWorkoutAt={row.firstWorkoutAt} />
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function FunnelSummary({ rows }: { rows: SignupRow[] }) {
+  const total = rows.length
+  const experienced = rows.filter((r) => r.experienceLevel === 'experienced').length
+  const freestyle = rows.filter((r) => r.welcomePath === 'freestyle').length
+  const program = rows.filter((r) => r.welcomePath === 'program').length
+  const skipped = rows.filter((r) => r.welcomePath === 'skipped').length
+  const noPath = rows.filter((r) => r.welcomePath === null).length
+  const firstWorkout = rows.filter((r) => r.firstWorkoutAt !== null).length
+
+  const intentCounts = rows.reduce<Record<string, number>>((acc, r) => {
+    if (r.signupIntent) acc[r.signupIntent] = (acc[r.signupIntent] || 0) + 1
+    return acc
+  }, {})
+  const intentAnswered = Object.values(intentCounts).reduce((a, b) => a + b, 0)
+
+  return (
+    <div className="border border-border rounded-lg p-4 bg-card space-y-4">
+      <div>
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+          Welcome funnel (experienced users only)
+        </h2>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+          <Stat label="Experienced signups" value={experienced} />
+          <Stat label="Freestyle" value={freestyle} of={experienced} />
+          <Stat label="Program" value={program} of={experienced} />
+          <Stat label="Skipped" value={skipped} of={experienced} />
+          <Stat label="Never reached path" value={noPath} of={experienced} />
+          <Stat label="Completed first workout" value={firstWorkout} of={total} />
+        </div>
+      </div>
+      {intentAnswered > 0 && (
+        <div>
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Intent ({intentAnswered}/{experienced} answered)
+          </h2>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            {Object.entries(intentCounts)
+              .sort((a, b) => b[1] - a[1])
+              .map(([key, count]) => (
+                <Stat
+                  key={key}
+                  label={INTENT_LABELS[key] ?? key}
+                  value={count}
+                  of={intentAnswered}
+                />
+              ))}
+          </div>
         </div>
       )}
     </div>
+  )
+}
+
+function Stat({ label, value, of }: { label: string; value: number; of?: number }) {
+  const pct = of && of > 0 ? Math.round((value / of) * 100) : null
+  return (
+    <span className="text-foreground">
+      <span className="font-semibold">{value}</span>
+      {pct !== null && <span className="text-muted-foreground"> ({pct}%)</span>}
+      <span className="text-muted-foreground ml-1">{label}</span>
+    </span>
   )
 }
 

--- a/app/(app)/welcome/page.tsx
+++ b/app/(app)/welcome/page.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { ArrowRight, CalendarDays, Zap } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { useToast } from '@/components/ToastProvider'
+import { LoadingFrog } from '@/components/ui/loading-frog'
+import { startFreestyleWorkout } from '@/lib/api/adhoc-workout'
+import { trackEvent } from '@/lib/analytics'
+import { clientLogger } from '@/lib/client-logger'
+
+const INTENT_OPTIONS = [
+  { value: 'new_to_apps', label: 'New to strength training apps' },
+  { value: 'from_another_app', label: 'Coming from another app' },
+  { value: 'returning_to_training', label: 'Returning to training after a break' },
+  { value: 'just_curious', label: 'Just curious / looking' },
+] as const
+
+type IntentValue = (typeof INTENT_OPTIONS)[number]['value']
+type Step = 'intent' | 'path'
+
+export default function WelcomePage() {
+  const router = useRouter()
+  const toast = useToast()
+  const mountedAtRef = useRef<number>(Date.now())
+  const [step, setStep] = useState<Step>('intent')
+  const [intent, setIntent] = useState<IntentValue | null>(null)
+  const [startingFreestyle, setStartingFreestyle] = useState(false)
+
+  useEffect(() => {
+    mountedAtRef.current = Date.now()
+    trackEvent('welcome_viewed')
+  }, [])
+
+  const elapsedMs = () => Date.now() - mountedAtRef.current
+
+  async function pickIntent(value: IntentValue) {
+    if (intent) return
+    setIntent(value)
+    trackEvent('welcome_intent', { intent: value, ms_to_choice: elapsedMs() })
+    fetch('/api/welcome/intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ intent: value }),
+    }).catch((err) => clientLogger.error('Failed to save welcome intent', err))
+    // Brief beat so the chip's active state is visible, then advance.
+    setTimeout(() => setStep('path'), 280)
+  }
+
+  function skipIntent() {
+    trackEvent('welcome_intent_skipped', { ms_to_choice: elapsedMs() })
+    setStep('path')
+  }
+
+  async function startFreestyle() {
+    if (startingFreestyle) return
+    setStartingFreestyle(true)
+    trackEvent('welcome_path_freestyle', { ms_to_choice: elapsedMs() })
+    try {
+      const completion = await startFreestyleWorkout()
+      router.push(`/training/adhoc/${completion.id}?new=1`)
+    } catch (err) {
+      clientLogger.error('Failed to start freestyle workout from welcome', err)
+      toast.warning('Could not start workout', 'Try again, or pick a program instead.')
+      setStartingFreestyle(false)
+    }
+  }
+
+  function browsePrograms() {
+    trackEvent('welcome_path_program', { ms_to_choice: elapsedMs() })
+    router.push('/programs')
+  }
+
+  function skipToTraining() {
+    trackEvent('welcome_skipped', { ms_to_choice: elapsedMs() })
+    router.push('/training')
+  }
+
+  return (
+    <div className="bg-background min-h-[calc(100vh-4rem)] flex flex-col">
+      <div className="flex-1 max-w-md md:max-w-lg w-full mx-auto px-5 sm:px-6 py-10 flex flex-col">
+        <header className="flex items-center gap-4 mb-12">
+          <LoadingFrog size={44} speed={1.8} />
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground doom-title uppercase tracking-wider leading-none">
+            Welcome
+          </h1>
+        </header>
+
+        {step === 'intent' ? (
+          <IntentStep intent={intent} onPick={pickIntent} onSkip={skipIntent} />
+        ) : (
+          <PathStep
+            startingFreestyle={startingFreestyle}
+            onFreestyle={startFreestyle}
+            onPrograms={browsePrograms}
+            onSkip={skipToTraining}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function IntentStep({
+  intent,
+  onPick,
+  onSkip,
+}: {
+  intent: IntentValue | null
+  onPick: (v: IntentValue) => void
+  onSkip: () => void
+}) {
+  return (
+    <section className="flex-1 flex flex-col">
+      <h2 className="text-lg font-semibold text-foreground mb-6 leading-snug">
+        Just one question first: which of these sounds like you?
+      </h2>
+
+      <div className="grid grid-cols-1 gap-2.5">
+        {INTENT_OPTIONS.map((option) => {
+          const active = intent === option.value
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onPick(option.value)}
+              disabled={intent !== null && !active}
+              aria-pressed={active}
+              className={`w-full px-4 py-3.5 border-2 text-sm font-semibold uppercase tracking-wider transition-all text-left ${
+                active
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-card text-foreground hover:border-primary disabled:opacity-50'
+              }`}
+            >
+              {option.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <button
+        type="button"
+        onClick={onSkip}
+        disabled={intent !== null}
+        className="mt-5 w-full px-4 py-3 bg-transparent border border-dashed border-border/60 text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center justify-between gap-3 group disabled:opacity-40"
+      >
+        <span className="text-xs font-semibold uppercase tracking-widest">
+          Prefer not to say
+        </span>
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider">
+          Skip
+          <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" strokeWidth={2.5} />
+        </span>
+      </button>
+    </section>
+  )
+}
+
+function PathStep({
+  startingFreestyle,
+  onFreestyle,
+  onPrograms,
+  onSkip,
+}: {
+  startingFreestyle: boolean
+  onFreestyle: () => void
+  onPrograms: () => void
+  onSkip: () => void
+}) {
+  return (
+    <section className="flex-1 flex flex-col">
+      <h2 className="text-lg font-semibold text-foreground mb-1">
+        How do you want to start?
+      </h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Switch anytime from the menu.
+      </p>
+
+      <div className="space-y-5">
+        <article className="doom-corners bg-card p-5 relative">
+          <div className="inline-flex items-center gap-1.5 px-2 py-1 bg-primary/15 text-primary text-[10px] font-bold uppercase tracking-widest mb-3">
+            <Zap className="w-3 h-3" strokeWidth={2.5} />
+            Quick start
+          </div>
+          <h3 className="text-lg font-bold text-foreground uppercase tracking-wider mb-2">
+            Freestyle a workout
+          </h3>
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            Pick exercises as you go. Nothing to set up first.
+          </p>
+          <button
+            type="button"
+            onClick={onFreestyle}
+            disabled={startingFreestyle}
+            className="doom-button-3d w-full px-6 py-3 bg-primary text-primary-foreground border-2 border-primary font-bold uppercase tracking-wider text-sm disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {startingFreestyle ? 'Starting…' : 'Start now'}
+          </button>
+        </article>
+
+        <article className="doom-corners bg-card/60 p-5 relative">
+          <div className="inline-flex items-center gap-1.5 px-2 py-1 bg-secondary/15 text-secondary text-[10px] font-bold uppercase tracking-widest mb-3">
+            <CalendarDays className="w-3 h-3" strokeWidth={2.5} />
+            Structured
+          </div>
+          <h3 className="text-lg font-bold text-foreground uppercase tracking-wider mb-2">
+            Follow a program
+          </h3>
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            Multi-week plans. Activate one and follow day by day.
+          </p>
+          <button
+            type="button"
+            onClick={onPrograms}
+            className="w-full px-6 py-3 bg-card text-foreground border-2 border-border hover:border-primary transition-colors font-bold uppercase tracking-wider text-sm"
+          >
+            Browse programs
+          </button>
+        </article>
+      </div>
+
+      <button
+        type="button"
+        onClick={onSkip}
+        className="mt-5 w-full px-4 py-3 bg-transparent border border-dashed border-border/60 text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center justify-between gap-3 group"
+      >
+        <span className="text-xs font-semibold uppercase tracking-widest">
+          Just looking around
+        </span>
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider">
+          Skip to Training
+          <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" strokeWidth={2.5} />
+        </span>
+      </button>
+    </section>
+  )
+}

--- a/app/api/admin/signups/route.ts
+++ b/app/api/admin/signups/route.ts
@@ -14,6 +14,9 @@ interface SignupRow {
   source: string | null
   experienceLevel: string | null
   firstWorkoutAt: Date | null
+  signupIntent: string | null
+  welcomePath: string | null
+  welcomeMsToChoice: number | null
 }
 
 export async function GET(request: NextRequest) {
@@ -36,7 +39,10 @@ export async function GET(request: NextRequest) {
         u."createdAt",
         ae.source,
         us."experienceLevel",
-        wc."firstWorkoutAt"
+        us."signupIntent",
+        wc."firstWorkoutAt",
+        wp.path AS "welcomePath",
+        wp."msToChoice" AS "welcomeMsToChoice"
       FROM "user" u
       LEFT JOIN LATERAL (
         SELECT (ae_inner.properties->>'source') AS source
@@ -53,6 +59,20 @@ export async function GET(request: NextRequest) {
         WHERE wc_inner."userId" = u.id
           AND wc_inner.status = 'completed'
       ) wc ON true
+      LEFT JOIN LATERAL (
+        SELECT
+          CASE
+            WHEN wp_inner.event = 'welcome_path_freestyle' THEN 'freestyle'
+            WHEN wp_inner.event = 'welcome_path_program' THEN 'program'
+            WHEN wp_inner.event = 'welcome_skipped' THEN 'skipped'
+          END AS path,
+          (wp_inner.properties->>'ms_to_choice')::int AS "msToChoice"
+        FROM "AppEvent" wp_inner
+        WHERE wp_inner."userId" = u.id
+          AND wp_inner.event IN ('welcome_path_freestyle', 'welcome_path_program', 'welcome_skipped')
+        ORDER BY wp_inner."createdAt" DESC
+        LIMIT 1
+      ) wp ON true
       WHERE u."createdAt" >= ${since}
         ${ONLY_END_USERS}
       ORDER BY u."createdAt" DESC

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -115,7 +115,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const redirect = experienceLevel === 'beginner' ? '/training?expand=first' : '/programs'
+    const redirect = experienceLevel === 'beginner' ? '/training?expand=first' : '/welcome'
 
     logger.info(
       { userId: user.id, experienceLevel, equipmentPreference, programId },

--- a/app/api/welcome/intent/route.ts
+++ b/app/api/welcome/intent/route.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, programManagementLimiter } from '@/lib/rate-limit'
+
+const VALID_INTENTS = ['new_to_apps', 'from_another_app', 'returning_to_training', 'just_curious'] as const
+type SignupIntent = (typeof VALID_INTENTS)[number]
+
+interface IntentRequest {
+  intent: SignupIntent
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const rateLimited = await checkRateLimit(programManagementLimiter, user.id)
+    if (rateLimited) return rateLimited
+
+    const body = (await request.json()) as IntentRequest
+    const { intent } = body
+
+    if (!intent || !VALID_INTENTS.includes(intent)) {
+      return NextResponse.json(
+        { error: `intent must be one of: ${VALID_INTENTS.join(', ')}` },
+        { status: 400 }
+      )
+    }
+
+    await prisma.userSettings.upsert({
+      where: { userId: user.id },
+      update: { signupIntent: intent, updatedAt: new Date() },
+      create: { userId: user.id, signupIntent: intent },
+    })
+
+    logger.info({ userId: user.id, intent }, 'Welcome intent recorded')
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ error, context: 'welcome-intent' }, 'Failed to record welcome intent')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/prisma/migrations/20260519024221_add_signup_intent/migration.sql
+++ b/prisma/migrations/20260519024221_add_signup_intent/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN "signupIntent" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,6 +313,7 @@ model UserSettings {
   seenMessageIds            String    @default("[]")
   pwaPromptShownCount       Int       @default(0)
   pwaPromptDismissedAt      DateTime?
+  signupIntent              String?
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
 


### PR DESCRIPTION
## Summary
- Experienced users now land on a new `/welcome` route after onboarding instead of going straight to `/programs`. Reduces commitment friction and creates a data-collection moment for the bounce mystery (5 experienced signups, 0 first workouts).
- **Step 1**: optional single-question chip survey (new to apps / from another app / returning to training / just curious). One question, skippable. Persisted to `UserSettings.signupIntent` for future segmentation.
- **Step 2**: two-channel chooser. Freestyle workout (zero-setup, primary CTA) or browse programs (multi-week, secondary). Skippable to Training.
- Admin `/admin/signups` page gains **Intent** and **Welcome path** columns plus a funnel summary panel above the table (experienced count, path breakdown with %, intent breakdown with %, first-workout completion).

## Data captured
- `welcome_viewed`, `welcome_intent`, `welcome_intent_skipped`, `welcome_path_freestyle`, `welcome_path_program`, `welcome_skipped` AppEvents, all with `ms_to_choice`.
- `UserSettings.signupIntent` persistent column (new migration: `20260519024221_add_signup_intent`).

## Test plan
- [ ] Fresh signup as experienced → lands on `/welcome`
- [ ] Fresh signup as beginner → still lands on `/training?expand=first` (unchanged)
- [ ] Tap chip → brief active state, advances to step 2, intent saved to DB
- [ ] Tap "Skip" on step 1 → advances to step 2, emits `welcome_intent_skipped`
- [ ] Tap "Start now" → creates ad-hoc completion, lands on `/training/adhoc/{id}?new=1`
- [ ] Tap "Browse programs" → goes to `/programs`
- [ ] Tap "Just looking around" → goes to `/training`
- [ ] `/admin/signups` shows new columns + funnel panel populated
- [ ] Migration auto-applies on staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)