### PR TITLE
chore(msv): add milestone-visualizer config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ yarn-error.log*
 # doppler
 .doppler.yaml
 
+# msv milestone graphs (local scratch)
+/milestones
+
 # vercel
 .vercel
 

--- a/.msv.yaml
+++ b/.msv.yaml
@@ -1,0 +1,4 @@
+owner: aptx-health
+repo: ripit-fitness
+milestone: Suggest Workout (LLM-powered)
+graph_file: milestones/suggest-workout.md


### PR DESCRIPTION
## Summary
- Adds `.msv.yaml` so `msv` commands resolve owner/repo/milestone/graph path without positional args
- Adds `/milestones/` to `.gitignore` where the local canonical Mermaid dependency graph lives

Rationale, postmortem on the recent issue↔PR mismatch, and the going-forward rules for grooming agents are captured in the canonical block prepended to Discussion #868.

`msv` itself: https://github.com/aptx-health/milestone-visualizer

## Test plan
- [ ] `msv status` from repo root resolves owner/repo/milestone from `.msv.yaml` (no flags needed)
- [ ] `git check-ignore milestones/suggest-workout.md` returns the `/milestones` rule