### PR TITLE
Logger UI: show last session reference for current exercise

### DIFF
--- a/__tests__/lib/format/last-session-reference.test.ts
+++ b/__tests__/lib/format/last-session-reference.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatLastSessionSummary,
+  type LastSessionSet,
+} from '@/lib/format/last-session-reference'
+
+function mkSet(overrides: Partial<LastSessionSet> = {}): LastSessionSet {
+  return {
+    setNumber: 1,
+    reps: 5,
+    weight: 185,
+    weightUnit: 'lbs',
+    rpe: null,
+    rir: null,
+    isWarmup: false,
+    ...overrides,
+  }
+}
+
+describe('formatLastSessionSummary', () => {
+  it('returns never-logged when history is null', () => {
+    const result = formatLastSessionSummary(null)
+    expect(result.summary).toBeNull()
+    expect(result.emptyReason).toBe('never-logged')
+  })
+
+  it('returns never-logged when sets array is empty', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [],
+    })
+    expect(result.emptyReason).toBe('never-logged')
+  })
+
+  it('returns warmups-only when only warmups are present', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [mkSet({ isWarmup: true }), mkSet({ setNumber: 2, isWarmup: true })],
+    })
+    expect(result.summary).toBeNull()
+    expect(result.emptyReason).toBe('warmups-only')
+  })
+
+  it('collapses uniform working sets into "weight × reps × sets"', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1 }),
+        mkSet({ setNumber: 2 }),
+        mkSet({ setNumber: 3 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5 × 3')
+    expect(result.emptyReason).toBeNull()
+  })
+
+  it('appends uniform RIR tag when present on all working sets', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, rir: 2 }),
+        mkSet({ setNumber: 2, rir: 2 }),
+        mkSet({ setNumber: 3, rir: 2 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5 × 3 @ RIR 2')
+  })
+
+  it('appends uniform RPE tag when RIR not present', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, rpe: 8 }),
+        mkSet({ setNumber: 2, rpe: 8 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5 × 2 @ RPE 8')
+  })
+
+  it('omits intensity tag when values vary across sets', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, rpe: 7 }),
+        mkSet({ setNumber: 2, rpe: 9 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5 × 2')
+  })
+
+  it('shows comma list when reps vary', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, reps: 5 }),
+        mkSet({ setNumber: 2, reps: 5 }),
+        mkSet({ setNumber: 3, reps: 4 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5,5,4')
+  })
+
+  it('shows weight range when weights vary', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, weight: 135 }),
+        mkSet({ setNumber: 2, weight: 185 }),
+      ],
+    })
+    expect(result.summary).toBe('135–185 lbs × 5')
+  })
+
+  it('renders BW for bodyweight (weight=0)', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [mkSet({ weight: 0 }), mkSet({ setNumber: 2, weight: 0 })],
+    })
+    expect(result.summary).toBe('BW × 5 × 2')
+  })
+
+  it('excludes warmups from the summary', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [
+        mkSet({ setNumber: 1, weight: 95, isWarmup: true }),
+        mkSet({ setNumber: 2 }),
+        mkSet({ setNumber: 3 }),
+      ],
+    })
+    expect(result.summary).toBe('185 lbs × 5 × 2')
+  })
+
+  it('produces a relative time string when working sets exist', () => {
+    const result = formatLastSessionSummary({
+      completedAt: new Date(),
+      sets: [mkSet()],
+    })
+    expect(result.relative).not.toBeNull()
+  })
+})

--- a/components/StrengthWeekView.tsx
+++ b/components/StrengthWeekView.tsx
@@ -98,6 +98,7 @@ type WorkoutMetadata = {
       weightUnit: string
       rpe: number | null
       rir: number | null
+      isWarmup: boolean
     }>
   } | null
   resumeExerciseIndex?: number

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -65,6 +65,7 @@ type ExerciseHistory = {
     weightUnit: string
     rpe: number | null
     rir: number | null
+    isWarmup: boolean
   }>
 }
 

--- a/components/workout-logging/ExerciseDisplayTabs.tsx
+++ b/components/workout-logging/ExerciseDisplayTabs.tsx
@@ -11,6 +11,7 @@ import type { LoadState } from '@/hooks/useProgressiveExercises'
 import type { LoggedSet } from '@/types/workout'
 import DrawerContextBanner from './DrawerContextBanner'
 import ExerciseInfoContent from './ExerciseInfoContent'
+import LastSessionReference from './LastSessionReference'
 import SetList from './SetList'
 
 interface PrescribedSet {
@@ -43,6 +44,7 @@ interface ExerciseHistorySet {
   weightUnit: string
   rpe: number | null
   rir: number | null
+  isWarmup: boolean
 }
 
 interface ExerciseHistory {
@@ -168,6 +170,12 @@ export default function ExerciseDisplayTabs({
           menuActions={menuActions}
         />
         <div className="px-4 pt-4 flex-1 flex flex-col gap-2">
+          {!isInputExpanded && (
+            <LastSessionReference
+              history={exerciseHistory}
+              isLoading={historyState === 'loading' || historyState === 'pending'}
+            />
+          )}
           {loggingForm}
           {!isInputExpanded && (
             <>

--- a/components/workout-logging/LastSessionReference.tsx
+++ b/components/workout-logging/LastSessionReference.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { History, Sparkles } from 'lucide-react'
+import { formatLastSessionSummary, type LastSessionSet } from '@/lib/format/last-session-reference'
+
+interface ExerciseHistoryForReference {
+  completedAt: Date | string
+  sets: LastSessionSet[]
+}
+
+interface LastSessionReferenceProps {
+  history: ExerciseHistoryForReference | null
+  /** When true, the parent is still fetching history — render nothing to avoid flicker. */
+  isLoading?: boolean
+}
+
+/**
+ * Compact reference line shown above the logger input area: answers
+ * "what did I do last time?" without leaving the logger.
+ *
+ * Three states:
+ *   - Has working sets: "Last time: 185 × 5 × 3 @ RPE 8 (3 days ago)"
+ *   - No previous logs: "First time logging this — see Info tab for guidance"
+ *   - Only warmups previously: "Last logged sets were warmups"
+ */
+export default function LastSessionReference({
+  history,
+  isLoading = false,
+}: LastSessionReferenceProps) {
+  if (isLoading) return null
+
+  const { summary, relative, emptyReason } = formatLastSessionSummary(history)
+
+  if (summary) {
+    return (
+      <div
+        className="flex items-baseline gap-2 px-3 py-2 border-l-4 border-success bg-success/5 text-sm"
+        data-testid="last-session-reference"
+      >
+        <History
+          aria-hidden="true"
+          size={14}
+          className="text-success self-center flex-shrink-0"
+        />
+        <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          Last time:
+        </span>
+        <span className="font-bold text-foreground">{summary}</span>
+        {relative && (
+          <span className="text-xs text-muted-foreground ml-auto">({relative})</span>
+        )}
+      </div>
+    )
+  }
+
+  if (emptyReason === 'never-logged') {
+    return (
+      <div
+        className="flex items-center gap-2 px-3 py-2 border-l-4 border-border bg-muted/30 text-sm text-muted-foreground"
+        data-testid="last-session-reference-empty"
+      >
+        <Sparkles aria-hidden="true" size={14} className="flex-shrink-0" />
+        <span>First time logging this — see Info tab for guidance</span>
+      </div>
+    )
+  }
+
+  if (emptyReason === 'warmups-only') {
+    return (
+      <div
+        className="flex items-center gap-2 px-3 py-2 border-l-4 border-border bg-muted/30 text-sm text-muted-foreground"
+        data-testid="last-session-reference-warmups"
+      >
+        <History aria-hidden="true" size={14} className="flex-shrink-0" />
+        <span>Last logged sets were warmups</span>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/hooks/useProgressiveExercises.ts
+++ b/hooks/useProgressiveExercises.ts
@@ -41,6 +41,7 @@ export type ExerciseHistorySet = {
   weightUnit: string
   rpe: number | null
   rir: number | null
+  isWarmup: boolean
 }
 
 export type ExerciseHistory = {

--- a/lib/format/last-session-reference.ts
+++ b/lib/format/last-session-reference.ts
@@ -1,0 +1,97 @@
+/**
+ * Formats a compact "last session" summary string for display above the
+ * logger input area. Answers the gym-floor question "what did I do last time?"
+ *
+ * Examples:
+ *   formatLastSessionSummary({ sets: [...] })
+ *     -> "185 × 5 × 3 @ RPE 8"       (3 working sets, same reps/weight)
+ *     -> "185 × 5,5,4"                (varied reps)
+ *     -> "135–185 × 5 × 3"            (varied weight)
+ */
+
+import { formatRelativeTime } from './relativeTime'
+
+export interface LastSessionSet {
+  setNumber: number
+  reps: number
+  weight: number
+  weightUnit: string
+  rpe: number | null
+  rir: number | null
+  isWarmup: boolean
+}
+
+export interface LastSessionResult {
+  /** Headline line, e.g. "185 × 5 × 3 @ RPE 8". null when there's nothing to show. */
+  summary: string | null
+  /** Human-readable relative time, e.g. "3 days ago". null when no working sets. */
+  relative: string | null
+  /** Reason code for an empty result; UI can map this to a tip line. */
+  emptyReason: 'never-logged' | 'warmups-only' | null
+}
+
+/**
+ * Build a one-line summary of the user's last completed session for an exercise.
+ *
+ * @param history Previous session payload, or null when none exists.
+ */
+export function formatLastSessionSummary(
+  history: { completedAt: Date | string; sets: LastSessionSet[] } | null
+): LastSessionResult {
+  if (!history || history.sets.length === 0) {
+    return { summary: null, relative: null, emptyReason: 'never-logged' }
+  }
+
+  const workingSets = history.sets.filter((s) => !s.isWarmup)
+  if (workingSets.length === 0) {
+    return { summary: null, relative: null, emptyReason: 'warmups-only' }
+  }
+
+  // Weight component: collapse to single value when uniform; otherwise show range.
+  const unit = workingSets[0].weightUnit
+  const weights = workingSets.map((s) => s.weight)
+  const minW = Math.min(...weights)
+  const maxW = Math.max(...weights)
+  const weightStr =
+    minW === maxW
+      ? minW === 0
+        ? 'BW'
+        : `${formatNumber(minW)} ${unit}`
+      : `${formatNumber(minW)}–${formatNumber(maxW)} ${unit}`
+
+  // Reps component: collapse when uniform; show comma-separated otherwise.
+  const reps = workingSets.map((s) => s.reps)
+  const allSameReps = reps.every((r) => r === reps[0])
+  const repsStr = allSameReps ? `${reps[0]}` : reps.join(',')
+
+  // Sets component: only show " × N" when reps and weight are uniform — that's
+  // when "N sets of W × R" is the natural reading. With varied reps we already
+  // show each set in the comma list, so don't repeat the count.
+  const setsStr = allSameReps && minW === maxW ? ` × ${workingSets.length}` : ''
+
+  // Intensity tag: prefer RIR (more concrete for users), fall back to RPE.
+  // Only show when uniform across working sets so we don't lie about variance.
+  const intensityStr = pickIntensityTag(workingSets)
+
+  const summary = `${weightStr} × ${repsStr}${setsStr}${intensityStr}`
+  const relative = formatRelativeTime(history.completedAt)
+
+  return { summary, relative, emptyReason: null }
+}
+
+function formatNumber(n: number): string {
+  // Drop trailing ".0" but keep meaningful fractional weights (e.g. 102.5).
+  return Number.isInteger(n) ? String(n) : String(n)
+}
+
+function pickIntensityTag(sets: LastSessionSet[]): string {
+  const rirs = sets.map((s) => s.rir).filter((v): v is number => v != null)
+  if (rirs.length === sets.length && rirs.every((v) => v === rirs[0])) {
+    return ` @ RIR ${rirs[0]}`
+  }
+  const rpes = sets.map((s) => s.rpe).filter((v): v is number => v != null)
+  if (rpes.length === sets.length && rpes.every((v) => v === rpes[0])) {
+    return ` @ RPE ${rpes[0]}`
+  }
+  return ''
+}


### PR DESCRIPTION
## Summary
- Adds a compact "Last time:" reference line above the logger input area so users can see what they did in their most recent session for the current exercise without leaving the logger
- Three states: working sets summary (e.g. `185 lbs × 5 × 3 @ RPE 8 (3 days ago)`), never-logged tip, and warmups-only tip
- Reuses the existing exercise-history fetch (no new query); adds `isWarmup` to the client-side `ExerciseHistorySet` type so warmups can be filtered out of the headline
- Formatter collapses uniform sets, falls back to comma-listed reps / weight range when sets vary, and only attaches an intensity tag when RIR/RPE is uniform across working sets

## Implementation notes
- New util `lib/format/last-session-reference.ts` (pure, fully unit tested — 12 cases)
- New component `components/workout-logging/LastSessionReference.tsx` (rendered above `loggingForm` in the log-sets tab, hidden while an input drawer is open)
- Type widening: `ExerciseHistorySet` now includes `isWarmup` in `hooks/useProgressiveExercises.ts`, `components/workout-logging/ExerciseDisplayTabs.tsx`, `components/StrengthWeekView.tsx`, and `components/adhoc/AdHocLoggerView.tsx`. The underlying Prisma queries already returned `isWarmup`.

Fixes #891

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` — no new issues in changed files (pre-existing unrelated warnings remain)
- [x] New unit tests pass (12/12) — covers never-logged, warmups-only, uniform sets, varied reps, varied weight, bodyweight, intensity rendering
- [ ] Manual: open logger on an exercise with prior history → see "Last time" line
- [ ] Manual: open logger on a fresh exercise → see "First time logging this" tip
- [ ] Manual: open logger on an exercise whose last session was only warmups → see warmups-only tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)