### PR TITLE
fix(editor): keep workout plan sidebar below iOS safe area

### DIFF
--- a/components/workout-logging/WorkoutPlanEditor.tsx
+++ b/components/workout-logging/WorkoutPlanEditor.tsx
@@ -121,8 +121,8 @@ export default function WorkoutPlanEditor({
         tabIndex={-1}
       />
       <div
-        className="relative bg-muted flex flex-col w-[88vw] max-w-[420px] h-[100dvh] border-r-2 border-border shadow-[8px_0_24px_rgba(0,0,0,0.25)] animate-in slide-in-from-left duration-200
-                   sm:w-full sm:max-w-2xl sm:h-[85vh] sm:max-h-[85vh] sm:border-2 sm:shadow-xl sm:slide-in-from-bottom"
+        className="relative bg-muted flex flex-col w-[88vw] max-w-[420px] mt-[env(safe-area-inset-top)] h-[calc(100dvh-env(safe-area-inset-top))] border-r-2 border-border shadow-[8px_0_24px_rgba(0,0,0,0.25)] animate-in slide-in-from-left duration-200
+                   sm:w-full sm:max-w-2xl sm:h-[85vh] sm:max-h-[85vh] sm:mt-0 sm:border-2 sm:shadow-xl sm:slide-in-from-bottom"
       >
       <EditorHeader onClose={onClose} />
 
@@ -175,7 +175,6 @@ function EditorHeader({ onClose }: { onClose: () => void }) {
     <div
       className="bg-secondary text-secondary-foreground flex-shrink-0"
       style={{
-        paddingTop: 'env(safe-area-inset-top)',
         boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.25)',
       }}
     >


### PR DESCRIPTION
## Summary

Fixes #858 — the workout plan editor sidebar (program logger + ad-hoc logger) was painting its right border, shadow, and background through the iOS status bar / notch area at the top of the screen.

The container used `h-[100dvh]` and a `paddingTop: env(safe-area-inset-top)` was applied only to the inner header (so its text avoided the notch). The sidebar surface itself still extended edge-to-edge from the very top of the viewport, so the right border and drop shadow drew over the iOS notification area.

## Change

- Shift the sidebar container down by `env(safe-area-inset-top)` on mobile (`mt-[env(safe-area-inset-top)]`) and reduce height accordingly (`h-[calc(100dvh-env(safe-area-inset-top))]`)
- Drop the now-redundant `paddingTop: env(safe-area-inset-top)` from the header to avoid double-counting
- Preserve desktop centered-modal layout via existing `sm:` overrides (`sm:mt-0 sm:h-[85vh]`)

One-file, ~5-line change to `components/workout-logging/WorkoutPlanEditor.tsx`.

## Test plan

- [x] Open program logger on iOS Safari → tap LCD/hamburger → sidebar slides in from the left, but its right border and shadow stop below the notch
- [x] Same on ad-hoc logger
- [x] Header title/close button remain vertically positioned (not double-padded)
- [x] Desktop ≥640px still shows centered modal at `85vh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)