### PR TITLE
fix(ux): don't auto-focus search input on mobile in exercise search modal

### DIFF
--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -879,6 +879,9 @@ function ExercisePickerModal({
       <DialogContent
         showClose={false}
         fullScreenMobile={true}
+        // Body renders ExerciseSearchInterface; prevent default Radix auto-focus
+        // so the mobile keyboard doesn't pop up automatically (issue #846).
+        onOpenAutoFocus={(e) => e.preventDefault()}
         className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
       >
         <DialogHeader className="border-b border-border bg-primary py-2">

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Check, Filter, Search } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/radix/popover'
 import { clientLogger } from '@/lib/client-logger'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
@@ -104,6 +104,18 @@ export function ExerciseSearchInterface({
   const [hasSearched, setHasSearched] = useState(preloadExercises)
   const [fauPopoverOpen, setFauPopoverOpen] = useState(false)
   const [equipmentPopoverOpen, setEquipmentPopoverOpen] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-focus the search input on devices with a physical keyboard (desktop)
+  // but NOT on touch devices, where focusing pops up the on-screen keyboard
+  // and obscures the page. Touch users tap the field to bring it up.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const prefersKeyboard = window.matchMedia('(hover: hover) and (pointer: fine)').matches
+    if (prefersKeyboard) {
+      searchInputRef.current?.focus()
+    }
+  }, [])
 
   const searchExercises = useCallback(async () => {
     setIsLoading(true)
@@ -164,6 +176,7 @@ export function ExerciseSearchInterface({
         <div className="relative mb-3">
           <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
           <input
+            ref={searchInputRef}
             type="text"
             placeholder="Search exercises..."
             value={searchQuery}

--- a/components/ui/radix/wizard-dialog.tsx
+++ b/components/ui/radix/wizard-dialog.tsx
@@ -33,6 +33,12 @@ export interface WizardDialogProps {
   currentStep: number
   onStepChange: (step: number) => void
   title: string
+  /**
+   * Forwarded to Radix Dialog.Content. Use to prevent the default behavior of
+   * auto-focusing the first focusable child on open (e.g. to avoid popping
+   * up the mobile keyboard when a search input is the first focusable).
+   */
+  onOpenAutoFocus?: (event: Event) => void
 }
 
 export function WizardDialog({
@@ -42,6 +48,7 @@ export function WizardDialog({
   currentStep,
   onStepChange,
   title: _title,
+  onOpenAutoFocus,
 }: WizardDialogProps) {
   const [isProcessing, setIsProcessing] = React.useState(false)
 
@@ -82,7 +89,7 @@ export function WizardDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showClose={false} fullScreenMobile={true} className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card">
+      <DialogContent showClose={false} fullScreenMobile={true} onOpenAutoFocus={onOpenAutoFocus} className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card">
         <DialogHeader className="border-b border-border bg-primary py-2">
           <div className="flex items-center justify-between">
             <div className="flex-1">

--- a/components/workout-logging/wizards/AddExerciseWizard.tsx
+++ b/components/workout-logging/wizards/AddExerciseWizard.tsx
@@ -211,6 +211,9 @@ export function AddExerciseWizard({
       currentStep={currentStep}
       onStepChange={setCurrentStep}
       title="Add Exercise"
+      // First step is exercise search; prevent default Radix auto-focus so the
+      // mobile keyboard doesn't pop up automatically (issue #846).
+      onOpenAutoFocus={(e) => e.preventDefault()}
     />
   )
 }

--- a/components/workout-logging/wizards/SwapExerciseWizard.tsx
+++ b/components/workout-logging/wizards/SwapExerciseWizard.tsx
@@ -210,6 +210,9 @@ export function SwapExerciseWizard({
       currentStep={currentStep}
       onStepChange={setCurrentStep}
       title="Replace Exercise"
+      // First step is exercise search; prevent default Radix auto-focus so the
+      // mobile keyboard doesn't pop up automatically (issue #846).
+      onOpenAutoFocus={(e) => e.preventDefault()}
     />
   )
 }


### PR DESCRIPTION
## Summary

Closes #846. The exercise search modal (Add Exercise wizard, Replace Exercise wizard, and the ad-hoc exercise picker) was popping up the mobile on-screen keyboard automatically because Radix Dialog auto-focuses the first focusable child — which is the search input. The keyboard then obscured the muscle-group / equipment filters and most of the results.

- Pass `onOpenAutoFocus={(e) => e.preventDefault()}` to the Radix `DialogContent` for the three dialogs that host `ExerciseSearchInterface` (via a new optional `onOpenAutoFocus` prop on `WizardDialog`, plus a direct override in `ExercisePickerModal`).
- Restore desktop auto-focus inside `ExerciseSearchInterface` itself, gated on `matchMedia('(hover: hover) and (pointer: fine)')` so it only fires on devices with a real keyboard/pointer. Touch users see the modal cleanly and tap the input when they want to type.

## Test plan

- [ ] On mobile / PWA: open Add Exercise from a workout — modal opens without the keyboard, filters and exercise list are fully visible. Tapping the search input still brings up the keyboard.
- [ ] On mobile / PWA: same check for Replace Exercise and the ad-hoc workout exercise picker.
- [ ] On desktop: open any of the three flows — the search input is focused automatically so typing works immediately.
- [ ] Keyboard navigation on desktop still works (tab through filters, results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)