### PR TITLE
feat(profile): UserTrainingProfile schema + helper for Suggest Workout

### DIFF
--- a/__tests__/api/user-training-profile.test.ts
+++ b/__tests__/api/user-training-profile.test.ts
@@ -1,0 +1,99 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getDefaultMuscleBalanceTargets } from '@/lib/muscle-balance'
+import {
+  getOrCreateUserTrainingProfile,
+  normalizeUserTrainingProfile,
+} from '@/lib/user-training-profile'
+import { getTestDatabase } from '@/lib/test/database'
+import { createTestUser } from '@/lib/test/factories'
+
+describe('UserTrainingProfile normalization', () => {
+  it('trims, dedupes, drops empties, and caps lengths', () => {
+    const result = normalizeUserTrainingProfile({
+      goalSentences: ['  improve bench  ', 'improve bench', '', 'spare legs'],
+      weeklyIntent: ['1 heavy leg day'],
+      equipmentAvailable: ['barbell', 'barbell', '  dumbbells '],
+      bannedExerciseIds: ['ex_1', 'ex_2'],
+      ratioTargets: { chest: 1.5 },
+      defaultIntensityPreference: 'hypertrophy',
+    })
+
+    expect(result.goalSentences).toEqual(['improve bench', 'spare legs'])
+    expect(result.weeklyIntent).toEqual(['1 heavy leg day'])
+    expect(result.equipmentAvailable).toEqual(['barbell', 'dumbbells'])
+    expect(result.bannedExerciseIds).toEqual(['ex_1', 'ex_2'])
+    expect(result.defaultIntensityPreference).toBe('hypertrophy')
+    expect(result.ratioTargets.chest).toBeCloseTo(1.5)
+  })
+
+  it('rejects invalid intensity preference and non-array list inputs', () => {
+    const result = normalizeUserTrainingProfile({
+      goalSentences: 'not an array' as unknown as string[],
+      weeklyIntent: [],
+      equipmentAvailable: [],
+      bannedExerciseIds: [],
+      ratioTargets: {},
+      defaultIntensityPreference: 'bogus',
+    })
+
+    expect(result.goalSentences).toEqual([])
+    expect(result.defaultIntensityPreference).toBeNull()
+  })
+})
+
+describe('UserTrainingProfile persistence', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('creates a default profile when none exists', async () => {
+    const profile = await getOrCreateUserTrainingProfile(prisma, userId)
+
+    expect(profile.goalSentences).toEqual([])
+    expect(profile.weeklyIntent).toEqual([])
+    expect(profile.equipmentAvailable).toEqual([])
+    expect(profile.bannedExerciseIds).toEqual([])
+    expect(profile.defaultIntensityPreference).toBeNull()
+    expect(profile.ratioTargets).toEqual(getDefaultMuscleBalanceTargets())
+  })
+
+  it('is idempotent on repeated calls', async () => {
+    const a = await getOrCreateUserTrainingProfile(prisma, userId)
+    const b = await getOrCreateUserTrainingProfile(prisma, userId)
+    expect(a).toEqual(b)
+
+    const rows = await prisma.userTrainingProfile.findMany({ where: { userId } })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('seeds ratioTargets from existing UserMuscleBalanceSettings if present', async () => {
+    const customTargets = {
+      ...getDefaultMuscleBalanceTargets(),
+      chest: 1.5,
+      quads: 0.5,
+    }
+    await prisma.userMuscleBalanceSettings.create({
+      data: {
+        userId,
+        targets: customTargets,
+        lookbackWorkouts: 8,
+        includeSecondary: true,
+        secondaryWeight: 0.5,
+        excludeWarmups: true,
+      },
+    })
+
+    const profile = await getOrCreateUserTrainingProfile(prisma, userId)
+    expect(profile.ratioTargets.chest).toBeCloseTo(1.5)
+    expect(profile.ratioTargets.quads).toBeCloseTo(0.5)
+  })
+})

--- a/lib/user-training-profile.ts
+++ b/lib/user-training-profile.ts
@@ -1,0 +1,142 @@
+import type { Prisma, PrismaClient } from '@prisma/client'
+import {
+  getDefaultMuscleBalanceTargets,
+  normalizeMuscleBalanceTargets,
+  type MuscleBalanceTargets,
+} from '@/lib/muscle-balance'
+
+export const INTENSITY_PREFERENCES = [
+  'hypertrophy',
+  'strength',
+  'balanced',
+] as const
+export type IntensityPreference = (typeof INTENSITY_PREFERENCES)[number]
+
+export const MAX_GOAL_SENTENCES = 10
+export const MAX_GOAL_SENTENCE_LENGTH = 280
+export const MAX_WEEKLY_INTENTS = 10
+export const MAX_WEEKLY_INTENT_LENGTH = 280
+export const MAX_EQUIPMENT_ITEMS = 32
+export const MAX_BANNED_EXERCISE_IDS = 500
+
+export type UserTrainingProfileDTO = {
+  goalSentences: string[]
+  weeklyIntent: string[]
+  equipmentAvailable: string[]
+  bannedExerciseIds: string[]
+  ratioTargets: MuscleBalanceTargets
+  defaultIntensityPreference: IntensityPreference | null
+}
+
+export function normalizeIntensityPreference(
+  value: unknown
+): IntensityPreference | null {
+  if (typeof value !== 'string') return null
+  return (INTENSITY_PREFERENCES as readonly string[]).includes(value)
+    ? (value as IntensityPreference)
+    : null
+}
+
+function normalizeStringList(
+  value: unknown,
+  maxItems: number,
+  maxLength: number
+): string[] {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of value) {
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const truncated = trimmed.slice(0, maxLength)
+    if (seen.has(truncated)) continue
+    seen.add(truncated)
+    result.push(truncated)
+    if (result.length >= maxItems) break
+  }
+  return result
+}
+
+export function normalizeUserTrainingProfile(
+  profile:
+    | {
+        goalSentences: string[]
+        weeklyIntent: string[]
+        equipmentAvailable: string[]
+        bannedExerciseIds: string[]
+        ratioTargets: Prisma.JsonValue
+        defaultIntensityPreference: string | null
+      }
+    | null
+    | undefined
+): UserTrainingProfileDTO {
+  return {
+    goalSentences: normalizeStringList(
+      profile?.goalSentences,
+      MAX_GOAL_SENTENCES,
+      MAX_GOAL_SENTENCE_LENGTH
+    ),
+    weeklyIntent: normalizeStringList(
+      profile?.weeklyIntent,
+      MAX_WEEKLY_INTENTS,
+      MAX_WEEKLY_INTENT_LENGTH
+    ),
+    equipmentAvailable: normalizeStringList(
+      profile?.equipmentAvailable,
+      MAX_EQUIPMENT_ITEMS,
+      64
+    ),
+    bannedExerciseIds: normalizeStringList(
+      profile?.bannedExerciseIds,
+      MAX_BANNED_EXERCISE_IDS,
+      64
+    ),
+    ratioTargets: normalizeMuscleBalanceTargets(profile?.ratioTargets),
+    defaultIntensityPreference: normalizeIntensityPreference(
+      profile?.defaultIntensityPreference ?? null
+    ),
+  }
+}
+
+/**
+ * Get the user's training profile, creating defaults if it doesn't exist.
+ *
+ * On first creation, seeds `ratioTargets` from `UserMuscleBalanceSettings.targets`
+ * if the user already has muscle balance settings; otherwise uses defaults.
+ */
+export async function getOrCreateUserTrainingProfile(
+  prisma: PrismaClient,
+  userId: string
+): Promise<UserTrainingProfileDTO> {
+  const existing = await prisma.userTrainingProfile.findUnique({
+    where: { userId },
+  })
+  if (existing) {
+    return normalizeUserTrainingProfile(existing)
+  }
+
+  const muscleBalance = await prisma.userMuscleBalanceSettings.findUnique({
+    where: { userId },
+    select: { targets: true },
+  })
+  const ratioTargets = muscleBalance
+    ? normalizeMuscleBalanceTargets(muscleBalance.targets)
+    : getDefaultMuscleBalanceTargets()
+
+  const created = await prisma.userTrainingProfile.upsert({
+    where: { userId },
+    update: {},
+    create: {
+      userId,
+      goalSentences: [],
+      weeklyIntent: [],
+      equipmentAvailable: [],
+      bannedExerciseIds: [],
+      ratioTargets,
+      defaultIntensityPreference: null,
+    },
+  })
+
+  return normalizeUserTrainingProfile(created)
+}

--- a/prisma/migrations/20260630162734_add_user_training_profile/migration.sql
+++ b/prisma/migrations/20260630162734_add_user_training_profile/migration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "UserTrainingProfile" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "goalSentences" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "weeklyIntent" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "equipmentAvailable" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "bannedExerciseIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "ratioTargets" JSONB NOT NULL,
+  "defaultIntensityPreference" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "UserTrainingProfile_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "UserTrainingProfile_userId_key" ON "UserTrainingProfile"("userId");
+CREATE INDEX "UserTrainingProfile_userId_idx" ON "UserTrainingProfile"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -352,6 +352,21 @@ model UserMuscleBalanceSettings {
   @@index([userId])
 }
 
+model UserTrainingProfile {
+  id                          String   @id @default(cuid())
+  userId                      String   @unique
+  goalSentences               String[] @default([])
+  weeklyIntent                String[] @default([])
+  equipmentAvailable          String[] @default([])
+  bannedExerciseIds           String[] @default([])
+  ratioTargets                Json
+  defaultIntensityPreference  String?
+  createdAt                   DateTime @default(now())
+  updatedAt                   DateTime @updatedAt
+
+  @@index([userId])
+}
+
 model CommunityProgram {
   id                String   @id(map: "community_programs_pkey") @default(cuid())
   name              String


### PR DESCRIPTION
## Summary
- New `UserTrainingProfile` table (1:1 with User) — durable storage for the Suggest Workout LLM planner.
- Fields: `goalSentences[]`, `weeklyIntent[]`, `equipmentAvailable[]`, `bannedExerciseIds[]`, `ratioTargets` (JSON, FAU → weight), `defaultIntensityPreference` (hypertrophy/strength/balanced/null).
- `getOrCreateUserTrainingProfile(prisma, userId)` helper mirrors the existing muscle-balance pattern; on first create, seeds `ratioTargets` from any existing `UserMuscleBalanceSettings.targets`.
- Migration committed (CLAUDE.md migration process).

## Out of scope
- UI to edit the profile (onboarding agent — separate issue).
- Migrating data away from `UserMuscleBalanceSettings` (both tables coexist for now).
- Ephemeral request inputs.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean for new files
- [ ] `npm test user-training-profile` — covers default creation, idempotency, normalization, and ratio seeding from muscle balance settings

Fixes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
