### PR TITLE
feat: add Suggestion table and Workout.sourceSuggestionId link

### DIFF
--- a/lib/suggest/types.ts
+++ b/lib/suggest/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Type definitions for the Suggest Workout flow (LLM-powered).
+ *
+ * These types describe the JSON payloads stored on the `Suggestion` model:
+ *   - `requestPayload`  → SuggestionRequestPayload  (input sent to LLM)
+ *   - `responsePayload` → SuggestionResponsePayload (structured output from LLM)
+ *
+ * See issues #871 (this table), #879 (Suggest Workout flow), #875 (implicit feedback).
+ */
+
+/**
+ * Friendly loading messages surfaced in the polling UI (#879).
+ * Stored in `Suggestion.progressStep`.
+ */
+export type SuggestionProgressStep = 'analyzing' | 'planning' | 'finalizing';
+
+/**
+ * Lifecycle states for a Suggestion (mirrors the Prisma `SuggestionStatus` enum).
+ * Re-declared here so frontend code can import without pulling in the full Prisma client.
+ */
+export type SuggestionStatus = 'queued' | 'in_progress' | 'ready' | 'failed';
+
+/**
+ * Snapshot of the user's training profile at the time the suggestion was requested.
+ * Mirrors the durable profile from #870 (`UserTrainingProfile`).
+ */
+export interface SuggestionProfileSnapshot {
+  experienceLevel?: string;
+  goals?: string[];
+  equipmentAvailable?: string[];
+  preferredSplits?: string[];
+  injuriesOrLimitations?: string[];
+  preferredDurationMinutes?: number;
+  intensityPreference?: 'rir' | 'rpe' | 'none';
+}
+
+/**
+ * Lightweight summary of a recent workout used as context for the LLM.
+ */
+export interface SuggestionRecentWorkoutSummary {
+  workoutId: string;
+  completedAt: string; // ISO timestamp
+  name: string;
+  muscleGroupsTrained: string[];
+  totalVolume?: number;
+}
+
+/**
+ * The full input payload sent to the LLM and persisted in `Suggestion.requestPayload`.
+ * Persisted verbatim so suggestions can be replayed or debugged without re-running the LLM.
+ */
+export interface SuggestionRequestPayload {
+  /** Schema version for forward compatibility */
+  version: 1;
+
+  /** User-provided context for this specific suggestion (e.g., "today I have 45min, no squats") */
+  userPrompt?: string;
+
+  /** Snapshot of the user's training profile at request time */
+  profile: SuggestionProfileSnapshot;
+
+  /** Recent workout history fed to the LLM for context */
+  recentWorkouts: SuggestionRecentWorkoutSummary[];
+
+  /** Muscle-group balance signals from `UserMuscleBalanceSettings` */
+  muscleBalance?: Record<string, number>;
+
+  /** Optional: ID of a saved workout the user wants to use as a starting point */
+  basedOnSavedWorkoutId?: string;
+
+  /** Timestamp the request was assembled */
+  requestedAt: string;
+}
+
+/**
+ * A single prescribed set proposed by the LLM.
+ */
+export interface SuggestedSet {
+  reps: number;
+  weight?: string; // flexible: "135lbs" | "65%" | "RPE 8"
+  rir?: number;
+  rpe?: number;
+  isWarmup?: boolean;
+  notes?: string;
+}
+
+/**
+ * A single exercise proposed by the LLM, including rationale.
+ */
+export interface SuggestedExercise {
+  /** Name as proposed by the LLM (may be matched to ExerciseDefinition during workout creation) */
+  name: string;
+
+  /** Optional resolved ExerciseDefinition id (set by the worker after matching) */
+  exerciseDefinitionId?: string;
+
+  /** Primary muscle groups the LLM intends to target */
+  targetMuscleGroups: string[];
+
+  /** LLM's per-exercise rationale (why this exercise, in this order) */
+  rationale?: string;
+
+  sets: SuggestedSet[];
+}
+
+/**
+ * The structured output produced by the LLM and persisted in `Suggestion.responsePayload`.
+ */
+export interface SuggestionResponsePayload {
+  /** Schema version for forward compatibility */
+  version: 1;
+
+  /** Suggested workout name (user can edit) */
+  workoutName: string;
+
+  /** High-level rationale: why this workout, now, for this user */
+  overallRationale: string;
+
+  /** Ordered list of exercises with sets */
+  exercises: SuggestedExercise[];
+
+  /** Estimated duration in minutes */
+  estimatedDurationMinutes?: number;
+
+  /** Optional warm-up suggestions */
+  warmupNotes?: string;
+
+  /** Optional cool-down / recovery suggestions */
+  cooldownNotes?: string;
+}

--- a/prisma/migrations/20260630162820_add_suggestion_table/migration.sql
+++ b/prisma/migrations/20260630162820_add_suggestion_table/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "SuggestionStatus" AS ENUM ('queued', 'in_progress', 'ready', 'failed');
+
+-- CreateTable
+CREATE TABLE "Suggestion" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" "SuggestionStatus" NOT NULL DEFAULT 'queued',
+    "progressStep" TEXT,
+    "errorMessage" TEXT,
+    "requestPayload" JSONB NOT NULL,
+    "responsePayload" JSONB,
+    "model" TEXT,
+    "provider" TEXT,
+    "latencyMs" INTEGER,
+    "validationFailures" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Suggestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Suggestion_userId_idx" ON "Suggestion"("userId");
+
+-- CreateIndex
+CREATE INDEX "Suggestion_userId_status_idx" ON "Suggestion"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "Suggestion_status_createdAt_idx" ON "Suggestion"("status", "createdAt");
+
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN "sourceSuggestionId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workout_sourceSuggestionId_key" ON "Workout"("sourceSuggestionId");
+
+-- CreateIndex
+CREATE INDEX "Workout_sourceSuggestionId_idx" ON "Workout"("sourceSuggestionId");
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_sourceSuggestionId_fkey" FOREIGN KEY ("sourceSuggestionId") REFERENCES "Suggestion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,18 +55,21 @@ model Week {
 }
 
 model Workout {
-  id          String              @id @default(cuid())
-  name        String
-  dayNumber   Int
-  weekId      String
-  userId      String
-  exercises   Exercise[]
-  week        Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
-  completions WorkoutCompletion[]
+  id                  String              @id @default(cuid())
+  name                String
+  dayNumber           Int
+  weekId              String
+  userId              String
+  sourceSuggestionId  String?             @unique
+  exercises           Exercise[]
+  week                Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
+  completions         WorkoutCompletion[]
+  sourceSuggestion    Suggestion?         @relation("WorkoutSourceSuggestion", fields: [sourceSuggestionId], references: [id], onDelete: SetNull)
 
   @@unique([weekId, dayNumber])
   @@index([weekId])
   @@index([userId])
+  @@index([sourceSuggestionId])
 }
 
 model ExerciseDefinition {
@@ -614,4 +617,33 @@ model InAppMessage {
   @@index([placement, active])
   @@index([placement, userType, active])
   @@index([ownerType, ownerId])
+}
+
+enum SuggestionStatus {
+  queued
+  in_progress
+  ready
+  failed
+}
+
+model Suggestion {
+  id                 String           @id @default(cuid())
+  userId             String
+  status             SuggestionStatus @default(queued)
+  progressStep       String?
+  errorMessage       String?
+  requestPayload     Json
+  responsePayload    Json?
+  model              String?
+  provider           String?
+  latencyMs          Int?
+  validationFailures Int              @default(0)
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+
+  workout            Workout?         @relation("WorkoutSourceSuggestion")
+
+  @@index([userId])
+  @@index([userId, status])
+  @@index([status, createdAt])
 }


### PR DESCRIPTION
## Summary
- New `Suggestion` table with status lifecycle (queued/in_progress/ready/failed), request/response JSON payloads, progress step, model/provider metadata, latency, and validation-retry counts
- New `Workout.sourceSuggestionId` (nullable, unique FK to Suggestion, `ON DELETE SET NULL`) so workouts created from an LLM suggestion can be traced back for the implicit-feedback loop (#875)
- New `lib/suggest/types.ts` exporting the `SuggestionRequestPayload` / `SuggestionResponsePayload` contracts that the worker (#879) and frontend will share

Closes #871. Part of the Suggest Workout milestone — designed alongside #879 (flow) and #875 (implicit feedback).

## Schema details
- `SuggestionStatus` enum added at the Postgres level
- Indexes: `(userId)`, `(userId, status)`, `(status, createdAt)` — covers per-user history pages and worker polling
- Workout side: unique index on `sourceSuggestionId` enforces the 1:1 relationship; back-relation exposes `Suggestion.workout` without a redundant FK column

## Migration
- `prisma/migrations/20260630162820_add_suggestion_table/migration.sql` follows the standard pattern. Production migration auto-applies on deploy.

## Test plan
- [ ] CI typecheck passes (validated locally with `npm run type-check`)
- [ ] Prisma schema validates (`prisma validate` green)
- [ ] Confirm migration runs cleanly against staging when deploy job picks it up