### PR TITLE
feat(logger): workout plan editor

### DIFF
--- a/app/api/workouts/adhoc/[completionId]/exercises/reorder/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/exercises/reorder/route.ts
@@ -1,0 +1,79 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
+import { logger } from '@/lib/logger'
+import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
+
+type ReorderItem = {
+  exerciseId: string
+  order: number
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimit(workoutActionLimiter, user.id)
+    if (limited) return limited
+
+    const body = (await request.json()) as { exercises?: ReorderItem[] }
+    const exercises = body.exercises
+    if (!Array.isArray(exercises) || exercises.length === 0) {
+      return NextResponse.json(
+        { error: 'Exercises array is required' },
+        { status: 400 },
+      )
+    }
+    for (const item of exercises) {
+      if (!item.exerciseId || typeof item.order !== 'number') {
+        return NextResponse.json(
+          { error: 'Each exercise must have exerciseId and order' },
+          { status: 400 },
+        )
+      }
+    }
+
+    const lookup = await findAdHocCompletion(completionId, user.id)
+    if (!lookup.ok) {
+      return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+    }
+
+    // Verify all exercises belong to this ad-hoc completion and to this user.
+    const existing = await prisma.exercise.findMany({
+      where: { workoutCompletionId: completionId },
+      select: { id: true, userId: true },
+    })
+    const ownedIds = new Set(existing.filter((e) => e.userId === user.id).map((e) => e.id))
+    for (const item of exercises) {
+      if (!ownedIds.has(item.exerciseId)) {
+        return NextResponse.json(
+          { error: `Exercise ${item.exerciseId} does not belong to this workout` },
+          { status: 400 },
+        )
+      }
+    }
+
+    await prisma.$transaction(
+      exercises.map((item) =>
+        prisma.exercise.update({
+          where: { id: item.exerciseId },
+          data: { order: item.order },
+        }),
+      ),
+    )
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ error, context: 'adhoc-exercises-reorder' }, 'Failed to reorder ad-hoc exercises')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -28,6 +28,7 @@ import FollowAlongFooter from './workout-logging/FollowAlongFooter'
 import FollowAlongHeader from './workout-logging/FollowAlongHeader'
 import FollowAlongTabs from './workout-logging/FollowAlongTabs'
 import SetLoggingForm, { type ExpandedInput } from './workout-logging/SetLoggingForm'
+import WorkoutPlanEditor, { type WorkoutPlanEditorExercise } from './workout-logging/WorkoutPlanEditor'
 import { AddExerciseWizard } from './workout-logging/wizards/AddExerciseWizard'
 import { DeleteExerciseWizard } from './workout-logging/wizards/DeleteExerciseWizard'
 import { EditExerciseWizard } from './workout-logging/wizards/EditExerciseWizard'
@@ -140,8 +141,14 @@ export default function ExerciseLoggingModal({
 
   // Wizard state
   const [activeWizard, setActiveWizard] = useState<'add' | 'swap' | 'edit' | 'delete' | null>(null)
+  const [wizardTarget, setWizardTarget] = useState<{ id: string; name: string } | null>(null)
   const [navigateToLastExercise, setNavigateToLastExercise] = useState(false)
   const [editingExerciseDefinitionId, setEditingExerciseDefinitionId] = useState<string | null>(null)
+
+  // Workout plan editor state
+  const [planEditorOpen, setPlanEditorOpen] = useState(false)
+  const [planExercises, setPlanExercises] = useState<WorkoutPlanEditorExercise[]>([])
+  const [isReorderingPlan, setIsReorderingPlan] = useState(false)
 
   // Progressive loading of exercises
   const {
@@ -377,10 +384,100 @@ export default function ExerciseLoggingModal({
     }
   }, [])
 
-  const handleReplaceExercise = () => setActiveWizard('swap')
-  const handleAddExercise = () => setActiveWizard('add')
-  const handleDeleteExercise = () => setActiveWizard('delete')
+  const handleReplaceExercise = () => {
+    setWizardTarget(null)
+    setActiveWizard('swap')
+  }
+  const handleAddExercise = () => {
+    setWizardTarget(null)
+    setActiveWizard('add')
+  }
+  const handleDeleteExercise = () => {
+    setWizardTarget(null)
+    setActiveWizard('delete')
+  }
   const handleEditExercise = () => setActiveWizard('edit')
+
+  // Plan editor: fetch full exercise list when opening
+  const handleOpenPlanEditor = useCallback(async () => {
+    setPlanEditorOpen(true)
+    try {
+      const res = await fetch(`/api/workouts/${workoutId}/exercises`)
+      if (!res.ok) throw new Error('Failed to load')
+      const data = (await res.json()) as { exercises: { id: string; name: string }[] }
+      setPlanExercises(data.exercises.map((e) => ({ id: e.id, name: e.name })))
+    } catch (err) {
+      clientLogger.error('Failed to load workout exercises for plan editor', err)
+    }
+  }, [workoutId])
+
+  const handleReorderPlan = useCallback(
+    async (orderedIds: string[]) => {
+      setIsReorderingPlan(true)
+      // Optimistic; editor already updated its own local order.
+      setPlanExercises((prev) => {
+        const byId = new Map(prev.map((e) => [e.id, e] as const))
+        return orderedIds.map((id) => byId.get(id)).filter(Boolean) as WorkoutPlanEditorExercise[]
+      })
+      try {
+        const res = await fetch(`/api/workouts/${workoutId}/exercises/reorder`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            exercises: orderedIds.map((exerciseId, idx) => ({ exerciseId, order: idx + 1 })),
+          }),
+        })
+        if (!res.ok) throw new Error('Reorder failed')
+        refreshExercises()
+        if (onRefresh) await onRefresh()
+      } catch (err) {
+        clientLogger.error('Reorder failed', err)
+      } finally {
+        setIsReorderingPlan(false)
+      }
+    },
+    [workoutId, refreshExercises, onRefresh],
+  )
+
+  const handleJumpToExercise = useCallback(
+    (exerciseId: string) => {
+      const index = planExercises.findIndex((e) => e.id === exerciseId)
+      if (index >= 0) {
+        lastPrefillKey.current = ''
+        setExtraSetsMode(false)
+        goToExercise(index)
+      }
+    },
+    [planExercises, goToExercise],
+  )
+
+  const handlePlanSwap = useCallback(
+    (exerciseId: string) => {
+      const target = planExercises.find((e) => e.id === exerciseId)
+      if (!target) return
+      setWizardTarget({ id: target.id, name: target.name })
+      setPlanEditorOpen(false)
+      setActiveWizard('swap')
+    },
+    [planExercises],
+  )
+
+  const handlePlanDelete = useCallback(
+    (exerciseId: string) => {
+      const target = planExercises.find((e) => e.id === exerciseId)
+      if (!target) return
+      setWizardTarget({ id: target.id, name: target.name })
+      setPlanEditorOpen(false)
+      setActiveWizard('delete')
+    },
+    [planExercises],
+  )
+
+  const handlePlanAdd = useCallback(() => {
+    setWizardTarget(null)
+    setPlanEditorOpen(false)
+    setActiveWizard('add')
+  }, [])
 
   const handleEditExerciseDefinition = () => {
     if (currentExercise?.exerciseDefinition && !currentExercise.exerciseDefinition.isSystem) {
@@ -422,6 +519,7 @@ export default function ExerciseLoggingModal({
       setNavigateToLastExercise(true)
     }
     setActiveWizard(null)
+    setWizardTarget(null)
   }
 
   const handleCompleteWorkout = async () => {
@@ -561,6 +659,7 @@ export default function ExerciseLoggingModal({
               startedAt={startedAt}
               onCompleteWorkout={() => setIsConfirming(true)}
               onClose={handleExitWorkout}
+              onOpenPlanEditor={handleOpenPlanEditor}
             />
           )}
 
@@ -792,6 +891,20 @@ export default function ExerciseLoggingModal({
         }}
       />
 
+      {/* Workout plan editor */}
+      <WorkoutPlanEditor
+        open={planEditorOpen}
+        onClose={() => setPlanEditorOpen(false)}
+        exercises={planExercises}
+        currentExerciseId={currentExercise?.id}
+        isReordering={isReorderingPlan}
+        onReorder={handleReorderPlan}
+        onJump={handleJumpToExercise}
+        onAdd={handlePlanAdd}
+        onSwap={handlePlanSwap}
+        onDelete={handlePlanDelete}
+      />
+
       {/* Wizards */}
       {activeWizard === 'add' && (
         <AddExerciseWizard
@@ -803,12 +916,17 @@ export default function ExerciseLoggingModal({
         />
       )}
 
-      {activeWizard === 'swap' && currentExercise && (
+      {activeWizard === 'swap' && (wizardTarget || currentExercise) && (
         <SwapExerciseWizard
           open={true}
-          onOpenChange={(open) => !open && setActiveWizard(null)}
-          currentExerciseId={currentExercise.id}
-          currentExerciseName={currentExercise.name}
+          onOpenChange={(open) => {
+            if (!open) {
+              setActiveWizard(null)
+              setWizardTarget(null)
+            }
+          }}
+          currentExerciseId={wizardTarget?.id ?? currentExercise!.id}
+          currentExerciseName={wizardTarget?.name ?? currentExercise!.name}
           onComplete={handleWizardComplete}
         />
       )}
@@ -824,12 +942,17 @@ export default function ExerciseLoggingModal({
         />
       )}
 
-      {activeWizard === 'delete' && currentExercise && (
+      {activeWizard === 'delete' && (wizardTarget || currentExercise) && (
         <DeleteExerciseWizard
           open={true}
-          onOpenChange={(open) => !open && setActiveWizard(null)}
-          exerciseId={currentExercise.id}
-          exerciseName={currentExercise.name}
+          onOpenChange={(open) => {
+            if (!open) {
+              setActiveWizard(null)
+              setWizardTarget(null)
+            }
+          }}
+          exerciseId={wizardTarget?.id ?? currentExercise!.id}
+          exerciseName={wizardTarget?.name ?? currentExercise!.name}
           onComplete={handleWizardComplete}
         />
       )}

--- a/components/adhoc/AdHocExercisePickerModal.tsx
+++ b/components/adhoc/AdHocExercisePickerModal.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import {
+  type ExerciseDefinition,
+  ExerciseSearchInterface,
+} from '@/components/exercise-selection/ExerciseSearchInterface'
+import ExerciseDefinitionEditorModal from '@/components/features/exercise-definition/ExerciseDefinitionEditorModal'
+import { Button } from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/radix/dialog'
+import { TipAnnotation } from '@/components/ui/TipAnnotation'
+
+export type PickerMode =
+  | { kind: 'add' }
+  | { kind: 'swap'; replacingName: string; targetId?: string }
+
+export function AdHocEmptyState() {
+  return (
+    <div className="flex-1 flex items-center justify-center px-6 py-8">
+      <TipAnnotation
+        icon={<Sparkles aria-hidden="true" size={20} strokeWidth={1.8} />}
+      >
+        <span className="text-xl sm:text-2xl leading-relaxed text-foreground">
+          Pick your first exercise to start logging. Add as many as you want as you go.
+        </span>
+      </TipAnnotation>
+    </div>
+  )
+}
+
+type Props = {
+  mode: PickerMode
+  onClose: () => void
+  onConfirm: (defs: ExerciseDefinition[]) => void
+  isBusy: boolean
+}
+
+export function AdHocExercisePickerModal({ mode, onClose, onConfirm, isBusy }: Props) {
+  const isAdd = mode.kind === 'add'
+  const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
+  const selectedIds = new Set(selectedDefs.map((d) => d.id))
+  const [showCreateModal, setShowCreateModal] = useState(false)
+
+  const handleAddToggle = useCallback((def: ExerciseDefinition) => {
+    setSelectedDefs((prev) =>
+      prev.some((d) => d.id === def.id)
+        ? prev.filter((d) => d.id !== def.id)
+        : [...prev, def]
+    )
+  }, [])
+
+  const handleSwapSelect = useCallback(
+    (def: ExerciseDefinition) => {
+      if (isBusy) return
+      onConfirm([def])
+    },
+    [isBusy, onConfirm]
+  )
+
+  const count = selectedDefs.length
+  const title = isAdd ? 'Search Exercises' : 'Swap Exercise'
+  const description = isAdd
+    ? 'Pick one or more to add to your workout'
+    : `Pick a replacement for ${mode.kind === 'swap' ? mode.replacingName : ''}`
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        showClose={false}
+        fullScreenMobile={true}
+        // ExerciseSearchInterface auto-focuses search input; prevent Radix's
+        // default open-focus so the mobile keyboard doesn't pop up (#846).
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
+      >
+        <DialogHeader className="border-b border-border bg-primary py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
+                {title}
+              </DialogTitle>
+              <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
+                {description}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <DialogBody className="flex-1 min-h-0">
+          <ExerciseSearchInterface
+            onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
+            selectedIds={isAdd ? selectedIds : undefined}
+            preloadExercises
+          />
+        </DialogBody>
+
+        <DialogFooter className="border-t border-border bg-card py-2">
+          <div className="flex items-center justify-end gap-2 w-full">
+            <Button variant="secondary" onClick={onClose} doom disabled={isBusy}>
+              Cancel
+            </Button>
+            {isAdd && (
+              <>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowCreateModal(true)}
+                  doom
+                  disabled={isBusy}
+                >
+                  + Create New Exercise
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={() => onConfirm(selectedDefs)}
+                  disabled={count === 0 || isBusy}
+                  loading={isBusy}
+                  doom
+                >
+                  {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
+                </Button>
+              </>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+      <ExerciseDefinitionEditorModal
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        mode="create"
+        onSuccess={(newExercise) => {
+          setShowCreateModal(false)
+          // Auto-select the newly created exercise so the user can add it
+          // straight away without having to re-find it in search results.
+          const def: ExerciseDefinition = {
+            id: newExercise.id,
+            name: newExercise.name,
+            primaryFAUs: newExercise.primaryFAUs,
+            secondaryFAUs: newExercise.secondaryFAUs,
+            equipment: newExercise.equipment,
+            instructions: newExercise.instructions,
+          }
+          if (isAdd) {
+            setSelectedDefs((prev) =>
+              prev.some((d) => d.id === def.id) ? prev : [...prev, def]
+            )
+          } else {
+            onConfirm([def])
+          }
+        }}
+      />
+    </Dialog>
+  )
+}

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -1,37 +1,28 @@
 'use client'
 
-import { Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import {
-  type ExerciseDefinition,
-  ExerciseSearchInterface,
-} from '@/components/exercise-selection/ExerciseSearchInterface'
-import ExerciseDefinitionEditorModal from '@/components/features/exercise-definition/ExerciseDefinitionEditorModal'
+import type { ExerciseDefinition } from '@/components/exercise-selection/ExerciseSearchInterface'
 import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
 import { useToast } from '@/components/ToastProvider'
 import { Button } from '@/components/ui/Button'
 import { LoadingFrog } from '@/components/ui/loading-frog'
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/radix/dialog'
-import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
 import ExerciseLoggingHeader from '@/components/workout-logging/ExerciseLoggingHeader'
 import type { QuickAction } from '@/components/workout-logging/ExerciseQuickActionsMenu'
 import ExitWorkoutConfirm from '@/components/workout-logging/ExitWorkoutConfirm'
-import WorkoutPlanEditor from '@/components/workout-logging/WorkoutPlanEditor'
 import SetLoggingForm, {
   type ExpandedInput,
 } from '@/components/workout-logging/SetLoggingForm'
+import WorkoutPlanEditor from '@/components/workout-logging/WorkoutPlanEditor'
+import {
+  AdHocEmptyState,
+  AdHocExercisePickerModal,
+  type PickerMode,
+} from './AdHocExercisePickerModal'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import {
@@ -785,7 +776,7 @@ export default function AdHocLoggerView({
               ] satisfies QuickAction[]}
             />
           ) : (
-            <EmptyState />
+            <AdHocEmptyState />
           )}
         </div>
 
@@ -829,7 +820,7 @@ export default function AdHocLoggerView({
       </div>
 
       {pickerMode && (
-        <ExercisePickerModal
+        <AdHocExercisePickerModal
           mode={pickerMode}
           onClose={() => setPickerMode(null)}
           onConfirm={pickerMode.kind === 'add' ? handleAddExercises : handleSwapExercise}
@@ -906,151 +897,5 @@ export default function AdHocLoggerView({
         onClose={handleRollupClose}
       />
     </>
-  )
-}
-
-function EmptyState() {
-  return (
-    <div className="flex-1 flex items-center justify-center px-6 py-8">
-      <TipAnnotation
-        icon={<Sparkles aria-hidden="true" size={20} strokeWidth={1.8} />}
-      >
-        <span className="text-xl sm:text-2xl leading-relaxed text-foreground">
-          Pick your first exercise to start logging. Add as many as you want as you go.
-        </span>
-      </TipAnnotation>
-    </div>
-  )
-}
-
-type PickerMode =
-  | { kind: 'add' }
-  | { kind: 'swap'; replacingName: string; targetId?: string }
-
-function ExercisePickerModal({
-  mode,
-  onClose,
-  onConfirm,
-  isBusy,
-}: {
-  mode: PickerMode
-  onClose: () => void
-  onConfirm: (defs: ExerciseDefinition[]) => void
-  isBusy: boolean
-}) {
-  const isAdd = mode.kind === 'add'
-  // Multi-select state used only in add mode.
-  const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
-  const selectedIds = new Set(selectedDefs.map((d) => d.id))
-  const [showCreateModal, setShowCreateModal] = useState(false)
-
-  const handleAddToggle = useCallback((def: ExerciseDefinition) => {
-    setSelectedDefs((prev) =>
-      prev.some((d) => d.id === def.id)
-        ? prev.filter((d) => d.id !== def.id)
-        : [...prev, def]
-    )
-  }, [])
-
-  const handleSwapSelect = useCallback(
-    (def: ExerciseDefinition) => {
-      if (isBusy) return
-      onConfirm([def])
-    },
-    [isBusy, onConfirm]
-  )
-
-  const count = selectedDefs.length
-  const title = isAdd ? 'Search Exercises' : 'Swap Exercise'
-  const description = isAdd
-    ? 'Pick one or more to add to your workout'
-    : `Pick a replacement for ${mode.kind === 'swap' ? mode.replacingName : ''}`
-
-  return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent
-        showClose={false}
-        fullScreenMobile={true}
-        // Body renders ExerciseSearchInterface; prevent default Radix auto-focus
-        // so the mobile keyboard doesn't pop up automatically (issue #846).
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
-      >
-        <DialogHeader className="border-b border-border bg-primary py-2">
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
-              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
-                {title}
-              </DialogTitle>
-              <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
-                {description}
-              </DialogDescription>
-            </div>
-          </div>
-        </DialogHeader>
-
-        <DialogBody className="flex-1 min-h-0">
-          <ExerciseSearchInterface
-            onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
-            selectedIds={isAdd ? selectedIds : undefined}
-            preloadExercises
-          />
-        </DialogBody>
-
-        <DialogFooter className="border-t border-border bg-card py-2">
-          <div className="flex items-center justify-end gap-2 w-full">
-            <Button variant="secondary" onClick={onClose} doom disabled={isBusy}>
-              Cancel
-            </Button>
-            {isAdd && (
-              <>
-                <Button
-                  variant="secondary"
-                  onClick={() => setShowCreateModal(true)}
-                  doom
-                  disabled={isBusy}
-                >
-                  + Create New Exercise
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={() => onConfirm(selectedDefs)}
-                  disabled={count === 0 || isBusy}
-                  loading={isBusy}
-                  doom
-                >
-                  {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
-                </Button>
-              </>
-            )}
-          </div>
-        </DialogFooter>
-      </DialogContent>
-      <ExerciseDefinitionEditorModal
-        isOpen={showCreateModal}
-        onClose={() => setShowCreateModal(false)}
-        mode="create"
-        onSuccess={(newExercise) => {
-          setShowCreateModal(false)
-          // Auto-select the newly created exercise so the user can add it
-          // straight away without having to re-find it in search results.
-          const def: ExerciseDefinition = {
-            id: newExercise.id,
-            name: newExercise.name,
-            primaryFAUs: newExercise.primaryFAUs,
-            secondaryFAUs: newExercise.secondaryFAUs,
-            equipment: newExercise.equipment,
-            instructions: newExercise.instructions,
-          }
-          if (isAdd) {
-            setSelectedDefs((prev) =>
-              prev.some((d) => d.id === def.id) ? prev : [...prev, def]
-            )
-          } else {
-            onConfirm([def])
-          }
-        }}
-      />
-    </Dialog>
   )
 }

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -28,6 +28,7 @@ import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTab
 import ExerciseLoggingHeader from '@/components/workout-logging/ExerciseLoggingHeader'
 import type { QuickAction } from '@/components/workout-logging/ExerciseQuickActionsMenu'
 import ExitWorkoutConfirm from '@/components/workout-logging/ExitWorkoutConfirm'
+import WorkoutPlanEditor from '@/components/workout-logging/WorkoutPlanEditor'
 import SetLoggingForm, {
   type ExpandedInput,
 } from '@/components/workout-logging/SetLoggingForm'
@@ -41,6 +42,7 @@ import {
   discardAdHocWorkout,
   fetchExerciseHistory,
   logAdHocSet,
+  reorderAdHocExercises,
   swapAdHocExercise,
 } from '@/lib/api/adhoc-workout'
 import { FetchError } from '@/lib/api/fetch'
@@ -128,6 +130,7 @@ export default function AdHocLoggerView({
   const [currentSet, setCurrentSet] = useState(EMPTY_SET)
   const [expandedInput, setExpandedInput] = useState<ExpandedInput>(null)
   const [pickerMode, setPickerMode] = useState<PickerMode | null>(null)
+  const [planEditorOpen, setPlanEditorOpen] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
   const [isSwapping, setIsSwapping] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -272,7 +275,11 @@ export default function AdHocLoggerView({
 
   const handleSwapExercise = useCallback(
     async (definitions: ExerciseDefinition[]) => {
-      const target = exercises[currentIndex]
+      const targetId =
+        pickerMode?.kind === 'swap' && pickerMode.targetId
+          ? pickerMode.targetId
+          : exercises[currentIndex]?.id
+      const target = exercises.find((e) => e.id === targetId)
       const replacement = definitions[0]
       if (!target || !replacement || isSwapping) return
       setIsSwapping(true)
@@ -281,8 +288,8 @@ export default function AdHocLoggerView({
           onRetry: onRetryToast('Swapping exercise'),
         })
         setExercises((prev) =>
-          prev.map((ex, i) =>
-            i === currentIndex
+          prev.map((ex) =>
+            ex.id === target.id
               ? {
                   ...ex,
                   name: updated.name,
@@ -311,11 +318,13 @@ export default function AdHocLoggerView({
         setIsSwapping(false)
       }
     },
-    [currentIndex, exercises, isSwapping, onRetryToast, toast]
+    [currentIndex, exercises, isSwapping, onRetryToast, toast, pickerMode]
   )
 
-  const handleDeleteExercise = useCallback(async () => {
-    const target = exercises[currentIndex]
+  const handleDeleteExercise = useCallback(async (targetId?: string) => {
+    const target = targetId
+      ? exercises.find((e) => e.id === targetId)
+      : exercises[currentIndex]
     if (!target || isDeleting) return
     setIsDeleting(true)
     try {
@@ -324,9 +333,14 @@ export default function AdHocLoggerView({
       })
       setLoggedSets((prev) => prev.filter((s) => s.exerciseId !== target.id))
       setExercises((prev) => {
+        const removedIdx = prev.findIndex((ex) => ex.id === target.id)
         const next = prev.filter((ex) => ex.id !== target.id)
-        // Keep currentIndex in range; bias toward the previous exercise.
-        setCurrentIndex((idx) => Math.max(0, Math.min(idx, next.length - 1)))
+        // Keep currentIndex pointing at a valid exercise; bias toward previous.
+        setCurrentIndex((idx) => {
+          if (next.length === 0) return 0
+          if (removedIdx < idx) return Math.max(0, idx - 1)
+          return Math.min(idx, next.length - 1)
+        })
         return next
       })
       setCurrentSet(EMPTY_SET)
@@ -341,6 +355,69 @@ export default function AdHocLoggerView({
       setIsDeleting(false)
     }
   }, [currentIndex, exercises, isDeleting, onRetryToast, toast])
+
+  const handleReorderExercises = useCallback(
+    async (orderedIds: string[]) => {
+      const currentId = exercises[currentIndex]?.id
+      setExercises((prev) => {
+        const byId = new Map(prev.map((e) => [e.id, e] as const))
+        return orderedIds.map((id) => byId.get(id)).filter(Boolean) as AdHocExercise[]
+      })
+      if (currentId) {
+        const nextIdx = orderedIds.indexOf(currentId)
+        if (nextIdx >= 0) setCurrentIndex(nextIdx)
+      }
+      try {
+        await reorderAdHocExercises(completionId, orderedIds, {
+          onRetry: onRetryToast('Reordering exercises'),
+        })
+      } catch (err) {
+        clientLogger.error('Failed to reorder ad-hoc exercises:', err)
+        toast.error(
+          "Couldn't save order",
+          err instanceof FetchError && err.message
+            ? err.message
+            : 'Check your connection and try again.'
+        )
+      }
+    },
+    [completionId, currentIndex, exercises, onRetryToast, toast]
+  )
+
+  const handleJumpToExercise = useCallback(
+    (exerciseId: string) => {
+      const idx = exercises.findIndex((e) => e.id === exerciseId)
+      if (idx >= 0) {
+        setCurrentIndex(idx)
+        setCurrentSet(EMPTY_SET)
+        setExpandedInput(null)
+      }
+    },
+    [exercises]
+  )
+
+  const handlePlanSwap = useCallback(
+    (exerciseId: string) => {
+      const target = exercises.find((e) => e.id === exerciseId)
+      if (!target) return
+      setPlanEditorOpen(false)
+      setPickerMode({ kind: 'swap', replacingName: target.name, targetId: target.id })
+    },
+    [exercises]
+  )
+
+  const handlePlanDelete = useCallback(
+    (exerciseId: string) => {
+      setPlanEditorOpen(false)
+      void handleDeleteExercise(exerciseId)
+    },
+    [handleDeleteExercise]
+  )
+
+  const handlePlanAdd = useCallback(() => {
+    setPlanEditorOpen(false)
+    setPickerMode({ kind: 'add' })
+  }, [])
 
   const handleLogSet = useCallback(async () => {
     if (!currentExercise || isLoggingSet) return
@@ -638,6 +715,7 @@ export default function AdHocLoggerView({
           startedAt={startedAt}
           onCompleteWorkout={handleRequestComplete}
           onClose={handleClose}
+          onOpenPlanEditor={hasExercises ? () => setPlanEditorOpen(true) : undefined}
         />
 
         <div
@@ -758,6 +836,17 @@ export default function AdHocLoggerView({
           isBusy={pickerMode.kind === 'add' ? isAdding : isSwapping}
         />
       )}
+      <WorkoutPlanEditor
+        open={planEditorOpen}
+        onClose={() => setPlanEditorOpen(false)}
+        exercises={exercises.map((e) => ({ id: e.id, name: e.name }))}
+        currentExerciseId={exercises[currentIndex]?.id}
+        onReorder={handleReorderExercises}
+        onJump={handleJumpToExercise}
+        onAdd={handlePlanAdd}
+        onSwap={handlePlanSwap}
+        onDelete={handlePlanDelete}
+      />
       {showExitConfirm && (
         <ExitWorkoutConfirm
           hasUnsavedWork={totalLoggedSets > 0 || exercises.length > 0}
@@ -836,7 +925,7 @@ function EmptyState() {
 
 type PickerMode =
   | { kind: 'add' }
-  | { kind: 'swap'; replacingName: string }
+  | { kind: 'swap'; replacingName: string; targetId?: string }
 
 function ExercisePickerModal({
   mode,

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -18,11 +18,6 @@ import SetLoggingForm, {
   type ExpandedInput,
 } from '@/components/workout-logging/SetLoggingForm'
 import WorkoutPlanEditor from '@/components/workout-logging/WorkoutPlanEditor'
-import {
-  AdHocEmptyState,
-  AdHocExercisePickerModal,
-  type PickerMode,
-} from './AdHocExercisePickerModal'
 import { useIntensityAccess } from '@/hooks/useIntensityAccess'
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation'
 import {
@@ -40,6 +35,11 @@ import { FetchError } from '@/lib/api/fetch'
 import { clientLogger } from '@/lib/client-logger'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
+import {
+  AdHocEmptyState,
+  AdHocExercisePickerModal,
+  type PickerMode,
+} from './AdHocExercisePickerModal'
 
 export type AdHocExercise = {
   id: string

--- a/components/workout-logging/ExerciseLoggingHeader.tsx
+++ b/components/workout-logging/ExerciseLoggingHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { X } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
 import { useMemo } from 'react'
 import { useWorkoutTimer } from '@/hooks/useWorkoutTimer'
 
@@ -11,6 +11,7 @@ interface ExerciseLoggingHeaderProps {
   startedAt?: string | null
   onCompleteWorkout: () => void
   onClose: () => void
+  onOpenPlanEditor?: () => void
   modeToggle?: React.ReactNode
 }
 
@@ -18,22 +19,25 @@ function ProgressIndicator({ current, total }: { current: number; total: number 
   const useDoubleRow = total > 5
   const topCount = useDoubleRow ? Math.ceil(total / 2) : total
   const bottomCount = useDoubleRow ? total - topCount : 0
+  const barHeight = useDoubleRow ? 5 : 12
 
   const renderRow = (count: number, startIndex: number) => (
     <div className="flex gap-[3px]" style={{ width: '110px' }}>
       {Array.from({ length: count }, (_, i) => {
         const exerciseIndex = startIndex + i
+        const lit = exerciseIndex <= current
         return (
           <div
             key={exerciseIndex}
-            className="h-[5px] flex-1 transition-colors"
+            className="flex-1 transition-colors"
             style={{
-              backgroundColor: exerciseIndex <= current
+              height: barHeight,
+              backgroundColor: lit
                 ? 'var(--primary)'
-                : 'rgba(0,0,0,0.25)',
-              boxShadow: exerciseIndex <= current
-                ? undefined
-                : 'inset 0 1px 0 rgba(0,0,0,0.20)',
+                : 'rgba(16, 185, 129, 0.14)',
+              boxShadow: lit
+                ? 'inset 0 1px 0 rgba(255,255,255,0.28), 0 0 4px rgba(16,185,129,0.45)'
+                : 'inset 0 1px 1px rgba(0,0,0,0.40)',
             }}
           />
         )
@@ -56,6 +60,7 @@ export default function ExerciseLoggingHeader({
   startedAt,
   onCompleteWorkout,
   onClose,
+  onOpenPlanEditor,
   modeToggle,
 }: ExerciseLoggingHeaderProps) {
   const initialElapsed = useMemo(() => {
@@ -71,9 +76,45 @@ export default function ExerciseLoggingHeader({
       style={{ paddingTop: 'env(safe-area-inset-top)', boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.25)' }}
     >
       <div className="px-3 py-2.5 grid items-center gap-3" style={{ gridTemplateColumns: '1fr auto 1fr' }}>
-        {/* Left: progress indicator */}
+        {/* Left: progress indicator (button when editor wired) */}
         <div className="flex items-center">
-          <ProgressIndicator current={currentExerciseIndex} total={totalExercises} />
+          {onOpenPlanEditor ? (
+            <button
+              type="button"
+              onClick={onOpenPlanEditor}
+              aria-label="Edit workout plan"
+              className="group inline-flex items-center gap-2 p-1.5 doom-focus-ring transition-transform active:translate-y-[2px]"
+              style={{
+                backgroundColor: 'rgba(254, 243, 199, 0.06)',
+                boxShadow:
+                  'inset 0 1px 0 rgba(255,255,255,0.22), inset 0 -1px 0 rgba(0,0,0,0.35), 0 2px 0 rgba(0,0,0,0.40)',
+              }}
+            >
+              <Menu
+                size={18}
+                strokeWidth={2.5}
+                className="text-secondary-foreground/85 ml-0.5 sm:hidden"
+                aria-hidden="true"
+              />
+              <span
+                className="inline-flex items-center px-1.5 py-1 max-[359px]:hidden"
+                style={{
+                  backgroundColor: 'rgba(0,0,0,0.45)',
+                  boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.55), inset 0 0 0 1px rgba(0,0,0,0.25)',
+                }}
+              >
+                <ProgressIndicator current={currentExerciseIndex} total={totalExercises} />
+              </span>
+              <span
+                className="hidden sm:inline text-[10px] font-bold uppercase tracking-[0.15em] text-secondary-foreground/85 pr-1"
+                aria-hidden="true"
+              >
+                Plan
+              </span>
+            </button>
+          ) : (
+            <ProgressIndicator current={currentExerciseIndex} total={totalExercises} />
+          )}
           {failedSetCount > 0 && (
             <span className="ml-2 text-xs text-warning font-semibold">{failedSetCount} unsaved</span>
           )}

--- a/components/workout-logging/ExerciseQuickActionsMenu.tsx
+++ b/components/workout-logging/ExerciseQuickActionsMenu.tsx
@@ -71,7 +71,7 @@ export default function ExerciseQuickActionsMenu({
             sideOffset={8}
             align="end"
             collisionPadding={12}
-            className="z-[80] min-w-[260px] bg-card border-2 border-primary doom-corners shadow-[0_8px_32px_rgba(0,0,0,0.4)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+            className="z-[100] min-w-[260px] bg-card border-2 border-primary doom-corners shadow-[0_8px_32px_rgba(0,0,0,0.4)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
           >
             {heading && (
               <div className="px-4 py-2.5 border-b-2 border-border bg-primary/10">

--- a/components/workout-logging/WorkoutPlanEditor.tsx
+++ b/components/workout-logging/WorkoutPlanEditor.tsx
@@ -14,14 +14,12 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
-  useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { ChevronRight, GripVertical, Plus, RefreshCw, Settings, Trash2, X } from 'lucide-react'
+import { Plus, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
-import ExerciseQuickActionsMenu, { type QuickAction } from './ExerciseQuickActionsMenu'
+import { WorkoutPlanEditorRow } from './WorkoutPlanEditorRow'
 
 export type WorkoutPlanEditorExercise = {
   id: string
@@ -60,14 +58,13 @@ export default function WorkoutPlanEditor({
     setLocalOrder(exercises)
   }, [exercises])
 
-  // Close on Escape, but defer to any nested popper (Radix DropdownMenu calls
-  // preventDefault on Escape when it dismisses its own content). Without this
-  // guard, opening the gear menu and pressing Escape closes the editor too.
+  // Close on Escape, but defer to any nested popper (Radix DropdownMenu
+  // calls preventDefault on its own Escape handling) — checking
+  // defaultPrevented keeps the gear menu's Escape from closing the editor.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || e.defaultPrevented) return
-      onClose()
+      if (e.key === 'Escape' && !e.defaultPrevented) onClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -111,14 +108,20 @@ export default function WorkoutPlanEditor({
       role="dialog"
       aria-modal="true"
       aria-label="Workout plan editor"
-      className="fixed inset-0 z-[90] flex justify-start bg-black/40 backdrop-blur-md sm:items-center sm:justify-center"
+      className="fixed inset-0 z-[90] flex justify-start sm:items-center sm:justify-center"
       style={{ position: 'fixed', inset: 0 }}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
     >
+      {/* Backdrop as a real button so a11y rules are satisfied and screen
+          readers see an explicit dismissal target. The sheet sits above it. */}
+      <button
+        type="button"
+        aria-label="Close workout plan editor"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40 backdrop-blur-md cursor-default focus:outline-none"
+        tabIndex={-1}
+      />
       <div
-        className="bg-muted flex flex-col w-[88vw] max-w-[420px] h-[100dvh] border-r-2 border-border shadow-[8px_0_24px_rgba(0,0,0,0.25)] animate-in slide-in-from-left duration-200
+        className="relative bg-muted flex flex-col w-[88vw] max-w-[420px] h-[100dvh] border-r-2 border-border shadow-[8px_0_24px_rgba(0,0,0,0.25)] animate-in slide-in-from-left duration-200
                    sm:w-full sm:max-w-2xl sm:h-[85vh] sm:max-h-[85vh] sm:border-2 sm:shadow-xl sm:slide-in-from-bottom"
       >
       <EditorHeader onClose={onClose} />
@@ -135,7 +138,7 @@ export default function WorkoutPlanEditor({
             <SortableContext items={ids} strategy={verticalListSortingStrategy}>
               <ul className="flex flex-col gap-2.5" aria-busy={isReordering || undefined}>
                 {localOrder.map((exercise) => (
-                  <SortableRow
+                  <WorkoutPlanEditorRow
                     key={exercise.id}
                     exercise={exercise}
                     isCurrent={exercise.id === currentExerciseId}
@@ -158,18 +161,7 @@ export default function WorkoutPlanEditor({
           className="flex-shrink-0 bg-muted border-t-2 border-border px-3 pt-3"
           style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 12px)' }}
         >
-          <button
-            type="button"
-            onClick={onAdd}
-            className="w-full h-12 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-base flex items-center justify-center gap-2 doom-focus-ring transition-colors hover:bg-primary-hover active:translate-y-[2px]"
-            style={{
-              boxShadow:
-                'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 3px 0 var(--primary-active, #047857)',
-            }}
-          >
-            <Plus size={20} strokeWidth={2.5} />
-            Add exercise
-          </button>
+          <AddExerciseButton onClick={onAdd} block />
         </div>
       )}
       </div>
@@ -213,122 +205,6 @@ function EditorHeader({ onClose }: { onClose: () => void }) {
   )
 }
 
-type SortableRowProps = {
-  exercise: WorkoutPlanEditorExercise
-  isCurrent: boolean
-  onJump: () => void
-  onSwap: () => void
-  onDelete: () => void
-}
-
-function SortableRow({ exercise, isCurrent, onJump, onSwap, onDelete }: SortableRowProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: exercise.id,
-  })
-
-  const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    zIndex: isDragging ? 10 : undefined,
-  }
-
-  const menuActions: QuickAction[] = [
-    {
-      label: 'Swap exercise',
-      icon: RefreshCw,
-      onClick: onSwap,
-    },
-    {
-      label: 'Delete exercise',
-      icon: Trash2,
-      onClick: onDelete,
-      variant: 'danger',
-      requiresConfirmation: true,
-      confirmationMessage: `Are you sure you want to delete "${exercise.name}"?`,
-    },
-  ]
-
-  return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      className={`relative select-none transition-shadow ${
-        isCurrent ? 'doom-corners' : ''
-      } ${
-        isDragging
-          ? 'border-2 border-primary bg-card shadow-[0_10px_24px_rgba(0,0,0,0.30)] scale-[1.01]'
-          : isCurrent
-            ? 'border-2 border-border'
-            : 'border-2 border-border bg-card'
-      }`}
-      data-current={isCurrent || undefined}
-    >
-      {isCurrent && (
-        <>
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 pointer-events-none"
-            style={{ backgroundColor: 'rgba(16, 185, 129, 0.06)' }}
-          />
-          <div
-            aria-hidden="true"
-            className="absolute top-0 bottom-0 left-0 w-[6px] bg-secondary"
-            style={{ marginLeft: '-2px' }}
-          />
-        </>
-      )}
-      <div
-        className="relative flex items-stretch min-h-[52px]"
-        style={{
-          boxShadow: isDragging ? undefined : '0 2px 0 rgba(58, 40, 23, 0.18)',
-        }}
-      >
-        <button
-          type="button"
-          aria-label={`Drag to reorder ${exercise.name}`}
-          {...attributes}
-          {...listeners}
-          className="relative flex-shrink-0 w-11 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors doom-focus-ring touch-none cursor-grab active:cursor-grabbing"
-          style={{
-            touchAction: 'none',
-            backgroundColor: 'rgba(58, 40, 23, 0.04)',
-            boxShadow: 'inset -1px 0 0 rgba(58, 40, 23, 0.12), inset 0 1px 1px rgba(58, 40, 23, 0.06)',
-          }}
-        >
-          <GripVertical size={20} strokeWidth={2.25} />
-        </button>
-
-        <button
-          type="button"
-          onClick={onJump}
-          className="flex-1 min-w-0 flex items-center py-2.5 pl-3 pr-2 text-left doom-focus-ring"
-        >
-          <span className="min-w-0 inline-flex items-baseline gap-1.5 max-w-full">
-            <span className="truncate text-base font-bold uppercase tracking-wider text-foreground">
-              {exercise.name}
-            </span>
-            <ChevronRight
-              size={16}
-              strokeWidth={2.5}
-              className="flex-shrink-0 text-muted-foreground/70 self-center"
-            />
-          </span>
-        </button>
-
-        <div className="flex-shrink-0 flex items-center pr-1">
-          <ExerciseQuickActionsMenu
-            actions={menuActions}
-            triggerIcon={Settings}
-            triggerAriaLabel={`Edit options for ${exercise.name}`}
-            heading={exercise.name.toUpperCase()}
-            triggerClassName="h-11 w-11 text-muted-foreground hover:text-foreground"
-          />
-        </div>
-      </div>
-    </li>
-  )
-}
-
 function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
     <div className="h-full flex flex-col items-center justify-center text-center px-6">
@@ -338,18 +214,27 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
       <p className="text-muted-foreground text-sm mb-6 max-w-[280px]">
         Add an exercise to get started. Changes apply to today&apos;s session only.
       </p>
-      <button
-        type="button"
-        onClick={onAdd}
-        className="h-12 px-6 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-base flex items-center gap-2 doom-focus-ring transition-colors hover:bg-primary-hover active:translate-y-[2px]"
-        style={{
-          boxShadow:
-            'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 3px 0 var(--primary-active, #047857)',
-        }}
-      >
-        <Plus size={20} strokeWidth={2.5} />
-        Add exercise
-      </button>
+      <AddExerciseButton onClick={onAdd} />
     </div>
+  )
+}
+
+/** Primary "+ Add exercise" CTA. `block` stretches to fill its row (footer). */
+function AddExerciseButton({ onClick, block = false }: { onClick: () => void; block?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-12 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-base flex items-center gap-2 doom-focus-ring transition-colors hover:bg-primary-hover active:translate-y-[2px] ${
+        block ? 'w-full justify-center' : 'px-6'
+      }`}
+      style={{
+        boxShadow:
+          'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 3px 0 var(--primary-active, #047857)',
+      }}
+    >
+      <Plus size={20} strokeWidth={2.5} />
+      Add exercise
+    </button>
   )
 }

--- a/components/workout-logging/WorkoutPlanEditor.tsx
+++ b/components/workout-logging/WorkoutPlanEditor.tsx
@@ -1,0 +1,355 @@
+'use client'
+
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ChevronRight, GripVertical, Plus, RefreshCw, Settings, Trash2, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import ExerciseQuickActionsMenu, { type QuickAction } from './ExerciseQuickActionsMenu'
+
+export type WorkoutPlanEditorExercise = {
+  id: string
+  name: string
+}
+
+type WorkoutPlanEditorProps = {
+  open: boolean
+  onClose: () => void
+  exercises: WorkoutPlanEditorExercise[]
+  currentExerciseId?: string | null
+  isReordering?: boolean
+  onReorder: (orderedIds: string[]) => Promise<void> | void
+  onJump: (exerciseId: string) => void
+  onAdd: () => void
+  onSwap: (exerciseId: string) => void
+  onDelete: (exerciseId: string) => void
+}
+
+export default function WorkoutPlanEditor({
+  open,
+  onClose,
+  exercises,
+  currentExerciseId,
+  isReordering = false,
+  onReorder,
+  onJump,
+  onAdd,
+  onSwap,
+  onDelete,
+}: WorkoutPlanEditorProps) {
+  // Optimistic local order so drags feel instant; reconciles when `exercises` prop changes.
+  const [localOrder, setLocalOrder] = useState<WorkoutPlanEditorExercise[]>(exercises)
+
+  useEffect(() => {
+    setLocalOrder(exercises)
+  }, [exercises])
+
+  // Close on Escape, but defer to any nested popper (Radix DropdownMenu calls
+  // preventDefault on Escape when it dismisses its own content). Without this
+  // guard, opening the gear menu and pressing Escape closes the editor too.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return
+      onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  // Lock body scroll while open
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  const sensors = useSensors(
+    // Pointer activates after 5px to avoid eating taps.
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Touch activates after a 180ms press, so list scroll still wins by default.
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const ids = useMemo(() => localOrder.map((e) => e.id), [localOrder])
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = localOrder.findIndex((e) => e.id === active.id)
+    const newIndex = localOrder.findIndex((e) => e.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    const next = arrayMove(localOrder, oldIndex, newIndex)
+    setLocalOrder(next)
+    void onReorder(next.map((e) => e.id))
+  }
+
+  if (!open || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Workout plan editor"
+      className="fixed inset-0 z-[90] flex justify-start bg-black/40 backdrop-blur-md sm:items-center sm:justify-center"
+      style={{ position: 'fixed', inset: 0 }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="bg-muted flex flex-col w-[88vw] max-w-[420px] h-[100dvh] border-r-2 border-border shadow-[8px_0_24px_rgba(0,0,0,0.25)] animate-in slide-in-from-left duration-200
+                   sm:w-full sm:max-w-2xl sm:h-[85vh] sm:max-h-[85vh] sm:border-2 sm:shadow-xl sm:slide-in-from-bottom"
+      >
+      <EditorHeader onClose={onClose} />
+
+      <div className="flex-1 overflow-y-auto overscroll-contain px-3 py-3">
+        {localOrder.length === 0 ? (
+          <EmptyState onAdd={onAdd} />
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+              <ul className="flex flex-col gap-2.5" aria-busy={isReordering || undefined}>
+                {localOrder.map((exercise) => (
+                  <SortableRow
+                    key={exercise.id}
+                    exercise={exercise}
+                    isCurrent={exercise.id === currentExerciseId}
+                    onJump={() => {
+                      onJump(exercise.id)
+                      onClose()
+                    }}
+                    onSwap={() => onSwap(exercise.id)}
+                    onDelete={() => onDelete(exercise.id)}
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
+        )}
+      </div>
+
+      {localOrder.length > 0 && (
+        <div
+          className="flex-shrink-0 bg-muted border-t-2 border-border px-3 pt-3"
+          style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 12px)' }}
+        >
+          <button
+            type="button"
+            onClick={onAdd}
+            className="w-full h-12 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-base flex items-center justify-center gap-2 doom-focus-ring transition-colors hover:bg-primary-hover active:translate-y-[2px]"
+            style={{
+              boxShadow:
+                'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 3px 0 var(--primary-active, #047857)',
+            }}
+          >
+            <Plus size={20} strokeWidth={2.5} />
+            Add exercise
+          </button>
+        </div>
+      )}
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function EditorHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="bg-secondary text-secondary-foreground flex-shrink-0"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.25)',
+      }}
+    >
+      <div className="px-3 py-2.5 grid items-center gap-3" style={{ gridTemplateColumns: '1fr auto' }}>
+        <div className="min-w-0">
+          <div className="text-lg font-bold uppercase tracking-widest leading-tight">
+            Workout plan
+          </div>
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-secondary-foreground/70 leading-tight mt-0.5">
+            Drag to reorder · tap name to jump
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close workout plan editor"
+          className="h-9 w-9 flex items-center justify-center text-secondary-foreground/80 hover:text-secondary-foreground transition-colors doom-focus-ring"
+          style={{
+            backgroundColor: 'rgba(0,0,0,0.30)',
+            boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.45), inset 0 0 0 1px rgba(255,255,255,0.05)',
+          }}
+        >
+          <X size={18} strokeWidth={2.5} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+type SortableRowProps = {
+  exercise: WorkoutPlanEditorExercise
+  isCurrent: boolean
+  onJump: () => void
+  onSwap: () => void
+  onDelete: () => void
+}
+
+function SortableRow({ exercise, isCurrent, onJump, onSwap, onDelete }: SortableRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: exercise.id,
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  }
+
+  const menuActions: QuickAction[] = [
+    {
+      label: 'Swap exercise',
+      icon: RefreshCw,
+      onClick: onSwap,
+    },
+    {
+      label: 'Delete exercise',
+      icon: Trash2,
+      onClick: onDelete,
+      variant: 'danger',
+      requiresConfirmation: true,
+      confirmationMessage: `Are you sure you want to delete "${exercise.name}"?`,
+    },
+  ]
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`relative select-none transition-shadow ${
+        isCurrent ? 'doom-corners' : ''
+      } ${
+        isDragging
+          ? 'border-2 border-primary bg-card shadow-[0_10px_24px_rgba(0,0,0,0.30)] scale-[1.01]'
+          : isCurrent
+            ? 'border-2 border-border'
+            : 'border-2 border-border bg-card'
+      }`}
+      data-current={isCurrent || undefined}
+    >
+      {isCurrent && (
+        <>
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 pointer-events-none"
+            style={{ backgroundColor: 'rgba(16, 185, 129, 0.06)' }}
+          />
+          <div
+            aria-hidden="true"
+            className="absolute top-0 bottom-0 left-0 w-[6px] bg-secondary"
+            style={{ marginLeft: '-2px' }}
+          />
+        </>
+      )}
+      <div
+        className="relative flex items-stretch min-h-[52px]"
+        style={{
+          boxShadow: isDragging ? undefined : '0 2px 0 rgba(58, 40, 23, 0.18)',
+        }}
+      >
+        <button
+          type="button"
+          aria-label={`Drag to reorder ${exercise.name}`}
+          {...attributes}
+          {...listeners}
+          className="relative flex-shrink-0 w-11 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors doom-focus-ring touch-none cursor-grab active:cursor-grabbing"
+          style={{
+            touchAction: 'none',
+            backgroundColor: 'rgba(58, 40, 23, 0.04)',
+            boxShadow: 'inset -1px 0 0 rgba(58, 40, 23, 0.12), inset 0 1px 1px rgba(58, 40, 23, 0.06)',
+          }}
+        >
+          <GripVertical size={20} strokeWidth={2.25} />
+        </button>
+
+        <button
+          type="button"
+          onClick={onJump}
+          className="flex-1 min-w-0 flex items-center py-2.5 pl-3 pr-2 text-left doom-focus-ring"
+        >
+          <span className="min-w-0 inline-flex items-baseline gap-1.5 max-w-full">
+            <span className="truncate text-base font-bold uppercase tracking-wider text-foreground">
+              {exercise.name}
+            </span>
+            <ChevronRight
+              size={16}
+              strokeWidth={2.5}
+              className="flex-shrink-0 text-muted-foreground/70 self-center"
+            />
+          </span>
+        </button>
+
+        <div className="flex-shrink-0 flex items-center pr-1">
+          <ExerciseQuickActionsMenu
+            actions={menuActions}
+            triggerIcon={Settings}
+            triggerAriaLabel={`Edit options for ${exercise.name}`}
+            heading={exercise.name.toUpperCase()}
+            triggerClassName="h-11 w-11 text-muted-foreground hover:text-foreground"
+          />
+        </div>
+      </div>
+    </li>
+  )
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="h-full flex flex-col items-center justify-center text-center px-6">
+      <p className="text-foreground text-lg font-bold uppercase tracking-wider mb-2">
+        No exercises yet
+      </p>
+      <p className="text-muted-foreground text-sm mb-6 max-w-[280px]">
+        Add an exercise to get started. Changes apply to today&apos;s session only.
+      </p>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="h-12 px-6 bg-primary text-primary-foreground font-bold uppercase tracking-wider text-base flex items-center gap-2 doom-focus-ring transition-colors hover:bg-primary-hover active:translate-y-[2px]"
+        style={{
+          boxShadow:
+            'inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -2px 0 rgba(0,0,0,0.30), 0 3px 0 var(--primary-active, #047857)',
+        }}
+      >
+        <Plus size={20} strokeWidth={2.5} />
+        Add exercise
+      </button>
+    </div>
+  )
+}

--- a/components/workout-logging/WorkoutPlanEditorRow.tsx
+++ b/components/workout-logging/WorkoutPlanEditorRow.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ChevronRight, GripVertical, RefreshCw, Settings, Trash2 } from 'lucide-react'
+import ExerciseQuickActionsMenu, { type QuickAction } from './ExerciseQuickActionsMenu'
+import type { WorkoutPlanEditorExercise } from './WorkoutPlanEditor'
+
+type Props = {
+  exercise: WorkoutPlanEditorExercise
+  isCurrent: boolean
+  onJump: () => void
+  onSwap: () => void
+  onDelete: () => void
+}
+
+/**
+ * A draggable, jumpable, gear-menu row inside the WorkoutPlanEditor list.
+ *
+ * Lives in its own file to keep the editor shell readable — the row owns
+ * dnd-kit wiring, the layered "current row" cues (brackets + brown stripe
+ * + mint wash), and the inline gear menu. Nothing here is exported beyond
+ * this component.
+ */
+export function WorkoutPlanEditorRow({
+  exercise,
+  isCurrent,
+  onJump,
+  onSwap,
+  onDelete,
+}: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: exercise.id,
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  }
+
+  const menuActions: QuickAction[] = [
+    { label: 'Swap exercise', icon: RefreshCw, onClick: onSwap },
+    {
+      label: 'Delete exercise',
+      icon: Trash2,
+      onClick: onDelete,
+      variant: 'danger',
+      requiresConfirmation: true,
+      confirmationMessage: `Are you sure you want to delete "${exercise.name}"?`,
+    },
+  ]
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`relative select-none transition-shadow ${
+        isCurrent ? 'doom-corners border-2 border-border' : 'border-2 border-border bg-card'
+      } ${
+        isDragging
+          ? 'border-primary bg-card shadow-[0_10px_24px_rgba(0,0,0,0.30)] scale-[1.01]'
+          : ''
+      }`}
+      data-current={isCurrent || undefined}
+    >
+      {isCurrent && <CurrentRowCues />}
+      <div
+        className="relative flex items-stretch min-h-[52px]"
+        style={{ boxShadow: isDragging ? undefined : '0 2px 0 rgba(58, 40, 23, 0.18)' }}
+      >
+        <button
+          type="button"
+          aria-label={`Drag to reorder ${exercise.name}`}
+          {...attributes}
+          {...listeners}
+          className="relative flex-shrink-0 w-11 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors doom-focus-ring touch-none cursor-grab active:cursor-grabbing"
+          style={{
+            touchAction: 'none',
+            backgroundColor: 'rgba(58, 40, 23, 0.04)',
+            boxShadow:
+              'inset -1px 0 0 rgba(58, 40, 23, 0.12), inset 0 1px 1px rgba(58, 40, 23, 0.06)',
+          }}
+        >
+          <GripVertical size={20} strokeWidth={2.25} />
+        </button>
+
+        <button
+          type="button"
+          onClick={onJump}
+          className="flex-1 min-w-0 flex items-center py-2.5 pl-3 pr-2 text-left doom-focus-ring"
+        >
+          <span className="min-w-0 inline-flex items-baseline gap-1.5 max-w-full">
+            <span className="truncate text-base font-bold uppercase tracking-wider text-foreground">
+              {exercise.name}
+            </span>
+            <ChevronRight
+              size={16}
+              strokeWidth={2.5}
+              className="flex-shrink-0 text-muted-foreground/70 self-center"
+            />
+          </span>
+        </button>
+
+        <div className="flex-shrink-0 flex items-center pr-1">
+          <ExerciseQuickActionsMenu
+            actions={menuActions}
+            triggerIcon={Settings}
+            triggerAriaLabel={`Edit options for ${exercise.name}`}
+            heading={exercise.name.toUpperCase()}
+            triggerClassName="h-11 w-11 text-muted-foreground hover:text-foreground"
+          />
+        </div>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * The three coordinated cues that mark a row as the active exercise: mint
+ * wash overlay + the documented `border-l-4` brown stripe + (via the
+ * parent's `doom-corners` class) the L-bracket frame.
+ */
+function CurrentRowCues() {
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 pointer-events-none"
+        style={{ backgroundColor: 'rgba(16, 185, 129, 0.06)' }}
+      />
+      <div
+        aria-hidden="true"
+        className="absolute top-0 bottom-0 left-0 w-[6px] bg-secondary"
+        style={{ marginLeft: '-2px' }}
+      />
+    </>
+  )
+}

--- a/lib/api/adhoc-workout.ts
+++ b/lib/api/adhoc-workout.ts
@@ -97,6 +97,24 @@ export async function deleteAdHocExercise(
   )
 }
 
+export async function reorderAdHocExercises(
+  completionId: string,
+  orderedIds: string[],
+  retry: RetryOpts = {}
+): Promise<void> {
+  await fetchJsonWithRetry<{ success: boolean }>(
+    `/api/workouts/adhoc/${completionId}/exercises/reorder`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        exercises: orderedIds.map((exerciseId, idx) => ({ exerciseId, order: idx + 1 })),
+      }),
+    },
+    retry
+  )
+}
+
 export async function logAdHocSet(
   completionId: string,
   set: {


### PR DESCRIPTION
## Summary
- Turns the logger header's progress indicator into an editor trigger. Opens a full-screen plan editor where users can drag-reorder exercises, tap a name to jump to it, and add / swap / delete from one surface.
- Works for both the program logger (`ExerciseLoggingModal`) and the ad-hoc logger (`AdHocLoggerView`). Reuses the existing add/swap/delete wizards and `/exercises/reorder` route for the program path; new `/api/workouts/adhoc/[completionId]/exercises/reorder` covers the ad-hoc path.
- Responsive: on mobile the editor slides in from the left as a sidebar, with the hamburger sitting left of the LCD bars inside a raised bezel; on screens ≤359px the LCD collapses out and only the hamburger remains. Desktop keeps the "PLAN" label and a centered modal.

## Editor styling notes
- Per the cartridge-era theme: corner brackets are now a **selected-state** cue (current row only), paired with the documented brown left stripe and a faint mint wash. Inactive rows are plain bracketed-bordered cards with a recessed grip column.
- Indicator-as-button reads as a raised bezel containing a recessed LCD screen — unlit segments are dim olive, lit segments carry a top highlight and subtle outer glow. The whole bezel depresses on tap, matching `FINISH` / X button language.

## Commits
1. **feat**: the editor itself + all the wiring
2. **refactor(adhoc)**: extracted the search-picker modal and tip-style empty state out of `AdHocLoggerView` (was 1056 lines, now ~900) into a sibling file with a clearer home
3. **refactor(workout-editor)**: extracted `SortableRow` into its own file and folded two identical "Add exercise" CTAs into a single `AddExerciseButton` helper; rewrote backdrop dismissal as a real labelled `<button>` so a11y rules pass without suppressions

## Test plan
- [ ] Open a program workout with ≥3 exercises and tap the indicator → editor opens
- [ ] Drag a row to reorder; current-exercise marker follows the row
- [ ] Tap a row name → editor closes and logger advances to that exercise
- [ ] Use gear → Swap; the swap wizard targets the row you picked (not the current exercise)
- [ ] Use gear → Delete; destructive-confirm appears for the picked row
- [ ] Tap "+ Add exercise" → existing add wizard opens
- [ ] Repeat in an ad-hoc workout — reorder hits the new `/api/workouts/adhoc/[id]/exercises/reorder` route
- [ ] Verify at 320×568 (iPhone SE), 390×844, and 1280×900: indicator collapses to hamburger-only on the smallest size
- [ ] Backdrop click and Escape close the editor; Escape inside an open gear dropdown closes only the dropdown
- [ ] Keyboard reorder via dnd-kit's `KeyboardSensor` (Space + arrow keys on a focused handle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)