### PR TITLE
feat(workouts): start-from-saved hydrates SavedWorkout into a new draft

### DIFF
--- a/__tests__/api/saved-workout-start.test.ts
+++ b/__tests__/api/saved-workout-start.test.ts
@@ -1,0 +1,272 @@
+import { createId } from '@paralleldrive/cuid2'
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import {
+  createTestExerciseDefinition,
+  createTestUser,
+} from '@/lib/test/factories'
+import type { SavedWorkoutData } from '@/types/saved-workout'
+
+// Mirrors the transaction logic in app/api/workouts/saved/[id]/start/route.ts
+// Auth, rate-limiting, event logging are owned by the route layer.
+
+type StartResult =
+  | { ok: true; completionId: string }
+  | { ok: false; status: 404 | 409 | 500; error: string; draftId?: string }
+
+async function simulateStartFromSaved(
+  prisma: PrismaClient,
+  userId: string,
+  savedWorkoutId: string,
+  now: Date = new Date()
+): Promise<StartResult> {
+  const saved = await prisma.savedWorkout.findFirst({
+    where: { id: savedWorkoutId, userId },
+  })
+  if (!saved) return { ok: false, status: 404, error: 'Saved workout not found' }
+
+  const existing = await prisma.workoutCompletion.findFirst({
+    where: { userId, status: 'draft', isArchived: false },
+  })
+  if (existing) {
+    return { ok: false, status: 409, error: 'DRAFT_EXISTS', draftId: existing.id }
+  }
+
+  const workoutData = saved.workoutData as unknown as SavedWorkoutData
+  if (!Array.isArray(workoutData)) {
+    return { ok: false, status: 500, error: 'Bad workoutData' }
+  }
+
+  const completionId = await prisma.$transaction(async (tx) => {
+    const completion = await tx.workoutCompletion.create({
+      data: {
+        workoutId: null,
+        savedWorkoutId: saved.id,
+        userId,
+        status: 'draft',
+        isAdHoc: true,
+        name: saved.name,
+        startedAt: now,
+        completedAt: now,
+      },
+      select: { id: true },
+    })
+
+    const exerciseRows = workoutData.map((ex) => ({
+      id: createId(),
+      name: ex.name,
+      exerciseDefinitionId: ex.exerciseDefinitionId,
+      order: ex.order,
+      notes: ex.notes ?? null,
+      exerciseGroup: ex.exerciseGroup ?? null,
+      workoutId: null,
+      workoutCompletionId: completion.id,
+      userId,
+      isOneOff: true,
+    }))
+    if (exerciseRows.length > 0) {
+      await tx.exercise.createMany({ data: exerciseRows })
+    }
+
+    const prescribedRows = workoutData.flatMap((ex, idx) =>
+      (ex.sets ?? []).map((s) => ({
+        exerciseId: exerciseRows[idx].id,
+        userId,
+        setNumber: s.setNumber,
+        reps: s.reps,
+        rir: s.rir ?? null,
+        rpe: s.rpe ?? null,
+        isWarmup: Boolean(s.isWarmup),
+      }))
+    )
+    if (prescribedRows.length > 0) {
+      await tx.prescribedSet.createMany({ data: prescribedRows })
+    }
+
+    await tx.savedWorkout.update({
+      where: { id: saved.id },
+      data: { lastUsedAt: now },
+    })
+
+    return completion.id
+  })
+
+  return { ok: true, completionId }
+}
+
+describe('POST /api/workouts/saved/[id]/start', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  async function seedSaved(workoutData: SavedWorkoutData, name = 'Push Day') {
+    return prisma.savedWorkout.create({
+      data: {
+        userId,
+        name,
+        workoutData: workoutData as unknown as object,
+        exerciseCount: workoutData.length,
+      },
+    })
+  }
+
+  it('hydrates exercises and prescribed sets onto a new draft completion', async () => {
+    const def1 = await createTestExerciseDefinition(prisma, { name: 'Bench Press' })
+    const def2 = await createTestExerciseDefinition(prisma, { name: 'Row' })
+
+    const saved = await seedSaved([
+      {
+        name: 'Bench Press',
+        exerciseDefinitionId: def1.id,
+        order: 1,
+        notes: null,
+        exerciseGroup: null,
+        sets: [
+          { setNumber: 1, reps: '5', rir: 2, rpe: null, isWarmup: false },
+          { setNumber: 2, reps: '5', rir: 1, rpe: null, isWarmup: false },
+        ],
+      },
+      {
+        name: 'Row',
+        exerciseDefinitionId: def2.id,
+        order: 2,
+        notes: 'neutral grip',
+        exerciseGroup: 'A',
+        sets: [{ setNumber: 1, reps: '8', rir: null, rpe: 8, isWarmup: false }],
+      },
+    ])
+
+    const res = await simulateStartFromSaved(prisma, userId, saved.id)
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    const completion = await prisma.workoutCompletion.findUnique({
+      where: { id: res.completionId },
+      include: {
+        exercises: {
+          orderBy: { order: 'asc' },
+          include: { prescribedSets: { orderBy: { setNumber: 'asc' } } },
+        },
+      },
+    })
+    expect(completion).not.toBeNull()
+    expect(completion?.status).toBe('draft')
+    expect(completion?.isAdHoc).toBe(true)
+    expect(completion?.savedWorkoutId).toBe(saved.id)
+    expect(completion?.name).toBe('Push Day')
+    expect(completion?.exercises).toHaveLength(2)
+
+    const bench = completion?.exercises.find((e) => e.order === 1)
+    expect(bench?.name).toBe('Bench Press')
+    expect(bench?.isOneOff).toBe(true)
+    expect(bench?.prescribedSets).toHaveLength(2)
+    expect(bench?.prescribedSets[0].reps).toBe('5')
+    expect(bench?.prescribedSets[0].rir).toBe(2)
+
+    const row = completion?.exercises.find((e) => e.order === 2)
+    expect(row?.notes).toBe('neutral grip')
+    expect(row?.exerciseGroup).toBe('A')
+    expect(row?.prescribedSets[0].rpe).toBe(8)
+  })
+
+  it('updates SavedWorkout.lastUsedAt on start', async () => {
+    const def = await createTestExerciseDefinition(prisma)
+    const saved = await seedSaved([
+      {
+        name: 'Squat',
+        exerciseDefinitionId: def.id,
+        order: 1,
+        notes: null,
+        exerciseGroup: null,
+        sets: [{ setNumber: 1, reps: '5', rir: null, rpe: null, isWarmup: false }],
+      },
+    ])
+    expect(saved.lastUsedAt).toBeNull()
+
+    const now = new Date('2026-05-19T20:00:00Z')
+    const res = await simulateStartFromSaved(prisma, userId, saved.id, now)
+    expect(res.ok).toBe(true)
+
+    const after = await prisma.savedWorkout.findUnique({ where: { id: saved.id } })
+    expect(after?.lastUsedAt?.toISOString()).toBe(now.toISOString())
+  })
+
+  it('returns 409 when an open draft already exists', async () => {
+    const def = await createTestExerciseDefinition(prisma)
+    const saved = await seedSaved([
+      {
+        name: 'OHP',
+        exerciseDefinitionId: def.id,
+        order: 1,
+        notes: null,
+        exerciseGroup: null,
+        sets: [{ setNumber: 1, reps: '5', rir: null, rpe: null, isWarmup: false }],
+      },
+    ])
+
+    const existingDraft = await prisma.workoutCompletion.create({
+      data: {
+        userId,
+        status: 'draft',
+        isAdHoc: true,
+        name: 'Existing draft',
+      },
+    })
+
+    const res = await simulateStartFromSaved(prisma, userId, saved.id)
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.status).toBe(409)
+    expect(res.draftId).toBe(existingDraft.id)
+  })
+
+  it('returns 404 when the saved workout belongs to another user', async () => {
+    const otherUser = await createTestUser()
+    const def = await createTestExerciseDefinition(prisma)
+    const saved = await prisma.savedWorkout.create({
+      data: {
+        userId: otherUser.id,
+        name: "Other's workout",
+        workoutData: [
+          {
+            name: 'Bench',
+            exerciseDefinitionId: def.id,
+            order: 1,
+            notes: null,
+            exerciseGroup: null,
+            sets: [],
+          },
+        ] as unknown as object,
+        exerciseCount: 1,
+      },
+    })
+
+    const res = await simulateStartFromSaved(prisma, userId, saved.id)
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.status).toBe(404)
+  })
+
+  it('handles a saved workout with no exercises (no-op hydration)', async () => {
+    const saved = await seedSaved([], 'Empty')
+
+    const res = await simulateStartFromSaved(prisma, userId, saved.id)
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    const completion = await prisma.workoutCompletion.findUnique({
+      where: { id: res.completionId },
+      include: { exercises: true },
+    })
+    expect(completion?.exercises).toHaveLength(0)
+  })
+})

--- a/app/api/workouts/saved/[id]/start/route.ts
+++ b/app/api/workouts/saved/[id]/start/route.ts
@@ -1,0 +1,202 @@
+import { createId } from '@paralleldrive/cuid2'
+import { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { recordEvent } from '@/lib/events'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+import type { SavedWorkoutData, SavedWorkoutExercise } from '@/types/saved-workout'
+
+/**
+ * POST /api/workouts/saved/[id]/start
+ *
+ * Hydrates a SavedWorkout snapshot into a new draft WorkoutCompletion so the
+ * user can log against it like a freestyle session that's pre-populated with
+ * exercises and prescribed sets.
+ *
+ * Conflict semantics mirror /api/workouts/adhoc: only one open draft per user
+ * — if one exists we return 409 with the existing draft so the client can
+ * show the resume-vs-abandon prompt.
+ */
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: savedWorkoutId } = await params
+
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
+
+    const saved = await prisma.savedWorkout.findFirst({
+      where: { id: savedWorkoutId, userId: user.id },
+    })
+    if (!saved) {
+      return NextResponse.json({ error: 'Saved workout not found' }, { status: 404 })
+    }
+
+    const workoutData = saved.workoutData as unknown as SavedWorkoutData
+    if (!Array.isArray(workoutData)) {
+      logger.error(
+        { savedWorkoutId, userId: user.id },
+        'SavedWorkout.workoutData is not an array'
+      )
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    }
+
+    const now = new Date()
+    let completionId: string | null = null
+    let existingDraft:
+      | {
+          id: string
+          isAdHoc: boolean
+          name: string | null
+          workout: { name: string } | null
+        }
+      | null = null
+
+    try {
+      completionId = await prisma.$transaction(
+        async (tx) => {
+          const found = await tx.workoutCompletion.findFirst({
+            where: { userId: user.id, status: 'draft', isArchived: false },
+            select: {
+              id: true,
+              isAdHoc: true,
+              name: true,
+              workout: { select: { name: true } },
+            },
+          })
+          if (found) {
+            existingDraft = found
+            return null
+          }
+
+          const completion = await tx.workoutCompletion.create({
+            data: {
+              workoutId: null,
+              savedWorkoutId: saved.id,
+              userId: user.id,
+              status: 'draft',
+              isAdHoc: true,
+              name: saved.name,
+              startedAt: now,
+              completedAt: now,
+            },
+            select: { id: true },
+          })
+
+          // Pre-generate exercise ids so we can link prescribed sets in a
+          // single createMany without a per-exercise round-trip.
+          const exerciseRows = workoutData.map((ex: SavedWorkoutExercise) => ({
+            id: createId(),
+            name: ex.name,
+            exerciseDefinitionId: ex.exerciseDefinitionId,
+            order: ex.order,
+            notes: ex.notes ?? null,
+            exerciseGroup: ex.exerciseGroup ?? null,
+            workoutId: null,
+            workoutCompletionId: completion.id,
+            userId: user.id,
+            isOneOff: true,
+          }))
+
+          if (exerciseRows.length > 0) {
+            await tx.exercise.createMany({ data: exerciseRows })
+          }
+
+          const prescribedRows = workoutData.flatMap(
+            (ex: SavedWorkoutExercise, idx: number) =>
+              (ex.sets ?? []).map((s) => ({
+                exerciseId: exerciseRows[idx].id,
+                userId: user.id,
+                setNumber: s.setNumber,
+                reps: s.reps,
+                rir: s.rir ?? null,
+                rpe: s.rpe ?? null,
+                isWarmup: Boolean(s.isWarmup),
+              }))
+          )
+
+          if (prescribedRows.length > 0) {
+            await tx.prescribedSet.createMany({ data: prescribedRows })
+          }
+
+          await tx.savedWorkout.update({
+            where: { id: saved.id },
+            data: { lastUsedAt: now },
+          })
+
+          return completion.id
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+      )
+    } catch (txErr) {
+      if (
+        txErr instanceof Prisma.PrismaClientKnownRequestError &&
+        (txErr.code === 'P2034' || txErr.code === 'P2002')
+      ) {
+        existingDraft = await prisma.workoutCompletion.findFirst({
+          where: { userId: user.id, status: 'draft', isArchived: false },
+          select: {
+            id: true,
+            isAdHoc: true,
+            name: true,
+            workout: { select: { name: true } },
+          },
+        })
+      } else {
+        throw txErr
+      }
+    }
+
+    if (existingDraft) {
+      const draft = existingDraft as {
+        id: string
+        isAdHoc: boolean
+        name: string | null
+        workout: { name: string } | null
+      }
+      return NextResponse.json(
+        {
+          error: 'DRAFT_EXISTS',
+          message: 'Finish your current workout before starting a new one.',
+          draft: {
+            completionId: draft.id,
+            isAdHoc: draft.isAdHoc,
+            name: draft.name ?? draft.workout?.name ?? null,
+          },
+        },
+        { status: 409 }
+      )
+    }
+
+    if (!completionId) {
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    }
+
+    recordEvent(user.id, 'workout_started_from_saved', {
+      savedWorkoutId: saved.id,
+      completionId,
+    })
+
+    logger.info(
+      { userId: user.id, savedWorkoutId: saved.id, completionId },
+      'Workout started from saved'
+    )
+
+    return NextResponse.json({ completionId })
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'saved-workout-start', savedWorkoutId },
+      'Failed to start workout from saved'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/types/saved-workout.ts
+++ b/types/saved-workout.ts
@@ -1,0 +1,32 @@
+/**
+ * Shape of the JSON snapshot stored in `SavedWorkout.workoutData`.
+ *
+ * A saved workout captures the *template* of a completed freestyle
+ * session: which exercises were done, in what order, and what set
+ * structure (reps / RIR / RPE / warmup flag). Weight, timestamps, and
+ * the source completion id are intentionally dropped — those are
+ * per-session and shouldn't bias the next attempt.
+ */
+export interface SavedWorkoutSet {
+  setNumber: number
+  /**
+   * Stored as a string to mirror `PrescribedSet.reps`, which supports
+   * range/cluster notations like "3-5" even though LoggedSet.reps is
+   * a single integer.
+   */
+  reps: string
+  rir: number | null
+  rpe: number | null
+  isWarmup: boolean
+}
+
+export interface SavedWorkoutExercise {
+  name: string
+  exerciseDefinitionId: string
+  order: number
+  notes: string | null
+  exerciseGroup: string | null
+  sets: SavedWorkoutSet[]
+}
+
+export type SavedWorkoutData = SavedWorkoutExercise[]


### PR DESCRIPTION
## Summary
- Adds `POST /api/workouts/saved/[id]/start` that creates a draft `WorkoutCompletion` (`isAdHoc: true`, `savedWorkoutId` linked) hydrated from the saved snapshot's exercises + prescribed sets.
- Uses two `createMany` calls inside a `$transaction` (constant query count regardless of exercise/set count, per the issue's perf note) with pre-generated cuid2 ids to link prescribed sets to their parent exercise without per-exercise round-trips.
- Mirrors `/api/workouts/adhoc` 409 semantics: if an open draft already exists, return the existing draft so the client can drive the resume-vs-abandon prompt.
- Bumps `SavedWorkout.lastUsedAt` to `now()` and emits a `workout_started_from_saved` AppEvent with `{ savedWorkoutId, completionId }`.
- Introduces `types/saved-workout.ts` as the single source of truth for the `workoutData` JSON shape, so this PR and #808 stay aligned.

## Notes
- Scoped this PR to the API only. The "Start this workout" button on the saved-workout detail page is being built in #809 (list/detail) and can call this endpoint when that page lands.
- Auth via `getCurrentUser`; rate-limited with the existing `workoutActionLimiter`.

## Test plan
- [x] `npm run type-check`
- [x] Integration tests (5): hydration produces the expected exercises + prescribed sets; `lastUsedAt` is updated; 409 on existing draft; 404 on cross-user; empty-exercise no-op
- [x] Manual: open a saved workout, hit endpoint, verify completion appears in logger and old draft (if any) blocks creation

Fixes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)