### PR TITLE
style(copy): em-dash sweep in user-facing UI copy

### DIFF
--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -218,7 +218,7 @@ export default function AdHocLoggerView({
   const onRetryToast = useCallback(
     (label: string) =>
       ({ attempt }: { attempt: number }) => {
-        toast.warning('Slow connection', `${label} — retrying (attempt ${attempt + 1})…`)
+        toast.warning('Slow connection', `${label}: retrying (attempt ${attempt + 1})…`)
       },
     [toast]
   )

--- a/components/features/training/BeginnerPrimerWizard.tsx
+++ b/components/features/training/BeginnerPrimerWizard.tsx
@@ -23,7 +23,7 @@ const PAGES = [
           Just follow along and log what you did. No planning required.
         </p>
         <p className="text-muted-foreground">
-          Everything in your program uses equipment at this gym — no guesswork.
+          Everything in your program uses equipment at this gym. No guesswork.
         </p>
       </>
     ),
@@ -33,7 +33,7 @@ const PAGES = [
     content: (
       <>
         <p className="text-muted-foreground mb-3">
-          Controlled reps at moderate effort beat heavy weight with sloppy form. Your first week, pick weights that feel almost too easy — you&apos;ll dial it in.
+          Controlled reps at moderate effort beat heavy weight with sloppy form. Your first week, pick weights that feel almost too easy; you&apos;ll dial it in.
         </p>
         <p className="text-muted-foreground mb-4">
           A good rule of thumb: after each set, you should feel like you could have done 2-3 more reps. If you&apos;re grinding out every rep, go lighter.
@@ -52,7 +52,7 @@ const PAGES = [
           Everyone in the gym started somewhere. Nobody is watching you as closely as you think.
         </p>
         <p className="text-muted-foreground mb-3">
-          Wipe down equipment when you&apos;re done, rerack your weights, and don&apos;t camp on a machine while scrolling — that&apos;s really it.
+          Wipe down equipment when you&apos;re done, rerack your weights, and don&apos;t camp on a machine while scrolling. That&apos;s really it.
         </p>
         <p className="text-muted-foreground mb-4">
           If you&apos;re unsure how a machine works, ask someone. Gym regulars genuinely like helping.
@@ -68,7 +68,7 @@ const PAGES = [
     content: (
       <>
         <p className="text-muted-foreground mb-3">
-          Feeling sore a day or two after your first workout is completely normal — especially the first week.
+          Feeling sore a day or two after your first workout is completely normal, especially the first week.
         </p>
         <p className="text-muted-foreground mb-3">
           Sharp pain during a lift is not. Stop, lower the weight, or skip that exercise.

--- a/components/features/training/WarmupInterstitial.tsx
+++ b/components/features/training/WarmupInterstitial.tsx
@@ -84,7 +84,7 @@ export function WarmupInterstitial({ open, onContinue, onCancel, onDismissPerman
               Your first sets are warm-ups
             </h3>
             <p className="text-sm text-muted-foreground">
-              Each exercise starts with warm-up sets — use a weight that feels easy. Focus on the movement, not the load. More complex lifts have more warm-up sets built in.
+              Each exercise starts with warm-up sets. Use a weight that feels easy and focus on the movement, not the load. More complex lifts have more warm-up sets built in.
             </p>
           </div>
         </div>

--- a/components/workout-logging/inputs/LoggingEducationPanel.tsx
+++ b/components/workout-logging/inputs/LoggingEducationPanel.tsx
@@ -32,11 +32,11 @@ const CONTENT: Record<Mode, ModeContent> = {
     tint: 'primary',
     heading: 'RECORDING WEIGHT',
     cards: [
-      { label: 'MACHINES', description: 'Read the number off the stack — plates are usually 10 lb / 5 kg each' },
+      { label: 'MACHINES', description: 'Read the number off the stack. Plates are usually 10 lb / 5 kg each' },
       { label: 'DUMBBELLS', description: 'Log the weight of one dumbbell, not the pair combined' },
       { label: 'BODYWEIGHT', description: 'Leave at 0 unless you added a weight vest or belt' },
       { label: 'BARBELL', description: "Include the bar's weight (usually 45 lb / 20 kg)" },
-      { label: 'OTHER EQUIPMENT', description: "Smith-machine bar is ~15 lb, EZ-bar is ~25 lb — add them to your loaded plates" },
+      { label: 'OTHER EQUIPMENT', description: "Smith-machine bar is ~15 lb, EZ-bar is ~25 lb. Add them to your loaded plates" },
     ],
   },
   reps: {
@@ -45,7 +45,7 @@ const CONTENT: Record<Mode, ModeContent> = {
     cards: [
       { label: 'PER SIDE', description: 'For single-arm or single-leg work (unilateral), log the count of one side, not all combined' },
       { label: 'BREATHER MID-SET', description: "If you paused briefly but didn't rack the weight, it still counts as one set" },
-      { label: 'WOBBLY REP', description: 'A shaky rep counts as long as you completed the full range of motion — careful to watch your form!' },
+      { label: 'WOBBLY REP', description: 'A shaky rep counts as long as you completed the full range of motion. Careful to watch your form!' },
       { label: 'PARTIAL REP', description: "Half reps usually don't count toward your set total" },
     ],
   },


### PR DESCRIPTION
## Summary
- Replace em dashes with terminal punctuation (`.`, `;`, `:`, `,`) in JSX text and one toast string across recently changed UI files.
- Mechanical sweep per the impeccable copy rule. Code comments are left untouched.
- No behavior change; type-check passes.

## Files touched
- `components/workout-logging/inputs/LoggingEducationPanel.tsx`
- `components/features/training/WarmupInterstitial.tsx`
- `components/features/training/BeginnerPrimerWizard.tsx`
- `components/adhoc/AdHocLoggerView.tsx` (toast warning string)

## Deferred follow-ups
- #796 — `AdHocLoggerView.tsx` at 926/1000 lines, approaching the file-size limit (medium urgency)

## Test plan
- [ ] Visual spot-check of the warm-up interstitial, beginner primer wizard pages, and weight/reps education panel
- [ ] Trigger slow-connection retry toast in ad-hoc logger to confirm wording reads naturally

Generated with Claude Code