### PR TITLE
feat(quality-check): integrate network-resilience-audit + harden skill invocation

### DIFF
--- a/.claude/agents/quality-check.md
+++ b/.claude/agents/quality-check.md
@@ -4,6 +4,8 @@ description: >
   Reviews recently changed files for code clarity, consistency, and
   maintainability. Simplifies without changing behavior.
 tools: Bash, Read, Edit, Write, Glob, Grep, Task
+skills:
+  - network-resilience-audit
 mode: proactive
 output: pr
 stages:
@@ -37,32 +39,29 @@ You are a code quality reviewer for the Ripit Fitness codebase. Your job is to r
 
 ## Step 1: Survey
 
-Identify changed files from the last 7 days:
+You MUST complete every item below before moving on. Each is non-optional; report the outcome of each in the final summary (see "Final report"). If any step fails, record the failure and continue — do not silently skip.
 
-```bash
-git diff --name-only HEAD~$(git rev-list --count --since='7 days ago' HEAD) -- '*.ts' '*.tsx'
-```
+- [REQUIRED] **1a. Changed files (last 7 days)**
+  ```bash
+  git diff --name-only HEAD~$(git rev-list --count --since='7 days ago' HEAD) -- '*.ts' '*.tsx'
+  ```
 
-Run the ground-truth tools before reading any files:
+- [REQUIRED] **1b. Type-check**
+  ```bash
+  npm run type-check
+  ```
 
-```bash
-npm run type-check
-npm run lint:all
-```
+- [REQUIRED] **1c. Lint**
+  ```bash
+  npm run lint:all
+  ```
 
-Skim the recent commit log to understand what kinds of changes have been landing:
+- [REQUIRED] **1d. Recent commit log**
+  ```bash
+  git log --oneline --since='7 days ago' HEAD
+  ```
 
-```bash
-git log --oneline --since='7 days ago' HEAD
-```
-
-Run the **network resilience audit** skill against the same window to surface fetch/transaction fragility. Treat its output as a survey signal, not a mandate — you'll decide in Step 2 whether to adopt it as the run's theme or file its findings as deferred issues.
-
-```
-Skill: network-resilience-audit  (argument: 7)
-```
-
-The skill's severity levels map directly to the deferred-issue urgency rubric: CRITICAL/HIGH → high, MEDIUM → medium, LOW → low.
+- [REQUIRED] **1e. Network resilience audit** — invoke the `network-resilience-audit` skill with argument `7` (7-day window). This is not optional. The skill produces a report only; you decide in Step 2 whether to adopt its findings as the run's theme or file them as deferred issues. Severity → urgency mapping: CRITICAL/HIGH → high, MEDIUM → medium, LOW → low. If the skill returns zero findings, record "no findings" in the final report — do not omit the line.
 
 ## Step 2: Decide scope
 
@@ -228,9 +227,16 @@ Subjective UI issues (gradient text, side-stripe accents, glassmorphism, hero-me
 
 ## Final report
 
-When you're done, output a summary in this format:
+When you're done, output a summary in this format. Every line under "Survey steps completed" is REQUIRED — if a step was skipped or failed, say so explicitly. Omitting a line is a process error.
 
 ```
+## Survey steps completed
+- 1a. Changed files: <count> files
+- 1b. Type-check: pass/fail
+- 1c. Lint: <N problems> (<E errors>, <W warnings>)
+- 1d. Recent commits: <count> commits scanned
+- 1e. Network resilience audit: <N findings: C critical, H high, M medium, L low> | "no findings" | "skipped — <reason>"
+
 ## Scope chosen
 <the theme you picked>
 
@@ -247,5 +253,5 @@ When you're done, output a summary in this format:
 
 ## Deferred follow-ups
 - #<issue> — <title> (urgency)
-- #<issue> — <title> (urgency>
+- #<issue> — <title> (urgency)
 ```

--- a/.claude/agents/quality-check.md
+++ b/.claude/agents/quality-check.md
@@ -56,6 +56,14 @@ Skim the recent commit log to understand what kinds of changes have been landing
 git log --oneline --since='7 days ago' HEAD
 ```
 
+Run the **network resilience audit** skill against the same window to surface fetch/transaction fragility. Treat its output as a survey signal, not a mandate — you'll decide in Step 2 whether to adopt it as the run's theme or file its findings as deferred issues.
+
+```
+Skill: network-resilience-audit  (argument: 7)
+```
+
+The skill's severity levels map directly to the deferred-issue urgency rubric: CRITICAL/HIGH → high, MEDIUM → medium, LOW → low.
+
 ## Step 2: Decide scope
 
 **Do not try to fix everything you find.** Pick ONE focused theme for this run based on the highest ratio of `(coverage × confidence) / (risk × effort)`.
@@ -77,6 +85,7 @@ Good themes for a single run:
 - Removing dead code from a coherent module
 - Fixing all instances of one specific lint rule
 - **Impeccable anti-pattern sweep** on changed UI files — pick ONE anti-pattern (e.g. side-stripe borders, gradient text, em dashes in copy, hardcoded hex colors that should be theme tokens) and remove every instance across the surveyed surface. See `.claude/skills/impeccable/SKILL.md` for the full list.
+- **Network resilience sweep** on one surface (e.g. "ad-hoc logger mutations", "draft context refetch path") — route raw `fetch(` calls through `fetchWithRetry`, add toast feedback on failure, collapse renumber loops into single SQL statements, etc. Drive this from the network-resilience-audit findings gathered in Step 1. Pick ONE surface; defer the rest.
 
 Bad scopes for a single run:
 - "Review every changed file"

--- a/.claude/skills/network-resilience-audit/SKILL.md
+++ b/.claude/skills/network-resilience-audit/SKILL.md
@@ -9,6 +9,11 @@ argument-hint: [since-ref-or-days]
 
 Audit recently-changed code for fragility under poor network conditions (cellular dead spots, gym wifi, PWA backgrounding). Most "weird bugs at the gym" are not logic bugs — they're a fetch that failed silently, an optimistic UI mismatch, or a server route that does N round trips when one would do.
 
+## Invocation modes
+
+- **Standalone** (default) — produce the audit report described under "Output format" and stop. No code edits.
+- **Called from `quality-check` agent** — produce the same report, but the caller will split findings into "fix this run" (one surface, picked as the run's theme) and "file as `needs-review` issues" (everything else). Do not edit code yourself; the agent owns that step. Severity → urgency mapping: CRITICAL/HIGH → high, MEDIUM → medium, LOW → low.
+
 ## Scope
 
 1. **Determine what to audit:**


### PR DESCRIPTION
## Summary

Wires the `network-resilience-audit` skill into the weekly `quality-check` agent and hardens the agent definition so it can't silently skip required survey steps.

### Changes

- **`.claude/skills/network-resilience-audit/SKILL.md`** — documents two invocation modes (standalone vs called from `quality-check`); skill stays edit-free in both.
- **`.claude/agents/quality-check.md`**:
  - Declares `skills: [network-resilience-audit]` in frontmatter to preload the skill.
  - Adds "network resilience sweep" as a valid Step 2 theme.
  - Rewrites Step 1 as an explicit `[REQUIRED]` checklist (`1a` … `1e`) with imperative "MUST" language.
  - Adds a mandatory "Survey steps completed" section to the final report template, so a skipped step is visibly missing instead of silently absent.

### Motivation

First autonomous audit run of the integration (PR #791, then #794) silently skipped the skill invocation entirely. Root cause: the original instruction was descriptive ("Run the skill...") rather than imperative, and the final report didn't require accounting per step.

### Test plan

- [ ] Run `claude --worktree` off this branch (or merge to dev first), invoke the quality-check agent, and confirm:
  - Final report contains a `1e. Network resilience audit:` line with either findings or "no findings"
  - If the audit surfaces real findings, they appear either as the chosen scope or as deferred issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)