### PR TITLE
feat: provider-agnostic LLM client wrapper with structured output

### DIFF
--- a/__tests__/lib/llm/clean-output.test.ts
+++ b/__tests__/lib/llm/clean-output.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { cleanLLMOutput } from '@/lib/llm/clean-output'
+
+/**
+ * Each test feeds a known cheap-model failure mode into cleanLLMOutput
+ * and asserts that the result is parseable AND structurally equal to the
+ * expected object.
+ */
+function parse(raw: string): unknown {
+  const cleaned = cleanLLMOutput(raw)
+  return JSON.parse(cleaned)
+}
+
+describe('cleanLLMOutput', () => {
+  it('passes valid JSON unchanged', () => {
+    expect(parse('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('strips ```json code fences', () => {
+    const raw = '```json\n{"a":1,"b":[1,2]}\n```'
+    expect(parse(raw)).toEqual({ a: 1, b: [1, 2] })
+  })
+
+  it('strips plain ``` code fences', () => {
+    const raw = '```\n{"a":1}\n```'
+    expect(parse(raw)).toEqual({ a: 1 })
+  })
+
+  it('strips preamble prose before JSON', () => {
+    const raw = "Here's your workout: {\"name\":\"squat\"}"
+    expect(parse(raw)).toEqual({ name: 'squat' })
+  })
+
+  it('strips trailing prose after JSON', () => {
+    const raw = '{"name":"squat"} — let me know if you want more!'
+    expect(parse(raw)).toEqual({ name: 'squat' })
+  })
+
+  it('strips both preamble and trailing prose', () => {
+    const raw = 'Sure! {"x":1} hope that helps.'
+    expect(parse(raw)).toEqual({ x: 1 })
+  })
+
+  it('handles preamble + code fences combined', () => {
+    const raw = "Here you go:\n```json\n{\"a\":1}\n```\nlet me know!"
+    expect(parse(raw)).toEqual({ a: 1 })
+  })
+
+  it('removes trailing commas in objects', () => {
+    const raw = '{"a":1, "b":2,}'
+    expect(parse(raw)).toEqual({ a: 1, b: 2 })
+  })
+
+  it('removes trailing commas in arrays', () => {
+    const raw = '{"xs":[1,2,3,]}'
+    expect(parse(raw)).toEqual({ xs: [1, 2, 3] })
+  })
+
+  it('converts single-quoted strings to double-quoted', () => {
+    const raw = "{'name': 'squat', 'reps': 5}"
+    expect(parse(raw)).toEqual({ name: 'squat', reps: 5 })
+  })
+
+  it('handles nested objects with depth counting', () => {
+    const raw = 'preamble {"a":{"b":{"c":1}}} trailing'
+    expect(parse(raw)).toEqual({ a: { b: { c: 1 } } })
+  })
+
+  it('handles braces inside string values without breaking', () => {
+    const raw = '{"template":"hello {name}"}'
+    expect(parse(raw)).toEqual({ template: 'hello {name}' })
+  })
+
+  it('handles arrays as the top-level structure', () => {
+    const raw = '```json\n[1,2,3]\n```'
+    expect(parse(raw)).toEqual([1, 2, 3])
+  })
+
+  it('handles JSON with embedded escaped quotes', () => {
+    const raw = '{"q":"she said \\"hi\\""}'
+    expect(parse(raw)).toEqual({ q: 'she said "hi"' })
+  })
+
+  it('handles unwanted wrapper like {"response": {...}}', () => {
+    // We don't unwrap, but we should still extract the outer object.
+    const raw = '```json\n{"response":{"exercises":[1,2]}}\n```'
+    expect(parse(raw)).toEqual({ response: { exercises: [1, 2] } })
+  })
+
+  it('handles single quotes + trailing commas combined', () => {
+    const raw = "{'a': 1, 'b': [1,2,],}"
+    expect(parse(raw)).toEqual({ a: 1, b: [1, 2] })
+  })
+
+  it('throws on non-string input', () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => cleanLLMOutput(123)).toThrow(TypeError)
+  })
+
+  it('returns input gracefully when no JSON is present', () => {
+    // Cleanup falls back to a string the caller can fail to parse.
+    const out = cleanLLMOutput('no json here')
+    expect(typeof out).toBe('string')
+    expect(() => JSON.parse(out)).toThrow()
+  })
+
+  it('handles fenced JSON with language tag uppercase', () => {
+    const raw = '```JSON\n{"a":1}\n```'
+    expect(parse(raw)).toEqual({ a: 1 })
+  })
+
+  it('handles JSON with newlines/indentation', () => {
+    const raw = '```json\n{\n  "a": 1,\n  "b": 2\n}\n```'
+    expect(parse(raw)).toEqual({ a: 1, b: 2 })
+  })
+})

--- a/__tests__/lib/llm/client.test.ts
+++ b/__tests__/lib/llm/client.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import {
+  LLMClient,
+  LLMProviderError,
+  LLMTimeoutError,
+  LLMValidationError,
+} from '@/lib/llm/client'
+
+/**
+ * Unit tests for `callWithStructuredOutput` using a mocked OpenAI client.
+ *
+ * We construct an LLMClient with explicit config, then monkeypatch the
+ * underlying `openai.chat.completions.create` method on the instance.
+ */
+
+interface FakeChoice {
+  content: string | null
+}
+
+function makeClient(responses: FakeChoice[]) {
+  const client = new LLMClient({
+    apiKey: 'test-key',
+    baseURL: 'http://example.invalid',
+    model: 'test-model',
+  })
+
+  // Reach into the private openai instance and replace the create fn.
+  // biome-ignore lint/suspicious/noExplicitAny: test-only access
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const openai = (client as any).openai as {
+    chat: { completions: { create: (...args: unknown[]) => Promise<unknown> } }
+  }
+  let call = 0
+  openai.chat.completions.create = vi.fn(async () => {
+    const r = responses[call++] ?? { content: null }
+    return {
+      choices: [{ message: { content: r.content } }],
+    }
+  })
+
+  return { client, createSpy: openai.chat.completions.create as ReturnType<typeof vi.fn> }
+}
+
+const schema = z.object({
+  name: z.string(),
+  reps: z.number(),
+})
+
+describe('LLMClient.callWithStructuredOutput', () => {
+  it('parses valid JSON and returns data', async () => {
+    const { client } = makeClient([
+      { content: '{"name":"squat","reps":5}' },
+    ])
+    const result = await client.callWithStructuredOutput('go', schema)
+    expect(result.data).toEqual({ name: 'squat', reps: 5 })
+    expect(result.retries).toBe(0)
+    expect(result.validationFailures).toBe(0)
+    expect(result.model).toBe('test-model')
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('cleans markdown fences before parsing', async () => {
+    const { client } = makeClient([
+      { content: '```json\n{"name":"squat","reps":5}\n```' },
+    ])
+    const result = await client.callWithStructuredOutput('go', schema)
+    expect(result.data).toEqual({ name: 'squat', reps: 5 })
+  })
+
+  it('retries once on schema validation failure and succeeds', async () => {
+    const { client, createSpy } = makeClient([
+      { content: '{"name":"squat"}' }, // missing reps
+      { content: '{"name":"squat","reps":5}' },
+    ])
+    const result = await client.callWithStructuredOutput('go', schema)
+    expect(result.data).toEqual({ name: 'squat', reps: 5 })
+    expect(result.retries).toBe(1)
+    expect(result.validationFailures).toBe(1)
+    expect(createSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws LLMValidationError after retry also fails', async () => {
+    const { client } = makeClient([
+      { content: '{"name":"squat"}' },
+      { content: '{"name":"squat"}' },
+    ])
+    await expect(
+      client.callWithStructuredOutput('go', schema),
+    ).rejects.toBeInstanceOf(LLMValidationError)
+  })
+
+  it('throws LLMValidationError on unparseable JSON after retry', async () => {
+    const { client } = makeClient([
+      { content: 'not json at all' },
+      { content: 'still not json' },
+    ])
+    await expect(
+      client.callWithStructuredOutput('go', schema),
+    ).rejects.toBeInstanceOf(LLMValidationError)
+  })
+
+  it('throws LLMProviderError on empty response', async () => {
+    const { client } = makeClient([{ content: null }])
+    await expect(
+      client.callWithStructuredOutput('go', schema),
+    ).rejects.toBeInstanceOf(LLMProviderError)
+  })
+
+  it('respects timeout', async () => {
+    const client = new LLMClient({
+      apiKey: 'k',
+      baseURL: 'http://x.invalid',
+      model: 'm',
+    })
+    // biome-ignore lint/suspicious/noExplicitAny: test-only access
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const openai = (client as any).openai as {
+      chat: {
+        completions: { create: (...args: unknown[]) => Promise<unknown> }
+      }
+    }
+    openai.chat.completions.create = vi.fn(
+      () => new Promise(() => {}), // never resolves
+    )
+    await expect(
+      client.callWithStructuredOutput('go', schema, { timeoutMs: 20 }),
+    ).rejects.toBeInstanceOf(LLMTimeoutError)
+  })
+
+  it('throws on missing API key', () => {
+    const prev = process.env.LLM_API_KEY
+    delete process.env.LLM_API_KEY
+    try {
+      expect(() => new LLMClient({ model: 'm' })).toThrow(LLMProviderError)
+    } finally {
+      if (prev !== undefined) process.env.LLM_API_KEY = prev
+    }
+  })
+
+  it('throws on missing model', () => {
+    const prev = process.env.LLM_MODEL
+    delete process.env.LLM_MODEL
+    try {
+      expect(() => new LLMClient({ apiKey: 'k' })).toThrow(LLMProviderError)
+    } finally {
+      if (prev !== undefined) process.env.LLM_MODEL = prev
+    }
+  })
+
+  it('passes system prompt into messages', async () => {
+    const { client, createSpy } = makeClient([
+      { content: '{"name":"squat","reps":5}' },
+    ])
+    await client.callWithStructuredOutput('go', schema, {
+      system: 'you are a coach',
+    })
+    const args = createSpy.mock.calls[0][0] as {
+      messages: Array<{ role: string; content: string }>
+    }
+    expect(args.messages[0]).toEqual({
+      role: 'system',
+      content: 'you are a coach',
+    })
+    expect(args.messages[1]).toEqual({ role: 'user', content: 'go' })
+  })
+
+  it('includes retry context in the second-attempt prompt', async () => {
+    const { client, createSpy } = makeClient([
+      { content: '{"name":"squat"}' },
+      { content: '{"name":"squat","reps":5}' },
+    ])
+    await client.callWithStructuredOutput('please return JSON', schema)
+    const secondArgs = createSpy.mock.calls[1][0] as {
+      messages: Array<{ role: string; content: string }>
+    }
+    const userMsg = secondArgs.messages.find((m) => m.role === 'user')
+    expect(userMsg?.content).toContain('please return JSON')
+    expect(userMsg?.content).toContain('failed validation')
+  })
+})

--- a/__tests__/lib/llm/integration.test.ts
+++ b/__tests__/lib/llm/integration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { LLMClient } from '@/lib/llm/client'
+
+/**
+ * Integration test that hits a real LLM provider. Gated behind the
+ * `LLM_INTEGRATION_TEST=true` env var so it does not run in CI by default.
+ *
+ * To run locally:
+ *   LLM_INTEGRATION_TEST=true \
+ *   LLM_PROVIDER_URL=... LLM_API_KEY=... LLM_MODEL=... \
+ *   npm test integration
+ */
+const enabled = process.env.LLM_INTEGRATION_TEST === 'true'
+
+describe.skipIf(!enabled)('LLMClient (real provider)', () => {
+  it('returns a valid structured response', async () => {
+    const client = new LLMClient()
+    const schema = z.object({
+      capital: z.string(),
+      country: z.string(),
+    })
+    const result = await client.callWithStructuredOutput(
+      'Return JSON with keys "country" and "capital" for France.',
+      schema,
+      { timeoutMs: 30_000 },
+    )
+    expect(result.data.country.toLowerCase()).toContain('france')
+    expect(result.data.capital.toLowerCase()).toContain('paris')
+  }, 60_000)
+})

--- a/docs/LLM_CLIENT.md
+++ b/docs/LLM_CLIENT.md
@@ -1,0 +1,135 @@
+# LLM Client
+
+A thin provider-agnostic wrapper around the `openai` SDK so we can swap
+LLM providers by changing environment variables. Used by the Suggest
+Workout worker, the onboarding agent, and the exercise tagger.
+
+## Configuration
+
+The client reads three env vars via Doppler:
+
+| Var                | Example                                                    |
+| ------------------ | ---------------------------------------------------------- |
+| `LLM_PROVIDER_URL` | `https://api.deepinfra.com/v1/openai`                      |
+| `LLM_API_KEY`      | Provider API key                                           |
+| `LLM_MODEL`        | `meta-llama/Meta-Llama-3.1-70B-Instruct` (provider-scoped) |
+
+Any OpenAI-compatible endpoint works: DeepInfra, Together, Groq, Ollama
+(`http://localhost:11434/v1`), or Anthropic via a proxy. There is **no
+multi-provider fallback** — one provider per environment.
+
+Optional:
+
+- `LLM_DEBUG=true` — emit full prompt/response payloads at `debug` level
+  via the shared `lib/logger.ts`.
+
+## Basic usage
+
+```ts
+import { z } from 'zod'
+
+import { getLLMClient } from '@/lib/llm/client'
+
+const schema = z.object({
+  exercises: z.array(
+    z.object({
+      name: z.string(),
+      sets: z.number().int().positive(),
+      reps: z.number().int().positive(),
+    }),
+  ),
+})
+
+const client = getLLMClient()
+const { data, model, latencyMs, retries } = await client.callWithStructuredOutput(
+  'Suggest a 4-exercise upper-body workout as JSON with keys "exercises".',
+  schema,
+  {
+    system: 'You are a strength coach. Respond with JSON only.',
+    temperature: 0.2,
+    timeoutMs: 30_000,
+  },
+)
+```
+
+`data` is fully typed from the Zod schema. `model`, `latencyMs`, and
+`retries` are useful for the Suggestion table audit trail.
+
+## Output cleanup
+
+Cheap models routinely return malformed JSON. `cleanLLMOutput`
+(`lib/llm/clean-output.ts`) normalizes the common failure modes before
+`JSON.parse`:
+
+1. Strip markdown code fences (` ```json `, ` ```JSON `, plain ` ``` `).
+2. Use depth-counted brace matching to extract the first balanced
+   `{ ... }` or `[ ... ]` from arbitrary surrounding prose
+   (e.g. `"Here's your workout: { ... } let me know!"`).
+3. Try `JSON.parse`; on failure, apply repairs:
+   - Remove trailing commas (`{"a":1,}` → `{"a":1}`)
+   - Convert single-quoted JSON delimiters to double-quoted
+4. Return the cleaned string. The caller is responsible for the final
+   `JSON.parse`.
+
+The function is pure and heavily unit-tested
+(`__tests__/lib/llm/clean-output.test.ts`).
+
+## Validation + retry
+
+`callWithStructuredOutput` runs the cleaned response through Zod
+`safeParse`. On failure it retries **once** with the original prompt plus
+the Zod error message and a truncated copy of the bad response, then
+gives up.
+
+Outcomes:
+
+| Outcome                                  | Result                                |
+| ---------------------------------------- | ------------------------------------- |
+| Valid JSON, valid schema                 | `{ data, model, latencyMs, retries }` |
+| Cleanup fixes JSON, valid schema         | `retries=0`, `validationFailures=0`   |
+| Invalid first time, valid after retry    | `retries=1`, `validationFailures=1`   |
+| Invalid both times                       | throws `LLMValidationError`           |
+| Provider error / empty content           | throws `LLMProviderError`             |
+| Call exceeds `timeoutMs` (default 60 s)  | throws `LLMTimeoutError`              |
+
+## Error types
+
+```ts
+import {
+  LLMProviderError,
+  LLMValidationError,
+  LLMTimeoutError,
+} from '@/lib/llm/client'
+
+try {
+  await client.callWithStructuredOutput(prompt, schema)
+} catch (err) {
+  if (err instanceof LLMValidationError) {
+    // err.rawResponse, err.issues
+  } else if (err instanceof LLMTimeoutError) {
+    // err.timeoutMs
+  } else if (err instanceof LLMProviderError) {
+    // err.cause, err.status
+  }
+}
+```
+
+## Testing
+
+- **Unit tests**: `npm test clean-output` and `npm test llm/client`
+  (mock-based, no network).
+- **Integration test**: gated behind `LLM_INTEGRATION_TEST=true`. Set
+  the three `LLM_*` env vars and run:
+
+  ```bash
+  LLM_INTEGRATION_TEST=true \
+    LLM_PROVIDER_URL=... LLM_API_KEY=... LLM_MODEL=... \
+    npm test llm/integration
+  ```
+
+## Out of scope (deferred)
+
+- Streaming responses (v2).
+- Per-call cost tracking — sum costs from the `Suggestion` table.
+- Per-call response caching — that's the consumer's concern.
+- Multi-provider fallback.

--- a/lib/llm/clean-output.ts
+++ b/lib/llm/clean-output.ts
@@ -1,0 +1,160 @@
+/**
+ * Cheap LLM models routinely produce malformed JSON. This module strips
+ * the common failure-mode garbage and returns a best-effort JSON string
+ * that the caller can pass to `JSON.parse`.
+ *
+ * Known failure modes handled:
+ * - Markdown code fences (```json ... ``` or ``` ... ```)
+ * - Preambles ("Here's your workout: { ... }")
+ * - Trailing prose after the JSON body
+ * - Trailing commas before } or ]
+ * - Single-quoted JSON strings/keys
+ *
+ * Pure function. No I/O, no side effects.
+ */
+
+/**
+ * Strip leading/trailing markdown code fences from a string. Handles
+ * ```json, ```JSON, plain ``` and optional surrounding whitespace.
+ */
+function stripCodeFences(input: string): string {
+  let s = input.trim()
+  // Leading fence
+  const leading = s.match(/^```[a-zA-Z0-9_-]*\s*\n?/)
+  if (leading) {
+    s = s.slice(leading[0].length)
+  }
+  // Trailing fence
+  const trailing = s.match(/\n?```\s*$/)
+  if (trailing) {
+    s = s.slice(0, s.length - trailing[0].length)
+  }
+  return s.trim()
+}
+
+/**
+ * Extract the first balanced JSON object or array substring using depth
+ * counting. Returns null if no balanced structure is found.
+ *
+ * Walks the string while tracking depth across `{}` and `[]`. Skips over
+ * string literals (both " and ') so that braces inside strings don't
+ * affect depth.
+ */
+function extractBalancedJson(input: string): string | null {
+  // Find the first { or [
+  let start = -1
+  let opener: '{' | '[' | null = null
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i]
+    if (c === '{' || c === '[') {
+      start = i
+      opener = c
+      break
+    }
+  }
+  if (start === -1 || opener === null) return null
+
+  const closer = opener === '{' ? '}' : ']'
+  let depth = 0
+  let inString: '"' | "'" | null = null
+  let escapeNext = false
+
+  for (let i = start; i < input.length; i++) {
+    const c = input[i]
+    if (escapeNext) {
+      escapeNext = false
+      continue
+    }
+    if (inString) {
+      if (c === '\\') {
+        escapeNext = true
+        continue
+      }
+      if (c === inString) {
+        inString = null
+      }
+      continue
+    }
+    if (c === '"' || c === "'") {
+      inString = c
+      continue
+    }
+    if (c === opener) depth++
+    else if (c === closer) {
+      depth--
+      if (depth === 0) {
+        return input.slice(start, i + 1)
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Remove trailing commas before } or ]. Naive, but safe enough for
+ * post-extraction cleanup since we've already isolated JSON.
+ */
+function removeTrailingCommas(input: string): string {
+  return input.replace(/,(\s*[}\]])/g, '$1')
+}
+
+/**
+ * Replace single-quoted strings/keys with double-quoted equivalents.
+ *
+ * Only operates when the input does NOT already contain double-quoted
+ * strings, OR when single quotes appear in JSON-key/value positions. We
+ * use a careful regex that:
+ *   1. Only replaces single quotes that look like JSON delimiters
+ *      (preceded by `{`, `[`, `,`, `:` or whitespace, and the closing
+ *      quote followed by `}`, `]`, `,`, `:` or whitespace).
+ *   2. Escapes any existing double quotes inside the captured content.
+ */
+function convertSingleQuotes(input: string): string {
+  return input.replace(
+    /([{\[,:\s])'((?:[^'\\]|\\.)*)'(?=[}\],:\s])/g,
+    (_match, prefix, content) => {
+      const escaped = content
+        .replace(/\\'/g, "'") // unescape single quotes
+        .replace(/"/g, '\\"') // escape double quotes
+      return `${prefix}"${escaped}"`
+    },
+  )
+}
+
+/**
+ * Clean a raw LLM response and return a string that should parse as JSON.
+ *
+ * The returned string is NOT guaranteed to parse — callers should still
+ * wrap `JSON.parse` in a try/catch — but it removes the common failure
+ * modes that cheap models produce. If no balanced JSON structure can be
+ * found, returns the trimmed/fence-stripped input so the caller's parse
+ * error message points at the original content.
+ */
+export function cleanLLMOutput(raw: string): string {
+  if (typeof raw !== 'string') {
+    throw new TypeError('cleanLLMOutput: expected string input')
+  }
+
+  // 1. Strip markdown code fences
+  const fenced = stripCodeFences(raw)
+
+  // 2. Find balanced JSON object/array
+  const extracted = extractBalancedJson(fenced)
+  const candidate = extracted ?? fenced
+
+  // 3. Try parse as-is. If it works we're done.
+  try {
+    JSON.parse(candidate)
+    return candidate
+  } catch {
+    // fall through to repairs
+  }
+
+  // 4. Repair: remove trailing commas + convert single quotes
+  let repaired = removeTrailingCommas(candidate)
+  repaired = convertSingleQuotes(repaired)
+  // Re-run trailing-comma removal in case quote conversion exposed any
+  repaired = removeTrailingCommas(repaired)
+
+  return repaired
+}

--- a/lib/llm/client.ts
+++ b/lib/llm/client.ts
@@ -1,0 +1,277 @@
+import OpenAI from 'openai'
+import type { z } from 'zod'
+
+import { logger } from '@/lib/logger'
+
+import { cleanLLMOutput } from './clean-output'
+import { LLMProviderError, LLMTimeoutError, LLMValidationError } from './errors'
+
+/**
+ * Provider-agnostic LLM client wrapper.
+ *
+ * Uses the `openai` SDK pointed at any OpenAI-compatible endpoint (DeepInfra,
+ * Together, Groq, Ollama, Anthropic-via-proxy). Provider selection is via
+ * environment variables — there is no multi-provider fallback. One provider
+ * per env.
+ *
+ * Env vars (Doppler):
+ *   - LLM_PROVIDER_URL  (e.g. https://api.deepinfra.com/v1/openai)
+ *   - LLM_API_KEY
+ *   - LLM_MODEL         (e.g. meta-llama/Meta-Llama-3.1-70B-Instruct)
+ *   - LLM_DEBUG=true    (logs full prompts/responses at debug level)
+ */
+
+export interface LLMClientConfig {
+  apiKey?: string
+  baseURL?: string
+  model?: string
+  debug?: boolean
+}
+
+export interface StructuredOutputOptions {
+  /** Schema description handed to the provider for JSON-schema mode. */
+  schemaName?: string
+  /** System prompt prepended before the user prompt. */
+  system?: string
+  /** Generation temperature; defaults to 0.2 for structured output. */
+  temperature?: number
+  /** Max output tokens. Provider-dependent default. */
+  maxTokens?: number
+  /** Overall call timeout in ms. Defaults to 60_000. */
+  timeoutMs?: number
+  /** Override the configured model for this call. */
+  model?: string
+}
+
+export interface StructuredOutputResult<T> {
+  data: T
+  model: string
+  latencyMs: number
+  retries: number
+  validationFailures: number
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000
+
+function readEnv(name: string): string | undefined {
+  const v = process.env[name]
+  return v && v.length > 0 ? v : undefined
+}
+
+export class LLMClient {
+  private readonly openai: OpenAI
+  private readonly model: string
+  private readonly debug: boolean
+
+  constructor(config: LLMClientConfig = {}) {
+    const apiKey = config.apiKey ?? readEnv('LLM_API_KEY')
+    const baseURL = config.baseURL ?? readEnv('LLM_PROVIDER_URL')
+    const model = config.model ?? readEnv('LLM_MODEL')
+
+    if (!apiKey) {
+      throw new LLMProviderError(
+        'LLM_API_KEY is not configured (pass apiKey or set env var)',
+      )
+    }
+    if (!model) {
+      throw new LLMProviderError(
+        'LLM_MODEL is not configured (pass model or set env var)',
+      )
+    }
+
+    // dangerouslyAllowBrowser: this client is server-side only (workers,
+    // API routes) but the openai SDK's browser sniff trips under vitest's
+    // jsdom environment. We never bundle this for the browser.
+    this.openai = new OpenAI({ apiKey, baseURL, dangerouslyAllowBrowser: true })
+    this.model = model
+    this.debug = config.debug ?? readEnv('LLM_DEBUG') === 'true'
+  }
+
+  /**
+   * Issue a chat completion expecting JSON output, then validate against a
+   * Zod schema. On validation failure, retries ONCE with the zod error
+   * message appended to the user prompt.
+   *
+   * Response is run through `cleanLLMOutput` before parsing to handle the
+   * common cheap-model failure modes (markdown fences, prose preambles,
+   * trailing commas, single quotes).
+   */
+  async callWithStructuredOutput<T>(
+    prompt: string,
+    schema: z.ZodType<T>,
+    options: StructuredOutputOptions = {},
+  ): Promise<StructuredOutputResult<T>> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const model = options.model ?? this.model
+    const temperature = options.temperature ?? 0.2
+    const maxTokens = options.maxTokens
+    const system = options.system
+
+    const start = Date.now()
+    let retries = 0
+    let validationFailures = 0
+    let lastRaw = ''
+    let lastIssues: unknown
+
+    // Up to 2 attempts: original + 1 validation retry
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const userPrompt =
+        attempt === 0
+          ? prompt
+          : buildRetryPrompt(prompt, lastRaw, lastIssues)
+
+      if (this.debug) {
+        logger.debug(
+          { model, attempt, system, userPrompt },
+          '[llm] sending request',
+        )
+      }
+
+      let raw: string
+      try {
+        raw = await this.callChatJSON({
+          model,
+          system,
+          userPrompt,
+          temperature,
+          maxTokens,
+          timeoutMs,
+        })
+      } catch (err) {
+        if (err instanceof LLMTimeoutError) throw err
+        throw new LLMProviderError(
+          err instanceof Error ? err.message : 'LLM provider error',
+          { cause: err },
+        )
+      }
+
+      lastRaw = raw
+
+      if (this.debug) {
+        logger.debug({ model, attempt, raw }, '[llm] received response')
+      }
+
+      // Clean + parse + validate
+      const cleaned = cleanLLMOutput(raw)
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(cleaned)
+      } catch (err) {
+        validationFailures++
+        lastIssues = {
+          parseError: err instanceof Error ? err.message : String(err),
+        }
+        if (attempt === 0) {
+          retries++
+          continue
+        }
+        throw new LLMValidationError(
+          'LLM response is not valid JSON after cleanup',
+          raw,
+          lastIssues,
+        )
+      }
+
+      const result = schema.safeParse(parsed)
+      if (result.success) {
+        return {
+          data: result.data,
+          model,
+          latencyMs: Date.now() - start,
+          retries,
+          validationFailures,
+        }
+      }
+
+      validationFailures++
+      lastIssues = result.error.issues
+      if (attempt === 0) {
+        retries++
+        continue
+      }
+
+      throw new LLMValidationError(
+        'LLM response failed schema validation after retry',
+        raw,
+        result.error.issues,
+      )
+    }
+
+    // Unreachable — the loop always returns or throws.
+    throw new LLMProviderError('LLM call exhausted attempts without result')
+  }
+
+  private async callChatJSON(args: {
+    model: string
+    system?: string
+    userPrompt: string
+    temperature: number
+    maxTokens?: number
+    timeoutMs: number
+  }): Promise<string> {
+    const messages: Array<{ role: 'system' | 'user'; content: string }> = []
+    if (args.system) messages.push({ role: 'system', content: args.system })
+    messages.push({ role: 'user', content: args.userPrompt })
+
+    const completionPromise = this.openai.chat.completions.create({
+      model: args.model,
+      messages,
+      temperature: args.temperature,
+      max_tokens: args.maxTokens,
+      // Request JSON mode where supported. Providers that don't support it
+      // typically ignore the field; the prompt + cleanup handle fallback.
+      response_format: { type: 'json_object' },
+    })
+
+    const completion = await withTimeout(completionPromise, args.timeoutMs)
+    const content = completion.choices?.[0]?.message?.content
+    if (!content) {
+      throw new LLMProviderError('LLM returned empty response')
+    }
+    return content
+  }
+}
+
+function buildRetryPrompt(
+  original: string,
+  previousRaw: string,
+  issues: unknown,
+): string {
+  const issueText =
+    typeof issues === 'string' ? issues : JSON.stringify(issues, null, 2)
+  return [
+    original,
+    '',
+    '---',
+    'Your previous response failed validation. Please respond with valid JSON that matches the requested schema.',
+    'Validation errors:',
+    issueText,
+    '',
+    'Previous response (truncated):',
+    previousRaw.slice(0, 500),
+  ].join('\n')
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new LLMTimeoutError(timeoutMs)), timeoutMs)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/**
+ * Lazy singleton for app code that just wants "the" LLM client. Tests
+ * should construct their own `LLMClient` to control configuration.
+ */
+let cached: LLMClient | undefined
+export function getLLMClient(): LLMClient {
+  if (!cached) cached = new LLMClient()
+  return cached
+}
+
+export { LLMProviderError, LLMTimeoutError, LLMValidationError }

--- a/lib/llm/errors.ts
+++ b/lib/llm/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Typed errors thrown by the LLM client wrapper. Consumers can branch on
+ * `instanceof` to distinguish provider failures from validation failures
+ * from timeouts.
+ */
+
+export class LLMProviderError extends Error {
+  readonly cause?: unknown
+  readonly status?: number
+
+  constructor(message: string, options?: { cause?: unknown; status?: number }) {
+    super(message)
+    this.name = 'LLMProviderError'
+    this.cause = options?.cause
+    this.status = options?.status
+  }
+}
+
+export class LLMValidationError extends Error {
+  readonly issues: unknown
+  readonly rawResponse: string
+
+  constructor(message: string, rawResponse: string, issues: unknown) {
+    super(message)
+    this.name = 'LLMValidationError'
+    this.rawResponse = rawResponse
+    this.issues = issues
+  }
+}
+
+export class LLMTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`LLM call exceeded ${timeoutMs}ms timeout`)
+    this.name = 'LLMTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lucide-react": "^1.16.0",
         "minio": "^8.0.7",
         "next": "16.2.6",
+        "openai": "^6.45.0",
         "pg": "^8.20.0",
         "pino": "^10.3.1",
         "rate-limiter-flexible": "^11.0.1",
@@ -39,7 +40,8 @@
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
-        "resend": "^6.12.2"
+        "resend": "^6.12.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
@@ -5226,6 +5228,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@serwist/build/node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@serwist/next": {
       "version": "9.5.11",
       "resolved": "https://registry.npmjs.org/@serwist/next/-/next-9.5.11.tgz",
@@ -5339,6 +5350,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@serwist/next/node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@serwist/utils": {
       "version": "9.5.11",
       "resolved": "https://registry.npmjs.org/@serwist/utils/-/utils-9.5.11.tgz",
@@ -5378,6 +5398,15 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@serwist/webpack-plugin/node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@serwist/window": {
@@ -14231,6 +14260,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -18181,7 +18240,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18423,9 +18482,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
-      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^1.16.0",
     "minio": "^8.0.7",
     "next": "16.2.6",
+    "openai": "^6.45.0",
     "pg": "^8.20.0",
     "pino": "^10.3.1",
     "rate-limiter-flexible": "^11.0.1",
@@ -46,7 +47,8 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
-    "resend": "^6.12.2"
+    "resend": "^6.12.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",


### PR DESCRIPTION
## Summary
- `LLMClient` with `callWithStructuredOutput<T>()` — one retry on zod validation failure, configurable timeout, typed errors
- `clean-output.ts` strips markdown fences, extracts balanced JSON, repairs trailing commas + single quotes
- Typed errors: `LLMProviderError`, `LLMValidationError`, `LLMTimeoutError`
- 31 unit tests + gated integration test (`LLM_INTEGRATION_TEST=true`)
- Docs: `docs/LLM_CLIENT.md`

Fixes #872

## Test plan
- [ ] `npm test lib/llm` passes
- [ ] `npm run type-check` passes
- [ ] Spot-check `clean-output` edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)