### PR TITLE
feat(analytics): record signup_completed server-side via BetterAuth hook

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,6 +11,7 @@ import { flushEvents, trackEvent } from '@/lib/analytics'
 import { signUp } from '@/lib/auth-client'
 import {
   getAttribution,
+  postSignupAttribution,
   resolveSource,
 } from '@/lib/signup-attribution'
 
@@ -49,6 +50,11 @@ export default function SignupPage() {
     trackEvent('signup_started', startedProps)
 
     setLoading(true)
+
+    // Server-side hook reads this cookie in databaseHooks.user.create.after
+    // to stamp signup_completed reliably. Done before signUp.email so the
+    // cookie is set when the user row is created.
+    await postSignupAttribution('email', attribution)
 
     try {
       const { error } = await signUp.email({

--- a/app/api/signup-attribution/route.ts
+++ b/app/api/signup-attribution/route.ts
@@ -6,10 +6,10 @@ import {
   getClientIp,
 } from "@/lib/rate-limit"
 import {
-  SIGNUP_ATTRIBUTION_COOKIE,
-  SIGNUP_ATTRIBUTION_TTL_SECONDS,
   encodeSignupAttribution,
   isValidSignupAttribution,
+  SIGNUP_ATTRIBUTION_COOKIE,
+  SIGNUP_ATTRIBUTION_TTL_SECONDS,
 } from "@/lib/signup-attribution-cookie"
 
 /**

--- a/app/api/signup-attribution/route.ts
+++ b/app/api/signup-attribution/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { logger } from "@/lib/logger"
+import {
+  authSensitiveLimiter,
+  checkRateLimit,
+  getClientIp,
+} from "@/lib/rate-limit"
+import {
+  SIGNUP_ATTRIBUTION_COOKIE,
+  SIGNUP_ATTRIBUTION_TTL_SECONDS,
+  encodeSignupAttribution,
+  isValidSignupAttribution,
+} from "@/lib/signup-attribution-cookie"
+
+/**
+ * Sets a short-lived cookie carrying signup attribution (source / method /
+ * gymSlug / mode). Called by the signup form and OAuth buttons immediately
+ * before the user is sent into BetterAuth.
+ *
+ * The cookie is read inside `databaseHooks.user.create.after` (lib/auth.ts)
+ * to stamp the `signup_completed` AppEvent — this is what /admin/signups
+ * surfaces as the "Source" column.
+ *
+ * Cookies (unlike sessionStorage) survive the OAuth top-level redirect
+ * across storage partitions, in-app-browser handoffs, etc., which is why
+ * the prior client-beacon approach was losing events.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const ip = getClientIp(request)
+    const limited = await checkRateLimit(authSensitiveLimiter, `signup-attr:${ip}`)
+    if (limited) return limited
+
+    const body = (await request.json().catch(() => null)) as unknown
+    if (!isValidSignupAttribution(body)) {
+      return NextResponse.json(
+        { error: "Invalid attribution payload" },
+        { status: 400 }
+      )
+    }
+
+    const response = NextResponse.json({ ok: true })
+    response.cookies.set({
+      name: SIGNUP_ATTRIBUTION_COOKIE,
+      value: encodeSignupAttribution(body),
+      httpOnly: true,
+      sameSite: "lax", // must be lax so the cookie rides the OAuth redirect back
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: SIGNUP_ATTRIBUTION_TTL_SECONDS,
+    })
+    return response
+  } catch (error) {
+    logger.error({ error, context: "signup-attribution" }, "Failed to set signup attribution cookie")
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/components/features/auth/OAuthButtons.tsx
+++ b/components/features/auth/OAuthButtons.tsx
@@ -5,6 +5,7 @@ import { trackEvent } from '@/lib/analytics'
 import { signIn } from '@/lib/auth-client'
 import {
   getAttribution,
+  postSignupAttribution,
   resolveSource,
   setPendingOAuthSignup,
 } from '@/lib/signup-attribution'
@@ -36,6 +37,12 @@ export function OAuthButtons({ intent = 'login' }: OAuthButtonsProps = {}) {
       if (attribution.gymSlug) startedProps.gymSlug = attribution.gymSlug
       trackEvent('signup_started', startedProps)
       setPendingOAuthSignup(provider, attribution)
+      // Hand attribution to the server via cookie BEFORE the OAuth redirect
+      // so the BetterAuth user.create hook can stamp signup_completed even
+      // if the client-side tracker is lost across the round-trip (Safari
+      // ITP, in-app browser handoffs, etc.). Awaited so the Set-Cookie
+      // response is processed before the top-level navigation.
+      await postSignupAttribution(provider, attribution)
     }
 
     try {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from "better-auth"
 import { Pool } from "pg"
 import { Resend } from "resend"
+import { prisma } from "@/lib/db"
 import { logger } from "@/lib/logger"
+import { readSignupAttributionFromHeader } from "@/lib/signup-attribution-cookie"
 
 const isRelaxedRateLimits = process.env.RELAXED_RATE_LIMITS === "true"
 
@@ -89,6 +91,40 @@ export const auth = betterAuth({
         defaultValue: "user",
         required: false,
         input: false, // users cannot set their own role via signup
+      },
+    },
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (user, ctx) => {
+          // Record signup_completed server-side so attribution doesn't depend
+          // on a client beacon surviving OAuth round-trips, Safari ITP, etc.
+          // Attribution (source/method/gymSlug/mode) is read from a cookie
+          // set by /api/signup-attribution before the auth flow began.
+          try {
+            const cookieHeader = ctx?.headers?.get("cookie") ?? null
+            const attribution = readSignupAttributionFromHeader(cookieHeader)
+            await prisma.appEvent.create({
+              data: {
+                userId: user.id,
+                event: "signup_completed",
+                properties: {
+                  source: attribution?.source ?? "organic",
+                  method: attribution?.method ?? "unknown",
+                  ...(attribution?.gymSlug ? { gymSlug: attribution.gymSlug } : {}),
+                  ...(attribution?.mode ? { mode: attribution.mode } : {}),
+                  recordedBy: "server-hook",
+                },
+              },
+            })
+          } catch (error) {
+            logger.error(
+              { error, userId: user.id },
+              "Failed to record server-side signup_completed event"
+            )
+          }
+        },
       },
     },
   },

--- a/lib/signup-attribution-cookie.ts
+++ b/lib/signup-attribution-cookie.ts
@@ -1,0 +1,91 @@
+/**
+ * Server-shared shape for signup attribution carried via cookie across the
+ * OAuth round-trip. The cookie is set by `POST /api/signup-attribution`
+ * right before the user is sent to BetterAuth (email signup or OAuth), and
+ * read by the `databaseHooks.user.create.after` hook to stamp the
+ * `signup_completed` AppEvent.
+ *
+ * Cookies (unlike sessionStorage) survive OAuth top-level redirects across
+ * storage partitions, in-app-browser → Safari handoffs, etc. — which is
+ * exactly the path where the prior client-beacon approach was losing events.
+ */
+
+export const SIGNUP_ATTRIBUTION_COOKIE = "ripit_signup_attribution"
+
+/** Cookie TTL: long enough for any plausible OAuth round-trip, short enough
+ *  that a sign-in days later can't accidentally inherit a stale signup. */
+export const SIGNUP_ATTRIBUTION_TTL_SECONDS = 30 * 60
+
+export type SignupMethod = "email" | "google" | "discord"
+export type SignupSource = "qr" | "organic" | "oauth"
+export type QrMode = "beginner" | "experienced"
+
+export interface SignupAttributionPayload {
+  source: SignupSource
+  method: SignupMethod
+  gymSlug?: string
+  mode?: QrMode
+}
+
+const ALLOWED_SOURCES = new Set<SignupSource>(["qr", "organic", "oauth"])
+const ALLOWED_METHODS = new Set<SignupMethod>(["email", "google", "discord"])
+const ALLOWED_MODES = new Set<QrMode>(["beginner", "experienced"])
+
+export function isValidSignupAttribution(
+  value: unknown
+): value is SignupAttributionPayload {
+  if (!value || typeof value !== "object") return false
+  const v = value as Record<string, unknown>
+  if (typeof v.source !== "string" || !ALLOWED_SOURCES.has(v.source as SignupSource)) {
+    return false
+  }
+  if (typeof v.method !== "string" || !ALLOWED_METHODS.has(v.method as SignupMethod)) {
+    return false
+  }
+  if (v.gymSlug !== undefined && (typeof v.gymSlug !== "string" || v.gymSlug.length > 100)) {
+    return false
+  }
+  if (v.mode !== undefined && !ALLOWED_MODES.has(v.mode as QrMode)) {
+    return false
+  }
+  return true
+}
+
+export function encodeSignupAttribution(
+  payload: SignupAttributionPayload
+): string {
+  return encodeURIComponent(JSON.stringify(payload))
+}
+
+export function decodeSignupAttribution(
+  raw: string
+): SignupAttributionPayload | null {
+  try {
+    const decoded = decodeURIComponent(raw)
+    const parsed = JSON.parse(decoded) as unknown
+    if (!isValidSignupAttribution(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse a raw `Cookie` request header and pull out the signup attribution
+ * payload if present and valid. Returns null for any malformed input.
+ */
+export function readSignupAttributionFromHeader(
+  cookieHeader: string | null
+): SignupAttributionPayload | null {
+  if (!cookieHeader) return null
+  const cookies = cookieHeader.split(";")
+  for (const part of cookies) {
+    const eq = part.indexOf("=")
+    if (eq < 0) continue
+    const name = part.slice(0, eq).trim()
+    if (name !== SIGNUP_ATTRIBUTION_COOKIE) continue
+    const value = part.slice(eq + 1).trim()
+    return decodeSignupAttribution(value)
+  }
+  return null
+}

--- a/lib/signup-attribution.ts
+++ b/lib/signup-attribution.ts
@@ -128,3 +128,37 @@ export function resolveSource(
   if (attribution.gymSlug) return 'qr'
   return attribution.source ?? 'organic'
 }
+
+/**
+ * Hands signup attribution to the server via cookie so the BetterAuth
+ * `user.create.after` hook can stamp it onto the `signup_completed`
+ * AppEvent. This is the durable path — the client-side `trackEvent` calls
+ * elsewhere are best-effort and frequently lost across OAuth round-trips
+ * on Safari / in-app browsers.
+ *
+ * Returns true on success, false otherwise. Callers should not block on
+ * the result — failing to post attribution still lets signup proceed; the
+ * server hook will fall back to `source: 'organic'`.
+ */
+export async function postSignupAttribution(
+  method: SignupMethod,
+  attribution: SignupAttribution
+): Promise<boolean> {
+  if (!isBrowser()) return false
+  const source = resolveSource(method, attribution)
+  const payload: Record<string, unknown> = { source, method }
+  if (attribution.gymSlug) payload.gymSlug = attribution.gymSlug
+  if (attribution.mode) payload.mode = attribution.mode
+  try {
+    const res = await fetch('/api/signup-attribution', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'same-origin',
+      keepalive: true,
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- A new prod user signed up via Google OAuth on iPhone Safari and ended up with **zero** `AppEvent` rows — including no `signup_completed` — leaving `/admin/signups` showing only their email and timestamp.
- Root cause: the client-side beacon to `/api/events` and the `sessionStorage` "pending OAuth signup" record both depend on client storage surviving the OAuth round-trip. They don't, reliably — Safari ITP / in-app-browser handoffs / storage-partition changes silently drop them. The infra agent confirmed against prod logs: `POST /api/events` was never hit by this user.
- Fix: stop depending on client beacons for signup attribution. Set a server-readable cookie via `POST /api/signup-attribution` right before BetterAuth runs, and write `signup_completed` from `databaseHooks.user.create.after` in `lib/auth.ts`. Cookies survive OAuth redirects.

### What changed
- **`lib/signup-attribution-cookie.ts`** — shared payload shape (`source` / `method` / `gymSlug` / `mode`), validator, encoder, and a `readSignupAttributionFromHeader()` helper used by the auth hook.
- **`app/api/signup-attribution/route.ts`** — IP-rate-limited POST that sets a 30-min `HttpOnly`, `SameSite=Lax` cookie. `Lax` is deliberate so the cookie rides the top-level OAuth redirect back.
- **`lib/auth.ts`** — adds `databaseHooks.user.create.after` that reads the cookie and writes the `signup_completed` `AppEvent`. Falls back to `source: 'organic'` / `method: 'unknown'` if the cookie is missing so the row is *always* written.
- **`lib/signup-attribution.ts`** — new client helper `postSignupAttribution(method, attribution)`.
- **`components/features/auth/OAuthButtons.tsx`**, **`app/(auth)/signup/page.tsx`** — `await postSignupAttribution(...)` before triggering BetterAuth.

### Why keep the existing client `trackEvent('signup_completed', …)`?
`/admin/signups` already does `ORDER BY createdAt DESC LIMIT 1` per user — so when the client beacon does land, it's slightly fresher and still wins; when it doesn't, the server-hook row covers us. Belt and suspenders, no migration needed.

### Not in scope
- Historical backfill for the affected user (no AppEvent row exists to enrich; would need a manual SQL insert).
- Re-architecting `signup_started`, which is still lost for OAuth users (queued in client buffer when the page redirects to Google). Mentioned in the discussion but deferred.

## Test plan
- [ ] **Local email signup** (`./scripts/dev.sh start -l postgres,app`): create a new account, then check `SELECT event, properties FROM "AppEvent" WHERE "userId" = '<id>'` — expect one `signup_completed` with `properties.source = 'organic'` and `properties.method = 'email'`, `recordedBy = 'server-hook'`.
- [ ] **Local QR flow**: visit `/go/<gymSlug>` first, then sign up — expect `properties.source = 'qr'` and `gymSlug` populated.
- [ ] **Local Google OAuth signup**: same check — expect `properties.source = 'oauth'`, `properties.method = 'google'`.
- [ ] **`/admin/signups`**: new test signup shows up with a non-blank Source column.
- [ ] Type-check / `npm test` pass.
- [ ] Staging deploy: cut a fresh signup, confirm `AppEvent` row lands without depending on the client beacon (DevTools → Network → block `/api/events` to simulate the failure mode and confirm the server row still appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)