### PR TITLE
feat(schema): add SavedWorkout table (workouts v1)

### DIFF
--- a/prisma/migrations/20260519212553_add_saved_workouts/migration.sql
+++ b/prisma/migrations/20260519212553_add_saved_workouts/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "SavedWorkout" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "notes" TEXT,
+    "sourceCompletionId" TEXT,
+    "workoutData" JSONB NOT NULL,
+    "exerciseCount" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "SavedWorkout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SavedWorkout_sourceCompletionId_key" ON "SavedWorkout"("sourceCompletionId");
+
+-- CreateIndex
+CREATE INDEX "SavedWorkout_userId_lastUsedAt_idx" ON "SavedWorkout"("userId", "lastUsedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SavedWorkout_userId_createdAt_idx" ON "SavedWorkout"("userId", "createdAt" DESC);
+
+-- AlterTable
+ALTER TABLE "WorkoutCompletion" ADD COLUMN "savedWorkoutId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "WorkoutCompletion_userId_savedWorkoutId_idx" ON "WorkoutCompletion"("userId", "savedWorkoutId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,20 +139,21 @@ model PrescribedSet {
 }
 
 model WorkoutCompletion {
-  id          String      @id @default(cuid())
-  workoutId   String?
-  userId      String
-  completedAt DateTime    @default(now())
-  startedAt   DateTime?
-  status      String
-  notes       String?
-  isArchived  Boolean     @default(false)
-  cycleNumber Int         @default(1)
-  isAdHoc     Boolean     @default(false)
-  name        String?
-  exercises   Exercise[]
-  loggedSets  LoggedSet[]
-  workout     Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)
+  id              String      @id @default(cuid())
+  workoutId       String?
+  savedWorkoutId  String?
+  userId          String
+  completedAt     DateTime    @default(now())
+  startedAt       DateTime?
+  status          String
+  notes           String?
+  isArchived      Boolean     @default(false)
+  cycleNumber     Int         @default(1)
+  isAdHoc         Boolean     @default(false)
+  name            String?
+  exercises       Exercise[]
+  loggedSets      LoggedSet[]
+  workout         Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)
 
   @@index([workoutId, userId])
   @@index([userId, completedAt])
@@ -160,6 +161,23 @@ model WorkoutCompletion {
   @@index([userId, isArchived])
   @@index([workoutId, userId, isArchived])
   @@index([userId, isAdHoc, status])
+  @@index([userId, savedWorkoutId])
+}
+
+model SavedWorkout {
+  id                 String    @id @default(cuid())
+  userId             String
+  name               String
+  notes              String?
+  sourceCompletionId String?   @unique
+  workoutData        Json
+  exerciseCount      Int
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  lastUsedAt         DateTime?
+
+  @@index([userId, lastUsedAt(sort: Desc)])
+  @@index([userId, createdAt(sort: Desc)])
 }
 
 model LoggedSet {


### PR DESCRIPTION
Closes #807 · Milestone: [Workouts v1: Save & repeat](https://github.com/aptx-health/ripit-fitness/milestone/11) · Spike: #783

## Summary
- Adds `SavedWorkout` table — stores workout templates saved from completed freestyles. Uses the JSON-blob pattern that already works well for `CommunityProgram`.
- Adds `WorkoutCompletion.savedWorkoutId` nullable column so future completions can be traced back to the saved workout they started from (used by v3 intelligence features).
- Additive migration — no destructive ops, safe for prod auto-apply.

## Design decisions (per spike #783 + planning thread)
- **JSON blob over relational template**: mirrors `CommunityProgram` pattern, keeps existing queries (history, performance log, completion) untouched.
- **No weight capture**: product decision for v1; sets capture `reps` (String, matches `PrescribedSet`), `rir`, `rpe`, `isWarmup`.
- **`sourceCompletionId` is `@unique`**: DB-level idempotency for save-from-completion. Postgres allows multiple NULLs on a unique nullable column, so saved-from-scratch entries in v4 won't collide.
- **`exerciseGroup` included in JSON**: cheap to include now; awkward to add later without a data migration. Enables future superset support.
- **No User FK relation**: matches the pattern used everywhere else (`WorkoutCompletion.userId`, `CommunityProgram.authorUserId` are both loose strings — BetterAuth manages its own tables).

## workoutData JSON shape
```json
[
  {
    "exerciseDefinitionId": "cl...",
    "order": 1,
    "name": "Bench Press",
    "notes": null,
    "exerciseGroup": null,
    "sets": [
      { "setNumber": 1, "reps": "5", "rir": 2, "rpe": null, "isWarmup": false }
    ]
  }
]
```

## Indexes
- `SavedWorkout(userId, lastUsedAt DESC)` — list page sort
- `SavedWorkout(userId, createdAt DESC)` — list page secondary sort
- `SavedWorkout(sourceCompletionId)` UNIQUE — idempotency
- `WorkoutCompletion(userId, savedWorkoutId)` — v3 "history of this saved workout" queries (added now since it's free)

## Test plan
- [x] `db push` equivalent applied to worktree DB (schema matches)
- [x] Migration SQL applied cleanly via `psql`
- [x] `prisma generate` succeeds with new model
- [x] `prisma migrate resolve --applied` accepts the migration
- [ ] Type-check passes in CI
- [ ] Migration auto-applies in staging on merge to `dev`

## Out of scope (follow-up issues)
- #808 — Save-from-completion API + UI (snapshot logic)
- #809 — /workouts/saved list page
- #810 — Start-from-saved (hydrate JSON into a new WorkoutCompletion)
- #811 — Quick action sheet entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)