### PR TITLE
fix(api): include imageUrls in exercise add/swap responses

### DIFF
--- a/app/api/exercises/[exerciseId]/replace/route.ts
+++ b/app/api/exercises/[exerciseId]/replace/route.ts
@@ -140,7 +140,8 @@ export async function POST(
                 primaryFAUs: true,
                 secondaryFAUs: true,
                 equipment: true,
-                instructions: true
+                instructions: true,
+                imageUrls: true
               }
             }
           }
@@ -223,7 +224,8 @@ export async function POST(
                 primaryFAUs: true,
                 secondaryFAUs: true,
                 equipment: true,
-                instructions: true
+                instructions: true,
+                imageUrls: true
               }
             }
           }

--- a/app/api/workouts/[workoutId]/swap/route.ts
+++ b/app/api/workouts/[workoutId]/swap/route.ts
@@ -116,6 +116,8 @@ export async function POST(
                 primaryFAUs: true,
                 secondaryFAUs: true,
                 equipment: true,
+                instructions: true,
+                imageUrls: true,
               }
             }
           },

--- a/app/api/workouts/adhoc/[completionId]/exercises/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/exercises/route.ts
@@ -22,6 +22,7 @@ const exerciseInclude = {
       secondaryFAUs: true,
       equipment: true,
       instructions: true,
+      imageUrls: true,
     },
   },
 } satisfies Prisma.ExerciseInclude


### PR DESCRIPTION
## Summary
- Exercises added to a freestyle adhoc workout (and exercises swapped in any workout) came back without `imageUrls`, so the Info tab rendered "MORE IMAGES TO COME" until the page was hard-reloaded. The server component query on reload selects `imageUrls`, which is why the issue self-healed after a navigation away and back.
- Root cause: the `exerciseDefinition.select` block in four API routes omitted `imageUrls`. Fixed all four.
- Day-swap route was also missing `instructions` — added that too.

## Files
- `app/api/workouts/adhoc/[completionId]/exercises/route.ts`
- `app/api/exercises/[exerciseId]/replace/route.ts` (both branches)
- `app/api/workouts/[workoutId]/swap/route.ts`

## Test plan
- [ ] Start a fresh adhoc workout, add an exercise that has images (e.g. Lat Pulldown) → Info tab shows the images immediately, no reload needed
- [ ] Swap an exercise inside a programmed workout → Info tab shows new exercise's images
- [ ] Existing populated workouts still render images