### PR TITLE
refactor(db): canonical ExerciseDefinition selects + contract test

### DIFF
--- a/.claude/agents/autopilot.md
+++ b/.claude/agents/autopilot.md
@@ -35,6 +35,7 @@ If `doppler run` fails with "You must specify a project", this is why.
 - Use `fd` instead of `find` for file searching.
 - Next.js 15: Dynamic route params are Promise-based — `const { id } = await params;`
 - Wrap git file paths containing brackets in double quotes to prevent shell glob expansion.
+- When a route returns an entity that's read by multiple routes (e.g. `ExerciseDefinition`), use the canonical select constants from `lib/db/selects.ts` rather than inlining the `select` block. If a canonical select doesn't exist yet for the shape you need, define it there. See `docs/PRISMA_SELECT_PATTERN.md`.
 
 ## Your first steps
 

--- a/.claude/agents/quality-check.md
+++ b/.claude/agents/quality-check.md
@@ -166,6 +166,7 @@ Commit with a clear message describing what was simplified and why. Open a PR wi
 - All Prisma queries must be scoped to the authenticated user: `where: { userId: user.id }`
 - Dynamic route params must be awaited: `const { id } = await params` (Next.js 15 pattern)
 - Use `select` to fetch only needed fields; avoid loading full records when a subset suffices
+- For entities consumed by multiple routes (e.g. `ExerciseDefinition`), use the canonical select constants from `lib/db/selects.ts`. Flag inline selects that duplicate a canonical shape — they're how drift bugs like PR #854 happen. See `docs/PRISMA_SELECT_PATTERN.md`.
 - Use `Promise.all([...])` for independent parallel queries
 - Use `prisma.$transaction(async (tx) => { ... })` for multi-step writes
 - Use `logger.error({ error, context: 'route-name' }, 'message')` — never `console.error`

--- a/__tests__/api/exercise-definition-select-contract.test.ts
+++ b/__tests__/api/exercise-definition-select-contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
+
+/**
+ * Contract tests for the canonical `ExerciseDefinition` select shapes.
+ *
+ * These exist to catch the bug class that produced PR #854: a route was
+ * silently returning exercises without `imageUrls`, and the logger UI
+ * rendered "MORE IMAGES TO COME" forever. The fix was a missing
+ * `imageUrls: true` in the route's Prisma `select`.
+ *
+ * Each assertion below names a field that the workout-logger UI (LOG SETS
+ * / INFO / HISTORY) consumes. If you remove one of these from the
+ * canonical shape, every route that imports it loses the field too — and
+ * this test fails before merge, prompting you to confirm the change is
+ * intentional and update consumers.
+ *
+ * See `docs/PRISMA_SELECT_PATTERN.md` for the wider convention.
+ */
+describe('exerciseDefinitionSelectForLogger', () => {
+  const REQUIRED_FIELDS = [
+    'id',
+    'name',
+    'primaryFAUs',
+    'secondaryFAUs',
+    'equipment',
+    'instructions',
+    'imageUrls',
+  ] as const
+
+  for (const field of REQUIRED_FIELDS) {
+    it(`includes "${field}"`, () => {
+      expect(exerciseDefinitionSelectForLogger).toHaveProperty(field, true)
+    })
+  }
+})

--- a/app/api/exercises/[exerciseId]/replace/route.ts
+++ b/app/api/exercises/[exerciseId]/replace/route.ts
@@ -2,6 +2,7 @@ import type { Exercise } from '@prisma/client'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 import { checkRateLimit, destructiveOpLimiter } from '@/lib/rate-limit'
 
@@ -133,17 +134,7 @@ export async function POST(
             prescribedSets: {
               orderBy: { setNumber: 'asc' }
             },
-            exerciseDefinition: {
-              select: {
-                id: true,
-                name: true,
-                primaryFAUs: true,
-                secondaryFAUs: true,
-                equipment: true,
-                instructions: true,
-                imageUrls: true
-              }
-            }
+            exerciseDefinition: { select: exerciseDefinitionSelectForLogger }
           }
         })
       })
@@ -217,17 +208,7 @@ export async function POST(
             prescribedSets: {
               orderBy: { setNumber: 'asc' }
             },
-            exerciseDefinition: {
-              select: {
-                id: true,
-                name: true,
-                primaryFAUs: true,
-                secondaryFAUs: true,
-                equipment: true,
-                instructions: true,
-                imageUrls: true
-              }
-            }
+            exerciseDefinition: { select: exerciseDefinitionSelectForLogger }
           }
         })
       })

--- a/app/api/workouts/[workoutId]/exercises/[order]/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/[order]/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 
 /**
@@ -96,13 +97,7 @@ export async function GET(
         exerciseDefinitionId: true,
         exerciseDefinition: {
           select: {
-            id: true,
-            name: true,
-            primaryFAUs: true,
-            secondaryFAUs: true,
-            equipment: true,
-            instructions: true,
-            imageUrls: true,
+            ...exerciseDefinitionSelectForLogger,
             isSystem: true,
             createdBy: true,
           },

--- a/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
+++ b/app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts
@@ -2,6 +2,7 @@ import type { Prisma } from '@prisma/client'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 
 type AddDuringLoggingRequest = {
@@ -96,16 +97,7 @@ export async function POST(
       prescribedSets: {
         orderBy: { setNumber: 'asc' as const },
       },
-      exerciseDefinition: {
-        select: {
-          id: true,
-          name: true,
-          primaryFAUs: true,
-          secondaryFAUs: true,
-          equipment: true,
-          instructions: true,
-        },
-      },
+      exerciseDefinition: { select: exerciseDefinitionSelectForLogger },
     } satisfies Prisma.ExerciseInclude
 
     type ExerciseWithDetails = Prisma.ExerciseGetPayload<{

--- a/app/api/workouts/[workoutId]/metadata/route.ts
+++ b/app/api/workouts/[workoutId]/metadata/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 import { getLastExercisePerformance } from '@/lib/queries/exercise-history'
 
@@ -75,13 +76,7 @@ export async function GET(
       exerciseDefinitionId: true,
       exerciseDefinition: {
         select: {
-          id: true,
-          name: true,
-          primaryFAUs: true,
-          secondaryFAUs: true,
-          equipment: true,
-          instructions: true,
-          imageUrls: true,
+          ...exerciseDefinitionSelectForLogger,
           isSystem: true,
           createdBy: true,
         },

--- a/app/api/workouts/[workoutId]/route.ts
+++ b/app/api/workouts/[workoutId]/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 import { getBatchExercisePerformance } from '@/lib/queries/exercise-history'
 
@@ -89,13 +90,7 @@ export async function GET(
         exerciseDefinitionId: true,
         exerciseDefinition: {
           select: {
-            id: true,
-            name: true,
-            primaryFAUs: true,
-            secondaryFAUs: true,
-            equipment: true,
-            instructions: true,
-            imageUrls: true,
+            ...exerciseDefinitionSelectForLogger,
             isSystem: true,
             createdBy: true,
           },

--- a/app/api/workouts/[workoutId]/swap/route.ts
+++ b/app/api/workouts/[workoutId]/swap/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 
 export async function POST(
@@ -109,17 +110,7 @@ export async function POST(
             prescribedSets: {
               orderBy: { setNumber: 'asc' }
             },
-            exerciseDefinition: {
-              select: {
-                id: true,
-                name: true,
-                primaryFAUs: true,
-                secondaryFAUs: true,
-                equipment: true,
-                instructions: true,
-                imageUrls: true,
-              }
-            }
+            exerciseDefinition: { select: exerciseDefinitionSelectForLogger }
           },
           orderBy: { order: 'asc' }
         },

--- a/app/api/workouts/adhoc/[completionId]/exercises/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/exercises/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
 import { logger } from '@/lib/logger'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 
@@ -14,17 +15,7 @@ type AddAdHocExerciseRequest = {
 
 const exerciseInclude = {
   prescribedSets: { orderBy: { setNumber: 'asc' as const } },
-  exerciseDefinition: {
-    select: {
-      id: true,
-      name: true,
-      primaryFAUs: true,
-      secondaryFAUs: true,
-      equipment: true,
-      instructions: true,
-      imageUrls: true,
-    },
-  },
+  exerciseDefinition: { select: exerciseDefinitionSelectForLogger },
 } satisfies Prisma.ExerciseInclude
 
 export async function POST(

--- a/docs/PRISMA_SELECT_PATTERN.md
+++ b/docs/PRISMA_SELECT_PATTERN.md
@@ -1,0 +1,180 @@
+# Prisma `select` pattern
+
+## TL;DR
+
+If a Prisma `select` shape is used by more than one route, **define it
+once** in `lib/db/selects.ts` and import it. Adding a field updates every
+consumer. One-off selects (admin debug endpoints, migration scripts) stay
+inline.
+
+This is a convention, not a hard constraint. Code review and the contract
+tests in `__tests__/api/*-select-contract.test.ts` catch drift.
+
+## Why
+
+We hit a bug where the workout logger UI rendered "MORE IMAGES TO COME"
+in the gym for exercises that had images at home. Root cause: four API
+routes that hydrate an exercise on add/swap omitted `imageUrls: true`
+from their hand-rolled `select` blocks. The page-level server component
+selected it correctly, so a full reload masked the bug — only the
+in-session optimistic update was wrong.
+
+The deeper issue: every route that returns an `ExerciseDefinition` was
+hand-rolling its own `select`. Drift between these hand-rolled blocks
+was inevitable. The fix that ships fields back to the UI today fixes
+nothing structural — the next field added to the schema will produce
+the same bug class.
+
+See PR #854 for the post-mortem.
+
+## The pattern
+
+### Declare canonical shapes
+
+```typescript
+// lib/db/selects.ts
+import type { Prisma } from '@prisma/client'
+
+export const exerciseDefinitionSelectForLogger = {
+  id: true,
+  name: true,
+  primaryFAUs: true,
+  secondaryFAUs: true,
+  equipment: true,
+  instructions: true,
+  imageUrls: true,
+} satisfies Prisma.ExerciseDefinitionSelect
+
+export type ExerciseDefinitionForLogger = Prisma.ExerciseDefinitionGetPayload<{
+  select: typeof exerciseDefinitionSelectForLogger
+}>
+```
+
+Key choices:
+
+- **`satisfies`, not `as`.** `as` asserts compatibility without checking;
+  `satisfies` checks compatibility while preserving the literal type.
+  TypeScript still knows the exact shape, so derived types are precise.
+- **Named by consumer, not by content.** `forLogger` describes *who*
+  uses the shape, not *what's in it*. Fields will change; the consumer
+  relationship is stable.
+- **Const, not function.** Module-level constants are evaluated once.
+  Zero per-request cost — every route references the same object in
+  memory.
+
+### Use at call sites
+
+```typescript
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
+
+const exerciseInclude = {
+  prescribedSets: { orderBy: { setNumber: 'asc' as const } },
+  exerciseDefinition: { select: exerciseDefinitionSelectForLogger },
+} satisfies Prisma.ExerciseInclude
+```
+
+### Compose when you need extra fields
+
+If one route needs the canonical shape *plus* a field or two, spread:
+
+```typescript
+exerciseDefinition: {
+  select: {
+    ...exerciseDefinitionSelectForLogger,
+    isSystem: true,
+    createdBy: true,
+  },
+},
+```
+
+The spread is type-checked. If the canonical shape gains a new field
+tomorrow, this route gets it too.
+
+### When to define a new variant vs. spread
+
+- **Spread** when one or two routes need a small addition. Keeps the
+  number of named constants low.
+- **New named variant** when three or more routes share the same
+  superset, OR when the extension is a distinct conceptual surface
+  (`exerciseDefinitionSelectForAdmin`, `...ForSearch`).
+
+Do not proliferate variants for single-use cases. Do not shy away from
+naming a pattern that repeats.
+
+### Narrowing
+
+Need *fewer* fields than the canonical (e.g., just `id` and `name`)?
+Don't pick `forLogger` and ignore the extras — overfetching adds up and
+the wire shape becomes ambiguous. Define a narrower named variant
+(`exerciseDefinitionSelectForList`, etc.) or inline if truly one-off.
+
+### Deriving types
+
+The killer feature. Get a TypeScript type *out of* the select constant
+via `Prisma.GetPayload`:
+
+```typescript
+export type ExerciseDefinitionForLogger = Prisma.ExerciseDefinitionGetPayload<{
+  select: typeof exerciseDefinitionSelectForLogger
+}>
+```
+
+Now this type can be used as a prop type for any component that consumes
+the shape — the DB query, the API response, and the React prop type are
+all linked. Adding a field updates the type everywhere; TypeScript flags
+consumers that need to handle it.
+
+## Contract tests
+
+For every canonical select, write a contract test asserting the required
+keys:
+
+```typescript
+// __tests__/api/exercise-definition-select-contract.test.ts
+import { exerciseDefinitionSelectForLogger } from '@/lib/db/selects'
+
+describe('exerciseDefinitionSelectForLogger', () => {
+  const REQUIRED = ['id', 'name', 'imageUrls', /* ... */] as const
+  for (const field of REQUIRED) {
+    it(`includes "${field}"`, () => {
+      expect(exerciseDefinitionSelectForLogger).toHaveProperty(field, true)
+    })
+  }
+})
+```
+
+The test asserts the *shape definition* itself. If someone removes a
+field thinking nothing depends on it, CI fails before merge, forcing
+them to either restore the field or audit every consumer.
+
+This won't catch a route that drifted away from the canonical shape
+(e.g., reverted to an inline `select` missing fields). That's caught by
+code review and by the quality-check agent's sweep.
+
+## When this pattern is the wrong fit
+
+Signs you've outgrown named-select constants and should consider richer
+options (repository functions, tRPC, GraphQL):
+
+- The same select is used 10+ places and every change ripples loudly
+- You're doing post-query transformation (computed fields, joins in
+  memory) that doesn't fit `select` syntax
+- API responses diverge from DB shape in ways that matter (different
+  field names, computed `daysSince`)
+- Maintaining parallel "select" and "transform" code paths
+
+Ripit is nowhere near that threshold. Named selects are the right tool
+for this stage.
+
+## For agents
+
+The `quality-check` and `autopilot` agents are told to:
+
+- Use the canonical select when writing a new route that returns
+  `ExerciseDefinition`
+- Flag inline selects of `ExerciseDefinition` that duplicate the
+  canonical shape
+- Suggest contract tests for newly-added canonical selects
+
+If you add a new canonical select for a different entity, update the
+agent prompts so they know to apply the same pattern.

--- a/lib/db/selects.ts
+++ b/lib/db/selects.ts
@@ -1,0 +1,35 @@
+import type { Prisma } from '@prisma/client'
+
+/**
+ * Canonical Prisma `select` shapes for entities that are read by more than
+ * one route. See `docs/PRISMA_SELECT_PATTERN.md` for the convention and
+ * the reasoning behind it.
+ *
+ * Rule of thumb: if a select is used by more than one route, it belongs
+ * here. One-off selects (admin debug endpoints, migration scripts) stay
+ * inline. When a route needs the canonical shape *plus* extra fields,
+ * spread the constant: `{ ...exerciseDefinitionSelectForLogger, extra: true }`.
+ */
+
+/**
+ * Fields needed by the in-workout exercise info tab (LOG SETS / INFO /
+ * HISTORY). Used by every route that returns an exercise back to the
+ * logger UI — both the initial workout fetch and the mutation responses
+ * (add, swap, replace).
+ *
+ * Missing a field here is what caused the "MORE IMAGES TO COME" bug — see
+ * PR #854 for the post-mortem.
+ */
+export const exerciseDefinitionSelectForLogger = {
+  id: true,
+  name: true,
+  primaryFAUs: true,
+  secondaryFAUs: true,
+  equipment: true,
+  instructions: true,
+  imageUrls: true,
+} satisfies Prisma.ExerciseDefinitionSelect
+
+export type ExerciseDefinitionForLogger = Prisma.ExerciseDefinitionGetPayload<{
+  select: typeof exerciseDefinitionSelectForLogger
+}>


### PR DESCRIPTION
## Summary
Structural follow-up to PR #854. That PR fixed four routes that omitted `imageUrls: true` from their Prisma `select` — symptom: "MORE IMAGES TO COME" in the logger UI for freshly-added/swapped exercises. This PR prevents the bug class from recurring.

## Changes

- **`lib/db/selects.ts`** — new file defining `exerciseDefinitionSelectForLogger` (the canonical shape) and the derived `ExerciseDefinitionForLogger` type via `Prisma.GetPayload`.
- **Seven routes refactored** to import the canonical select instead of inlining:
  - Write path (use the constant directly):
    - `app/api/workouts/adhoc/[completionId]/exercises/route.ts`
    - `app/api/exercises/[exerciseId]/replace/route.ts` (both branches)
    - `app/api/workouts/[workoutId]/swap/route.ts`
    - `app/api/workouts/[workoutId]/exercises/add-during-logging/route.ts` ← **also a same-class bug fix**: this route was missing `imageUrls: true`
  - Read path (compose with spread to add `isSystem`, `createdBy`):
    - `app/api/workouts/[workoutId]/route.ts`
    - `app/api/workouts/[workoutId]/exercises/[order]/route.ts`
    - `app/api/workouts/[workoutId]/metadata/route.ts`
- **`__tests__/api/exercise-definition-select-contract.test.ts`** — asserts every required field is present in the canonical select. Fails fast if anyone removes one.
- **`docs/PRISMA_SELECT_PATTERN.md`** — the convention written down: where shapes live, how to compose, when to define a new variant vs. spread, when to graduate to a richer pattern.
- **Agent updates** — `quality-check.md` and `autopilot.md` now reference the convention so future agent work applies the pattern.

## Why this design

- **Named by consumer (`forLogger`), not by content.** Fields will evolve; the consumer relationship is stable.
- **`satisfies` not `as`** — preserves the literal type so `Prisma.GetPayload` produces a precise derived type. The DB query, API response, and component prop type stay linked.
- **Spread composition** for read routes that need extras. Avoids proliferating near-identical constants while still routing changes through the canonical shape.
- **Convention, not constraint.** A lint rule forbidding inline selects would be high-friction for legitimate one-offs. Code review + contract test is the right level of rigor for our stage.

## Test plan

- [ ] `npm test exercise-definition-select-contract` — new contract test passes
- [ ] `npm run type-check` — passes
- [ ] Manual: start a freestyle, add a Lat Pulldown, confirm images appear immediately (covers the PR #854 path)
- [ ] Manual: swap an exercise mid-workout, confirm images load (covers `add-during-logging` bug fix)

## Out of scope this PR

- Other entities with multi-route selects (`Workout`, `Program`, `User`) — same pattern applies, but defer until those actually drift or until we're touching those routes for another reason.
- Refactoring admin routes — admin and logger have legitimately different fields; if we add admin variants later, they live in the same `selects.ts` file.