### PR TITLE
chore(quality): clear safe lint warnings on recent files

### DIFF
--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -90,7 +90,7 @@ describe('rate-limit', () => {
 
   describe('checkRateLimit (backwards-compatible wrapper)', () => {
     beforeEach(() => {
-      // @ts-expect-error
+      // @ts-expect-error -- NODE_ENV is readonly in @types/node but we need to override it for this test
       process.env.NODE_ENV = 'development'
     })
 

--- a/components/QuickActionSheet.tsx
+++ b/components/QuickActionSheet.tsx
@@ -330,8 +330,8 @@ export default function QuickActionSheet({ open, onOpenChange }: Props) {
                   Freestyle is for logging
                 </h2>
                 <p className="text-base text-muted-foreground mt-2.5 leading-relaxed">
-                  It's a blank canvas where you pick exercises and log every
-                  set as you go. Worth a try if you're curious.
+                  It&apos;s a blank canvas where you pick exercises and log every
+                  set as you go. Worth a try if you&apos;re curious.
                 </p>
                 <p className="text-sm text-muted-foreground mt-3">
                   Prefer logging?{' '}

--- a/components/QuickActionSheet.tsx
+++ b/components/QuickActionSheet.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useToast } from '@/components/ToastProvider'
+import { useUserSettings } from '@/hooks/useUserSettings'
 import {
   discardAdHocWorkout,
   startFreestyleWorkout,
@@ -21,7 +22,6 @@ import { FetchError, fetchJsonWithRetry } from '@/lib/api/fetch'
 import { discardDraft } from '@/lib/api/workout-sets'
 import { clientLogger } from '@/lib/client-logger'
 import { useDraftWorkout } from '@/lib/contexts/DraftWorkoutContext'
-import { useUserSettings } from '@/hooks/useUserSettings'
 
 type NextWorkout = {
   workoutId: string

--- a/components/ui/MessageCard.tsx
+++ b/components/ui/MessageCard.tsx
@@ -44,7 +44,7 @@ interface MessageCardProps {
 
 export function MessageCard({
   message,
-  variant,
+  variant: _variant,
   tipCount = 0,
   onNextTip,
   onDismiss,

--- a/hooks/usePwaPrompt.ts
+++ b/hooks/usePwaPrompt.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { UserSettings } from '@/hooks/useUserSettings'
 
 const DAYS_BEFORE_REPROMPT = 14


### PR DESCRIPTION
## Summary

Mechanical lint cleanup across files changed on `dev` in the last 7 days. Behaviorally inert.

- Add description to `@ts-expect-error` in `__tests__/lib/rate-limit.test.ts`
- Escape apostrophes in `QuickActionSheet` freestyle heads-up copy (fixes `react/no-unescaped-entities`)
- Drop unused `useEffect` import from `hooks/usePwaPrompt.ts`
- Underscore-prefix unused `variant` arg in `MessageCard` to satisfy `no-unused-vars` without breaking the public prop API (callers still pass `variant`)

Lint problem count: 12 → 7 (errors 8 → 5, warnings 4 → 2).

## Deferred follow-ups

Remaining lint findings need per-component design judgment and have been filed separately:

- #789 — set-state-in-effect / impure Date.now across `PwaInstallButton`, `MessageCard`, `ExerciseDisplayTabs`, `FollowAlongTabs`, `ExerciseLoggingHeader`
- #790 — replace raw `<img>` with `next/image` in `MediaUploader` and `PwaInstallPrompt`

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` shows reduced finding count, no new errors
- [ ] Confirm `MessageCard` still renders identically wherever it's used (preview in admin, tip carousel in logger)
- [ ] Confirm QuickActionSheet freestyle copy reads correctly