### PR TITLE
style(copy): replace em dashes in user-facing strings

### DIFF
--- a/app/(app)/admin/analytics/page.tsx
+++ b/app/(app)/admin/analytics/page.tsx
@@ -115,7 +115,7 @@ export default function AdminAnalyticsPage() {
           <MetricCard
             label="Avg Workouts / User / Week"
             value={data.usage.avgWorkoutsPerUserPerWeek}
-            info="Average workouts each active user finished per week over the last 4 weeks. A casual lifter hits 2–3. Don't panic at low numbers early on — a handful of committed beta users is a win."
+            info="Average workouts each active user finished per week over the last 4 weeks. A casual lifter hits 2–3. Don't panic at low numbers early on; a handful of committed beta users is a win."
           />
           <MetricCard
             label="Completion Rate"
@@ -159,12 +159,12 @@ export default function AdminAnalyticsPage() {
           <MetricCard
             label="Daily Active"
             value={data.retention.dau}
-            info="DAU = Daily Active Users. How many different users finished a workout today. With a small beta, this will often be 0 or 1 — that's normal. Watch the trend over weeks, not day to day."
+            info="DAU = Daily Active Users. How many different users finished a workout today. With a small beta, this will often be 0 or 1, and that's normal. Watch the trend over weeks, not day to day."
           />
           <MetricCard
             label="Weekly Active"
             value={data.retention.wau}
-            info="WAU = Weekly Active Users. How many different users finished at least one workout in the last 7 days. This is the most useful number for a strength app — most people lift 2–4x/week, not daily."
+            info="WAU = Weekly Active Users. How many different users finished at least one workout in the last 7 days. This is the most useful number for a strength app, since most people lift 2–4x/week, not daily."
           />
           <MetricCard
             label="Monthly Active"
@@ -210,7 +210,7 @@ export default function AdminAnalyticsPage() {
                 <MetricCard
                   label="Slow 25%"
                   value={data.retention.timeToFirstWorkout.p75}
-                  info="p75 = '75th percentile.' Three quarters of users were faster than this. If this number is huge, a lot of people are signing up and then stalling before they ever lift — onboarding may need work."
+                  info="p75 = '75th percentile.' Three quarters of users were faster than this. If this number is huge, a lot of people are signing up and then stalling before they ever lift, and onboarding may need work."
                 />
               </div>
             )}
@@ -225,8 +225,8 @@ export default function AdminAnalyticsPage() {
           <p className="text-xs text-muted-foreground mb-3 max-w-2xl">
             A &ldquo;cohort&rdquo; is a group of users who signed up in the same week. This
             shows: of the people who signed up N weeks ago, what percent are
-            still lifting today? Retention in fitness apps is notoriously hard
-            — 10–20% is respectable, 30%+ is great.
+            still lifting today? Retention in fitness apps is notoriously hard;
+            10–20% is respectable, 30%+ is great.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">

--- a/app/(app)/admin/feedback/page.tsx
+++ b/app/(app)/admin/feedback/page.tsx
@@ -392,7 +392,7 @@ export default function AdminFeedbackPage() {
                     )}
                     {item.refinements?.length > 0 && (
                       <span className="text-sm text-muted-foreground">
-                        — {item.refinements.map((r) => REFINEMENT_LABELS[r] || r.replace(/_/g, ' ')).join(', ')}
+                        ({item.refinements.map((r) => REFINEMENT_LABELS[r] || r.replace(/_/g, ' ')).join(', ')})
                       </span>
                     )}
                     {item.message ? (

--- a/components/QuickActionSheet.tsx
+++ b/components/QuickActionSheet.tsx
@@ -135,7 +135,7 @@ export default function QuickActionSheet({ open, onOpenChange }: Props) {
         onRetry: ({ attempt }) =>
           toast.warning(
             'Slow connection',
-            `Starting workout — retrying (attempt ${attempt + 1})…`
+            `Starting workout, retrying (attempt ${attempt + 1})…`
           ),
       })
       onOpenChange(false)
@@ -180,7 +180,7 @@ export default function QuickActionSheet({ open, onOpenChange }: Props) {
       const onRetry = ({ attempt }: { attempt: number }) =>
         toast.warning(
           'Slow connection',
-          `Discarding draft — retrying (attempt ${attempt + 1})…`
+          `Discarding draft, retrying (attempt ${attempt + 1})…`
         )
       if (activeDraft.isAdHoc) {
         await discardAdHocWorkout(activeDraft.completionId, { onRetry })

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -218,7 +218,7 @@ export default function AdHocLoggerView({
   const onRetryToast = useCallback(
     (label: string) =>
       ({ attempt }: { attempt: number }) => {
-        toast.warning('Slow connection', `${label} — retrying (attempt ${attempt + 1})…`)
+        toast.warning('Slow connection', `${label}, retrying (attempt ${attempt + 1})…`)
       },
     [toast]
   )

--- a/components/programs/ActivationConfirmModal.tsx
+++ b/components/programs/ActivationConfirmModal.tsx
@@ -263,7 +263,7 @@ export default function ActivationConfirmModal({
 
         {hasHistory && (
           <p className="text-base text-muted-foreground mb-6">
-            {pluralize(historyState.completionCount, 'workout')} logged — continue or start fresh?
+            {pluralize(historyState.completionCount, 'workout')} logged. Continue or start fresh?
           </p>
         )}
 

--- a/components/programs/ConsolidatedProgramsView.tsx
+++ b/components/programs/ConsolidatedProgramsView.tsx
@@ -255,7 +255,7 @@ export default function ConsolidatedProgramsView({
           ) : (
             <div className="border border-border border-l-4 border-l-muted-foreground bg-card doom-noise p-3 sm:p-4">
               <p className="text-sm text-muted-foreground">
-                No active program — activate or browse one below
+                No active program. Activate or browse one below.
               </p>
             </div>
           )}

--- a/components/workout-logging/inputs/LoggingEducationPanel.tsx
+++ b/components/workout-logging/inputs/LoggingEducationPanel.tsx
@@ -32,11 +32,11 @@ const CONTENT: Record<Mode, ModeContent> = {
     tint: 'primary',
     heading: 'RECORDING WEIGHT',
     cards: [
-      { label: 'MACHINES', description: 'Read the number off the stack — plates are usually 10 lb / 5 kg each' },
+      { label: 'MACHINES', description: 'Read the number off the stack. Plates are usually 10 lb / 5 kg each.' },
       { label: 'DUMBBELLS', description: 'Log the weight of one dumbbell, not the pair combined' },
       { label: 'BODYWEIGHT', description: 'Leave at 0 unless you added a weight vest or belt' },
       { label: 'BARBELL', description: "Include the bar's weight (usually 45 lb / 20 kg)" },
-      { label: 'OTHER EQUIPMENT', description: "Smith-machine bar is ~15 lb, EZ-bar is ~25 lb — add them to your loaded plates" },
+      { label: 'OTHER EQUIPMENT', description: "Smith-machine bar is ~15 lb, EZ-bar is ~25 lb. Add them to your loaded plates." },
     ],
   },
   reps: {
@@ -45,7 +45,7 @@ const CONTENT: Record<Mode, ModeContent> = {
     cards: [
       { label: 'PER SIDE', description: 'For single-arm or single-leg work (unilateral), log the count of one side, not all combined' },
       { label: 'BREATHER MID-SET', description: "If you paused briefly but didn't rack the weight, it still counts as one set" },
-      { label: 'WOBBLY REP', description: 'A shaky rep counts as long as you completed the full range of motion — careful to watch your form!' },
+      { label: 'WOBBLY REP', description: 'A shaky rep counts as long as you completed the full range of motion. Careful to watch your form!' },
       { label: 'PARTIAL REP', description: "Half reps usually don't count toward your set total" },
     ],
   },


### PR DESCRIPTION
## Summary
- Sweep em dashes out of user-visible copy across recently-changed UI (logger education panel cards, slow-connection retry toasts, programs view empty state, activation modal history prompt, admin analytics help text, admin feedback row separator).
- Em dashes inside code comments are intentionally left alone (out of scope per the impeccable copy rule).
- No behavior changes; pure copy edits.

## Files
- app/(app)/admin/analytics/page.tsx
- app/(app)/admin/feedback/page.tsx
- components/QuickActionSheet.tsx
- components/adhoc/AdHocLoggerView.tsx
- components/programs/ActivationConfirmModal.tsx
- components/programs/ConsolidatedProgramsView.tsx
- components/workout-logging/inputs/LoggingEducationPanel.tsx

## Verification
- [x] type-check passes (`doppler run --config dev_personal -- npm run type-check`)
- [x] lint: no new violations introduced (pre-existing errors in FollowAlongTabs/useRestTimer/usePwaPrompt are unrelated)
- [ ] visual smoke: education panel carousel, retry toasts, activation modal, programs empty state, admin analytics info popovers

## Deferred follow-ups
- #792 — refactor: ExerciseLoggingModal and AdHocLoggerView approaching size budget (medium)