### PR TITLE
Add muscle balance targets for ad hoc workouts

### DIFF
--- a/__tests__/api/muscle-balance.test.ts
+++ b/__tests__/api/muscle-balance.test.ts
@@ -1,0 +1,168 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  calculateMuscleBalanceSnapshot,
+  getDefaultMuscleBalanceTargets,
+  getMuscleBalanceSnapshot,
+  normalizeMuscleBalanceSettings,
+} from '@/lib/muscle-balance'
+import { getTestDatabase } from '@/lib/test/database'
+import { createTestExerciseDefinition, createTestUser } from '@/lib/test/factories'
+
+describe('Muscle balance calculations', () => {
+  it('applies warmup exclusion and secondary set weighting', () => {
+    const settings = normalizeMuscleBalanceSettings({
+      targets: getDefaultMuscleBalanceTargets(),
+      lookbackWorkouts: 8,
+      includeSecondary: true,
+      secondaryWeight: 0.5,
+      excludeWarmups: true,
+    })
+
+    const snapshot = calculateMuscleBalanceSnapshot(settings, [
+      {
+        loggedSets: [
+          {
+            isWarmup: false,
+            exercise: {
+              exerciseDefinition: {
+                primaryFAUs: ['chest'],
+                secondaryFAUs: ['triceps'],
+              },
+            },
+          },
+          {
+            isWarmup: true,
+            exercise: {
+              exerciseDefinition: {
+                primaryFAUs: ['chest'],
+                secondaryFAUs: ['triceps'],
+              },
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(snapshot.items.find((item) => item.fau === 'chest')?.actualSets).toBe(1)
+    expect(snapshot.items.find((item) => item.fau === 'triceps')?.actualSets).toBe(0.5)
+    expect(snapshot.lookback.totalEffectiveSets).toBe(1.5)
+  })
+})
+
+describe('Muscle balance persistence', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('creates default settings and includes every FAU in the snapshot', async () => {
+    const snapshot = await getMuscleBalanceSnapshot(prisma, userId)
+
+    expect(snapshot.settings.lookbackWorkouts).toBe(8)
+    expect(snapshot.items).toHaveLength(18)
+    expect(snapshot.items.find((item) => item.fau === 'side-delts')).toBeTruthy()
+    expect(snapshot.items.some((item) => String(item.fau) === 'neck')).toBe(false)
+  })
+
+  it('uses the last N completed strength workouts', async () => {
+    const chestDefinition = await createTestExerciseDefinition(prisma, {
+      name: `Chest Press ${Date.now()}`,
+      primaryFAUs: ['chest'],
+      secondaryFAUs: ['triceps'],
+    })
+    const sideDeltDefinition = await createTestExerciseDefinition(prisma, {
+      name: `Lateral Raise ${Date.now()}`,
+      primaryFAUs: ['side-delts'],
+      secondaryFAUs: [],
+    })
+
+    await prisma.userMuscleBalanceSettings.create({
+      data: {
+        userId,
+        targets: getDefaultMuscleBalanceTargets(),
+        lookbackWorkouts: 1,
+        includeSecondary: true,
+        secondaryWeight: 0.5,
+        excludeWarmups: true,
+      },
+    })
+
+    await createCompletedWorkout(prisma, userId, sideDeltDefinition.id, 4, {
+      completedAt: new Date('2026-01-01T00:00:00Z'),
+    })
+    await createCompletedWorkout(prisma, userId, chestDefinition.id, 4, {
+      completedAt: new Date('2026-01-02T00:00:00Z'),
+    })
+    await createCompletedWorkout(prisma, userId, sideDeltDefinition.id, 10, {
+      completedAt: new Date('2026-01-03T00:00:00Z'),
+      status: 'draft',
+    })
+
+    const snapshot = await getMuscleBalanceSnapshot(prisma, userId)
+    const chest = snapshot.items.find((item) => item.fau === 'chest')
+    const sideDelts = snapshot.items.find((item) => item.fau === 'side-delts')
+
+    expect(snapshot.lookback.completedWorkouts).toBe(1)
+    expect(chest?.actualSets).toBe(4)
+    expect(sideDelts?.actualSets).toBe(0)
+    expect(sideDelts?.status).toBe('neglected')
+  })
+
+})
+
+async function createCompletedWorkout(
+  prisma: PrismaClient,
+  userId: string,
+  exerciseDefinitionId: string,
+  setCount: number,
+  options: {
+    completedAt: Date
+    status?: 'completed' | 'draft'
+  }
+) {
+  const completion = await prisma.workoutCompletion.create({
+    data: {
+      userId,
+      status: options.status ?? 'completed',
+      isAdHoc: true,
+      completedAt: options.completedAt,
+      startedAt: options.completedAt,
+      name: 'Test Workout',
+    },
+  })
+  const definition = await prisma.exerciseDefinition.findUniqueOrThrow({
+    where: { id: exerciseDefinitionId },
+  })
+  const exercise = await prisma.exercise.create({
+    data: {
+      userId,
+      name: definition.name,
+      order: 1,
+      exerciseDefinitionId,
+      workoutCompletionId: completion.id,
+      isOneOff: true,
+    },
+  })
+
+  for (let setNumber = 1; setNumber <= setCount; setNumber += 1) {
+    await prisma.loggedSet.create({
+      data: {
+        userId,
+        completionId: completion.id,
+        exerciseId: exercise.id,
+        setNumber,
+        reps: 10,
+        weight: 50,
+        weightUnit: 'lbs',
+      },
+    })
+  }
+}

--- a/app/(app)/settings/muscle-balance/page.tsx
+++ b/app/(app)/settings/muscle-balance/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation'
+import MuscleBalanceSettingsEditor from '@/components/features/muscle-balance/MuscleBalanceSettingsEditor'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { getMuscleBalanceSnapshot } from '@/lib/muscle-balance'
+
+export default async function MuscleBalanceSettingsPage() {
+  const { user, error } = await getCurrentUser()
+
+  if (error || !user) {
+    redirect('/login')
+  }
+
+  const snapshot = await getMuscleBalanceSnapshot(prisma, user.id)
+
+  return <MuscleBalanceSettingsEditor initialSnapshot={snapshot} />
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -293,9 +293,6 @@ export default function SettingsPage() {
                     </span>
                   </span>
                 </span>
-                <span className="text-lg font-bold" aria-hidden="true">
-                  &gt;
-                </span>
               </Link>
             </div>
 

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
+import { Dumbbell, Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -273,6 +273,31 @@ export default function SettingsPage() {
                 {error}
               </div>
             )}
+
+            <div className="pt-4 border-t border-border">
+              <span className="block text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                Training Targets
+              </span>
+              <Link
+                href="/settings/muscle-balance"
+                className="flex min-h-14 items-center justify-between gap-3 border-2 border-border bg-card px-4 py-3 text-foreground transition-colors doom-focus-ring hover:border-primary hover:bg-muted/50"
+              >
+                <span className="flex items-center gap-3">
+                  <Dumbbell size={18} aria-hidden="true" />
+                  <span>
+                    <span className="block text-sm font-bold uppercase tracking-wider">
+                      Muscle Balance
+                    </span>
+                    <span className="block text-sm text-muted-foreground">
+                      Set FAU ratios for ad-hoc exercise guidance.
+                    </span>
+                  </span>
+                </span>
+                <span className="text-lg font-bold" aria-hidden="true">
+                  &gt;
+                </span>
+              </Link>
+            </div>
 
             {/* Account Section */}
             <div className="pt-4 border-t border-border space-y-4">

--- a/app/(app)/training/adhoc/[completionId]/page.tsx
+++ b/app/(app)/training/adhoc/[completionId]/page.tsx
@@ -4,6 +4,7 @@ import AdHocLoggerView, { type AdHocExercise } from '@/components/adhoc/AdHocLog
 import { RestoringWorkoutSpinner } from '@/components/ui/RestoringWorkoutSpinner'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
+import { getMuscleBalanceSnapshot } from '@/lib/muscle-balance'
 
 type Props = {
   params: Promise<{ completionId: string }>
@@ -40,49 +41,52 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
     redirect('/login')
   }
 
-  const completion = await prisma.workoutCompletion.findUnique({
-    where: { id: completionId },
-    select: {
-      id: true,
-      userId: true,
-      status: true,
-      isAdHoc: true,
-      name: true,
-      startedAt: true,
-      exercises: {
-        orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          name: true,
-          notes: true,
-          order: true,
-          exerciseDefinition: {
-            select: {
-              primaryFAUs: true,
-              secondaryFAUs: true,
-              equipment: true,
-              instructions: true,
-              imageUrls: true,
+  const [completion, muscleBalanceSnapshot] = await Promise.all([
+    prisma.workoutCompletion.findUnique({
+      where: { id: completionId },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+        isAdHoc: true,
+        name: true,
+        startedAt: true,
+        exercises: {
+          orderBy: { order: 'asc' },
+          select: {
+            id: true,
+            name: true,
+            notes: true,
+            order: true,
+            exerciseDefinition: {
+              select: {
+                primaryFAUs: true,
+                secondaryFAUs: true,
+                equipment: true,
+                instructions: true,
+                imageUrls: true,
+              },
             },
           },
         },
-      },
-      loggedSets: {
-        orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }],
-        select: {
-          id: true,
-          exerciseId: true,
-          setNumber: true,
-          reps: true,
-          weight: true,
-          weightUnit: true,
-          rpe: true,
-          rir: true,
-          isWarmup: true,
+        loggedSets: {
+          orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }],
+          select: {
+            id: true,
+            exerciseId: true,
+            setNumber: true,
+            reps: true,
+            weight: true,
+            weightUnit: true,
+            rpe: true,
+            rir: true,
+            isWarmup: true,
+          },
         },
       },
-    },
-  })
+    }),
+    getMuscleBalanceSnapshot(prisma, user.id),
+  ])
 
   if (!completion || completion.userId !== user.id || !completion.isAdHoc) {
     redirect('/training')
@@ -112,6 +116,7 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
       startedAt={completion.startedAt?.toISOString() ?? null}
       initialExercises={exercises}
       initialLoggedSets={completion.loggedSets}
+      muscleBalanceSnapshot={muscleBalanceSnapshot}
     />
   )
 }

--- a/app/api/settings/muscle-balance/route.ts
+++ b/app/api/settings/muscle-balance/route.ts
@@ -1,0 +1,134 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import {
+  getMuscleBalanceSnapshot,
+  isFAUKey,
+  updateMuscleBalanceSettings,
+  type MuscleBalanceTargets,
+} from '@/lib/muscle-balance'
+import {
+  checkRateLimitWithHeaders,
+  programManagementLimiter,
+} from '@/lib/rate-limit'
+
+type UpdateMuscleBalanceRequest = {
+  targets?: Record<string, unknown>
+  lookbackWorkouts?: unknown
+  includeSecondary?: unknown
+  secondaryWeight?: unknown
+  excludeWarmups?: unknown
+}
+
+export async function GET(_request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const snapshot = await getMuscleBalanceSnapshot(prisma, user.id)
+    return NextResponse.json({ success: true, snapshot })
+  } catch (error) {
+    logger.error(
+      { error, context: 'muscle-balance-get' },
+      'Failed to fetch muscle balance settings'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimitWithHeaders(
+      programManagementLimiter,
+      user.id,
+      { endpoint: 'settings/muscle-balance' }
+    )
+    if (limited.response) return limited.response
+
+    const body = (await request.json()) as UpdateMuscleBalanceRequest
+    const validationError = validateUpdateRequest(body)
+    if (validationError) {
+      return NextResponse.json(
+        { error: validationError },
+        { status: 400, headers: limited.headers }
+      )
+    }
+
+    await updateMuscleBalanceSettings(prisma, user.id, {
+      targets: body.targets as MuscleBalanceTargets | undefined,
+      lookbackWorkouts: body.lookbackWorkouts as number | undefined,
+      includeSecondary: body.includeSecondary as boolean | undefined,
+      secondaryWeight: body.secondaryWeight as number | undefined,
+      excludeWarmups: body.excludeWarmups as boolean | undefined,
+    })
+
+    const snapshot = await getMuscleBalanceSnapshot(prisma, user.id)
+    return NextResponse.json(
+      { success: true, snapshot },
+      { headers: limited.headers }
+    )
+  } catch (error) {
+    logger.error(
+      { error, context: 'muscle-balance-update' },
+      'Failed to update muscle balance settings'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+function validateUpdateRequest(body: UpdateMuscleBalanceRequest): string | null {
+  if (body.targets !== undefined) {
+    if (!body.targets || typeof body.targets !== 'object' || Array.isArray(body.targets)) {
+      return 'Targets must be an object keyed by muscle group'
+    }
+    for (const [fau, value] of Object.entries(body.targets)) {
+      if (!isFAUKey(fau)) return `Invalid muscle group: ${fau}`
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return `Target for ${fau} must be a number`
+      }
+      if (value < 0 || value > 2) {
+        return `Target for ${fau} must be between 0 and 2`
+      }
+    }
+  }
+
+  if (
+    body.lookbackWorkouts !== undefined &&
+    (!Number.isInteger(body.lookbackWorkouts) ||
+      (body.lookbackWorkouts as number) < 1 ||
+      (body.lookbackWorkouts as number) > 52)
+  ) {
+    return 'Lookback workouts must be an integer between 1 and 52'
+  }
+
+  if (
+    body.secondaryWeight !== undefined &&
+    (typeof body.secondaryWeight !== 'number' ||
+      !Number.isFinite(body.secondaryWeight) ||
+      body.secondaryWeight < 0 ||
+      body.secondaryWeight > 1)
+  ) {
+    return 'Secondary weight must be between 0 and 1'
+  }
+
+  if (
+    body.includeSecondary !== undefined &&
+    typeof body.includeSecondary !== 'boolean'
+  ) {
+    return 'includeSecondary must be a boolean'
+  }
+
+  if (body.excludeWarmups !== undefined && typeof body.excludeWarmups !== 'boolean') {
+    return 'excludeWarmups must be a boolean'
+  }
+
+  return null
+}

--- a/components/adhoc/AdHocExercisePickerModal.tsx
+++ b/components/adhoc/AdHocExercisePickerModal.tsx
@@ -1,14 +1,12 @@
 'use client'
 
 import { Sparkles } from 'lucide-react'
-import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   type ExerciseDefinition,
   ExerciseSearchInterface,
 } from '@/components/exercise-selection/ExerciseSearchInterface'
 import ExerciseDefinitionEditorModal from '@/components/features/exercise-definition/ExerciseDefinitionEditorModal'
-import MuscleBalancePanel from '@/components/features/muscle-balance/MuscleBalancePanel'
 import type { MuscleBalanceSnapshot } from '@/components/features/muscle-balance/types'
 import { Button } from '@/components/ui/Button'
 import {
@@ -21,29 +19,18 @@ import {
   DialogTitle,
 } from '@/components/ui/radix/dialog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
-import type { FAUKey } from '@/lib/fau-volume'
+import { ALL_FAUS, type FAUKey } from '@/lib/fau-volume'
+
+const HYPOTHETICAL_SETS_PER_EXERCISE = 3
 
 export type PickerMode =
-  | { kind: 'add'; initialFau?: FAUKey }
+  | { kind: 'add' }
   | { kind: 'swap'; replacingName: string; targetId?: string }
 
-export function AdHocEmptyState({
-  muscleBalanceSnapshot,
-  onSelectFAU,
-}: {
-  muscleBalanceSnapshot: MuscleBalanceSnapshot
-  onSelectFAU: (fau: FAUKey) => void
-}) {
-  const [balanceOpen, setBalanceOpen] = useState(false)
-  const topNeglected = muscleBalanceSnapshot.neglected.slice(0, 3)
-  const neglectedLabel =
-    topNeglected.length > 0
-      ? topNeglected.map((item) => item.label).join(', ')
-      : 'No clear laggards yet'
-
+export function AdHocEmptyState() {
   return (
     <div className="flex-1 overflow-auto px-5 py-6">
-      <div className="mx-auto flex min-h-full max-w-xl flex-col justify-center gap-5">
+      <div className="mx-auto flex min-h-full max-w-xl items-center">
         <div className="flex min-h-[34vh] items-center">
           <TipAnnotation
             icon={<Sparkles aria-hidden="true" size={20} strokeWidth={1.8} />}
@@ -53,48 +40,6 @@ export function AdHocEmptyState({
             </span>
           </TipAnnotation>
         </div>
-
-        <section className="border-t-2 border-border pt-4">
-          <button
-            type="button"
-            onClick={() => setBalanceOpen((open) => !open)}
-            className="flex min-h-12 w-full items-center justify-between gap-3 text-left doom-focus-ring"
-            aria-expanded={balanceOpen}
-          >
-            <span>
-              <span className="block text-lg font-bold uppercase tracking-wider text-accent sm:text-xl">
-                Muscle Balance
-              </span>
-              <span className="block text-sm text-muted-foreground">
-                Suggested focus: {neglectedLabel}
-              </span>
-            </span>
-            <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">
-              {balanceOpen ? 'Hide' : 'Show'}
-            </span>
-          </button>
-
-          <p className="mt-3 text-sm text-muted-foreground">
-            Edit targets in{' '}
-            <Link
-              href="/settings/muscle-balance"
-              className="font-bold uppercase tracking-wider text-foreground underline decoration-border underline-offset-4 doom-focus-ring hover:text-primary"
-            >
-              Settings &gt; Muscle Balance
-            </Link>
-            .
-          </p>
-
-          {balanceOpen && (
-            <div className="mt-4">
-              <MuscleBalancePanel
-                snapshot={muscleBalanceSnapshot}
-                compact
-                onSelectFAU={onSelectFAU}
-              />
-            </div>
-          )}
-        </section>
       </div>
     </div>
   )
@@ -106,6 +51,10 @@ type Props = {
   onConfirm: (defs: ExerciseDefinition[]) => void
   isBusy: boolean
   muscleBalanceSnapshot: MuscleBalanceSnapshot
+  plannedExerciseDefinitions?: Array<{
+    primaryFAUs: string[]
+    secondaryFAUs: string[]
+  }>
 }
 
 export function AdHocExercisePickerModal({
@@ -114,14 +63,19 @@ export function AdHocExercisePickerModal({
   onConfirm,
   isBusy,
   muscleBalanceSnapshot,
+  plannedExerciseDefinitions = [],
 }: Props) {
   const isAdd = mode.kind === 'add'
   const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
   const selectedIds = new Set(selectedDefs.map((d) => d.id))
   const [showCreateModal, setShowCreateModal] = useState(false)
-  const [balanceOpen, setBalanceOpen] = useState(isAdd && !!mode.initialFau)
-  const [activeFau, setActiveFau] = useState<FAUKey | null>(
-    mode.kind === 'add' ? mode.initialFau ?? null : null
+  const plannedFAUVolume = useMemo(
+    () =>
+      calculatePlannedFAUVolume(
+        [...plannedExerciseDefinitions, ...selectedDefs],
+        muscleBalanceSnapshot
+      ),
+    [plannedExerciseDefinitions, selectedDefs, muscleBalanceSnapshot]
   )
 
   const handleAddToggle = useCallback((def: ExerciseDefinition) => {
@@ -170,38 +124,12 @@ export function AdHocExercisePickerModal({
         </DialogHeader>
 
         <DialogBody className="flex-1 min-h-0">
-          {isAdd && (
-            <div className="border-b border-border bg-muted/30 px-4 py-3 sm:px-6">
-              <button
-                type="button"
-                onClick={() => setBalanceOpen((value) => !value)}
-                className="flex min-h-11 w-full items-center justify-between gap-3 text-left font-bold uppercase tracking-wider text-foreground doom-focus-ring"
-              >
-                <span>Muscle Balance</span>
-                <span className="text-sm text-muted-foreground">
-                  {balanceOpen ? 'Hide' : 'Show'}
-                </span>
-              </button>
-              {balanceOpen && (
-                <div className="mt-3">
-                  <MuscleBalancePanel
-                    snapshot={muscleBalanceSnapshot}
-                    compact
-                    onSelectFAU={(fau) => {
-                      setActiveFau(fau)
-                      setBalanceOpen(false)
-                    }}
-                  />
-                </div>
-              )}
-            </div>
-          )}
           <ExerciseSearchInterface
-            key={activeFau ?? 'all'}
             onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
             selectedIds={isAdd ? selectedIds : undefined}
             preloadExercises
-            initialFauFilter={activeFau}
+            muscleBalanceSnapshot={isAdd ? muscleBalanceSnapshot : undefined}
+            plannedFAUVolume={isAdd ? plannedFAUVolume : undefined}
           />
         </DialogBody>
 
@@ -261,4 +189,37 @@ export function AdHocExercisePickerModal({
       />
     </Dialog>
   )
+}
+
+function calculatePlannedFAUVolume(
+  definitions: Array<{ primaryFAUs: string[]; secondaryFAUs: string[] }>,
+  snapshot: MuscleBalanceSnapshot
+): Partial<Record<FAUKey, number>> {
+  const volume = ALL_FAUS.reduce((acc, fau) => {
+    acc[fau] = 0
+    return acc
+  }, {} as Record<FAUKey, number>)
+
+  for (const definition of definitions) {
+    for (const fau of definition.primaryFAUs) {
+      if (isFAUKey(fau)) {
+        volume[fau] += HYPOTHETICAL_SETS_PER_EXERCISE
+      }
+    }
+
+    if (snapshot.settings.includeSecondary) {
+      for (const fau of definition.secondaryFAUs) {
+        if (isFAUKey(fau)) {
+          volume[fau] +=
+            HYPOTHETICAL_SETS_PER_EXERCISE * snapshot.settings.secondaryWeight
+        }
+      }
+    }
+  }
+
+  return volume
+}
+
+function isFAUKey(value: string): value is FAUKey {
+  return (ALL_FAUS as readonly string[]).includes(value)
 }

--- a/components/adhoc/AdHocExercisePickerModal.tsx
+++ b/components/adhoc/AdHocExercisePickerModal.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import {
+  type ExerciseDefinition,
+  ExerciseSearchInterface,
+} from '@/components/exercise-selection/ExerciseSearchInterface'
+import ExerciseDefinitionEditorModal from '@/components/features/exercise-definition/ExerciseDefinitionEditorModal'
+import MuscleBalancePanel from '@/components/features/muscle-balance/MuscleBalancePanel'
+import type { MuscleBalanceSnapshot } from '@/components/features/muscle-balance/types'
+import { Button } from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/radix/dialog'
+import type { FAUKey } from '@/lib/fau-volume'
+
+export type PickerMode =
+  | { kind: 'add'; initialFau?: FAUKey }
+  | { kind: 'swap'; replacingName: string }
+
+export default function AdHocExercisePickerModal({
+  mode,
+  onClose,
+  onConfirm,
+  isBusy,
+  muscleBalanceSnapshot,
+}: {
+  mode: PickerMode
+  onClose: () => void
+  onConfirm: (defs: ExerciseDefinition[]) => void
+  isBusy: boolean
+  muscleBalanceSnapshot: MuscleBalanceSnapshot
+}) {
+  const isAdd = mode.kind === 'add'
+  const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
+  const selectedIds = new Set(selectedDefs.map((d) => d.id))
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [balanceOpen, setBalanceOpen] = useState(isAdd && !!mode.initialFau)
+  const [activeFau, setActiveFau] = useState<FAUKey | null>(
+    mode.kind === 'add' ? mode.initialFau ?? null : null
+  )
+
+  const handleAddToggle = useCallback((def: ExerciseDefinition) => {
+    setSelectedDefs((prev) =>
+      prev.some((d) => d.id === def.id)
+        ? prev.filter((d) => d.id !== def.id)
+        : [...prev, def]
+    )
+  }, [])
+
+  const handleSwapSelect = useCallback(
+    (def: ExerciseDefinition) => {
+      if (isBusy) return
+      onConfirm([def])
+    },
+    [isBusy, onConfirm]
+  )
+
+  const count = selectedDefs.length
+  const title = isAdd ? 'Search Exercises' : 'Swap Exercise'
+  const description = isAdd
+    ? 'Pick one or more to add to your workout'
+    : `Pick a replacement for ${mode.kind === 'swap' ? mode.replacingName : ''}`
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        showClose={false}
+        fullScreenMobile={true}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
+      >
+        <DialogHeader className="border-b border-border bg-primary py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
+                {title}
+              </DialogTitle>
+              <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
+                {description}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <DialogBody className="flex-1 min-h-0">
+          {isAdd && (
+            <div className="border-b border-border bg-muted/30 px-4 py-3 sm:px-6">
+              <button
+                type="button"
+                onClick={() => setBalanceOpen((value) => !value)}
+                className="flex min-h-11 w-full items-center justify-between gap-3 text-left font-bold uppercase tracking-wider text-foreground doom-focus-ring"
+              >
+                <span>Muscle Balance</span>
+                <span className="text-sm text-muted-foreground">
+                  {balanceOpen ? 'Hide' : 'Show'}
+                </span>
+              </button>
+              {balanceOpen && (
+                <div className="mt-3">
+                  <MuscleBalancePanel
+                    snapshot={muscleBalanceSnapshot}
+                    compact
+                    onSelectFAU={(fau) => {
+                      setActiveFau(fau)
+                      setBalanceOpen(false)
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+          <ExerciseSearchInterface
+            key={activeFau ?? 'all'}
+            onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
+            selectedIds={isAdd ? selectedIds : undefined}
+            preloadExercises
+            initialFauFilter={activeFau}
+          />
+        </DialogBody>
+
+        <DialogFooter className="border-t border-border bg-card py-2">
+          <div className="flex items-center justify-end gap-2 w-full">
+            <Button variant="secondary" onClick={onClose} doom disabled={isBusy}>
+              Cancel
+            </Button>
+            {isAdd && (
+              <>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowCreateModal(true)}
+                  doom
+                  disabled={isBusy}
+                >
+                  + Create New Exercise
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={() => onConfirm(selectedDefs)}
+                  disabled={count === 0 || isBusy}
+                  loading={isBusy}
+                  doom
+                >
+                  {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
+                </Button>
+              </>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+      <ExerciseDefinitionEditorModal
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        mode="create"
+        onSuccess={(newExercise) => {
+          setShowCreateModal(false)
+          const def: ExerciseDefinition = {
+            id: newExercise.id,
+            name: newExercise.name,
+            primaryFAUs: newExercise.primaryFAUs,
+            secondaryFAUs: newExercise.secondaryFAUs,
+            equipment: newExercise.equipment,
+            instructions: newExercise.instructions,
+          }
+          if (isAdd) {
+            setSelectedDefs((prev) =>
+              prev.some((d) => d.id === def.id) ? prev : [...prev, def]
+            )
+          } else {
+            onConfirm([def])
+          }
+        }}
+      />
+    </Dialog>
+  )
+}

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -1,27 +1,20 @@
 'use client'
 
 import { Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import {
-  type ExerciseDefinition,
-  ExerciseSearchInterface,
-} from '@/components/exercise-selection/ExerciseSearchInterface'
-import ExerciseDefinitionEditorModal from '@/components/features/exercise-definition/ExerciseDefinitionEditorModal'
+import AdHocExercisePickerModal, {
+  type PickerMode,
+} from '@/components/adhoc/AdHocExercisePickerModal'
+import type { ExerciseDefinition } from '@/components/exercise-selection/ExerciseSearchInterface'
+import MuscleBalancePanel from '@/components/features/muscle-balance/MuscleBalancePanel'
+import type { MuscleBalanceSnapshot } from '@/components/features/muscle-balance/types'
 import { WorkoutRollupModal } from '@/components/features/training/WorkoutRollupModal'
 import { useToast } from '@/components/ToastProvider'
 import { Button } from '@/components/ui/Button'
 import { LoadingFrog } from '@/components/ui/loading-frog'
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/radix/dialog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import ExerciseActionsFooter from '@/components/workout-logging/ExerciseActionsFooter'
 import ExerciseDisplayTabs from '@/components/workout-logging/ExerciseDisplayTabs'
@@ -45,6 +38,7 @@ import {
 } from '@/lib/api/adhoc-workout'
 import { FetchError } from '@/lib/api/fetch'
 import { clientLogger } from '@/lib/client-logger'
+import type { FAUKey } from '@/lib/fau-volume'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
 
@@ -90,6 +84,7 @@ type Props = {
     rir: number | null
     isWarmup: boolean
   }>
+  muscleBalanceSnapshot: MuscleBalanceSnapshot
 }
 
 const EMPTY_SET = {
@@ -105,6 +100,7 @@ export default function AdHocLoggerView({
   startedAt,
   initialExercises,
   initialLoggedSets,
+  muscleBalanceSnapshot,
 }: Props) {
   const router = useRouter()
   const toast = useToast()
@@ -583,6 +579,9 @@ export default function AdHocLoggerView({
 
   const isInputExpanded = expandedInput !== null
   const hasExercises = exercises.length > 0
+  const openPickerForFAU = useCallback((fau: FAUKey) => {
+    setPickerMode({ kind: 'add', initialFau: fau })
+  }, [])
 
   // Swipe + slide-out animation, mirroring the programmed logger.
   const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(
@@ -707,7 +706,10 @@ export default function AdHocLoggerView({
               ] satisfies QuickAction[]}
             />
           ) : (
-            <EmptyState />
+            <EmptyState
+              muscleBalanceSnapshot={muscleBalanceSnapshot}
+              onSelectFAU={openPickerForFAU}
+            />
           )}
         </div>
 
@@ -751,11 +753,12 @@ export default function AdHocLoggerView({
       </div>
 
       {pickerMode && (
-        <ExercisePickerModal
+        <AdHocExercisePickerModal
           mode={pickerMode}
           onClose={() => setPickerMode(null)}
           onConfirm={pickerMode.kind === 'add' ? handleAddExercises : handleSwapExercise}
           isBusy={pickerMode.kind === 'add' ? isAdding : isSwapping}
+          muscleBalanceSnapshot={muscleBalanceSnapshot}
         />
       )}
       {showExitConfirm && (
@@ -820,148 +823,75 @@ export default function AdHocLoggerView({
   )
 }
 
-function EmptyState() {
-  return (
-    <div className="flex-1 flex items-center justify-center px-6 py-8">
-      <TipAnnotation
-        icon={<Sparkles aria-hidden="true" size={20} strokeWidth={1.8} />}
-      >
-        <span className="text-xl sm:text-2xl leading-relaxed text-foreground">
-          Pick your first exercise to start logging. Add as many as you want as you go.
-        </span>
-      </TipAnnotation>
-    </div>
-  )
-}
-
-type PickerMode =
-  | { kind: 'add' }
-  | { kind: 'swap'; replacingName: string }
-
-function ExercisePickerModal({
-  mode,
-  onClose,
-  onConfirm,
-  isBusy,
+function EmptyState({
+  muscleBalanceSnapshot,
+  onSelectFAU,
 }: {
-  mode: PickerMode
-  onClose: () => void
-  onConfirm: (defs: ExerciseDefinition[]) => void
-  isBusy: boolean
+  muscleBalanceSnapshot: MuscleBalanceSnapshot
+  onSelectFAU: (fau: FAUKey) => void
 }) {
-  const isAdd = mode.kind === 'add'
-  // Multi-select state used only in add mode.
-  const [selectedDefs, setSelectedDefs] = useState<ExerciseDefinition[]>([])
-  const selectedIds = new Set(selectedDefs.map((d) => d.id))
-  const [showCreateModal, setShowCreateModal] = useState(false)
-
-  const handleAddToggle = useCallback((def: ExerciseDefinition) => {
-    setSelectedDefs((prev) =>
-      prev.some((d) => d.id === def.id)
-        ? prev.filter((d) => d.id !== def.id)
-        : [...prev, def]
-    )
-  }, [])
-
-  const handleSwapSelect = useCallback(
-    (def: ExerciseDefinition) => {
-      if (isBusy) return
-      onConfirm([def])
-    },
-    [isBusy, onConfirm]
-  )
-
-  const count = selectedDefs.length
-  const title = isAdd ? 'Search Exercises' : 'Swap Exercise'
-  const description = isAdd
-    ? 'Pick one or more to add to your workout'
-    : `Pick a replacement for ${mode.kind === 'swap' ? mode.replacingName : ''}`
+  const [balanceOpen, setBalanceOpen] = useState(false)
+  const topNeglected = muscleBalanceSnapshot.neglected.slice(0, 3)
+  const neglectedLabel =
+    topNeglected.length > 0
+      ? topNeglected.map((item) => item.label).join(', ')
+      : 'No clear laggards yet'
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent
-        showClose={false}
-        fullScreenMobile={true}
-        // Body renders ExerciseSearchInterface; prevent default Radix auto-focus
-        // so the mobile keyboard doesn't pop up automatically (issue #846).
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
-      >
-        <DialogHeader className="border-b border-border bg-primary py-2">
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
-              <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
-                {title}
-              </DialogTitle>
-              <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
-                {description}
-              </DialogDescription>
+    <div className="flex-1 overflow-auto px-5 py-6">
+      <div className="mx-auto flex min-h-full max-w-xl flex-col justify-center gap-5">
+        <div className="flex min-h-[34vh] items-center">
+          <TipAnnotation
+            icon={<Sparkles aria-hidden="true" size={20} strokeWidth={1.8} />}
+          >
+            <span className="text-2xl sm:text-3xl leading-relaxed text-foreground">
+              Pick your first exercise to start logging. Add as many as you want as you go.
+            </span>
+          </TipAnnotation>
+        </div>
+
+        <section className="border-t-2 border-border pt-4">
+          <button
+            type="button"
+            onClick={() => setBalanceOpen((open) => !open)}
+            className="flex min-h-12 w-full items-center justify-between gap-3 text-left doom-focus-ring"
+            aria-expanded={balanceOpen}
+          >
+            <span>
+              <span className="block text-lg font-bold uppercase tracking-wider text-accent sm:text-xl">
+                Muscle Balance
+              </span>
+              <span className="block text-sm text-muted-foreground">
+                Suggested focus: {neglectedLabel}
+              </span>
+            </span>
+            <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">
+              {balanceOpen ? 'Hide' : 'Show'}
+            </span>
+          </button>
+
+          <p className="mt-3 text-sm text-muted-foreground">
+            Edit targets in{' '}
+            <Link
+              href="/settings/muscle-balance"
+              className="font-bold uppercase tracking-wider text-foreground underline decoration-border underline-offset-4 doom-focus-ring hover:text-primary"
+            >
+              Settings &gt; Muscle Balance
+            </Link>
+            .
+          </p>
+
+          {balanceOpen && (
+            <div className="mt-4">
+              <MuscleBalancePanel
+                snapshot={muscleBalanceSnapshot}
+                compact
+                onSelectFAU={onSelectFAU}
+              />
             </div>
-          </div>
-        </DialogHeader>
-
-        <DialogBody className="flex-1 min-h-0">
-          <ExerciseSearchInterface
-            onExerciseSelect={isAdd ? handleAddToggle : handleSwapSelect}
-            selectedIds={isAdd ? selectedIds : undefined}
-            preloadExercises
-          />
-        </DialogBody>
-
-        <DialogFooter className="border-t border-border bg-card py-2">
-          <div className="flex items-center justify-end gap-2 w-full">
-            <Button variant="secondary" onClick={onClose} doom disabled={isBusy}>
-              Cancel
-            </Button>
-            {isAdd && (
-              <>
-                <Button
-                  variant="secondary"
-                  onClick={() => setShowCreateModal(true)}
-                  doom
-                  disabled={isBusy}
-                >
-                  + Create New Exercise
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={() => onConfirm(selectedDefs)}
-                  disabled={count === 0 || isBusy}
-                  loading={isBusy}
-                  doom
-                >
-                  {count === 0 ? 'Add' : count === 1 ? 'Add 1 exercise' : `Add all (${count})`}
-                </Button>
-              </>
-            )}
-          </div>
-        </DialogFooter>
-      </DialogContent>
-      <ExerciseDefinitionEditorModal
-        isOpen={showCreateModal}
-        onClose={() => setShowCreateModal(false)}
-        mode="create"
-        onSuccess={(newExercise) => {
-          setShowCreateModal(false)
-          // Auto-select the newly created exercise so the user can add it
-          // straight away without having to re-find it in search results.
-          const def: ExerciseDefinition = {
-            id: newExercise.id,
-            name: newExercise.name,
-            primaryFAUs: newExercise.primaryFAUs,
-            secondaryFAUs: newExercise.secondaryFAUs,
-            equipment: newExercise.equipment,
-            instructions: newExercise.instructions,
-          }
-          if (isAdd) {
-            setSelectedDefs((prev) =>
-              prev.some((d) => d.id === def.id) ? prev : [...prev, def]
-            )
-          } else {
-            onConfirm([def])
-          }
-        }}
-      />
-    </Dialog>
+          )}
+        </section>
+      </div>
+    </div>
   )
 }

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -34,7 +34,6 @@ import {
 } from '@/lib/api/adhoc-workout'
 import { FetchError } from '@/lib/api/fetch'
 import { clientLogger } from '@/lib/client-logger'
-import type { FAUKey } from '@/lib/fau-volume'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
 import {
@@ -655,9 +654,6 @@ export default function AdHocLoggerView({
 
   const isInputExpanded = expandedInput !== null
   const hasExercises = exercises.length > 0
-  const openPickerForFAU = useCallback((fau: FAUKey) => {
-    setPickerMode({ kind: 'add', initialFau: fau })
-  }, [])
 
   // Swipe + slide-out animation, mirroring the programmed logger.
   const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(
@@ -783,10 +779,7 @@ export default function AdHocLoggerView({
               ] satisfies QuickAction[]}
             />
           ) : (
-            <AdHocEmptyState
-              muscleBalanceSnapshot={muscleBalanceSnapshot}
-              onSelectFAU={openPickerForFAU}
-            />
+            <AdHocEmptyState />
           )}
         </div>
 
@@ -836,6 +829,10 @@ export default function AdHocLoggerView({
           onConfirm={pickerMode.kind === 'add' ? handleAddExercises : handleSwapExercise}
           isBusy={pickerMode.kind === 'add' ? isAdding : isSwapping}
           muscleBalanceSnapshot={muscleBalanceSnapshot}
+          plannedExerciseDefinitions={exercises.map((exercise) => ({
+            primaryFAUs: exercise.exerciseDefinition.primaryFAUs,
+            secondaryFAUs: exercise.exerciseDefinition.secondaryFAUs,
+          }))}
         />
       )}
       <WorkoutPlanEditor

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -4,6 +4,7 @@ import { Check, Filter, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
+import { ALL_FAUS, FAU_DISPLAY_NAMES } from '@/lib/fau-volume'
 import { FilterChoiceSheet } from './FilterChoiceSheet'
 
 export type ExerciseDefinition = {
@@ -23,6 +24,7 @@ interface ExerciseSearchInterfaceProps {
   preloadExercises?: boolean
   onCreateExercise?: (searchQuery: string) => void
   onEditExercise?: (exercise: ExerciseDefinition) => void
+  initialFauFilter?: string | null
   /**
    * When provided, the picker switches to multi-select mode: cards highlight
    * when their id is in the set, and clicking a card (or its button) toggles
@@ -30,12 +32,6 @@ interface ExerciseSearchInterfaceProps {
    */
   selectedIds?: Set<string>
 }
-
-const ALL_FAUS = [
-  'chest', 'mid-back', 'lower-back', 'front-delts', 'side-delts', 'rear-delts',
-  'lats', 'traps', 'biceps', 'triceps', 'forearms',
-  'quads', 'adductors', 'hamstrings', 'glutes', 'calves', 'abs', 'obliques'
-]
 
 const EQUIPMENT_TYPES = [
   'barbell',
@@ -61,38 +57,18 @@ const EQUIPMENT_DISPLAY_NAMES: Record<string, string> = {
   'other': 'Other (specialized equipment)'
 }
 
-const FAU_DISPLAY_NAMES: Record<string, string> = {
-  'chest': 'Chest',
-  'mid-back': 'Mid Back',
-  'lower-back': 'Lower Back',
-  'front-delts': 'Front Delts',
-  'side-delts': 'Side Delts',
-  'rear-delts': 'Rear Delts',
-  'lats': 'Lats',
-  'traps': 'Traps',
-  'biceps': 'Biceps',
-  'triceps': 'Triceps',
-  'forearms': 'Forearms',
-  'quads': 'Quads',
-  'adductors': 'Adductors',
-  'hamstrings': 'Hamstrings',
-  'glutes': 'Glutes',
-  'calves': 'Calves',
-  'abs': 'Abs',
-  'obliques': 'Obliques'
-}
-
 export function ExerciseSearchInterface({
   onExerciseSelect,
   initialQuery = '',
   preloadExercises = false,
   onCreateExercise,
   onEditExercise,
+  initialFauFilter = null,
   selectedIds,
 }: ExerciseSearchInterfaceProps) {
   const isMultiSelect = selectedIds !== undefined
   const [searchQuery, setSearchQuery] = useState(initialQuery)
-  const [selectedFAU, setSelectedFAU] = useState<string | null>(null)
+  const [selectedFAU, setSelectedFAU] = useState<string | null>(initialFauFilter)
   const [selectedEquipment, setSelectedEquipment] = useState<string | null>(null)
   const [exercises, setExercises] = useState<ExerciseDefinition[]>([])
   const [isLoading, setIsLoading] = useState(false)

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -4,7 +4,8 @@ import { Check, Filter, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
-import { ALL_FAUS, FAU_DISPLAY_NAMES } from '@/lib/fau-volume'
+import { ALL_FAUS, FAU_DISPLAY_NAMES, type FAUKey } from '@/lib/fau-volume'
+import type { MuscleBalanceSnapshot } from '@/lib/muscle-balance'
 import { FilterChoiceSheet } from './FilterChoiceSheet'
 
 export type ExerciseDefinition = {
@@ -25,6 +26,8 @@ interface ExerciseSearchInterfaceProps {
   onCreateExercise?: (searchQuery: string) => void
   onEditExercise?: (exercise: ExerciseDefinition) => void
   initialFauFilter?: string | null
+  muscleBalanceSnapshot?: MuscleBalanceSnapshot
+  plannedFAUVolume?: Partial<Record<FAUKey, number>>
   /**
    * When provided, the picker switches to multi-select mode: cards highlight
    * when their id is in the set, and clicking a card (or its button) toggles
@@ -64,6 +67,8 @@ export function ExerciseSearchInterface({
   onCreateExercise,
   onEditExercise,
   initialFauFilter = null,
+  muscleBalanceSnapshot,
+  plannedFAUVolume = {},
   selectedIds,
 }: ExerciseSearchInterfaceProps) {
   const isMultiSelect = selectedIds !== undefined
@@ -76,15 +81,61 @@ export function ExerciseSearchInterface({
   const [hasSearched, setHasSearched] = useState(preloadExercises)
   const [fauSheetOpen, setFauSheetOpen] = useState(false)
   const [equipmentSheetOpen, setEquipmentSheetOpen] = useState(false)
+  const [fauSort, setFauSort] = useState<'alphabetical' | 'neglected'>('alphabetical')
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  const fauOptions = useMemo(
-    () => [
+  const balanceByFau = useMemo(() => {
+    if (!muscleBalanceSnapshot) return new Map<FAUKey, MuscleBalanceSnapshot['items'][number]>()
+    return new Map(muscleBalanceSnapshot.items.map((item) => [item.fau, item]))
+  }, [muscleBalanceSnapshot])
+
+  const fauOptions = useMemo(() => {
+    const scoreFAU = (fau: FAUKey) => {
+      const item = balanceByFau.get(fau)
+      if (!item || !muscleBalanceSnapshot) return 0
+      const plannedSets = plannedFAUVolume[fau] ?? 0
+      const adjustedSets = item.actualSets + plannedSets
+      const totalEffectiveSets = muscleBalanceSnapshot.lookback.totalEffectiveSets
+      const adjustedShare = totalEffectiveSets > 0 ? adjustedSets / totalEffectiveSets : 0
+      return item.targetShare - adjustedShare
+    }
+
+    const sortedFaus = [...ALL_FAUS].sort((a, b) => {
+      if (fauSort === 'neglected' && muscleBalanceSnapshot) {
+        const byAdjustedDeficit = scoreFAU(b) - scoreFAU(a)
+        if (byAdjustedDeficit !== 0) return byAdjustedDeficit
+      }
+      return (FAU_DISPLAY_NAMES[a] || a).localeCompare(FAU_DISPLAY_NAMES[b] || b)
+    })
+
+    return [
       { value: null, label: 'All Muscle Groups' },
-      ...ALL_FAUS.map((fau) => ({ value: fau, label: FAU_DISPLAY_NAMES[fau] || fau })),
-    ],
-    [],
-  )
+      ...sortedFaus.map((fau) => {
+        const item = balanceByFau.get(fau)
+        const plannedSets = plannedFAUVolume[fau] ?? 0
+        const adjustedSets = (item?.actualSets ?? 0) + plannedSets
+        const desiredSets =
+          item && muscleBalanceSnapshot
+            ? item.targetShare * muscleBalanceSnapshot.lookback.totalEffectiveSets
+            : null
+        const adjustedFulfillment =
+          item && desiredSets && desiredSets > 0
+            ? Math.min(adjustedSets / desiredSets, 9.99)
+            : item?.fulfillment
+        return {
+          value: fau,
+          label: FAU_DISPLAY_NAMES[fau] || fau,
+          description:
+            item && desiredSets !== null
+              ? `${formatSets(adjustedSets)} / ${formatSets(desiredSets)} target sets`
+              : undefined,
+          badge: item ? `${Math.round((adjustedFulfillment ?? item.fulfillment) * 100)}%` : undefined,
+          meta: plannedSets > 0 ? `+${formatSets(plannedSets)} planned` : undefined,
+          progress: item ? Math.min(100, (adjustedFulfillment ?? item.fulfillment) * 100) : undefined,
+        }
+      }),
+    ]
+  }, [balanceByFau, fauSort, muscleBalanceSnapshot, plannedFAUVolume])
   const equipmentOptions = useMemo(
     () => [
       { value: null, label: 'All Equipment' },
@@ -203,6 +254,39 @@ export function ExerciseSearchInterface({
         options={fauOptions}
         selected={selectedFAU}
         onSelect={handleFAUSelect}
+        headerContent={
+          muscleBalanceSnapshot ? (
+            <div>
+              <div className="mb-2 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                Sort muscle groups
+              </div>
+              <div className="grid grid-cols-2 border-2 border-border bg-muted/20">
+                <button
+                  type="button"
+                  onClick={() => setFauSort('alphabetical')}
+                  className={`min-h-10 px-3 text-sm font-bold uppercase tracking-wider transition-colors doom-focus-ring ${
+                    fauSort === 'alphabetical'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-foreground hover:bg-muted/50'
+                  }`}
+                >
+                  A-Z
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFauSort('neglected')}
+                  className={`min-h-10 border-l-2 border-border px-3 text-sm font-bold uppercase tracking-wider transition-colors doom-focus-ring ${
+                    fauSort === 'neglected'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-foreground hover:bg-muted/50'
+                  }`}
+                >
+                  Neglected
+                </button>
+              </div>
+            </div>
+          ) : undefined
+        }
       />
       <FilterChoiceSheet
         open={equipmentSheetOpen}
@@ -342,4 +426,8 @@ export function ExerciseSearchInterface({
       )}
     </div>
   )
+}
+
+function formatSets(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
 }

--- a/components/exercise-selection/FilterChoiceSheet.tsx
+++ b/components/exercise-selection/FilterChoiceSheet.tsx
@@ -2,11 +2,16 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { Check, X } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 
 export type FilterChoiceOption = {
   value: string | null
   label: string
+  description?: string
+  badge?: string
+  meta?: string
+  progress?: number
   disabled?: boolean
   disabledReason?: string
 }
@@ -16,6 +21,7 @@ type BaseProps = {
   onOpenChange: (open: boolean) => void
   title: string
   options: FilterChoiceOption[]
+  headerContent?: ReactNode
 }
 
 type SingleProps = BaseProps & {
@@ -129,6 +135,11 @@ export function FilterChoiceSheet(props: Props) {
                   touchAction: 'pan-y',
                 }}
               >
+                {props.headerContent && (
+                  <div className="border-b border-border/50 px-4 py-3">
+                    {props.headerContent}
+                  </div>
+                )}
                 <ul className="py-1">
                 {options.map((option) => {
                   const selected = isSelected(option.value)
@@ -148,15 +159,42 @@ export function FilterChoiceSheet(props: Props) {
                             : 'text-foreground hover:bg-muted/40 active:bg-muted/60'
                         }`}
                       >
-                        <span className="flex items-center gap-2">
-                          {option.label}
-                          {disabled && option.disabledReason && (
-                            <span className="text-xs font-normal opacity-60">
-                              ({option.disabledReason})
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span>{option.label}</span>
+                            {disabled && option.disabledReason && (
+                              <span className="text-xs font-normal opacity-60">
+                                ({option.disabledReason})
+                              </span>
+                            )}
+                          </span>
+                          {option.description && (
+                            <span className="mt-0.5 block text-sm font-semibold text-muted-foreground">
+                              {option.description}
+                            </span>
+                          )}
+                          {option.meta && (
+                            <span className="mt-0.5 block text-xs font-bold uppercase tracking-wider text-primary">
+                              {option.meta}
+                            </span>
+                          )}
+                          {option.progress !== undefined && (
+                            <span className="mt-2 block h-1.5 w-full border border-border bg-muted">
+                              <span
+                                className="block h-full bg-primary"
+                                style={{ width: `${Math.min(100, Math.max(0, option.progress))}%` }}
+                              />
                             </span>
                           )}
                         </span>
-                        {selected && <Check size={18} strokeWidth={3} />}
+                        <span className="flex flex-shrink-0 items-center gap-2">
+                          {option.badge && (
+                            <span className="text-sm font-bold tabular-nums text-accent">
+                              {option.badge}
+                            </span>
+                          )}
+                          {selected && <Check size={18} strokeWidth={3} />}
+                        </span>
                       </button>
                     </li>
                   )

--- a/components/features/muscle-balance/MuscleBalancePanel.tsx
+++ b/components/features/muscle-balance/MuscleBalancePanel.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { ChevronDown, ChevronUp, Target } from 'lucide-react'
+import { useState } from 'react'
+import type { FAUKey } from '@/lib/fau-volume'
+import type { MuscleBalanceSnapshot } from './types'
+
+type MuscleBalancePanelProps = {
+  snapshot: MuscleBalanceSnapshot
+  compact?: boolean
+  onSelectFAU?: (fau: FAUKey) => void
+}
+
+export default function MuscleBalancePanel({
+  snapshot,
+  compact = false,
+  onSelectFAU,
+}: MuscleBalancePanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const visibleItems = expanded ? snapshot.items : snapshot.items.slice(0, compact ? 3 : 5)
+  const hasHistory = snapshot.lookback.completedWorkouts > 0
+
+  return (
+    <section className="border-2 border-border bg-card p-4 doom-corners">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-foreground">
+            <Target size={18} strokeWidth={2.2} aria-hidden="true" />
+            <h2 className="text-sm font-bold uppercase tracking-wider">
+              Muscle Balance
+            </h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Last {snapshot.lookback.completedWorkouts} of {snapshot.lookback.requestedWorkouts} completed workouts
+          </p>
+        </div>
+        <div className="text-right tabular-nums">
+          <div className="text-lg font-bold text-foreground">
+            {formatSets(snapshot.lookback.totalEffectiveSets)}
+          </div>
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Effective sets
+          </div>
+        </div>
+      </div>
+
+      {!hasHistory ? (
+        <div className="mt-4 border border-dashed border-border bg-muted/35 p-3 text-sm text-muted-foreground">
+          Complete a few strength workouts and this will point at the muscles lagging behind your targets.
+        </div>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {visibleItems.map((item) => {
+            const fulfillment = Math.round(item.fulfillment * 100)
+            const barWidth = Math.min(100, fulfillment)
+            return (
+              <button
+                key={item.fau}
+                type="button"
+                onClick={() => onSelectFAU?.(item.fau)}
+                disabled={!onSelectFAU}
+                className={`block w-full text-left ${onSelectFAU ? 'doom-focus-ring hover:bg-muted/45' : 'cursor-default'} p-1 transition-colors`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-bold uppercase tracking-wide text-foreground">
+                    {item.label}
+                  </span>
+                  <span className={statusClass(item.status)}>
+                    {fulfillment}%
+                  </span>
+                </div>
+                <div className="mt-1 h-2 w-full border border-border bg-muted">
+                  <div
+                    className={item.status === 'neglected' ? 'h-full bg-warning' : 'h-full bg-primary'}
+                    style={{ width: `${barWidth}%` }}
+                  />
+                </div>
+                <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+                  <span>{formatSets(item.actualSets)} sets</span>
+                  <span>{Math.round(item.targetShare * 100)}% target share</span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {snapshot.items.length > visibleItems.length || expanded ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="mt-3 inline-flex min-h-11 items-center gap-2 text-sm font-bold uppercase tracking-wider text-foreground doom-focus-ring hover:text-primary"
+        >
+          {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          {expanded ? 'Show less' : 'Show all muscles'}
+        </button>
+      ) : null}
+    </section>
+  )
+}
+
+function statusClass(status: MuscleBalanceSnapshot['items'][number]['status']) {
+  const base = 'text-xs font-bold uppercase tracking-wider tabular-nums'
+  if (status === 'neglected') return `${base} text-warning`
+  if (status === 'over') return `${base} text-primary`
+  return `${base} text-muted-foreground`
+}
+
+function formatSets(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}

--- a/components/features/muscle-balance/MuscleBalanceSettingsEditor.tsx
+++ b/components/features/muscle-balance/MuscleBalanceSettingsEditor.tsx
@@ -1,0 +1,406 @@
+'use client'
+
+import { ArrowLeft, CheckCircle2, RotateCcw, Save, XCircle } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { ALL_FAUS, FAU_DISPLAY_NAMES, type FAUKey } from '@/lib/fau-volume'
+import {
+  DEFAULT_LOOKBACK_WORKOUTS,
+  DEFAULT_SECONDARY_WEIGHT,
+  getDefaultMuscleBalanceTargets,
+  updateMuscleBalanceSnapshotSettings,
+} from '@/lib/muscle-balance'
+import { clientLogger } from '@/lib/client-logger'
+import MuscleBalancePanel from './MuscleBalancePanel'
+import type {
+  MuscleBalanceSettingsDTO,
+  MuscleBalanceSnapshot,
+  MuscleBalanceTargets,
+} from './types'
+
+type Props = {
+  initialSnapshot: MuscleBalanceSnapshot
+}
+
+export default function MuscleBalanceSettingsEditor({ initialSnapshot }: Props) {
+  const router = useRouter()
+  const [snapshot, setSnapshot] = useState(initialSnapshot)
+  const [targets, setTargets] = useState<MuscleBalanceTargets>(
+    initialSnapshot.settings.targets
+  )
+  const [lookbackWorkoutsInput, setLookbackWorkoutsInput] = useState(
+    String(initialSnapshot.settings.lookbackWorkouts)
+  )
+  const [includeSecondary, setIncludeSecondary] = useState(
+    initialSnapshot.settings.includeSecondary
+  )
+  const [secondaryWeight, setSecondaryWeight] = useState(
+    initialSnapshot.settings.secondaryWeight
+  )
+  const [excludeWarmups, setExcludeWarmups] = useState(
+    initialSnapshot.settings.excludeWarmups
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const lookbackWorkouts = parseLookbackWorkouts(lookbackWorkoutsInput)
+
+  const targetTotal = useMemo(
+    () => ALL_FAUS.reduce((sum, fau) => sum + targets[fau], 0),
+    [targets]
+  )
+  const draftSettings = useMemo<MuscleBalanceSettingsDTO>(
+    () => ({
+      targets,
+      lookbackWorkouts: lookbackWorkouts ?? snapshot.settings.lookbackWorkouts,
+      includeSecondary,
+      secondaryWeight,
+      excludeWarmups,
+    }),
+    [
+      targets,
+      lookbackWorkouts,
+      snapshot.settings.lookbackWorkouts,
+      includeSecondary,
+      secondaryWeight,
+      excludeWarmups,
+    ]
+  )
+  const previewSnapshot = useMemo(
+    () => updateMuscleBalanceSnapshotSettings(snapshot, draftSettings),
+    [snapshot, draftSettings]
+  )
+
+  const updateTarget = (fau: FAUKey, value: number) => {
+    setSaved(false)
+    setTargets((current) => ({ ...current, [fau]: value }))
+  }
+
+  const resetTargets = () => {
+    setSaved(false)
+    setTargets(getDefaultMuscleBalanceTargets())
+    setLookbackWorkoutsInput(String(DEFAULT_LOOKBACK_WORKOUTS))
+    setIncludeSecondary(true)
+    setSecondaryWeight(DEFAULT_SECONDARY_WEIGHT)
+    setExcludeWarmups(true)
+  }
+
+  const save = async () => {
+    if (lookbackWorkouts === null) {
+      setError('Completed workouts must be a whole number from 1 to 52.')
+      return
+    }
+    setIsSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      const payload: MuscleBalanceSettingsDTO = {
+        targets,
+        lookbackWorkouts,
+        includeSecondary,
+        secondaryWeight,
+        excludeWarmups,
+      }
+      const response = await fetch('/api/settings/muscle-balance', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save muscle balance settings')
+      }
+      setSnapshot(data.snapshot)
+      setTargets(data.snapshot.settings.targets)
+      setLookbackWorkoutsInput(String(data.snapshot.settings.lookbackWorkouts))
+      setIncludeSecondary(data.snapshot.settings.includeSecondary)
+      setSecondaryWeight(data.snapshot.settings.secondaryWeight)
+      setExcludeWarmups(data.snapshot.settings.excludeWarmups)
+      setSaved(true)
+      window.setTimeout(() => {
+        router.push('/settings')
+      }, 650)
+    } catch (err) {
+      clientLogger.error('Failed to save muscle balance settings:', err)
+      setError(err instanceof Error ? err.message : 'Failed to save settings')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <main className="bg-background px-4 py-6 sm:px-6 sm:py-8">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-6 flex items-center justify-between gap-3">
+          <div>
+            <Link
+              href="/settings"
+              className="mb-3 inline-flex min-h-11 items-center gap-2 text-sm font-bold uppercase tracking-wider text-muted-foreground doom-focus-ring hover:text-foreground"
+            >
+              <ArrowLeft size={16} aria-hidden="true" />
+              Settings
+            </Link>
+            <h1 className="text-2xl font-bold uppercase tracking-wider text-foreground">
+              Muscle Balance
+            </h1>
+          </div>
+          <Button type="button" variant="primary" doom loading={isSaving} onClick={save}>
+            <Save size={16} aria-hidden="true" className="mr-1.5" />
+            Save
+          </Button>
+        </div>
+
+        {(error || saved) && (
+          <div
+            role={error ? 'alert' : 'status'}
+            className={`mb-5 flex items-start gap-3 border-2 p-3 text-sm font-semibold ${
+              error
+                ? 'border-error bg-error/10 text-error'
+                : 'border-success bg-success/10 text-foreground'
+            }`}
+          >
+            {error ? (
+              <XCircle size={18} aria-hidden="true" className="mt-0.5 flex-shrink-0" />
+            ) : (
+              <CheckCircle2 size={18} aria-hidden="true" className="mt-0.5 flex-shrink-0 text-success" />
+            )}
+            <span>
+              {error || 'Muscle balance saved. Returning to settings.'}
+            </span>
+          </div>
+        )}
+
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
+          <section className="border-2 border-border bg-card p-4 sm:p-5 doom-corners">
+            <div className="mb-5 flex flex-col gap-3 border-b border-border pb-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-base font-bold uppercase tracking-wider text-foreground">
+                  Target Ratios
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                  Set the ideal training share for each muscle. Equal values mean balanced training.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={resetTargets}
+                className="inline-flex min-h-11 items-center gap-2 self-start border-2 border-border bg-muted px-3 py-2 text-sm font-bold uppercase tracking-wider text-foreground doom-focus-ring hover:border-primary"
+              >
+                <RotateCcw size={16} aria-hidden="true" />
+                Reset
+              </button>
+            </div>
+
+            <div className="space-y-2 sm:space-y-5">
+              {ALL_FAUS.map((fau) => {
+                const value = targets[fau]
+                const share = targetTotal > 0 ? (value / targetTotal) * 100 : 0
+                return (
+                  <MuscleTargetRow
+                    key={fau}
+                    fau={fau}
+                    value={value}
+                    share={share}
+                    onChange={(next) => updateTarget(fau, next)}
+                  />
+                )
+              })}
+            </div>
+          </section>
+
+          <aside className="space-y-5 lg:sticky lg:top-6">
+            <section className="border-2 border-border bg-card p-4 doom-corners">
+              <h2 className="text-base font-bold uppercase tracking-wider text-foreground">
+                Window
+              </h2>
+              <label htmlFor="lookback-workouts" className="mt-4 block text-sm font-bold uppercase tracking-wider text-foreground">
+                Completed workouts
+              </label>
+              <input
+                id="lookback-workouts"
+                type="number"
+                min="1"
+                max="52"
+                value={lookbackWorkoutsInput}
+                onChange={(event) => {
+                  setSaved(false)
+                  setError(null)
+                  setLookbackWorkoutsInput(event.target.value)
+                }}
+                onBlur={() => {
+                  if (lookbackWorkouts === null) {
+                    setLookbackWorkoutsInput(String(snapshot.settings.lookbackWorkouts))
+                    return
+                  }
+                  setLookbackWorkoutsInput(String(lookbackWorkouts))
+                }}
+                className="mt-2 w-full border-2 border-input bg-input px-3 py-2 font-bold tabular-nums text-foreground focus:border-primary focus:outline-none"
+              />
+
+              <div className="mt-5 space-y-4">
+                <ToggleRow
+                  label="Include secondary muscles"
+                  checked={includeSecondary}
+                  onChange={setIncludeSecondary}
+                />
+                {includeSecondary && (
+                  <div>
+                    <label htmlFor="secondary-weight" className="block text-sm font-bold uppercase tracking-wider text-foreground">
+                      Secondary set credit: {secondaryWeight.toFixed(2)}
+                    </label>
+                    <input
+                      id="secondary-weight"
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.05"
+                      value={secondaryWeight}
+                      onChange={(event) => {
+                        setSaved(false)
+                        setSecondaryWeight(Number(event.target.value))
+                      }}
+                      className="mt-2 h-11 w-full accent-primary"
+                    />
+                  </div>
+                )}
+                <ToggleRow
+                  label="Ignore warmup sets"
+                  checked={excludeWarmups}
+                  onChange={setExcludeWarmups}
+                />
+              </div>
+            </section>
+
+            <MuscleBalancePanel snapshot={previewSnapshot} compact />
+          </aside>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+function MuscleTargetRow({
+  fau,
+  value,
+  share,
+  onChange,
+}: {
+  fau: FAUKey
+  value: number
+  share: number
+  onChange: (value: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const label = FAU_DISPLAY_NAMES[fau]
+  const formattedValue = formatRatio(value)
+
+  return (
+    <div className="border border-border/70 bg-muted/20 sm:border-0 sm:bg-transparent">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="flex min-h-14 w-full items-center justify-between gap-3 px-3 py-2 text-left doom-focus-ring sm:hidden"
+        aria-expanded={open}
+        aria-controls={`target-controls-${fau}`}
+      >
+        <span>
+          <span className="block text-sm font-bold uppercase tracking-wider text-foreground">
+            {label}
+          </span>
+          <span className="block text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {share.toFixed(1)}% share
+          </span>
+        </span>
+        <span className="border-2 border-border bg-input px-3 py-1 text-base font-bold tabular-nums text-foreground">
+          {formattedValue}
+        </span>
+      </button>
+
+      <div
+        id={`target-controls-${fau}`}
+        className={`${open ? 'grid' : 'hidden'} gap-3 px-3 pb-3 sm:grid sm:grid-cols-[150px_minmax(0,1fr)_74px] sm:items-center sm:px-0 sm:pb-0`}
+      >
+        <label
+          htmlFor={`target-${fau}`}
+          className="hidden text-sm font-bold uppercase tracking-wider text-foreground sm:block"
+        >
+          {label}
+        </label>
+        <input
+          id={`target-${fau}`}
+          type="range"
+          min="0"
+          max="2"
+          step="0.05"
+          value={value}
+          onChange={(event) => onChange(Number(event.target.value))}
+          className="h-11 w-full accent-primary"
+        />
+        <div className="flex items-center justify-between gap-2 sm:block sm:text-right">
+          <input
+            type="number"
+            min="0"
+            max="2"
+            step="0.05"
+            value={formattedValue}
+            onChange={(event) => onChange(Number(event.target.value))}
+            aria-label={`${label} target ratio`}
+            className="w-24 border-2 border-input bg-input px-2 py-1 text-right font-bold tabular-nums text-foreground focus:border-primary focus:outline-none sm:w-20"
+          />
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {share.toFixed(1)}%
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-sm font-bold uppercase tracking-wider text-foreground">
+        {label}
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-8 w-14 min-w-14 items-center rounded-full border-2 transition-colors doom-focus-ring ${
+          checked ? 'border-primary bg-primary' : 'border-border bg-muted'
+        }`}
+      >
+        <span
+          className={`inline-block h-5 w-5 rounded-full transition-transform ${
+            checked
+              ? 'translate-x-[26px] bg-primary-foreground'
+              : 'translate-x-[3px] bg-muted-foreground'
+          }`}
+        />
+      </button>
+    </div>
+  )
+}
+
+function parseLookbackWorkouts(value: string): number | null {
+  if (value.trim() === '') return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 52) return null
+  return parsed
+}
+
+function formatRatio(value: number): string {
+  return Number(value.toFixed(2)).toString()
+}

--- a/components/features/muscle-balance/types.ts
+++ b/components/features/muscle-balance/types.ts
@@ -1,0 +1,13 @@
+import type {
+  MuscleBalanceItem,
+  MuscleBalanceSettingsDTO,
+  MuscleBalanceSnapshot,
+  MuscleBalanceTargets,
+} from '@/lib/muscle-balance'
+
+export type {
+  MuscleBalanceItem,
+  MuscleBalanceSettingsDTO,
+  MuscleBalanceSnapshot,
+  MuscleBalanceTargets,
+}

--- a/lib/fau-volume.ts
+++ b/lib/fau-volume.ts
@@ -29,6 +29,29 @@ export type VolumeOptions = {
   secondaryWeight: number // 0.1 to 1.0
 }
 
+export const ALL_FAUS = [
+  'chest',
+  'mid-back',
+  'lower-back',
+  'front-delts',
+  'side-delts',
+  'rear-delts',
+  'lats',
+  'traps',
+  'biceps',
+  'triceps',
+  'forearms',
+  'quads',
+  'adductors',
+  'hamstrings',
+  'glutes',
+  'calves',
+  'abs',
+  'obliques',
+] as const
+
+export type FAUKey = (typeof ALL_FAUS)[number]
+
 /**
  * Calculate FAU volume for a single week
  */

--- a/lib/muscle-balance.ts
+++ b/lib/muscle-balance.ts
@@ -1,0 +1,372 @@
+import type { Prisma, PrismaClient } from '@prisma/client'
+import { ALL_FAUS, FAU_DISPLAY_NAMES, type FAUKey } from '@/lib/fau-volume'
+
+export const DEFAULT_LOOKBACK_WORKOUTS = 8
+export const DEFAULT_SECONDARY_WEIGHT = 0.5
+export const MIN_TARGET_WEIGHT = 0
+export const MAX_TARGET_WEIGHT = 2
+export const TARGET_STEP = 0.05
+
+export type MuscleBalanceTargets = Record<FAUKey, number>
+
+export type MuscleBalanceSettingsDTO = {
+  targets: MuscleBalanceTargets
+  lookbackWorkouts: number
+  includeSecondary: boolean
+  secondaryWeight: number
+  excludeWarmups: boolean
+}
+
+export type MuscleBalanceItem = {
+  fau: FAUKey
+  label: string
+  targetWeight: number
+  targetShare: number
+  actualSets: number
+  actualShare: number
+  deficitShare: number
+  fulfillment: number
+  status: 'neglected' | 'balanced' | 'over'
+}
+
+export type MuscleBalanceSnapshot = {
+  settings: MuscleBalanceSettingsDTO
+  lookback: {
+    requestedWorkouts: number
+    completedWorkouts: number
+    totalEffectiveSets: number
+  }
+  items: MuscleBalanceItem[]
+  neglected: MuscleBalanceItem[]
+}
+
+type CompletionForBalance = {
+  loggedSets: Array<{
+    isWarmup: boolean
+    exercise: {
+      exerciseDefinition: {
+        primaryFAUs: string[]
+        secondaryFAUs: string[]
+      }
+    }
+  }>
+}
+
+export function getDefaultMuscleBalanceTargets(): MuscleBalanceTargets {
+  return ALL_FAUS.reduce((targets, fau) => {
+    targets[fau] = 1
+    return targets
+  }, {} as MuscleBalanceTargets)
+}
+
+export function normalizeMuscleBalanceTargets(value: unknown): MuscleBalanceTargets {
+  const source =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  const defaults = getDefaultMuscleBalanceTargets()
+
+  return ALL_FAUS.reduce((targets, fau) => {
+    const raw = source[fau]
+    const numeric = typeof raw === 'number' ? raw : Number(raw)
+    targets[fau] = Number.isFinite(numeric)
+      ? clamp(roundToStep(numeric), MIN_TARGET_WEIGHT, MAX_TARGET_WEIGHT)
+      : defaults[fau]
+    return targets
+  }, {} as MuscleBalanceTargets)
+}
+
+export function normalizeMuscleBalanceSettings(
+  settings:
+    | {
+        targets: Prisma.JsonValue
+        lookbackWorkouts: number
+        includeSecondary: boolean
+        secondaryWeight: number
+        excludeWarmups: boolean
+      }
+    | null
+    | undefined
+): MuscleBalanceSettingsDTO {
+  return {
+    targets: normalizeMuscleBalanceTargets(settings?.targets),
+    lookbackWorkouts: normalizeInteger(
+      settings?.lookbackWorkouts,
+      DEFAULT_LOOKBACK_WORKOUTS,
+      1,
+      52
+    ),
+    includeSecondary: settings?.includeSecondary ?? true,
+    secondaryWeight: normalizeNumber(
+      settings?.secondaryWeight,
+      DEFAULT_SECONDARY_WEIGHT,
+      0,
+      1
+    ),
+    excludeWarmups: settings?.excludeWarmups ?? true,
+  }
+}
+
+export async function getOrCreateMuscleBalanceSettings(
+  prisma: PrismaClient,
+  userId: string
+): Promise<MuscleBalanceSettingsDTO> {
+  const defaults = getDefaultMuscleBalanceTargets()
+  const settings = await prisma.userMuscleBalanceSettings.upsert({
+    where: { userId },
+    update: {},
+    create: {
+      userId,
+      targets: defaults,
+      lookbackWorkouts: DEFAULT_LOOKBACK_WORKOUTS,
+      includeSecondary: true,
+      secondaryWeight: DEFAULT_SECONDARY_WEIGHT,
+      excludeWarmups: true,
+    },
+  })
+
+  return normalizeMuscleBalanceSettings(settings)
+}
+
+export async function updateMuscleBalanceSettings(
+  prisma: PrismaClient,
+  userId: string,
+  input: Partial<MuscleBalanceSettingsDTO>
+): Promise<MuscleBalanceSettingsDTO> {
+  const current = await getOrCreateMuscleBalanceSettings(prisma, userId)
+  const next: MuscleBalanceSettingsDTO = {
+    targets:
+      input.targets !== undefined
+        ? normalizeMuscleBalanceTargets(input.targets)
+        : current.targets,
+    lookbackWorkouts:
+      input.lookbackWorkouts !== undefined
+        ? normalizeInteger(input.lookbackWorkouts, current.lookbackWorkouts, 1, 52)
+        : current.lookbackWorkouts,
+    includeSecondary: input.includeSecondary ?? current.includeSecondary,
+    secondaryWeight:
+      input.secondaryWeight !== undefined
+        ? normalizeNumber(input.secondaryWeight, current.secondaryWeight, 0, 1)
+        : current.secondaryWeight,
+    excludeWarmups: input.excludeWarmups ?? current.excludeWarmups,
+  }
+
+  const settings = await prisma.userMuscleBalanceSettings.upsert({
+    where: { userId },
+    update: {
+      targets: next.targets,
+      lookbackWorkouts: next.lookbackWorkouts,
+      includeSecondary: next.includeSecondary,
+      secondaryWeight: next.secondaryWeight,
+      excludeWarmups: next.excludeWarmups,
+    },
+    create: {
+      userId,
+      targets: next.targets,
+      lookbackWorkouts: next.lookbackWorkouts,
+      includeSecondary: next.includeSecondary,
+      secondaryWeight: next.secondaryWeight,
+      excludeWarmups: next.excludeWarmups,
+    },
+  })
+
+  return normalizeMuscleBalanceSettings(settings)
+}
+
+export async function getMuscleBalanceSnapshot(
+  prisma: PrismaClient,
+  userId: string
+): Promise<MuscleBalanceSnapshot> {
+  const settings = await getOrCreateMuscleBalanceSettings(prisma, userId)
+  const completions = await prisma.workoutCompletion.findMany({
+    where: {
+      userId,
+      status: 'completed',
+      isArchived: false,
+    },
+    orderBy: { completedAt: 'desc' },
+    take: settings.lookbackWorkouts,
+    select: {
+      loggedSets: {
+        select: {
+          isWarmup: true,
+          exercise: {
+            select: {
+              exerciseDefinition: {
+                select: {
+                  primaryFAUs: true,
+                  secondaryFAUs: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return calculateMuscleBalanceSnapshot(settings, completions)
+}
+
+export function calculateMuscleBalanceSnapshot(
+  settings: MuscleBalanceSettingsDTO,
+  completions: CompletionForBalance[]
+): MuscleBalanceSnapshot {
+  const volume = ALL_FAUS.reduce((acc, fau) => {
+    acc[fau] = 0
+    return acc
+  }, {} as MuscleBalanceTargets)
+
+  for (const completion of completions) {
+    for (const set of completion.loggedSets) {
+      if (settings.excludeWarmups && set.isWarmup) continue
+      const definition = set.exercise.exerciseDefinition
+      for (const fau of definition.primaryFAUs) {
+        if (isFAUKey(fau)) volume[fau] += 1
+      }
+      if (settings.includeSecondary) {
+        for (const fau of definition.secondaryFAUs) {
+          if (isFAUKey(fau)) volume[fau] += settings.secondaryWeight
+        }
+      }
+    }
+  }
+
+  const targetTotal = ALL_FAUS.reduce(
+    (sum, fau) => sum + Math.max(0, settings.targets[fau]),
+    0
+  )
+  const safeTargetTotal = targetTotal > 0 ? targetTotal : ALL_FAUS.length
+  const totalEffectiveSets = ALL_FAUS.reduce((sum, fau) => sum + volume[fau], 0)
+
+  const items = ALL_FAUS.map((fau) => {
+    const targetWeight =
+      targetTotal > 0 ? settings.targets[fau] : getDefaultMuscleBalanceTargets()[fau]
+    const targetShare = Math.max(0, targetWeight) / safeTargetTotal
+    const actualSets = volume[fau]
+    const actualShare = totalEffectiveSets > 0 ? actualSets / totalEffectiveSets : 0
+    const deficitShare = targetShare - actualShare
+    const fulfillment =
+      targetShare > 0 ? Math.min(actualShare / targetShare, 9.99) : actualSets > 0 ? 9.99 : 1
+    const status =
+      targetShare === 0 || Math.abs(deficitShare) <= 0.02
+        ? 'balanced'
+        : deficitShare > 0
+          ? 'neglected'
+          : 'over'
+
+    return {
+      fau,
+      label: FAU_DISPLAY_NAMES[fau],
+      targetWeight,
+      targetShare,
+      actualSets,
+      actualShare,
+      deficitShare,
+      fulfillment,
+      status,
+    } satisfies MuscleBalanceItem
+  }).sort((a, b) => b.deficitShare - a.deficitShare)
+
+  return {
+    settings,
+    lookback: {
+      requestedWorkouts: settings.lookbackWorkouts,
+      completedWorkouts: completions.length,
+      totalEffectiveSets,
+    },
+    items,
+    neglected: items.filter((item) => item.status === 'neglected').slice(0, 5),
+  }
+}
+
+export function updateMuscleBalanceSnapshotSettings(
+  snapshot: MuscleBalanceSnapshot,
+  settings: MuscleBalanceSettingsDTO
+): MuscleBalanceSnapshot {
+  const totalEffectiveSets = snapshot.lookback.totalEffectiveSets
+  const targetTotal = ALL_FAUS.reduce(
+    (sum, fau) => sum + Math.max(0, settings.targets[fau]),
+    0
+  )
+  const safeTargetTotal = targetTotal > 0 ? targetTotal : ALL_FAUS.length
+  const volumeByFau = snapshot.items.reduce((acc, item) => {
+    acc[item.fau] = item.actualSets
+    return acc
+  }, {} as MuscleBalanceTargets)
+
+  const items = ALL_FAUS.map((fau) => {
+    const targetWeight =
+      targetTotal > 0 ? settings.targets[fau] : getDefaultMuscleBalanceTargets()[fau]
+    const targetShare = Math.max(0, targetWeight) / safeTargetTotal
+    const actualSets = volumeByFau[fau] ?? 0
+    const actualShare = totalEffectiveSets > 0 ? actualSets / totalEffectiveSets : 0
+    const deficitShare = targetShare - actualShare
+    const fulfillment =
+      targetShare > 0 ? Math.min(actualShare / targetShare, 9.99) : actualSets > 0 ? 9.99 : 1
+    const status =
+      targetShare === 0 || Math.abs(deficitShare) <= 0.02
+        ? 'balanced'
+        : deficitShare > 0
+          ? 'neglected'
+          : 'over'
+
+    return {
+      fau,
+      label: FAU_DISPLAY_NAMES[fau],
+      targetWeight,
+      targetShare,
+      actualSets,
+      actualShare,
+      deficitShare,
+      fulfillment,
+      status,
+    } satisfies MuscleBalanceItem
+  }).sort((a, b) => b.deficitShare - a.deficitShare)
+
+  return {
+    settings,
+    lookback: {
+      ...snapshot.lookback,
+      requestedWorkouts: settings.lookbackWorkouts,
+      completedWorkouts: Math.min(
+        snapshot.lookback.completedWorkouts,
+        settings.lookbackWorkouts
+      ),
+    },
+    items,
+    neglected: items.filter((item) => item.status === 'neglected').slice(0, 5),
+  }
+}
+
+export function isFAUKey(value: string): value is FAUKey {
+  return (ALL_FAUS as readonly string[]).includes(value)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function roundToStep(value: number): number {
+  return Math.round(value / TARGET_STEP) * TARGET_STEP
+}
+
+function normalizeNumber(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(numeric) ? clamp(numeric, min, max) : fallback
+}
+
+function normalizeInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  return Number.isInteger(numeric) ? clamp(numeric, min, max) : fallback
+}

--- a/prisma/exercise-library-seed.sql
+++ b/prisma/exercise-library-seed.sql
@@ -2,9 +2,9 @@
 -- Comprehensive exercise definitions with FAU (Functional Aesthetic Unit) mappings
 -- Run this in Supabase SQL Editor to populate the ExerciseDefinition table
 --
--- FAU Categories (19):
--- chest, mid-back, lower-back, traps, front-delts, mid-delts, rear-delts, lats,
--- biceps, triceps, forearms, neck, quads, adductors, hamstrings,
+-- FAU Categories (18):
+-- chest, mid-back, lower-back, traps, front-delts, side-delts, rear-delts, lats,
+-- biceps, triceps, forearms, quads, adductors, hamstrings,
 -- glutes, calves, abs, obliques
 
 -- ============================================================================

--- a/prisma/migrations/20260612000103_add_user_muscle_balance_settings/migration.sql
+++ b/prisma/migrations/20260612000103_add_user_muscle_balance_settings/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "UserMuscleBalanceSettings" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "targets" JSONB NOT NULL,
+  "lookbackWorkouts" INTEGER NOT NULL DEFAULT 8,
+  "includeSecondary" BOOLEAN NOT NULL DEFAULT true,
+  "secondaryWeight" DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+  "excludeWarmups" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "UserMuscleBalanceSettings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "UserMuscleBalanceSettings_userId_key" ON "UserMuscleBalanceSettings"("userId");
+CREATE INDEX "UserMuscleBalanceSettings_userId_idx" ON "UserMuscleBalanceSettings"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -338,6 +338,20 @@ model UserSettings {
   @@index([userId])
 }
 
+model UserMuscleBalanceSettings {
+  id               String   @id @default(cuid())
+  userId           String   @unique
+  targets          Json
+  lookbackWorkouts Int      @default(8)
+  includeSecondary Boolean  @default(true)
+  secondaryWeight  Float    @default(0.5)
+  excludeWarmups   Boolean  @default(true)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([userId])
+}
+
 model CommunityProgram {
   id                String   @id(map: "community_programs_pkey") @default(cuid())
   name              String


### PR DESCRIPTION
## Summary
- add per-user muscle balance settings with FAU target ratios and lookback preferences
- show neglected muscle guidance through the ad hoc exercise muscle-group filter
- account for draft/planned ad hoc exercises when sorting muscles by neglect

## Verification
- npm run type-check
- focused ESLint on touched UI files
- targeted muscle-balance calculation test passed; DB-backed Testcontainers cases were not runnable in this environment

Schema updated locally. **Production migration auto-applies on deploy.**