### PR TITLE
fix(saved-workouts): larger exercise font and clearer delete copy

### DIFF
--- a/components/features/saved-workouts/DeleteSavedWorkoutDialog.tsx
+++ b/components/features/saved-workouts/DeleteSavedWorkoutDialog.tsx
@@ -60,10 +60,10 @@ export default function DeleteSavedWorkoutDialog({ item, onOpenChange, onSuccess
           </AlertDialog.Title>
 
           <AlertDialog.Description asChild>
-            <div className="mb-4 text-sm text-muted-foreground">
+            <div className="mb-4 text-base text-muted-foreground">
               This will permanently delete{' '}
               <span className="font-medium text-foreground">&quot;{item.name}&quot;</span>.
-              Past completions that referenced it are not affected.
+              Your past workouts and the sets and reps you logged will be preserved.
             </div>
           </AlertDialog.Description>
 

--- a/components/features/saved-workouts/SavedWorkoutDetailDialog.tsx
+++ b/components/features/saved-workouts/SavedWorkoutDetailDialog.tsx
@@ -143,9 +143,9 @@ export default function SavedWorkoutDetailDialog({ item, onOpenChange }: Props) 
                     {exerciseNames.map((name, idx) => (
                       <li
                         key={`${name}-${idx}`}
-                        className="flex items-center gap-3 border-b border-border py-2 text-sm text-foreground last:border-b-0"
+                        className="flex items-center gap-3 border-b border-border py-2.5 text-base text-foreground last:border-b-0"
                       >
-                        <span className="w-6 text-xs text-muted-foreground">{idx + 1}.</span>
+                        <span className="w-6 text-sm text-muted-foreground">{idx + 1}.</span>
                         <span className="flex-1">{name}</span>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary
- Bumps exercise list font in the saved workout preview modal from `text-sm` to `text-base` (with `text-sm` for the index numerals) for readability.
- Bumps the delete confirmation warning copy to `text-base` and rewords it from insider phrasing ("Past completions that referenced it are not affected.") to user-friendly: "Your past workouts and the sets and reps you logged will be preserved."

Fixes #838

## Test plan
- [ ] Open My Saved Workouts, tap a row, verify exercise names are easier to read on mobile.
- [ ] Tap the trash icon on a saved workout, verify the warning copy is clearer and reads at the larger size.
- [ ] Visual check in both light/dark modes of the DOOM theme.

Generated with Claude Code