### PR TITLE
feat(nav): rename Workout chip to Lift

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -71,7 +71,7 @@ export default function BottomNav() {
                   strokeWidth={2.75}
                 />
                 <span className="text-[9px] font-black uppercase tracking-[0.1em] leading-none mt-0.5">
-                  Workout
+                  Lift
                 </span>
               </span>
             </span>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -71,7 +71,7 @@ export default function Header({ userEmail }: Props) {
               aria-label={
                 activeDraft
                   ? `Resume draft workout: ${activeDraft.workoutName}`
-                  : 'Start a workout'
+                  : 'Lift'
               }
               className="relative inline-flex items-center gap-2 px-4 h-9 bg-accent text-accent-foreground transition-transform active:translate-y-[2px] doom-focus-ring overflow-hidden"
               style={{
@@ -89,7 +89,7 @@ export default function Header({ userEmail }: Props) {
               {activeDraft && <span aria-hidden="true" className="chip-gold-shine" />}
               <Dumbbell size={16} strokeWidth={2.75} className="relative" />
               <span className="relative text-xs font-black uppercase tracking-[0.1em]">
-                Workout
+                Lift
               </span>
             </button>
             <ThemeSelector />

--- a/docs/PLAYWRIGHT_RECIPES.md
+++ b/docs/PLAYWRIGHT_RECIPES.md
@@ -47,7 +47,7 @@ After login, session cookies are attached to the browser context — any
 | Element | Selector | Notes |
 |---|---|---|
 | Chip sheet (mobile) | `button[aria-label="Quick actions"]` | Bottom nav. Use this on mobile viewports. |
-| Chip sheet (desktop) | `button[aria-label="Start a workout"]` | Header. Hidden on mobile viewport. There are TWO elements that match "Workout" text — filter by `aria-label`. |
+| Chip sheet (desktop) | `button[aria-label="Lift"]` | Header. Hidden on mobile viewport. There are TWO chip buttons — filter by `aria-label`. |
 | Bottom nav items | `nav a[aria-label="..."]` | "Training", "Programs", "Learn", "Settings" |
 | Workout finish | `button:has-text("Finish")` | On `/training/adhoc/[id]` |
 | Confirm dialog | `button:has-text("Confirm")` | Generic — appears after Finish |


### PR DESCRIPTION
## Summary
- Renames the global chip label from "Workout" to "Lift" in both desktop header and mobile bottom nav
- Updates the desktop chip's `aria-label` from "Start a workout" to "Lift" (matches the visible label)
- Updates `docs/PLAYWRIGHT_RECIPES.md` to reflect the new desktop chip aria-label selector

Avoids the "Workout" / "Workouts" overlap that will surface once curated workouts land inside the Training tab (Workouts v2). Icon, 3D styling, draft-resume behavior, and chip-sheet contents are all unchanged.

Fixes #833

## Test plan
- [ ] Verify desktop header chip reads "LIFT" with Dumbbell icon and tactile 3D press
- [ ] Verify mobile bottom-nav chip reads "LIFT" and still opens the QuickActionSheet
- [ ] Verify draft-resume pulse + gold shine still appear when an active draft exists
- [ ] Verify aria-label on desktop chip is "Lift" (or the resume-draft string when a draft is active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)