### PR TITLE
feat(exercises): LLM-bootstrap auto-tagger + top-100 backfill (#873)

### DIFF
--- a/__tests__/lib/auto-tag.test.ts
+++ b/__tests__/lib/auto-tag.test.ts
@@ -1,0 +1,155 @@
+import type { PrismaClient } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTestDatabase } from '@/lib/test/database';
+import { createTestExerciseDefinition, createTestUser } from '@/lib/test/factories';
+import {
+  buildTaggingPrompt,
+  type ExerciseTagInput,
+  type ExerciseTagResult,
+  type LLMTagger,
+  tagExercise,
+  tagExercises,
+  validateTagResult,
+} from '@/lib/exercises/auto-tag';
+
+describe('exercises/auto-tag', () => {
+  describe('validateTagResult', () => {
+    it('accepts valid labels', () => {
+      const r = validateTagResult({
+        id: 'abc',
+        movementPattern: 'horizontal_push',
+        intensityClass: 'heavy',
+      });
+      expect(r.movementPattern).toBe('horizontal_push');
+      expect(r.intensityClass).toBe('heavy');
+    });
+
+    it('rejects unknown movementPattern', () => {
+      expect(() =>
+        validateTagResult({ id: 'a', movementPattern: 'bench', intensityClass: 'heavy' }),
+      ).toThrow(/movementPattern/);
+    });
+
+    it('rejects unknown intensityClass', () => {
+      expect(() =>
+        validateTagResult({ id: 'a', movementPattern: 'squat', intensityClass: 'crushing' }),
+      ).toThrow(/intensityClass/);
+    });
+  });
+
+  describe('buildTaggingPrompt', () => {
+    it('includes the exercise name, allowed labels, and id', () => {
+      const prompt = buildTaggingPrompt([
+        { id: 'x1', name: 'Back Squat', primaryFAUs: ['quads'] },
+      ]);
+      expect(prompt).toContain('Back Squat');
+      expect(prompt).toContain('id=x1');
+      expect(prompt).toContain('squat');
+      expect(prompt).toContain('heavy');
+      expect(prompt).toContain('moderate');
+    });
+  });
+
+  describe('tagExercises (DB)', () => {
+    let prisma: PrismaClient;
+
+    beforeEach(async () => {
+      const testDb = await getTestDatabase();
+      prisma = testDb.getPrismaClient();
+      await testDb.reset();
+    });
+
+    it('writes movementPattern, intensityClass, taggedAt, taggedBy', async () => {
+      const user = await createTestUser();
+      const def = await createTestExerciseDefinition(prisma, {
+        name: 'Back Squat',
+        userId: user.id,
+        isSystem: false,
+      });
+
+      const llm: LLMTagger = {
+        modelId: 'mock-model-v1',
+        tag: vi.fn(async (exs: ExerciseTagInput[]): Promise<ExerciseTagResult[]> =>
+          exs.map((e) => ({
+            id: e.id,
+            movementPattern: 'squat',
+            intensityClass: 'heavy',
+          })),
+        ),
+      };
+
+      await tagExercise(def.id, { llm, db: prisma });
+
+      const updated = await prisma.exerciseDefinition.findUnique({ where: { id: def.id } });
+      expect(updated?.movementPattern).toBe('squat');
+      expect(updated?.intensityClass).toBe('heavy');
+      expect(updated?.taggedBy).toBe('mock-model-v1');
+      expect(updated?.taggedAt).toBeInstanceOf(Date);
+      expect(llm.tag).toHaveBeenCalledOnce();
+    });
+
+    it('batches multiple ids into a single LLM call', async () => {
+      const user = await createTestUser();
+      const a = await createTestExerciseDefinition(prisma, {
+        name: 'Deadlift',
+        userId: user.id,
+        isSystem: false,
+      });
+      const b = await createTestExerciseDefinition(prisma, {
+        name: 'Overhead Press',
+        userId: user.id,
+        isSystem: false,
+      });
+
+      const tagFn = vi.fn(
+        async (exs: ExerciseTagInput[]): Promise<ExerciseTagResult[]> =>
+          exs.map((e) => ({
+            id: e.id,
+            movementPattern: e.name.includes('Deadlift') ? 'hinge' : 'vertical_push',
+            intensityClass: 'heavy',
+          })),
+      );
+      const llm: LLMTagger = { modelId: 'mock-model-v1', tag: tagFn };
+
+      await tagExercises([a.id, b.id], { llm, db: prisma });
+
+      expect(tagFn).toHaveBeenCalledOnce();
+      const updatedA = await prisma.exerciseDefinition.findUnique({ where: { id: a.id } });
+      const updatedB = await prisma.exerciseDefinition.findUnique({ where: { id: b.id } });
+      expect(updatedA?.movementPattern).toBe('hinge');
+      expect(updatedB?.movementPattern).toBe('vertical_push');
+    });
+
+    it('no-ops on empty input', async () => {
+      const tagFn = vi.fn();
+      await tagExercises([], { llm: { modelId: 'm', tag: tagFn }, db: prisma });
+      expect(tagFn).not.toHaveBeenCalled();
+    });
+
+    it('throws (and does not write) when LLM returns invalid labels', async () => {
+      const user = await createTestUser();
+      const def = await createTestExerciseDefinition(prisma, {
+        name: 'Curl',
+        userId: user.id,
+        isSystem: false,
+      });
+
+      const llm: LLMTagger = {
+        modelId: 'mock-model-v1',
+        tag: async (exs) =>
+          exs.map((e) => ({
+            id: e.id,
+            // bogus label
+            movementPattern: 'biceps' as never,
+            intensityClass: 'light',
+          })),
+      };
+
+      await expect(tagExercise(def.id, { llm, db: prisma })).rejects.toThrow(/movementPattern/);
+
+      const after = await prisma.exerciseDefinition.findUnique({ where: { id: def.id } });
+      expect(after?.movementPattern).toBeNull();
+      expect(after?.taggedAt).toBeNull();
+    });
+  });
+});

--- a/lib/exercises/auto-tag.ts
+++ b/lib/exercises/auto-tag.ts
@@ -1,0 +1,178 @@
+/**
+ * LLM-bootstrapped exercise tagger.
+ *
+ * Tags ExerciseDefinitions with `movementPattern` and `intensityClass`
+ * by calling an LLM and caching the result to the database. Used by
+ * the Suggest Workout feature (Milestone #868) so candidate filtering
+ * can reason about movement patterns and fatigue cost.
+ *
+ * Downstream consumers MUST treat untagged exercises (null fields) as
+ * "include" / no constraint — never filter them out.
+ */
+
+import { logger } from '@/lib/logger';
+import { prisma } from '@/lib/db';
+
+export const MOVEMENT_PATTERNS = [
+  'squat',
+  'hinge',
+  'vertical_push',
+  'horizontal_push',
+  'vertical_pull',
+  'horizontal_pull',
+  'lunge',
+  'carry',
+  'isolation',
+  'accessory',
+] as const;
+
+export type MovementPattern = (typeof MOVEMENT_PATTERNS)[number];
+
+export const INTENSITY_CLASSES = ['heavy', 'moderate', 'light'] as const;
+export type IntensityClass = (typeof INTENSITY_CLASSES)[number];
+
+export interface ExerciseTagInput {
+  id: string;
+  name: string;
+  category?: string | null;
+  primaryFAUs?: string[];
+  secondaryFAUs?: string[];
+  equipment?: string[];
+  mechanic?: string | null;
+  force?: string | null;
+}
+
+export interface ExerciseTagResult {
+  id: string;
+  movementPattern: MovementPattern;
+  intensityClass: IntensityClass;
+}
+
+/**
+ * Pluggable LLM caller. Production code injects an implementation that
+ * hits the project's LLM client wrapper (#872). Tests inject a mock.
+ */
+export interface LLMTagger {
+  /** Identifier of the model used — written to `taggedBy` for auditability. */
+  readonly modelId: string;
+  tag(exercises: ExerciseTagInput[]): Promise<ExerciseTagResult[]>;
+}
+
+export interface TagDeps {
+  llm: LLMTagger;
+  db?: typeof prisma;
+}
+
+export function buildTaggingPrompt(exercises: ExerciseTagInput[]): string {
+  const lines = exercises.map((e) => {
+    const parts = [
+      `id=${e.id}`,
+      `name="${e.name}"`,
+      e.category ? `category=${e.category}` : null,
+      e.mechanic ? `mechanic=${e.mechanic}` : null,
+      e.force ? `force=${e.force}` : null,
+      e.equipment?.length ? `equipment=[${e.equipment.join(',')}]` : null,
+      e.primaryFAUs?.length ? `primary=[${e.primaryFAUs.join(',')}]` : null,
+    ].filter(Boolean);
+    return `- ${parts.join(' ')}`;
+  });
+
+  return [
+    'Classify each strength-training exercise.',
+    '',
+    `movementPattern must be one of: ${MOVEMENT_PATTERNS.join(', ')}`,
+    `intensityClass must be one of: ${INTENSITY_CLASSES.join(', ')} (typical systemic fatigue cost)`,
+    '',
+    'Return a JSON array of objects: { "id": string, "movementPattern": string, "intensityClass": string }',
+    '',
+    'Exercises:',
+    ...lines,
+  ].join('\n');
+}
+
+/** Validate a single tag result; throw on unknown labels. */
+export function validateTagResult(r: unknown): ExerciseTagResult {
+  if (!r || typeof r !== 'object') throw new Error('tag result not an object');
+  const obj = r as Record<string, unknown>;
+  if (typeof obj.id !== 'string') throw new Error('tag result missing id');
+  if (!MOVEMENT_PATTERNS.includes(obj.movementPattern as MovementPattern)) {
+    throw new Error(`invalid movementPattern: ${obj.movementPattern}`);
+  }
+  if (!INTENSITY_CLASSES.includes(obj.intensityClass as IntensityClass)) {
+    throw new Error(`invalid intensityClass: ${obj.intensityClass}`);
+  }
+  return {
+    id: obj.id,
+    movementPattern: obj.movementPattern as MovementPattern,
+    intensityClass: obj.intensityClass as IntensityClass,
+  };
+}
+
+/** Tag a single exercise by id. */
+export async function tagExercise(exerciseId: string, deps: TagDeps): Promise<void> {
+  await tagExercises([exerciseId], deps);
+}
+
+/** Tag many exercises in a single LLM call; writes back per-row. */
+export async function tagExercises(ids: string[], deps: TagDeps): Promise<void> {
+  if (ids.length === 0) return;
+  const db = deps.db ?? prisma;
+
+  const defs = await db.exerciseDefinition.findMany({
+    where: { id: { in: ids } },
+    select: {
+      id: true,
+      name: true,
+      category: true,
+      primaryFAUs: true,
+      secondaryFAUs: true,
+      equipment: true,
+      mechanic: true,
+      force: true,
+    },
+  });
+
+  if (defs.length === 0) return;
+
+  let results: ExerciseTagResult[];
+  try {
+    const raw = await deps.llm.tag(defs);
+    results = raw.map(validateTagResult);
+  } catch (error) {
+    logger.error({ error, ids }, 'auto-tag: LLM call failed');
+    throw error;
+  }
+
+  const now = new Date();
+  const taggedBy = deps.llm.modelId;
+
+  await Promise.all(
+    results.map((r) =>
+      db.exerciseDefinition.update({
+        where: { id: r.id },
+        data: {
+          movementPattern: r.movementPattern,
+          intensityClass: r.intensityClass,
+          taggedAt: now,
+          taggedBy,
+        },
+      }),
+    ),
+  );
+
+  logger.info(
+    { count: results.length, taggedBy },
+    'auto-tag: tagged exercises',
+  );
+}
+
+/**
+ * Fire-and-forget lazy tagging — call this when candidate filtering
+ * encounters an untagged exercise. Errors are swallowed (logged only)
+ * so the request never blocks on the LLM.
+ */
+export function queueLazyTag(exerciseId: string, deps: TagDeps): void {
+  void tagExercise(exerciseId, deps).catch((error) => {
+    logger.warn({ error, exerciseId }, 'auto-tag: lazy tag failed');
+  });
+}

--- a/prisma/migrations/20260630162706_add_exercise_auto_tags/migration.sql
+++ b/prisma/migrations/20260630162706_add_exercise_auto_tags/migration.sql
@@ -1,0 +1,8 @@
+-- Add LLM-bootstrapped classification fields to ExerciseDefinition
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "movementPattern" TEXT;
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "intensityClass" TEXT;
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "taggedAt" TIMESTAMP(3);
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "taggedBy" TEXT;
+
+CREATE INDEX "ExerciseDefinition_movementPattern_idx" ON "ExerciseDefinition"("movementPattern");
+CREATE INDEX "ExerciseDefinition_intensityClass_idx" ON "ExerciseDefinition"("intensityClass");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,13 @@ model ExerciseDefinition {
   mechanic       String?
   level          String?
   userId         String
+  // Auto-tagged classification (LLM-bootstrapped). See lib/exercises/auto-tag.ts
+  // movementPattern: squat | hinge | vertical_push | horizontal_push | vertical_pull | horizontal_pull | lunge | carry | isolation | accessory
+  movementPattern String?
+  // intensityClass: heavy | moderate | light (typical fatigue cost)
+  intensityClass  String?
+  taggedAt        DateTime?
+  taggedBy        String?
   exercises      Exercise[]
 
   @@index([normalizedName])
@@ -96,6 +103,8 @@ model ExerciseDefinition {
   @@index([createdBy])
   @@index([primaryFAUs])
   @@index([userId])
+  @@index([movementPattern])
+  @@index([intensityClass])
 }
 
 model Exercise {

--- a/scripts/backfill-exercise-tags.ts
+++ b/scripts/backfill-exercise-tags.ts
@@ -1,0 +1,124 @@
+/**
+ * Backfill exercise tags for the top-100 most-used ExerciseDefinitions.
+ *
+ * Usage:
+ *   doppler run --config dev_personal -- npx tsx scripts/backfill-exercise-tags.ts
+ *
+ * Requires an LLM client. Until #872 lands, plug a tagger in by editing
+ * `createLLMTagger()` below or set `ANTHROPIC_API_KEY` to use the
+ * default Anthropic-backed implementation.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import {
+  type ExerciseTagInput,
+  type ExerciseTagResult,
+  type LLMTagger,
+  MOVEMENT_PATTERNS,
+  INTENSITY_CLASSES,
+  buildTaggingPrompt,
+  tagExercises,
+} from '../lib/exercises/auto-tag';
+
+const BATCH_SIZE = 20;
+const TOP_N = 100;
+
+const prisma = new PrismaClient();
+
+function createLLMTagger(): LLMTagger {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const model = process.env.TAGGER_MODEL ?? 'claude-3-5-sonnet-20241022';
+
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY not set. Either export it or wire up the project LLM client (#872).',
+    );
+  }
+
+  return {
+    modelId: model,
+    async tag(exercises: ExerciseTagInput[]): Promise<ExerciseTagResult[]> {
+      const prompt = buildTaggingPrompt(exercises);
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 4096,
+          messages: [
+            {
+              role: 'user',
+              content: `${prompt}\n\nRespond ONLY with the JSON array, no prose.`,
+            },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Anthropic API ${response.status}: ${body}`);
+      }
+
+      const data = (await response.json()) as {
+        content: Array<{ type: string; text?: string }>;
+      };
+      const text = data.content.find((c) => c.type === 'text')?.text ?? '';
+      const jsonMatch = text.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) {
+        throw new Error(`No JSON array found in LLM response: ${text.slice(0, 200)}`);
+      }
+      const parsed = JSON.parse(jsonMatch[0]) as ExerciseTagResult[];
+      // Drop anything malformed; downstream validateTagResult will re-check.
+      return parsed.filter(
+        (r) =>
+          r &&
+          typeof r.id === 'string' &&
+          (MOVEMENT_PATTERNS as readonly string[]).includes(r.movementPattern) &&
+          (INTENSITY_CLASSES as readonly string[]).includes(r.intensityClass),
+      );
+    },
+  };
+}
+
+async function getTopExerciseIds(limit: number): Promise<string[]> {
+  // Rank by number of Exercise rows referencing each definition (proxy for usage).
+  const rows = await prisma.exercise.groupBy({
+    by: ['exerciseDefinitionId'],
+    _count: { exerciseDefinitionId: true },
+    orderBy: [{ _count: { exerciseDefinitionId: 'desc' } }, { exerciseDefinitionId: 'asc' }],
+    take: limit,
+  });
+  return rows.map((r) => r.exerciseDefinitionId);
+}
+
+async function main(): Promise<void> {
+  const llm = createLLMTagger();
+  console.log(`[backfill] selecting top ${TOP_N} exercise definitions by usage...`);
+  const ids = await getTopExerciseIds(TOP_N);
+  console.log(`[backfill] found ${ids.length} exercises, batching by ${BATCH_SIZE}`);
+
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const batch = ids.slice(i, i + BATCH_SIZE);
+    console.log(`[backfill] batch ${i / BATCH_SIZE + 1} (${batch.length} ids)`);
+    try {
+      await tagExercises(batch, { llm, db: prisma });
+    } catch (error) {
+      console.error('[backfill] batch failed, continuing:', error);
+    }
+  }
+
+  console.log('[backfill] done');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- Adds `movementPattern`, `intensityClass`, `taggedAt`, `taggedBy` to `ExerciseDefinition` (+ migration + indexes on the two label columns).
- New `lib/exercises/auto-tag.ts` exposes `tagExercise`, `tagExercises` (batched single LLM call), and `queueLazyTag` (fire-and-forget for the candidate filter). The LLM caller is a pluggable `LLMTagger` interface so production wires the project's LLM client (#872) and tests inject a mock.
- New `scripts/backfill-exercise-tags.ts` ranks the top-100 most-used definitions by `Exercise` row count and tags them in batches of 20. Default implementation hits Anthropic via `fetch` until #872 lands; swap in the project wrapper when available.
- New `__tests__/lib/auto-tag.test.ts` covers prompt construction, label validation (rejects unknown labels), DB write-back (single + batch), and the "throws and does not write" path on invalid LLM output. 8 tests, all passing.

## Contract for downstream code
Untagged exercises (`movementPattern` / `intensityClass` = null) MUST be treated as "include" / no constraint — the candidate filter falls back to including them and calls `queueLazyTag` so they get tagged for next time.

## Out of scope (per issue)
- Per-user fatigue calibration (EWMA, separate issue)
- Auto re-tagging when better models ship (manual re-run of the backfill is fine)

## Test plan
- [x] `npm test __tests__/lib/auto-tag.test.ts` — 8/8 pass
- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new errors introduced by this PR (9 pre-existing errors in unrelated files)
- [ ] Run `doppler run --config dev_personal -- npx tsx scripts/backfill-exercise-tags.ts` against staging once an `ANTHROPIC_API_KEY` (or the #872 wrapper) is wired in.

Fixes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
