### PR TITLE
docs: note SavedWorkout, signupIntent, and adhoc completions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,9 +160,11 @@ Program
 - **Exercise**: Exercises within a workout
 - **PrescribedSet**: Template/plan (what program prescribes)
 - **LoggedSet**: Actual performance (what user logged)
-- **WorkoutCompletion**: Tracks completed/incomplete/abandoned workouts
+- **WorkoutCompletion**: Tracks completed/incomplete/abandoned workouts (also supports ad-hoc/freestyle workouts not tied to a program)
+- **SavedWorkout**: User-saved workout templates (snapshot `workoutData` JSON) created from a completed workout; replayable via `/api/workouts/saved/[id]/start` and surfaced in `/workouts/saved`
 - **InAppMessage**: Admin-managed messages shown in workout UI (carousel slides, lifecycle targeting, placement rules)
-- **AppEvent**: Client-side analytics events (signup source, page views)
+- **AppEvent**: Client-side analytics events (signup source, page views, server-side `signup_completed` via BetterAuth hook)
+- **User.signupIntent**: Captured during onboarding to drive `/welcome` two-step screen for experienced users
 
 **Important**: We store BOTH prescribed and logged sets to enable plan vs reality comparison.
 


### PR DESCRIPTION
## Summary

Weekly docs drift sweep. The CLAUDE.md "Key Database Tables" list was missing entries for features merged in the last two weeks, so an agent (or human) skimming the data model overview would not see how recent flows connect to Prisma.

### Triggering changes
- `SavedWorkout` table + `/workouts/saved` UI and start/list APIs (#812, #813, #814, #816, #818)
- `User.signupIntent` field driving the experienced-user `/welcome` two-step (#788, migration `20260519024221_add_signup_intent`)
- Server-side `signup_completed` AppEvent via BetterAuth hook (#851)
- Ad-hoc/freestyle `WorkoutCompletion` rows not tied to a program (`20260514211653_workout_completion_adhoc`)

### What was stale
- `WorkoutCompletion` description implied program-linked completions only
- No mention of `SavedWorkout` (the entire saved-workouts feature)
- `AppEvent` description omitted the new server-side signup hook
- No pointer to `signupIntent` for the welcome flow

## Test plan

- [ ] CLAUDE.md renders cleanly on GitHub
- [ ] All referenced paths (`/api/workouts/saved/[id]/start`, `/workouts/saved`) exist in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)