### PR TITLE
feat: add Suggestion table and Workout.sourceSuggestionId

### DIFF
--- a/prisma/migrations/20260629164946_add_suggestion_table/migration.sql
+++ b/prisma/migrations/20260629164946_add_suggestion_table/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN "sourceSuggestionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Suggestion" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "requestPayload" JSONB NOT NULL,
+    "responsePayload" JSONB NOT NULL,
+    "model" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "latencyMs" INTEGER NOT NULL,
+    "validationFailures" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "Suggestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Suggestion_userId_createdAt_idx" ON "Suggestion"("userId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Workout_sourceSuggestionId_idx" ON "Workout"("sourceSuggestionId");
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_sourceSuggestionId_fkey" FOREIGN KEY ("sourceSuggestionId") REFERENCES "Suggestion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,18 +55,36 @@ model Week {
 }
 
 model Workout {
-  id          String              @id @default(cuid())
-  name        String
-  dayNumber   Int
-  weekId      String
-  userId      String
-  exercises   Exercise[]
-  week        Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
-  completions WorkoutCompletion[]
+  id                 String              @id @default(cuid())
+  name               String
+  dayNumber          Int
+  weekId             String
+  userId             String
+  sourceSuggestionId String?
+  exercises          Exercise[]
+  week               Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
+  sourceSuggestion   Suggestion?         @relation(fields: [sourceSuggestionId], references: [id])
+  completions        WorkoutCompletion[]
 
   @@unique([weekId, dayNumber])
   @@index([weekId])
   @@index([userId])
+  @@index([sourceSuggestionId])
+}
+
+model Suggestion {
+  id                 String    @id @default(cuid())
+  userId             String
+  createdAt          DateTime  @default(now())
+  requestPayload     Json
+  responsePayload    Json
+  model              String
+  provider           String
+  latencyMs          Int
+  validationFailures Int       @default(0)
+  workouts           Workout[]
+
+  @@index([userId, createdAt(sort: Desc)])
 }
 
 model ExerciseDefinition {

--- a/types/suggestion.ts
+++ b/types/suggestion.ts
@@ -1,0 +1,108 @@
+/**
+ * Type definitions for Suggest Workout LLM suggestion request/response payloads.
+ *
+ * These shapes are persisted in the Suggestion table (requestPayload, responsePayload
+ * JSON columns) so that suggestions can be debugged, replayed, and used as the source
+ * of truth for the implicit-feedback loop (distinguishing "user edited their own
+ * workout" from "user edited an AI suggestion").
+ *
+ * See issue #869 and design context in #868.
+ */
+
+/**
+ * Snapshot of the user's training profile at the time the suggestion was requested.
+ * Mirrors UserTrainingProfile (issue #870) — duplicated here so changes to the
+ * profile after the suggestion don't invalidate the original context.
+ */
+export interface SuggestionProfileSnapshot {
+  experienceLevel?: string | null
+  equipmentAvailable?: string[]
+  goals?: string[]
+  focusAreas?: string[]
+  intensityEnabled?: boolean
+  defaultIntensityRating?: 'rpe' | 'rir' | null
+  /** Free-form notes / additional context provided by the user */
+  notes?: string | null
+}
+
+/**
+ * One slot in the recent-history window the LLM sees.
+ * Lightweight by design — full workouts are too large to fit in context.
+ */
+export interface SuggestionHistoryEntry {
+  completedAt: string // ISO 8601
+  workoutName: string
+  /** Primary muscle groups / functional anatomy units hit by this session */
+  primaryFAUs?: string[]
+  /** Exercise names performed, in order */
+  exercises: string[]
+}
+
+/**
+ * Full payload sent to the LLM. Stored verbatim in Suggestion.requestPayload
+ * so we can replay or debug a specific suggestion.
+ */
+export interface SuggestionRequestPayload {
+  /** Schema version of this payload shape — bump when fields change incompatibly */
+  schemaVersion: 1
+  /** When the suggestion was requested (server time) */
+  requestedAt: string // ISO 8601
+  /** Snapshot of user profile at request time */
+  profile: SuggestionProfileSnapshot
+  /** Recent completed workouts (most recent first), bounded window */
+  history: SuggestionHistoryEntry[]
+  /** Optional user-supplied free-form prompt ("I want a push day, no barbell") */
+  userPrompt?: string
+  /** Optional explicit target FAUs / focus for this session */
+  targetFAUs?: string[]
+  /** Target session duration in minutes, if specified */
+  targetDurationMinutes?: number
+}
+
+/**
+ * One exercise the LLM suggests as part of the workout.
+ */
+export interface SuggestedExercise {
+  /** Canonical exercise name (should resolve to an ExerciseDefinition) */
+  name: string
+  /** Optional explicit ExerciseDefinition id if the LLM was given the catalog */
+  exerciseDefinitionId?: string
+  /** Optional grouping hint (e.g. "A1", "A2" for supersets) */
+  exerciseGroup?: string | null
+  order: number
+  sets: SuggestedSet[]
+  /** Per-exercise rationale / coaching note */
+  notes?: string | null
+}
+
+/**
+ * One prescribed set in a suggested exercise.
+ */
+export interface SuggestedSet {
+  setNumber: number
+  /** Rep prescription — string to allow ranges like "8-12" or "AMRAP" */
+  reps: string
+  /** Weight prescription — string to allow "135 lbs", "BW", "RPE 7", "%1RM" */
+  weight?: string | null
+  rpe?: number | null
+  rir?: number | null
+  isWarmup?: boolean
+}
+
+/**
+ * Full structured output from the LLM. Stored verbatim in Suggestion.responsePayload.
+ * The Suggest Workout flow translates this into Workout + Exercise + PrescribedSet rows,
+ * stamping Workout.sourceSuggestionId for traceability.
+ */
+export interface SuggestionResponsePayload {
+  schemaVersion: 1
+  workoutName: string
+  /** Overall rationale for the session (shown to user, used for implicit feedback) */
+  rationale: string
+  exercises: SuggestedExercise[]
+  /** Estimated duration in minutes, if the LLM provided one */
+  estimatedDurationMinutes?: number
+  /** Optional warm-up guidance / cooldown notes */
+  warmupNotes?: string | null
+  cooldownNotes?: string | null
+}


### PR DESCRIPTION
## Summary
- Adds `Suggestion` model and `Workout.sourceSuggestionId` FK for LLM workout suggestion traceability
- Adds `types/suggestion.ts` with request/response payload types
- Migration `20260629164946_add_suggestion_table`

Fixes #871

## Test plan
- [ ] `prisma validate` passes
- [ ] `npm run type-check` passes
- [ ] Migration applies cleanly on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)