### PR TITLE
Expand UserTrainingProfile with demographics, injuries, and importance ratings

### DIFF
--- a/__tests__/api/user-training-profile.test.ts
+++ b/__tests__/api/user-training-profile.test.ts
@@ -4,6 +4,13 @@ import { getDefaultMuscleBalanceTargets } from '@/lib/muscle-balance'
 import {
   getOrCreateUserTrainingProfile,
   normalizeUserTrainingProfile,
+  normalizeImportance,
+  normalizeBiologicalSex,
+  normalizePatternPreference,
+  normalizeInjuryAreas,
+  normalizeGoalCategories,
+  normalizeOtherActivities,
+  normalizeWeeklyIntent,
 } from '@/lib/user-training-profile'
 import { getTestDatabase } from '@/lib/test/database'
 import { createTestUser } from '@/lib/test/factories'
@@ -20,7 +27,9 @@ describe('UserTrainingProfile normalization', () => {
     })
 
     expect(result.goalSentences).toEqual(['improve bench', 'spare legs'])
-    expect(result.weeklyIntent).toEqual(['1 heavy leg day'])
+    expect(result.weeklyIntent).toEqual([
+      { type: 'free_text', text: '1 heavy leg day' },
+    ])
     expect(result.equipmentAvailable).toEqual(['barbell', 'dumbbells'])
     expect(result.bannedExerciseIds).toEqual(['ex_1', 'ex_2'])
     expect(result.defaultIntensityPreference).toBe('hypertrophy')
@@ -39,6 +48,179 @@ describe('UserTrainingProfile normalization', () => {
 
     expect(result.goalSentences).toEqual([])
     expect(result.defaultIntensityPreference).toBeNull()
+  })
+
+  it('normalizes new demographic and rhythm fields', () => {
+    const result = normalizeUserTrainingProfile({
+      goalSentences: [],
+      weeklyIntent: [],
+      equipmentAvailable: [],
+      bannedExerciseIds: [],
+      ratioTargets: {},
+      defaultIntensityPreference: null,
+      age: 34.7,
+      biologicalSex: 'female',
+      heightCm: 170,
+      weightKg: 65,
+      injuryAreas: null,
+      injuryFreeNotes: '  no notable injuries  ',
+      goalCategories: null,
+      otherActivities: null,
+      targetSessionsPerWeek: 4,
+      targetMinutesPerSession: 60,
+      patternPreference: 'upper_lower',
+    })
+
+    expect(result.age).toBe(35)
+    expect(result.biologicalSex).toBe('female')
+    expect(result.heightCm).toBe(170)
+    expect(result.weightKg).toBe(65)
+    expect(result.injuryFreeNotes).toBe('no notable injuries')
+    expect(result.targetSessionsPerWeek).toBe(4)
+    expect(result.targetMinutesPerSession).toBe(60)
+    expect(result.patternPreference).toBe('upper_lower')
+  })
+
+  it('rejects out-of-range demographics and bad enum strings', () => {
+    const result = normalizeUserTrainingProfile({
+      goalSentences: [],
+      weeklyIntent: [],
+      equipmentAvailable: [],
+      bannedExerciseIds: [],
+      ratioTargets: {},
+      defaultIntensityPreference: null,
+      age: 2, // below MIN_AGE
+      biologicalSex: 'bogus',
+      heightCm: 1000,
+      weightKg: -5,
+      targetSessionsPerWeek: 99,
+      targetMinutesPerSession: 0,
+      patternPreference: 'invalid',
+    })
+
+    expect(result.age).toBeNull()
+    expect(result.biologicalSex).toBeNull()
+    expect(result.heightCm).toBeNull()
+    expect(result.weightKg).toBeNull()
+    expect(result.targetSessionsPerWeek).toBeNull()
+    expect(result.targetMinutesPerSession).toBeNull()
+    expect(result.patternPreference).toBeNull()
+  })
+})
+
+describe('normalizeImportance', () => {
+  it('clamps to [1,5] and rounds', () => {
+    expect(normalizeImportance(3)).toBe(3)
+    expect(normalizeImportance(0)).toBe(1)
+    expect(normalizeImportance(-2)).toBe(1)
+    expect(normalizeImportance(6)).toBe(5)
+    expect(normalizeImportance(4.6)).toBe(5)
+    expect(normalizeImportance(4.4)).toBe(4)
+  })
+
+  it('rejects non-numeric values', () => {
+    expect(normalizeImportance('4')).toBeNull()
+    expect(normalizeImportance(null)).toBeNull()
+    expect(normalizeImportance(Number.NaN)).toBeNull()
+  })
+})
+
+describe('enum whitelisters', () => {
+  it('normalizeBiologicalSex whitelists known values', () => {
+    expect(normalizeBiologicalSex('female')).toBe('female')
+    expect(normalizeBiologicalSex('male')).toBe('male')
+    expect(normalizeBiologicalSex('prefer_not_to_say')).toBe('prefer_not_to_say')
+    expect(normalizeBiologicalSex('nonbinary')).toBeNull()
+    expect(normalizeBiologicalSex(42)).toBeNull()
+  })
+
+  it('normalizePatternPreference whitelists known values', () => {
+    expect(normalizePatternPreference('full_body')).toBe('full_body')
+    expect(normalizePatternPreference('body_part_split')).toBe('body_part_split')
+    expect(normalizePatternPreference('bro_split')).toBeNull()
+    expect(normalizePatternPreference(null)).toBeNull()
+  })
+})
+
+describe('normalizeWeeklyIntent', () => {
+  it('coerces legacy strings to free_text entries', () => {
+    const result = normalizeWeeklyIntent([
+      '  Deadlift day  ',
+      'Deadlift day', // dedup
+      '',
+      'Squat day',
+    ])
+    expect(result).toEqual([
+      { type: 'free_text', text: 'Deadlift day' },
+      { type: 'free_text', text: 'Squat day' },
+    ])
+  })
+
+  it('accepts structured free_text entries', () => {
+    const result = normalizeWeeklyIntent([
+      { type: 'free_text', text: 'Bench focus' },
+      { type: 'free_text', text: '' }, // empty is dropped
+      { type: 'unknown' as unknown as 'free_text', text: 'ignored' },
+    ])
+    expect(result).toEqual([{ type: 'free_text', text: 'Bench focus' }])
+  })
+
+  it('returns [] for non-array input', () => {
+    expect(normalizeWeeklyIntent(null)).toEqual([])
+    expect(normalizeWeeklyIntent('string')).toEqual([])
+  })
+})
+
+describe('normalizeInjuryAreas', () => {
+  it('whitelists area/severity, trims notes, dedupes by area', () => {
+    const result = normalizeInjuryAreas([
+      { area: 'shoulder', severity: 'active', notes: '  right side  ' },
+      { area: 'shoulder', severity: 'past' }, // duplicate area, dropped
+      { area: 'knee', severity: 'mindful' },
+      { area: 'nose', severity: 'active' }, // invalid area
+      { area: 'wrist', severity: 'wonky' }, // invalid severity
+    ])
+    expect(result).toEqual([
+      { area: 'shoulder', severity: 'active', notes: 'right side' },
+      { area: 'knee', severity: 'mindful' },
+    ])
+  })
+
+  it('returns [] for non-array', () => {
+    expect(normalizeInjuryAreas(null)).toEqual([])
+  })
+})
+
+describe('normalizeGoalCategories', () => {
+  it('whitelists categories, clamps importance, dedupes', () => {
+    const result = normalizeGoalCategories([
+      { category: 'build_muscle', importance: 5 },
+      { category: 'build_muscle', importance: 3 }, // dup dropped
+      { category: 'lose_fat', importance: 10 }, // clamp to 5
+      { category: 'get_stronger', importance: 0 }, // clamp to 1
+      { category: 'bogus', importance: 3 }, // invalid category
+      { category: 'general_fitness' }, // missing importance
+    ])
+    expect(result).toEqual([
+      { category: 'build_muscle', importance: 5 },
+      { category: 'lose_fat', importance: 5 },
+      { category: 'get_stronger', importance: 1 },
+    ])
+  })
+})
+
+describe('normalizeOtherActivities', () => {
+  it('whitelists activities, clamps importance, dedupes, trims cadence', () => {
+    const result = normalizeOtherActivities([
+      { activity: 'cycling', importance: 4, cadence: '  2x/week  ' },
+      { activity: 'cycling', importance: 2 }, // dup
+      { activity: 'yoga', importance: 100 }, // clamp
+      { activity: 'skydiving', importance: 3 }, // invalid
+    ])
+    expect(result).toEqual([
+      { activity: 'cycling', importance: 4, cadence: '2x/week' },
+      { activity: 'yoga', importance: 5 },
+    ])
   })
 })
 

--- a/lib/user-training-profile.ts
+++ b/lib/user-training-profile.ts
@@ -12,29 +12,173 @@ export const INTENSITY_PREFERENCES = [
 ] as const
 export type IntensityPreference = (typeof INTENSITY_PREFERENCES)[number]
 
+export const BIOLOGICAL_SEXES = ['female', 'male', 'prefer_not_to_say'] as const
+export type BiologicalSex = (typeof BIOLOGICAL_SEXES)[number]
+
+export const PATTERN_PREFERENCES = [
+  'no_preference',
+  'full_body',
+  'upper_lower',
+  'push_pull_legs',
+  'body_part_split',
+  'custom',
+] as const
+export type PatternPreference = (typeof PATTERN_PREFERENCES)[number]
+
+export const INJURY_AREAS = [
+  'lower_back',
+  'shoulder',
+  'knee',
+  'wrist',
+  'elbow',
+  'hip',
+] as const
+export type InjuryArea = (typeof INJURY_AREAS)[number]
+
+export const INJURY_SEVERITIES = ['past', 'mindful', 'active'] as const
+export type InjurySeverity = (typeof INJURY_SEVERITIES)[number]
+
+export const GOAL_CATEGORIES = [
+  'build_muscle',
+  'get_stronger',
+  'lose_fat',
+  'general_fitness',
+  'sport_performance',
+  'rehabilitation',
+  'aesthetic_specific',
+  'other',
+] as const
+export type GoalCategory = (typeof GOAL_CATEGORIES)[number]
+
+export const OTHER_ACTIVITIES = [
+  'cycling',
+  'running',
+  'hiking',
+  'climbing',
+  'yoga',
+  'team_sports',
+  'manual_labor',
+  'other',
+] as const
+export type OtherActivity = (typeof OTHER_ACTIVITIES)[number]
+
 export const MAX_GOAL_SENTENCES = 10
 export const MAX_GOAL_SENTENCE_LENGTH = 280
 export const MAX_WEEKLY_INTENTS = 10
 export const MAX_WEEKLY_INTENT_LENGTH = 280
 export const MAX_EQUIPMENT_ITEMS = 32
 export const MAX_BANNED_EXERCISE_IDS = 500
+export const MAX_INJURY_ENTRIES = 20
+export const MAX_INJURY_NOTES_LENGTH = 500
+export const MAX_INJURY_FREE_NOTES_LENGTH = 2000
+export const MAX_GOAL_CATEGORY_ENTRIES = GOAL_CATEGORIES.length
+export const MAX_OTHER_ACTIVITY_ENTRIES = OTHER_ACTIVITIES.length
+export const MAX_ACTIVITY_CADENCE_LENGTH = 120
+
+export const MIN_IMPORTANCE = 1
+export const MAX_IMPORTANCE = 5
+
+export const MIN_AGE = 5
+export const MAX_AGE = 120
+export const MIN_HEIGHT_CM = 50
+export const MAX_HEIGHT_CM = 300
+export const MIN_WEIGHT_KG = 10
+export const MAX_WEIGHT_KG = 500
+export const MIN_SESSIONS_PER_WEEK = 1
+export const MAX_SESSIONS_PER_WEEK = 14
+export const MIN_MINUTES_PER_SESSION = 5
+export const MAX_MINUTES_PER_SESSION = 480
+
+export type WeeklyIntentEntry = { type: 'free_text'; text: string }
+
+export type InjuryAreaEntry = {
+  area: InjuryArea
+  severity: InjurySeverity
+  notes?: string
+}
+
+export type GoalCategoryEntry = {
+  category: GoalCategory
+  importance: number
+}
+
+export type OtherActivityEntry = {
+  activity: OtherActivity
+  importance: number
+  cadence?: string
+}
 
 export type UserTrainingProfileDTO = {
   goalSentences: string[]
-  weeklyIntent: string[]
+  weeklyIntent: WeeklyIntentEntry[]
   equipmentAvailable: string[]
   bannedExerciseIds: string[]
   ratioTargets: MuscleBalanceTargets
   defaultIntensityPreference: IntensityPreference | null
+  age: number | null
+  biologicalSex: BiologicalSex | null
+  heightCm: number | null
+  weightKg: number | null
+  injuryAreas: InjuryAreaEntry[]
+  injuryFreeNotes: string | null
+  goalCategories: GoalCategoryEntry[]
+  otherActivities: OtherActivityEntry[]
+  targetSessionsPerWeek: number | null
+  targetMinutesPerSession: number | null
+  patternPreference: PatternPreference | null
+}
+
+function normalizeEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[]
+): T | null {
+  if (typeof value !== 'string') return null
+  return (allowed as readonly string[]).includes(value) ? (value as T) : null
 }
 
 export function normalizeIntensityPreference(
   value: unknown
 ): IntensityPreference | null {
-  if (typeof value !== 'string') return null
-  return (INTENSITY_PREFERENCES as readonly string[]).includes(value)
-    ? (value as IntensityPreference)
-    : null
+  return normalizeEnum(value, INTENSITY_PREFERENCES)
+}
+
+export function normalizeBiologicalSex(value: unknown): BiologicalSex | null {
+  return normalizeEnum(value, BIOLOGICAL_SEXES)
+}
+
+export function normalizePatternPreference(
+  value: unknown
+): PatternPreference | null {
+  return normalizeEnum(value, PATTERN_PREFERENCES)
+}
+
+function clampInt(
+  value: unknown,
+  min: number,
+  max: number
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const rounded = Math.round(value)
+  if (rounded < min || rounded > max) return null
+  return rounded
+}
+
+function clampFloat(
+  value: unknown,
+  min: number,
+  max: number
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value < min || value > max) return null
+  return value
+}
+
+export function normalizeImportance(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const rounded = Math.round(value)
+  if (rounded < MIN_IMPORTANCE) return MIN_IMPORTANCE
+  if (rounded > MAX_IMPORTANCE) return MAX_IMPORTANCE
+  return rounded
 }
 
 function normalizeStringList(
@@ -58,30 +202,156 @@ function normalizeStringList(
   return result
 }
 
+/**
+ * Normalize weeklyIntent from either legacy String[] or the new
+ * discriminated-union Json form. Legacy strings become
+ * `{ type: 'free_text', text }`.
+ */
+export function normalizeWeeklyIntent(value: unknown): WeeklyIntentEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: WeeklyIntentEntry[] = []
+  const seen = new Set<string>()
+  for (const raw of value) {
+    let text: string | null = null
+    if (typeof raw === 'string') {
+      text = raw
+    } else if (
+      raw &&
+      typeof raw === 'object' &&
+      (raw as { type?: unknown }).type === 'free_text' &&
+      typeof (raw as { text?: unknown }).text === 'string'
+    ) {
+      text = (raw as { text: string }).text
+    }
+    if (!text) continue
+    const trimmed = text.trim()
+    if (!trimmed) continue
+    const truncated = trimmed.slice(0, MAX_WEEKLY_INTENT_LENGTH)
+    if (seen.has(truncated)) continue
+    seen.add(truncated)
+    result.push({ type: 'free_text', text: truncated })
+    if (result.length >= MAX_WEEKLY_INTENTS) break
+  }
+  return result
+}
+
+export function normalizeInjuryAreas(value: unknown): InjuryAreaEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: InjuryAreaEntry[] = []
+  const seenAreas = new Set<InjuryArea>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const area = normalizeEnum(
+      (raw as { area?: unknown }).area,
+      INJURY_AREAS
+    )
+    const severity = normalizeEnum(
+      (raw as { severity?: unknown }).severity,
+      INJURY_SEVERITIES
+    )
+    if (!area || !severity) continue
+    if (seenAreas.has(area)) continue
+    seenAreas.add(area)
+    const entry: InjuryAreaEntry = { area, severity }
+    const notesRaw = (raw as { notes?: unknown }).notes
+    if (typeof notesRaw === 'string') {
+      const notes = notesRaw.trim().slice(0, MAX_INJURY_NOTES_LENGTH)
+      if (notes) entry.notes = notes
+    }
+    result.push(entry)
+    if (result.length >= MAX_INJURY_ENTRIES) break
+  }
+  return result
+}
+
+export function normalizeGoalCategories(value: unknown): GoalCategoryEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: GoalCategoryEntry[] = []
+  const seen = new Set<GoalCategory>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const category = normalizeEnum(
+      (raw as { category?: unknown }).category,
+      GOAL_CATEGORIES
+    )
+    const importance = normalizeImportance(
+      (raw as { importance?: unknown }).importance
+    )
+    if (!category || importance == null) continue
+    if (seen.has(category)) continue
+    seen.add(category)
+    result.push({ category, importance })
+    if (result.length >= MAX_GOAL_CATEGORY_ENTRIES) break
+  }
+  return result
+}
+
+export function normalizeOtherActivities(
+  value: unknown
+): OtherActivityEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: OtherActivityEntry[] = []
+  const seen = new Set<OtherActivity>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const activity = normalizeEnum(
+      (raw as { activity?: unknown }).activity,
+      OTHER_ACTIVITIES
+    )
+    const importance = normalizeImportance(
+      (raw as { importance?: unknown }).importance
+    )
+    if (!activity || importance == null) continue
+    if (seen.has(activity)) continue
+    seen.add(activity)
+    const entry: OtherActivityEntry = { activity, importance }
+    const cadenceRaw = (raw as { cadence?: unknown }).cadence
+    if (typeof cadenceRaw === 'string') {
+      const cadence = cadenceRaw.trim().slice(0, MAX_ACTIVITY_CADENCE_LENGTH)
+      if (cadence) entry.cadence = cadence
+    }
+    result.push(entry)
+    if (result.length >= MAX_OTHER_ACTIVITY_ENTRIES) break
+  }
+  return result
+}
+
+type ProfileLike = {
+  goalSentences: string[]
+  weeklyIntent: Prisma.JsonValue | string[]
+  equipmentAvailable: string[]
+  bannedExerciseIds: string[]
+  ratioTargets: Prisma.JsonValue
+  defaultIntensityPreference: string | null
+  age?: number | null
+  biologicalSex?: string | null
+  heightCm?: number | null
+  weightKg?: number | null
+  injuryAreas?: Prisma.JsonValue | null
+  injuryFreeNotes?: string | null
+  goalCategories?: Prisma.JsonValue | null
+  otherActivities?: Prisma.JsonValue | null
+  targetSessionsPerWeek?: number | null
+  targetMinutesPerSession?: number | null
+  patternPreference?: string | null
+}
+
 export function normalizeUserTrainingProfile(
-  profile:
-    | {
-        goalSentences: string[]
-        weeklyIntent: string[]
-        equipmentAvailable: string[]
-        bannedExerciseIds: string[]
-        ratioTargets: Prisma.JsonValue
-        defaultIntensityPreference: string | null
-      }
-    | null
-    | undefined
+  profile: ProfileLike | null | undefined
 ): UserTrainingProfileDTO {
+  const injuryFreeNotesRaw = profile?.injuryFreeNotes ?? null
+  const injuryFreeNotes =
+    typeof injuryFreeNotesRaw === 'string'
+      ? injuryFreeNotesRaw.trim().slice(0, MAX_INJURY_FREE_NOTES_LENGTH) || null
+      : null
+
   return {
     goalSentences: normalizeStringList(
       profile?.goalSentences,
       MAX_GOAL_SENTENCES,
       MAX_GOAL_SENTENCE_LENGTH
     ),
-    weeklyIntent: normalizeStringList(
-      profile?.weeklyIntent,
-      MAX_WEEKLY_INTENTS,
-      MAX_WEEKLY_INTENT_LENGTH
-    ),
+    weeklyIntent: normalizeWeeklyIntent(profile?.weeklyIntent),
     equipmentAvailable: normalizeStringList(
       profile?.equipmentAvailable,
       MAX_EQUIPMENT_ITEMS,
@@ -95,6 +365,27 @@ export function normalizeUserTrainingProfile(
     ratioTargets: normalizeMuscleBalanceTargets(profile?.ratioTargets),
     defaultIntensityPreference: normalizeIntensityPreference(
       profile?.defaultIntensityPreference ?? null
+    ),
+    age: clampInt(profile?.age ?? null, MIN_AGE, MAX_AGE),
+    biologicalSex: normalizeBiologicalSex(profile?.biologicalSex ?? null),
+    heightCm: clampFloat(profile?.heightCm ?? null, MIN_HEIGHT_CM, MAX_HEIGHT_CM),
+    weightKg: clampFloat(profile?.weightKg ?? null, MIN_WEIGHT_KG, MAX_WEIGHT_KG),
+    injuryAreas: normalizeInjuryAreas(profile?.injuryAreas),
+    injuryFreeNotes,
+    goalCategories: normalizeGoalCategories(profile?.goalCategories),
+    otherActivities: normalizeOtherActivities(profile?.otherActivities),
+    targetSessionsPerWeek: clampInt(
+      profile?.targetSessionsPerWeek ?? null,
+      MIN_SESSIONS_PER_WEEK,
+      MAX_SESSIONS_PER_WEEK
+    ),
+    targetMinutesPerSession: clampInt(
+      profile?.targetMinutesPerSession ?? null,
+      MIN_MINUTES_PER_SESSION,
+      MAX_MINUTES_PER_SESSION
+    ),
+    patternPreference: normalizePatternPreference(
+      profile?.patternPreference ?? null
     ),
   }
 }

--- a/prisma/migrations/20260701155637_expand_user_training_profile/migration.sql
+++ b/prisma/migrations/20260701155637_expand_user_training_profile/migration.sql
@@ -1,0 +1,38 @@
+-- Expand UserTrainingProfile with demographics, injuries, goal categories,
+-- other activities, and training rhythm. Also convert weeklyIntent from
+-- TEXT[] to JSONB (per #884) preserving existing entries as
+-- { type: 'free_text', text }.
+
+-- 1. Add new columns
+ALTER TABLE "UserTrainingProfile"
+  ADD COLUMN "age" INTEGER,
+  ADD COLUMN "biologicalSex" TEXT,
+  ADD COLUMN "heightCm" DOUBLE PRECISION,
+  ADD COLUMN "weightKg" DOUBLE PRECISION,
+  ADD COLUMN "injuryAreas" JSONB,
+  ADD COLUMN "injuryFreeNotes" TEXT,
+  ADD COLUMN "goalCategories" JSONB,
+  ADD COLUMN "otherActivities" JSONB,
+  ADD COLUMN "targetSessionsPerWeek" INTEGER,
+  ADD COLUMN "targetMinutesPerSession" INTEGER,
+  ADD COLUMN "patternPreference" TEXT;
+
+-- 2. Convert weeklyIntent TEXT[] -> JSONB, wrapping each string as free_text.
+ALTER TABLE "UserTrainingProfile"
+  ALTER COLUMN "weeklyIntent" DROP DEFAULT;
+
+ALTER TABLE "UserTrainingProfile"
+  ALTER COLUMN "weeklyIntent" TYPE JSONB
+  USING (
+    COALESCE(
+      (
+        SELECT jsonb_agg(jsonb_build_object('type', 'free_text', 'text', s))
+        FROM unnest("weeklyIntent") AS s
+      ),
+      '[]'::jsonb
+    )
+  );
+
+ALTER TABLE "UserTrainingProfile"
+  ALTER COLUMN "weeklyIntent" SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN "weeklyIntent" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -365,11 +365,33 @@ model UserTrainingProfile {
   id                          String   @id @default(cuid())
   userId                      String   @unique
   goalSentences               String[] @default([])
-  weeklyIntent                String[] @default([])
+  weeklyIntent                Json     @default("[]")
   equipmentAvailable          String[] @default([])
   bannedExerciseIds           String[] @default([])
   ratioTargets                Json
   defaultIntensityPreference  String?
+
+  // Demographics (nullable, skippable)
+  age                         Int?
+  biologicalSex               String?
+  heightCm                    Float?
+  weightKg                    Float?
+
+  // Injury data
+  injuryAreas                 Json?
+  injuryFreeNotes             String?
+
+  // Goal categories with importance
+  goalCategories              Json?
+
+  // Other physical activities with importance
+  otherActivities             Json?
+
+  // Training rhythm
+  targetSessionsPerWeek       Int?
+  targetMinutesPerSession     Int?
+  patternPreference           String?
+
   createdAt                   DateTime @default(now())
   updatedAt                   DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- Extends `UserTrainingProfile` with demographics (age/sex/height/weight), injury data, 1–5 importance ratings for goal categories and other activities, and training rhythm fields (sessions/minutes per week, split preference).
- Changes `weeklyIntent` from `String[]` to `Json` per #884; migration wraps each existing string as `{ type: 'free_text', text }`.
- Adds whitelist/clamp normalizers in `lib/user-training-profile.ts` and unit + persistence tests.

Fixes #897

## Test plan
- [x] `npm run type-check` clean (new code)
- [x] `npm run lint` clean on touched files (pre-existing errors elsewhere unrelated)
- [x] `npm test __tests__/api/user-training-profile.test.ts` → 18/18 pass
- [ ] Staging deploy applies migration (prod migration runs automatically on deploy per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)