### PR TITLE
chore(logging): surface silent /api/settings persistence failures

### DIFF
--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -111,7 +111,9 @@ export default function ExerciseLoggingModal({
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ loggingMode: 'full' }),
-    }).catch(() => {})
+    }).catch((err) => {
+      clientLogger.error('Failed to persist loggingMode=full from switch-to-logging', err)
+    })
   }, [])
 
   // Tip rotation — sequential through array order, then random
@@ -298,7 +300,10 @@ export default function ExerciseLoggingModal({
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ loggingMode: 'full' }),
-      }).catch(() => {}) // fire-and-forget
+      }).catch((err) => {
+        // fire-and-forget — log so we can diagnose persistence drift without surfacing to the user
+        clientLogger.error('Failed to auto-persist loggingMode=full after first logged set', err)
+      })
     }
 
     // Pre-fill for next set: reps from next prescribed, weight carried forward


### PR DESCRIPTION
## Summary
- Two fire-and-forget \`PUT /api/settings\` calls in \`ExerciseLoggingModal\` were catching errors into empty arrows, leaving us blind when \`loggingMode\` persistence drops on flaky gym wifi.
- Both now route the rejection through \`clientLogger.error\` with context so we can diagnose \"the app forgot my setting\" reports.
- No UX change — still fire-and-forget. Full toast/retry treatment is tracked in #862.

## Test plan
- [x] \`npm run type-check\` clean
- [x] No new lint issues in changed file
- [ ] Spot-check: switch to follow-along, log a set, confirm \`/api/settings\` PUT fires and that simulated network failure shows the new error in console

## Deferred follow-ups filed this run
- #860 — wizards lack retry/backoff for 5xx + network errors (medium)
- #861 — exercise propagation loops N round-trips inside tx (medium)
- #862 — \`/api/settings\` swallow needs toast/retry (this PR covers the logging slice only) (low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)