### PR TITLE
fix(adhoc): keep rollup modal visible during navigation to /training

### DIFF
--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -532,8 +532,9 @@ export default function AdHocLoggerView({
   }, [isCompleting, loggedSets, completionId, router, onRetryToast, toast])
 
   const handleRollupClose = useCallback(() => {
-    setShowRollup(false)
-    setRollup(null)
+    // Navigate first and leave the modal visible so the workout logger
+    // beneath it doesn't flash briefly while the route transitions.
+    // The component unmounts on navigation, which tears down the modal.
     router.push('/training')
     router.refresh()
   }, [router])


### PR DESCRIPTION
## Summary
- Fixes #842 — after hitting Done in the post-workout stats rollup, the ad-hoc workout logger flashed for 1–2 seconds before the route transition to `/training` completed.
- Root cause: `handleRollupClose` synchronously cleared the modal state (`setShowRollup(false)` / `setRollup(null)`) before calling `router.push('/training')`, unmounting the modal and exposing the logger view underneath until navigation finished.
- Fix: leave the rollup modal mounted while navigation is in flight. `AdHocLoggerView` unmounts on route change, which tears down the modal cleanly.

## Test plan
- [ ] Start a freestyle workout, log at least one set, tap Complete.
- [ ] In the stats rollup, tap Done.
- [ ] Verify the user is taken directly to `/training` with no flash of the logger UI.
- [ ] Same flow on mobile Safari (PWA) — matches the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)