### PR TITLE
feat(suggest): Suggestion model + Workout.sourceSuggestionId (#869)

### DIFF
--- a/lib/suggest/types.ts
+++ b/lib/suggest/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Type definitions for the Suggest Workout LLM pipeline.
+ *
+ * These types describe the JSON shapes stored in `Suggestion.requestPayload`
+ * and `Suggestion.responsePayload`. They are intentionally kept here (not in
+ * `types/`) so the suggest-worker and API surface share a single source of
+ * truth.
+ *
+ * NOTE: These types are the wire contract with the LLM. Changing a field name
+ * is a breaking change for any queued Suggestion rows; prefer additive changes
+ * and version bumps via `SuggestionRequestPayload.schemaVersion`.
+ */
+
+/**
+ * Snapshot of the caller's UserTrainingProfile at the time of enqueue.
+ * Locked into the Suggestion row so the LLM sees the same profile even if
+ * the user edits their profile mid-generation.
+ *
+ * Field names align with the `UserTrainingProfile` Prisma model (#870).
+ */
+export interface SuggestionProfileSnapshot {
+  goalSentences: string[];
+  weeklyIntent: string[];
+  equipmentAvailable: string[];
+  bannedExerciseIds: string[];
+  ratioTargets: Record<string, number>;
+  defaultIntensityPreference: string | null;
+}
+
+/**
+ * Recent history hints supplied to the LLM to bias its plan (e.g., avoid
+ * repeating yesterday's leg-day pattern). Kept intentionally lightweight —
+ * the worker enriches from the DB rather than shipping full session logs.
+ */
+export interface SuggestionRecentActivity {
+  /** ISO timestamps of the last N completed workouts, most recent first. */
+  recentCompletionDates: string[];
+  /** exerciseDefinitionIds trained in the last 7 days. */
+  recentExerciseIds: string[];
+  /** Optional muscle-balance signals derived server-side. */
+  muscleBalanceNotes?: string[];
+}
+
+/**
+ * The full LLM input payload. Stored verbatim in `Suggestion.requestPayload`
+ * so we can replay the same request against a different model for regression
+ * testing.
+ */
+export interface SuggestionRequestPayload {
+  /** Bump on any breaking shape change. */
+  schemaVersion: 1;
+  userId: string;
+  /** When the user requested this suggestion (client clock, ISO 8601). */
+  requestedAt: string;
+  profile: SuggestionProfileSnapshot;
+  recentActivity: SuggestionRecentActivity;
+  /** Free-form user prompt ("today I want something short and pushy"). */
+  userPrompt?: string;
+  /** Optional constraints — target duration, focus area, etc. */
+  constraints?: {
+    targetDurationMinutes?: number;
+    focusArea?: string;
+    excludeExerciseIds?: string[];
+  };
+}
+
+/**
+ * A single prescribed set inside the suggested workout. Shape mirrors the
+ * `PrescribedSet` Prisma model so the worker can materialize it directly.
+ */
+export interface SuggestedPrescribedSet {
+  setNumber: number;
+  reps: string;
+  weight?: string | null;
+  rpe?: number | null;
+  rir?: number | null;
+  isWarmup?: boolean;
+}
+
+/**
+ * A single exercise in the suggested workout.
+ */
+export interface SuggestedExercise {
+  order: number;
+  /** Preferred: reference an existing ExerciseDefinition. */
+  exerciseDefinitionId?: string;
+  /** Fallback name if the LLM proposed something we don't have a def for yet. */
+  name: string;
+  exerciseGroup?: string | null;
+  notes?: string | null;
+  prescribedSets: SuggestedPrescribedSet[];
+}
+
+/**
+ * The structured output from the LLM, stored in `Suggestion.responsePayload`.
+ */
+export interface SuggestionResponsePayload {
+  schemaVersion: 1;
+  workoutName: string;
+  /** Short human-readable rationale surfaced in the UI. */
+  rationale: string;
+  /** Longer form reasoning used for debugging / evals. */
+  reasoningNotes?: string;
+  estimatedDurationMinutes?: number;
+  exercises: SuggestedExercise[];
+}
+
+/**
+ * Status values stored in `Suggestion.status`. Kept as a union so callers
+ * can narrow without importing an enum.
+ */
+export type SuggestionStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'ready'
+  | 'failed';
+
+/**
+ * Progress substates surfaced to the polling UI while `status='in_progress'`.
+ */
+export type SuggestionProgressStep =
+  | 'analyzing'
+  | 'planning'
+  | 'finalizing';

--- a/prisma/migrations/20260701161416_add_suggestion/migration.sql
+++ b/prisma/migrations/20260701161416_add_suggestion/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "Suggestion" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "progressStep" TEXT,
+    "errorMessage" TEXT,
+    "requestPayload" JSONB NOT NULL,
+    "responsePayload" JSONB,
+    "model" TEXT,
+    "provider" TEXT,
+    "latencyMs" INTEGER,
+    "validationFailures" INTEGER NOT NULL DEFAULT 0,
+    "workoutId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Suggestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Suggestion_userId_createdAt_idx" ON "Suggestion"("userId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Suggestion_status_idx" ON "Suggestion"("status");
+
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN "sourceSuggestionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Workout_sourceSuggestionId_idx" ON "Workout"("sourceSuggestionId");
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_sourceSuggestionId_fkey" FOREIGN KEY ("sourceSuggestionId") REFERENCES "Suggestion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,28 +9,28 @@ datasource db {
 }
 
 model Program {
-  id                String    @id @default(cuid())
-  name              String
-  description       String?
-  userId            String
-  isActive          Boolean   @default(false)
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
-  isUserCreated     Boolean   @default(false)
-  programType       String    @default("strength")
-  isArchived        Boolean   @default(false)
-  archivedAt        DateTime?
-  deletedAt         DateTime?
-  copyStatus        String?   @default("ready")
-  goals             String[]  @default([])
-  level             String?
-  durationWeeks     Int?
-  durationDisplay   String?
-  targetDaysPerWeek Int?
-  equipmentNeeded   String[]  @default([])
-  focusAreas            String[]  @default([])
+  id                       String    @id @default(cuid())
+  name                     String
+  description              String?
+  userId                   String
+  isActive                 Boolean   @default(false)
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
+  isUserCreated            Boolean   @default(false)
+  programType              String    @default("strength")
+  isArchived               Boolean   @default(false)
+  archivedAt               DateTime?
+  deletedAt                DateTime?
+  copyStatus               String?   @default("ready")
+  goals                    String[]  @default([])
+  level                    String?
+  durationWeeks            Int?
+  durationDisplay          String?
+  targetDaysPerWeek        Int?
+  equipmentNeeded          String[]  @default([])
+  focusAreas               String[]  @default([])
   sourceCommunityProgramId String?
-  weeks                 Week[]
+  weeks                    Week[]
 
   @@index([userId, isActive])
   @@index([userId])
@@ -55,40 +55,43 @@ model Week {
 }
 
 model Workout {
-  id          String              @id @default(cuid())
-  name        String
-  dayNumber   Int
-  weekId      String
-  userId      String
-  exercises   Exercise[]
-  week        Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
-  completions WorkoutCompletion[]
+  id                 String              @id @default(cuid())
+  name               String
+  dayNumber          Int
+  weekId             String
+  userId             String
+  sourceSuggestionId String?
+  exercises          Exercise[]
+  week               Week                @relation(fields: [weekId], references: [id], onDelete: Cascade)
+  completions        WorkoutCompletion[]
+  sourceSuggestion   Suggestion?         @relation(fields: [sourceSuggestionId], references: [id], onDelete: SetNull)
 
   @@unique([weekId, dayNumber])
   @@index([weekId])
   @@index([userId])
+  @@index([sourceSuggestionId])
 }
 
 model ExerciseDefinition {
-  id             String     @id @default(cuid())
-  name           String
-  normalizedName String     @unique
-  aliases        String[]
-  category       String?
-  isSystem       Boolean    @default(false)
-  createdBy      String?
-  createdAt      DateTime   @default(now())
-  updatedAt      DateTime   @updatedAt
-  equipment      String[]   @default([])
-  instructions   String?
-  notes          String?
-  imageUrls      String[]   @default([])
-  primaryFAUs    String[]   @default([])
-  secondaryFAUs  String[]   @default([])
-  force          String?
-  mechanic       String?
-  level          String?
-  userId         String
+  id              String     @id @default(cuid())
+  name            String
+  normalizedName  String     @unique
+  aliases         String[]
+  category        String?
+  isSystem        Boolean    @default(false)
+  createdBy       String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+  equipment       String[]   @default([])
+  instructions    String?
+  notes           String?
+  imageUrls       String[]   @default([])
+  primaryFAUs     String[]   @default([])
+  secondaryFAUs   String[]   @default([])
+  force           String?
+  mechanic        String?
+  level           String?
+  userId          String
   // Auto-tagged classification (LLM-bootstrapped). See lib/exercises/auto-tag.ts
   // movementPattern: squat | hinge | vertical_push | horizontal_push | vertical_pull | horizontal_pull | lunge | carry | isolation | accessory
   movementPattern String?
@@ -96,7 +99,7 @@ model ExerciseDefinition {
   intensityClass  String?
   taggedAt        DateTime?
   taggedBy        String?
-  exercises      Exercise[]
+  exercises       Exercise[]
 
   @@index([normalizedName])
   @@index([isSystem])
@@ -148,21 +151,21 @@ model PrescribedSet {
 }
 
 model WorkoutCompletion {
-  id              String      @id @default(cuid())
-  workoutId       String?
-  savedWorkoutId  String?
-  userId          String
-  completedAt     DateTime    @default(now())
-  startedAt       DateTime?
-  status          String
-  notes           String?
-  isArchived      Boolean     @default(false)
-  cycleNumber     Int         @default(1)
-  isAdHoc         Boolean     @default(false)
-  name            String?
-  exercises       Exercise[]
-  loggedSets      LoggedSet[]
-  workout         Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)
+  id             String      @id @default(cuid())
+  workoutId      String?
+  savedWorkoutId String?
+  userId         String
+  completedAt    DateTime    @default(now())
+  startedAt      DateTime?
+  status         String
+  notes          String?
+  isArchived     Boolean     @default(false)
+  cycleNumber    Int         @default(1)
+  isAdHoc        Boolean     @default(false)
+  name           String?
+  exercises      Exercise[]
+  loggedSets     LoggedSet[]
+  workout        Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)
 
   @@index([workoutId, userId])
   @@index([userId, completedAt])
@@ -319,30 +322,30 @@ model UserCardioMetricPreferences {
 }
 
 model UserSettings {
-  id                        String    @id @default(cuid())
-  userId                    String    @unique
-  displayName               String?
-  defaultWeightUnit         String    @default("lbs")
-  defaultIntensityRating    String    @default("rir")
-  dismissedPrimer           Boolean   @default(false)
-  dismissedWarmup           Boolean   @default(false)
-  dismissedStickNudge       Boolean   @default(false)
-  completedTours            String    @default("[]")
-  postSessionPromptCount    Int       @default(0)
-  lastPostSessionPromptAt   DateTime?
-  experienceLevel           String?
-  equipmentPreference       String?
-  onboardingCompleted       Boolean   @default(false)
-  customProgramLimitBypass  Boolean   @default(false)
-  intensityEnabled          Boolean   @default(false)
-  loggingMode               String    @default("full")
-  dismissedMessageIds       String    @default("[]")
-  seenMessageIds            String    @default("[]")
-  pwaPromptShownCount       Int       @default(0)
-  pwaPromptDismissedAt      DateTime?
-  signupIntent              String?
-  createdAt                 DateTime  @default(now())
-  updatedAt                 DateTime  @updatedAt
+  id                       String    @id @default(cuid())
+  userId                   String    @unique
+  displayName              String?
+  defaultWeightUnit        String    @default("lbs")
+  defaultIntensityRating   String    @default("rir")
+  dismissedPrimer          Boolean   @default(false)
+  dismissedWarmup          Boolean   @default(false)
+  dismissedStickNudge      Boolean   @default(false)
+  completedTours           String    @default("[]")
+  postSessionPromptCount   Int       @default(0)
+  lastPostSessionPromptAt  DateTime?
+  experienceLevel          String?
+  equipmentPreference      String?
+  onboardingCompleted      Boolean   @default(false)
+  customProgramLimitBypass Boolean   @default(false)
+  intensityEnabled         Boolean   @default(false)
+  loggingMode              String    @default("full")
+  dismissedMessageIds      String    @default("[]")
+  seenMessageIds           String    @default("[]")
+  pwaPromptShownCount      Int       @default(0)
+  pwaPromptDismissedAt     DateTime?
+  signupIntent             String?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
 
   @@index([userId])
 }
@@ -362,16 +365,16 @@ model UserMuscleBalanceSettings {
 }
 
 model UserTrainingProfile {
-  id                          String   @id @default(cuid())
-  userId                      String   @unique
-  goalSentences               String[] @default([])
-  weeklyIntent                String[] @default([])
-  equipmentAvailable          String[] @default([])
-  bannedExerciseIds           String[] @default([])
-  ratioTargets                Json
-  defaultIntensityPreference  String?
-  createdAt                   DateTime @default(now())
-  updatedAt                   DateTime @updatedAt
+  id                         String   @id @default(cuid())
+  userId                     String   @unique
+  goalSentences              String[] @default([])
+  weeklyIntent               String[] @default([])
+  equipmentAvailable         String[] @default([])
+  bannedExerciseIds          String[] @default([])
+  ratioTargets               Json
+  defaultIntensityPreference String?
+  createdAt                  DateTime @default(now())
+  updatedAt                  DateTime @updatedAt
 
   @@index([userId])
 }
@@ -410,10 +413,10 @@ model CommunityProgram {
 }
 
 model ExercisePerformanceLog {
-  id                   String   @id @default(cuid())
-  userId               String
-  completedAt          DateTime
-  type                 String
+  id          String   @id @default(cuid())
+  userId      String
+  completedAt DateTime
+  type        String
 
   // Exercise reference
   exerciseDefinitionId String?
@@ -421,22 +424,22 @@ model ExercisePerformanceLog {
   exerciseName         String
 
   // Strength metrics
-  totalSets            Int?
-  totalReps            Int?
-  totalVolumeLbs       Float?
-  maxWeightLbs         Float?
-  estimated1RMLbs      Float?
-  avgRPE               Float?
+  totalSets       Int?
+  totalReps       Int?
+  totalVolumeLbs  Float?
+  maxWeightLbs    Float?
+  estimated1RMLbs Float?
+  avgRPE          Float?
 
   // Cardio metrics
-  distance             Float?
-  distanceUnit         String?
-  duration             Int?
-  avgPaceSeconds       Int?
+  distance       Float?
+  distanceUnit   String?
+  duration       Int?
+  avgPaceSeconds Int?
 
   // Reference back to source
-  workoutCompletionId  String?
-  cardioSessionId      String?
+  workoutCompletionId String?
+  cardioSessionId     String?
 
   @@index([userId, completedAt])
   @@index([userId, exerciseDefinitionId, completedAt])
@@ -593,14 +596,14 @@ model WaiverAcceptance {
 // -- User Feedback --
 
 model Feedback {
-  id        String   @id @default(cuid())
-  userId    String
-  category  String   // "bug" | "feature" | "confusion" | "general" | "post_session"
-  message   String   @default("")
-  pageUrl   String
-  userAgent String?
-  properties     String?  // JSON blob for extra context (e.g. question shown for post_session)
-  rating         Int?     // 1-5 experience rating (post_session)
+  id             String   @id @default(cuid())
+  userId         String
+  category       String // "bug" | "feature" | "confusion" | "general" | "post_session"
+  message        String   @default("")
+  pageUrl        String
+  userAgent      String?
+  properties     String? // JSON blob for extra context (e.g. question shown for post_session)
+  rating         Int? // 1-5 experience rating (post_session)
   refinements    String[] // ["confusing", "buggy", etc.] (post_session)
   status         String   @default("new") // "new" | "reviewed" | "resolved"
   adminNote      String?
@@ -616,9 +619,9 @@ model Feedback {
 
 model InAppMessage {
   id               String   @id @default(cuid())
-  name             String?  // admin-only label, not shown to users
-  content          String   // primary slide content (used when slides is null)
-  slides           String?  // JSON: [{ content: string, icon: string }] for multi-slide carousel
+  name             String? // admin-only label, not shown to users
+  content          String // primary slide content (used when slides is null)
+  slides           String? // JSON: [{ content: string, icon: string }] for multi-slide carousel
   placement        String
   userType         String   @default("all")
   icon             String   @default("Lightbulb")
@@ -638,4 +641,29 @@ model InAppMessage {
   @@index([placement, active])
   @@index([placement, userType, active])
   @@index([ownerType, ownerId])
+}
+
+/// Durable job record for the async Suggest Workout worker.
+/// Captures the LLM request/response so we can debug, replay, and later
+/// distinguish "user edited their own workout" from "user edited an AI suggestion."
+model Suggestion {
+  id                 String   @id @default(cuid())
+  userId             String
+  status             String // 'queued' | 'in_progress' | 'ready' | 'failed'
+  progressStep       String? // 'analyzing' | 'planning' | 'finalizing'
+  errorMessage       String? // populated on terminal failure
+  requestPayload     Json // full LLM input (locked at enqueue)
+  responsePayload    Json? // null until 'ready'
+  model              String? // null until worker records it
+  provider           String?
+  latencyMs          Int?
+  validationFailures Int      @default(0)
+  workoutId          String? // set when worker creates the workout
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  workouts Workout[]
+
+  @@index([userId, createdAt(sort: Desc)])
+  @@index([status])
 }


### PR DESCRIPTION
## Summary
- Adds `Suggestion` model — the durable job record for the async Suggest Workout worker (#880), using the locked expanded schema from #869 so the worker doesn't need a follow-up migration.
- Adds `Workout.sourceSuggestionId` FK (`ON DELETE SET NULL`) so workouts can be traced back to the LLM suggestion that produced them — required for the implicit-feedback loop to distinguish user-authored vs AI-authored workouts.
- Adds `lib/suggest/types.ts` with wire-contract types for the request/response payloads, status/progress unions, and a `UserTrainingProfile` snapshot shape aligned with #870.

## Schema shape (locked in #869)
`Suggestion`:
- `status` union: `queued | in_progress | ready | failed`
- `progressStep` union: `analyzing | planning | finalizing`
- `requestPayload` NOT NULL (locked at enqueue); `responsePayload/model/provider/latencyMs` nullable (filled on completion)
- `workoutId` nullable (set on `ready`)
- Indexes: `(userId, createdAt DESC)`, `(status)`

`Workout`:
- Added `sourceSuggestionId String?` + index + FK

## Out of scope
- Suggest Workout flow itself (#880)
- Admin browse UI
- Retry / re-queue
- Cost tracking

## Test plan
- [x] `npx prisma format` clean
- [x] `npx prisma generate` compiles Prisma Client with new model
- [x] `npm run type-check` passes
- [x] `npm run lint` — no new lint issues in changed files (12 pre-existing errors in unrelated files)
- [ ] Migration applies cleanly against staging (auto on deploy)

Fixes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)