### PR TITLE
feat(suggest): prompt module for the Suggest Workout LLM call

### DIFF
--- a/__tests__/lib/llm/suggest-workout-prompt.test.ts
+++ b/__tests__/lib/llm/suggest-workout-prompt.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  buildSuggestionResponseSchema,
+  exerciseCountRange,
+  suggestWorkoutPayloadSchema,
+  type SuggestionResponse,
+  type SuggestWorkoutPayload,
+} from '@/lib/llm/prompts/suggest-workout/schemas'
+import {
+  assembleSuggestWorkoutPrompt,
+  estimateTokens,
+} from '@/lib/llm/prompts/suggest-workout/system-prompt'
+import {
+  FEW_SHOT_EXAMPLES,
+  selectFewShotExample,
+} from '@/lib/llm/prompts/suggest-workout/few-shot-examples'
+import {
+  buildSuggestRetryPrompt,
+  summarizeValidationError,
+} from '@/lib/llm/prompts/suggest-workout/retry-prompt'
+
+function buildTestPayload(
+  overrides: {
+    timeBudget?: number
+    candidateCount?: number
+    goalSentences?: string[]
+    prioritize?: string | null
+    calibration?: boolean
+  } = {},
+): SuggestWorkoutPayload {
+  const candidateCount = overrides.candidateCount ?? 12
+  const payload: SuggestWorkoutPayload = {
+    durable_profile: {
+      goal_sentences: overrides.goalSentences ?? ['Upper-body hypertrophy focus'],
+      weekly_intent: [
+        { type: 'heavy_session', muscle_group: 'legs', min_per_week: 1 },
+      ],
+      equipment_available: ['barbell', 'dumbbells', 'cable', 'machines'],
+      banned_exercise_ids: [],
+      default_intensity_preference: 'hypertrophy',
+      ratio_targets: { chest: 1.3, 'mid-back': 1.2 },
+    },
+    ephemeral_context: {
+      time_budget_minutes: overrides.timeBudget ?? 45,
+      intensity_vibe: 'solid',
+      deprioritize_freetext: 'legs sore',
+      prioritize_freetext:
+        overrides.prioritize === undefined
+          ? 'want to hit chest hard'
+          : overrides.prioritize,
+      equipment_override: null,
+    },
+    training_state: {
+      now: '2026-06-29T18:00:00Z',
+      today_dow: 'monday',
+      per_fau: [
+        {
+          fau: 'chest',
+          last_session_days_ago: 3,
+          last_heavy_days_ago: 3,
+          rolling_7d_sets: 12,
+          rolling_14d_sets: 21,
+          target_share: 0.1,
+          actual_14d_share: 0.07,
+          deficit_share: 0.03,
+          status: 'neglected',
+        },
+        {
+          fau: 'quads',
+          last_session_days_ago: 9,
+          last_heavy_days_ago: null,
+          rolling_7d_sets: 0,
+          rolling_14d_sets: 4,
+          target_share: 0.08,
+          actual_14d_share: 0.03,
+          deficit_share: 0.05,
+          status: 'neglected',
+        },
+      ],
+      per_movement_calibration: overrides.calibration === false
+        ? []
+        : [
+            {
+              movement_pattern: 'horizontal_push',
+              current_ewma_top_weight_lbs: 192,
+              recent_observations: [185, 190, 190, 195, 195],
+              typical_rep_range: '5-8',
+              typical_rpe: 8,
+              last_session_days_ago: 3,
+            },
+          ],
+      weekly_intent_status: [
+        {
+          intent_summary: 'At least 1 heavy legs session per week',
+          satisfied_this_week: false,
+          last_satisfied_days_ago: 8,
+        },
+      ],
+      goal_progress: [],
+      recent_feedback: {
+        suggestions_last_30d: 0,
+        swap_rate: 0,
+        common_swaps: [],
+        common_additions_fau: [],
+        common_deletions_fau: [],
+      },
+      preferences_summary: {
+        high_confidence_likes: [],
+        high_confidence_dislikes: [],
+      },
+    },
+    candidate_exercises: Array.from({ length: candidateCount }, (_, i) => ({
+      id: `exr_${i.toString().padStart(3, '0')}`,
+      name: `Exercise ${i}`,
+      primary_faus: i % 2 === 0 ? ['chest'] : ['quads'],
+      secondary_faus: [],
+      equipment: 'dumbbells',
+      movement_pattern: i % 2 === 0 ? 'horizontal_push' : 'squat',
+      intensity_class: 'moderate',
+    })),
+  }
+  return payload
+}
+
+function buildValidResponse(ids: string[]): SuggestionResponse {
+  const exercise = (id: string) => ({
+    id,
+    name: 'Exercise',
+    rationale: 'Grounded in the data.',
+  })
+  return {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'Honors the request.',
+        summary: '4 exercises, ~40 min.',
+        exercises: [ids[0], ids[2], ids[4], ids[6]].map(exercise),
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Attacks deficits.',
+        summary: '4 exercises, ~40 min.',
+        exercises: [ids[1], ids[3], ids[5], ids[7]].map(exercise),
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Something different.',
+        summary: '4 exercises, ~40 min.',
+        exercises: [ids[8], ids[9], ids[0], ids[1]].map(exercise),
+      },
+    ],
+    warnings: [],
+  }
+}
+
+describe('few-shot examples', () => {
+  it.each(FEW_SHOT_EXAMPLES.map((e) => [e.archetype, e] as const))(
+    '%s example output passes its own validation schema',
+    (_name, example) => {
+      const schema = buildSuggestionResponseSchema(
+        example.candidateIds,
+        exerciseCountRange(example.timeBudgetMinutes),
+      )
+      const result = schema.safeParse(example.output)
+      expect(result.success, JSON.stringify(result.error?.issues)).toBe(true)
+    },
+  )
+
+  it('selects beginner example when calibration is empty', () => {
+    const payload = buildTestPayload({ calibration: false })
+    expect(selectFewShotExample(payload).archetype).toBe('beginner')
+  })
+
+  it('selects short-session example for tight time budgets', () => {
+    const payload = buildTestPayload({ timeBudget: 20 })
+    expect(selectFewShotExample(payload).archetype).toBe('short-session')
+  })
+
+  it('selects cyclist example on keyword match', () => {
+    const payload = buildTestPayload({
+      goalSentences: ['Spare legs for biking'],
+      prioritize: 'biking tomorrow',
+    })
+    expect(selectFewShotExample(payload).archetype).toBe('cyclist')
+  })
+})
+
+describe('assembleSuggestWorkoutPrompt', () => {
+  it('validates against the payload schema and assembles within budget', () => {
+    const payload = buildTestPayload()
+    expect(suggestWorkoutPayloadSchema.safeParse(payload).success).toBe(true)
+
+    const prompt = assembleSuggestWorkoutPrompt(payload)
+    expect(prompt.estimatedTokens).toBeLessThanOrEqual(6000)
+    expect(prompt.exampleArchetype).not.toBeNull()
+    // Every candidate id appears in the user message
+    for (const id of prompt.candidateIds) {
+      expect(prompt.user).toContain(id)
+    }
+    // Ephemeral context sits after the candidate list (recency position)
+    expect(prompt.user.indexOf("TODAY'S REQUEST")).toBeGreaterThan(
+      prompt.user.indexOf('CANDIDATE EXERCISES'),
+    )
+    expect(prompt.user).toContain('want to hit chest hard')
+    expect(prompt.user).toContain('legs sore')
+  })
+
+  it('drops the example when a large payload would exceed the budget', () => {
+    const payload = buildTestPayload({ candidateCount: 400 })
+    const prompt = assembleSuggestWorkoutPrompt(payload)
+    expect(prompt.exampleArchetype).toBeNull()
+    expect(prompt.user).not.toContain('EXAMPLE')
+  })
+
+  it('estimates tokens as chars/4', () => {
+    expect(estimateTokens('abcd'.repeat(10))).toBe(10)
+  })
+})
+
+describe('buildSuggestionResponseSchema', () => {
+  const payload = buildTestPayload()
+  const ids = payload.candidate_exercises.map((c) => c.id)
+  const range = exerciseCountRange(45)
+  const schema = buildSuggestionResponseSchema(ids, range)
+
+  it('accepts a valid response', () => {
+    const result = schema.safeParse(buildValidResponse(ids))
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true)
+  })
+
+  it('rejects hallucinated ids with the offending id in the message', () => {
+    const response = buildValidResponse(ids)
+    response.options[0].exercises[0].id = 'exr_fake'
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('exr_fake')
+  })
+
+  it('rejects duplicate exercises within an option', () => {
+    const response = buildValidResponse(ids)
+    response.options[0].exercises[1].id =
+      response.options[0].exercises[0].id
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('Duplicate')
+  })
+
+  it('rejects out-of-order option ids', () => {
+    const response = buildValidResponse(ids)
+    const [a, b] = [response.options[0], response.options[1]]
+    response.options[0] = { ...b }
+    response.options[1] = { ...a }
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects identical user_preference and data_driven', () => {
+    const response = buildValidResponse(ids)
+    response.options[1].exercises = response.options[0].exercises.map((e) => ({
+      ...e,
+    }))
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('data_driven')
+  })
+
+  it('rejects a wild_card with no novel exercises', () => {
+    const response = buildValidResponse(ids)
+    response.options[2].exercises = [
+      ...response.options[0].exercises.slice(0, 2),
+      ...response.options[1].exercises.slice(0, 2),
+    ].map((e) => ({ ...e }))
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('wild_card')
+  })
+
+  it('rejects exercise counts outside the time budget range', () => {
+    const response = buildValidResponse(ids)
+    response.options[0].exercises = response.options[0].exercises.slice(0, 2)
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('time budget')
+  })
+
+  it('defaults a missing warnings key instead of failing', () => {
+    const response = buildValidResponse(ids) as Record<string, unknown>
+    delete response.warnings
+    const result = schema.safeParse(response)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.warnings).toEqual([])
+  })
+})
+
+describe('retry prompt', () => {
+  it('includes errors, valid ids, count range, and previous output', () => {
+    const prompt = buildSuggestRetryPrompt({
+      errorSummary: 'These exercise ids do not exist: exr_fake.',
+      previousOutput: '{"options": []}',
+      candidateIds: ['exr_001', 'exr_002'],
+      countRange: { min: 4, max: 6 },
+    })
+    expect(prompt).toContain('exr_fake')
+    expect(prompt).toContain('exr_001, exr_002')
+    expect(prompt).toContain('4 and 6')
+    expect(prompt).toContain('{"options": []}')
+  })
+
+  it('summarizes zod-style issues with deduplication', () => {
+    const summary = summarizeValidationError([
+      { path: ['options', 0, 'exercises'], message: 'Bad id' },
+      { path: ['options', 0, 'exercises'], message: 'Bad id' },
+      { path: ['warnings'], message: 'Too many' },
+    ])
+    expect(summary).toBe('options.0.exercises: Bad id\nwarnings: Too many')
+  })
+
+  it('summarizes parse errors', () => {
+    const summary = summarizeValidationError({ parseError: 'Unexpected token' })
+    expect(summary).toContain('not valid JSON')
+  })
+})

--- a/__tests__/lib/llm/suggest-workout-prompt.test.ts
+++ b/__tests__/lib/llm/suggest-workout-prompt.test.ts
@@ -1,16 +1,4 @@
-import { describe, it, expect } from 'vitest'
-
-import {
-  buildSuggestionResponseSchema,
-  exerciseCountRange,
-  suggestWorkoutPayloadSchema,
-  type SuggestionResponse,
-  type SuggestWorkoutPayload,
-} from '@/lib/llm/prompts/suggest-workout/schemas'
-import {
-  assembleSuggestWorkoutPrompt,
-  estimateTokens,
-} from '@/lib/llm/prompts/suggest-workout/system-prompt'
+import { describe, expect, it } from 'vitest'
 import {
   FEW_SHOT_EXAMPLES,
   selectFewShotExample,
@@ -19,6 +7,17 @@ import {
   buildSuggestRetryPrompt,
   summarizeValidationError,
 } from '@/lib/llm/prompts/suggest-workout/retry-prompt'
+import {
+  buildSuggestionResponseSchema,
+  exerciseCountRange,
+  type SuggestionResponse,
+  type SuggestWorkoutPayload,
+  suggestWorkoutPayloadSchema,
+} from '@/lib/llm/prompts/suggest-workout/schemas'
+import {
+  assembleSuggestWorkoutPrompt,
+  estimateTokens,
+} from '@/lib/llm/prompts/suggest-workout/system-prompt'
 
 function buildTestPayload(
   overrides: {

--- a/docs/SUGGEST_PROMPT_DESIGN.md
+++ b/docs/SUGGEST_PROMPT_DESIGN.md
@@ -1,0 +1,341 @@
+# Suggest Workout Prompt Design
+
+Companion to `lib/llm/prompts/suggest-workout/`. This documents *why* the
+prompt is shaped the way it is, so future edits don't quietly undo a
+deliberate decision. The locked payload contract lives in the comment on
+issue #877 (note: some older references say #876 — the numbering shuffle
+documented in Discussion #868 applies). Output UX is issue #880.
+
+## Wiring
+
+```typescript
+import {
+  assembleSuggestWorkoutPrompt,
+  buildSuggestionResponseSchema,
+  buildSuggestRetryPrompt,
+  summarizeValidationError,
+} from '@/lib/llm/prompts/suggest-workout'
+
+const prompt = assembleSuggestWorkoutPrompt(payload)
+const schema = buildSuggestionResponseSchema(prompt.candidateIds, prompt.countRange)
+const result = await getLLMClient().callWithStructuredOutput(prompt.user, schema, {
+  system: prompt.system,
+})
+```
+
+On `LLMValidationError` (thrown after the client's internal retry), make
+one worker-level retry:
+
+```typescript
+const retryPrompt = buildSuggestRetryPrompt({
+  errorSummary: summarizeValidationError(err.issues),
+  previousOutput: err.rawResponse,
+  candidateIds: prompt.candidateIds,
+  countRange: prompt.countRange,
+})
+const retried = await getLLMClient().callWithStructuredOutput(retryPrompt, schema, {
+  system: prompt.system,
+})
+```
+
+If that also fails, mark the `Suggestion` row `failed` — do not loop.
+
+## Design rationale, section by section
+
+### Static system prompt, dynamic user message
+
+Everything user-specific lives in the user message. The system prompt is
+a single constant, byte-identical across all users and requests. Two
+reasons:
+
+1. **Prompt caching.** Anthropic and OpenAI cache by prefix. A static
+   system prompt is cached after the first call; a system prompt with
+   even one interpolated value never is.
+2. **Iteration discipline.** When behavior changes, you know it was the
+   payload or the model — not an interpolation bug in instructions.
+
+### The payload is rendered as text, not passed as JSON
+
+The builder produces JSON (locked contract, #877), but the prompt
+renders it into compact labeled sections. Three reasons:
+
+1. **Tokens.** Key names repeated across 100 candidate objects
+   (`"movement_pattern":` × 100) are pure waste. The pipe-table format
+   costs roughly 60% of the equivalent JSON.
+2. **Input/output separation.** If the input is a wall of JSON, cheap
+   models blur "JSON I read" with "JSON I write" and echo input
+   structure into output. In this design the only JSON the model ever
+   sees is shaped exactly like what it must produce (skeleton +
+   example output).
+3. **Nested-object confusion.** Cheap models lose track of deeply
+   nested payloads. Flat labeled sections with one fact per line don't
+   have that failure mode.
+
+Two payload fields are deliberately **not rendered**:
+
+- `banned_exercise_ids` — bans are enforced upstream by candidate
+  filtering. Telling the model about exercises it cannot see invites it
+  to reason about (and name) exercises outside the candidate list.
+- `ratio_targets` — fully expressed by the per-FAU `target`/`deficit`
+  columns. Rendering the raw dict would be the same information twice,
+  and duplicated signals get double-counted by small models.
+
+### Candidate table: id first, one line per exercise
+
+```
+id | name | muscles | equipment | pattern | intensity | preference
+exr_abc123 | Incline Dumbbell Press | chest,front-delts +triceps | dumbbells | horizontal_push | moderate | 0.78
+```
+
+Hallucinated ids are the primary failure mode (#880). The mitigations,
+in order of effect:
+
+1. The id is the **first token of each line** — models copy
+   line-leading tokens far more reliably than values buried in prose.
+2. The header says "the only N exercise ids that exist" — a positive
+   framing ("these exist") rather than a prohibition ("never invent"),
+   which cheap models handle better.
+3. The output requires `name` **next to** `id`. Writing the name forces
+   the model's attention through the actual candidate row instead of
+   pattern-completing a plausible id. The name is validated for
+   presence only — the transform step reads the canonical name from the
+   DB — so a paraphrased name can never fail a correct id.
+4. zod refinement rejects unknown ids **listing the offenders** in the
+   message, which the client feeds back on retry.
+
+Item 3 is an addition to the locked output shape in #877 (which had
+`{ id, rationale }`). It is additive and costs ~80 output tokens per
+response. Treat it as a proposed amendment to the contract; if it's
+rejected, delete `name` from `suggestedExerciseSchema` and the skeleton
+— nothing else depends on it.
+
+### TODAY'S REQUEST is the last content section
+
+Long-context models attend most strongly to the beginning and end of a
+prompt; cheap models mostly the end. The ephemeral input is the one
+section that must never be ignored (a suggestion that ignores "legs
+sore" is worse than useless), so it gets the recency slot — after the
+candidate list, immediately before the final instruction. The section
+header also binds it to an option by name ("user_preference must be
+built around this"), so the instruction survives even if the model
+skims the middle.
+
+### Exercise counts are precomputed
+
+The model never converts minutes to exercise counts. `exerciseCountRange`
+maps the time budget to a min–max range which appears (a) in the
+request section, (b) in the final instruction, and (c) in the zod
+refinement — all from the same function, so instruction and check
+cannot drift. LLM arithmetic is a known reliability sink on
+Haiku/8B-tier models; don't reintroduce it.
+
+### Option distinctness: recipes, not adjectives
+
+"Make the options distinct" does not survive contact with a small
+model. What works is giving each option a different *procedure* with a
+different *input*:
+
+- `user_preference` reads TODAY'S REQUEST.
+- `data_driven` reads TRAINING STATE and is explicitly told the request
+  does not steer it (safety inputs excepted).
+- `wild_card` is defined by rotation away from logged history, with an
+  anchor rule (≥ half the exercises still serve goals/deficits) so it
+  stays defensible rather than random.
+
+The convergence case (request already matches the data) gets an explicit
+tie-breaking rule in the system prompt. The schema backstops collapse:
+identical `user_preference`/`data_driven` sets are rejected, and
+`wild_card` must contain ≥ 2 exercises absent from both others (≥ 1 for
+very short sessions — see `wildCardNoveltyFloor`).
+
+### Counteracting training bias
+
+Models trained on general fitness content over-recommend bodyweight and
+band work "to be safe." The system prompt states the house position
+("bands and bodyweight are fillers, not defaults") as a **positive
+selection principle**, not a prohibition. Same technique for readiness
+(heavy 1–2 days ago → not ready) and safety (stated pain beats every
+deficit signal). Cheap models follow "do X when Y" far better than
+"never do Z" walls — that's why the system prompt contains exactly four
+HARD RULES and everything else is procedure.
+
+### Rationale voice
+
+The rationale copy is a product surface (#880: users pick an option
+partly on the explanation). Constraints that matter:
+
+- "One sentence each" — a hard, checkable shape beats "be concise."
+- "Use only numbers that appear in the input" — small models fabricate
+  impressive-sounding stats; a rationale citing a number the user can't
+  find in their history destroys trust in exactly the way the
+  "what the AI sees" panel (#879) is meant to build it.
+- Banned styles are named concretely (emoji, exclamation points, hype
+  words) instead of vaguely ("professional tone").
+
+### One few-shot example, archetype-matched
+
+Five to ten examples in-context would cost 4–8k tokens and — worse —
+teach the model to reuse example exercise ids. So:
+
+- The library (`few-shot-examples.ts`) holds six archetypes; exactly
+  **one** is included per request, chosen by structural signals first
+  (no calibration → beginner; everything ≥ 14 days stale → returning;
+  ≤ 25 minutes → short-session) and keyword match second.
+- Example ids use a `demo_` prefix. If one ever leaks into output, the
+  validation error is self-evident in logs.
+- The example opens with "the exercises below are NOT in today's
+  candidate list; never reuse their ids."
+- Example output is rendered as **compact JSON** (no whitespace).
+  Models imitate the format they see; compact output roughly halves
+  output-token cost and parses identically.
+- If the payload is large, the example is dropped automatically
+  (`maxTotalTokens`, default 6000 estimated). A big payload means a
+  data-rich user — precisely the case where the example adds least.
+
+The examples do double duty as regression fixtures: the test suite
+validates every example's output against the real per-request schema,
+so the "ground truth" in the prompt can never drift out of sync with
+validation. If you edit an example, run
+`npm test suggest-workout-prompt`.
+
+## Failure modes and mitigations
+
+| Failure mode | Seen in | Mitigation | Where |
+|---|---|---|---|
+| Hallucinated exercise ids | All cheap models | id-first table, name echo, positive framing, refinement message lists offenders | candidates renderer, output schema |
+| Example ids leak into output | Few-shot prompts generally | one example max, `demo_` prefix, explicit "not available today" framing | few-shot-examples.ts |
+| Three near-identical options | Any "give me N variants" prompt | per-option procedures with different inputs, convergence tie-breaker, set-equality + novelty refinements | system prompt, schema |
+| Ephemeral input ignored | Large payloads, small models | request rendered last, bound to `user_preference` by name, restated in final instruction | assembly order |
+| Markdown fences / prose preamble | JSON-mode-less providers | `cleanLLMOutput` (shipped), HARD RULE 4, no-schema variant appends first/last-char rule | client, provider-variants |
+| Missing `warnings` key | Optional fields on cheap models | prompt says "always present"; schema `.default([])` so absence never burns a retry | schema |
+| Wrong option order | 8B-tier models | order stated in three places; refinement message names the expected id per index | schema |
+| Invented statistics in rationales | All models | "only numbers that appear in the input" | system prompt |
+| Set/rep prescriptions sneaking in | Models' training prior (workouts have sets) | output shape has nowhere to put them; system prompt says the user logs sets live | schema |
+| Bodyweight/band over-recommendation | General-fitness training bias | equipment hierarchy stated as selection principle | system prompt |
+| Count arithmetic errors | Small models | precomputed range, shared function for instruction + check | `exerciseCountRange` |
+| First-JSON extraction grabs reasoning fragment | Thinking models | "no braces in reasoning" instruction; focused retry | provider-variants |
+
+## Provider matrix
+
+| Provider | Variant | Notes |
+|---|---|---|
+| Anthropic | `buildAnthropicToolRequest` | Forced tool call — the model *cannot* return prose. Strongest option. Requires native Messages API (or a proxy that forwards tools). |
+| OpenAI | `buildOpenAIStructuredRequest` | `json_schema` strict mode. The shared JSON schema intentionally uses only the keyword subset strict mode accepts (no min/max constraints). |
+| DeepInfra / Groq / Together | `buildJsonModeRequest` | What `LLMClient` does today (`response_format: json_object`). |
+| Anything else (incl. raw Ollama) | `buildNoSchemaRequest` | Prompt-only. Leans on `cleanLLMOutput` + retry. Expect a higher retry rate; still workable. |
+| DeepSeek-R1 class / o-series | `buildThinkingModelRequest` | No `response_format`; 180s timeout; "no braces in reasoning" guard. On validation failure prefer the focused retry — the model understood the task, the extraction failed. |
+
+Provider-side schemas **never replace** zod validation: they cannot
+check candidate-id membership, counts, ordering, or distinctness. Every
+variant's output goes through `buildSuggestionResponseSchema`.
+
+## Retry design
+
+Two layers, different jobs:
+
+1. **Client-internal retry** (shipped, `lib/llm/client.ts`): re-sends
+   the full prompt with zod issues appended. This works here because
+   every refinement message in `buildSuggestionResponseSchema` is
+   written as a repair instruction ("Replace each with an id copied
+   exactly from the CANDIDATE EXERCISES list"), not as a developer
+   assertion. **The schema messages are part of the prompt design.**
+2. **Worker-level focused retry** (`retry-prompt.ts`): if the client
+   still throws, one more call with error + rules + valid ids +
+   previous output — no profile, no training state. About a quarter of
+   the tokens, and a simpler task ("fix this JSON") that cheap models
+   complete more reliably than a full re-plan.
+
+After that: `Suggestion.status = 'failed'`. Never loop.
+
+## Token budget
+
+Estimates via `estimateTokens` (chars/4 — overestimates English prose by
+~20%, which is the safe direction):
+
+| Part | Estimated tokens |
+|---|---|
+| System prompt | ~1,100 |
+| Few-shot example (largest) | ~1,000 |
+| Profile + training state (typical) | ~500–700 |
+| Candidates (100 × ~22) | ~2,200 |
+| Request + final instruction | ~150 |
+| **Typical total** | **~5,000–5,300** |
+
+The 6,000 ceiling (`maxTotalTokens`) sheds the example first. If
+payloads grow past that, cut candidate count in the builder (the
+deterministic filter should get more aggressive) before cutting prompt
+sections here.
+
+## Deviations from / amendments to the locked #877 contract
+
+Flagging explicitly since the contract says changes require agreement:
+
+1. **`exercises[].name` added to the output shape** — anti-hallucination
+   grounding (see above). Additive; transform ignores it.
+2. **`per_movement_calibration[].typical_rpe` is nullable** — RPE/RIR
+   logging is opt-in, so the builder cannot always produce it. The spec
+   sample showed a bare number; the schema accepts `null` and the
+   renderer omits the RPE clause.
+3. **Exercise-count enforcement band** — #877 left "count fits time
+   budget" undefined; `exerciseCountRange` defines it (~8 min/exercise,
+   generous bands). This is now load-bearing for validation.
+4. **Distinctness refinements** — set-inequality between
+   `user_preference`/`data_driven` and the wild-card novelty floor are
+   new validation semantics not in #877.
+
+## Anti-pattern lint checklist for future edits
+
+Before merging any change to this module, check:
+
+- [ ] No new "you must NEVER…" walls in the system prompt. State the
+      desired behavior positively; reserve HARD RULES for the four
+      structural invariants.
+- [ ] System prompt is still a static constant — no interpolation.
+- [ ] Any new instruction that has a numeric threshold gets the number
+      computed in TypeScript and injected, never left for the model to
+      derive.
+- [ ] The output skeleton in the system prompt, the JSON schema in
+      `provider-variants.ts`, and `suggestionResponseBaseSchema` still
+      describe the same shape (three sources — keep them in sync, and
+      keep the test green).
+- [ ] New payload fields are either rendered by a section renderer or
+      explicitly listed as not-rendered with a reason (see
+      `renderDurableProfile` comments). Silent drops are how payload
+      work gets wasted.
+- [ ] Few-shot example edits still pass
+      `npm test suggest-workout-prompt` (schema validity, novelty
+      floor, count ranges).
+- [ ] No instruction assumes the model shares our bias (e.g. "pick
+      safe exercises" — its notion of safe is bands and bodyweight).
+- [ ] Refinement messages still read as instructions to the model, not
+      assertions for developers.
+- [ ] `TODAY'S REQUEST` is still the last content section.
+- [ ] Estimated typical total still ≤ 6,000 tokens (check the test).
+
+## What to change vs. what to leave alone when iterating
+
+**Cheap to change, iterate freely:**
+
+- Selection principles wording (readiness windows, equipment hierarchy)
+- Rationale voice rules
+- Warning trigger conditions
+- Few-shot example content (keep the test green)
+- Archetype selection heuristics
+- `exerciseCountRange` bands
+
+**Change only with evidence from real failures:**
+
+- Section ordering (the request-last position is the mitigation for the
+  single worst failure mode)
+- The candidate table format (id-first is load-bearing)
+- One-example policy (more examples = id bleed + budget blowout)
+- HARD RULES count and phrasing (four is deliberate; every addition
+  dilutes the others)
+
+**Don't change here at all:**
+
+- The payload contract — that's #877, change it there first
+- Validation semantics the UI depends on (three options, fixed ids) —
+  that's #880's contract
+- Retry counts — the two-layer, one-each design is a cost ceiling;
+  looping retries turns a bad model day into a bill

--- a/lib/llm/prompts/suggest-workout/few-shot-examples.ts
+++ b/lib/llm/prompts/suggest-workout/few-shot-examples.ts
@@ -1,0 +1,575 @@
+import type { SuggestWorkoutPayload, SuggestionResponse } from './schemas'
+
+/**
+ * Few-shot examples for the Suggest Workout prompt.
+ *
+ * Exactly ONE example is included per request (selected by archetype
+ * match) — including several would blow the token budget and, worse,
+ * teach cheap models to copy example exercise ids into real output.
+ * All example ids use the `demo_` prefix so any bleed is obvious in
+ * validation failures and logs.
+ *
+ * Every example's `output` must validate against
+ * `buildSuggestionResponseSchema(example.candidateIds,
+ * exerciseCountRange(example.timeBudgetMinutes))` — pinned by
+ * `__tests__/lib/llm/suggest-workout-prompt.test.ts`. If you edit an
+ * example, run that test.
+ */
+
+export interface FewShotExample {
+  archetype: string
+  /** Matched against goal sentences + today's free text when selecting. */
+  keywords: string[]
+  timeBudgetMinutes: number
+  /** Every id the example output may reference. Used by tests. */
+  candidateIds: string[]
+  /** Abridged input, in the same rendered format the real prompt uses. */
+  inputSnippet: string
+  output: SuggestionResponse
+}
+
+export const CYCLIST_EXAMPLE: FewShotExample = {
+  archetype: 'cyclist',
+  keywords: [
+    'bike', 'biking', 'cycling', 'ride', 'riding', 'run', 'running',
+    'cardio', 'race', 'spare legs', 'fresh legs',
+  ],
+  timeBudgetMinutes: 45,
+  candidateIds: [
+    'demo_bench', 'demo_incline_db', 'demo_ohp', 'demo_row', 'demo_latpull',
+    'demo_fly', 'demo_curl', 'demo_pushdown', 'demo_lateral', 'demo_facepull',
+    'demo_rdl', 'demo_legpress', 'demo_pullup',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: Upper-body hypertrophy focus; Spare legs for weekend rides
+Weekly intent: at least 1 heavy legs session per week
+Equipment: barbell, dumbbells, cable, machines
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+chest | 3d | 3d | 12 | 21 | 10% | 12% | -2% | balanced
+mid-back | 5d | never | 4 | 9 | 12% | 6% | +6% | neglected
+quads | 9d | 9d | 0 | 6 | 8% | 4% | +4% | neglected
+Weekly intent status: NOT satisfied: at least 1 heavy legs session per week (last satisfied 8d ago)
+Confident preferences — likes: demo_row; dislikes: (none)
+
+CANDIDATE EXERCISES (13 shown)
+demo_bench | Barbell Bench Press | chest +triceps | barbell | horizontal_push | heavy | -
+demo_row | Chest Supported Row | mid-back,lats | machines | horizontal_pull | moderate | 0.81
+demo_rdl | Romanian Deadlift | hamstrings,glutes +lower-back | barbell | hinge | heavy | -
+demo_legpress | Leg Press | quads,glutes | machines | squat | moderate | -
+... (9 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 45 minutes -> 4 to 6 exercises per option
+Vibe: solid — normal working session
+Prioritize: "biking tomorrow, keep legs out of it"`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'Upper-body only, exactly as asked — legs stay fresh for tomorrow\'s ride.',
+        summary: '5 exercises, ~40 min. Push-pull upper session built around your favorites.',
+        exercises: [
+          { id: 'demo_bench', name: 'Barbell Bench Press', rationale: 'Chest is your stated focus and the pattern was last loaded 3 days ago — ready to press.' },
+          { id: 'demo_row', name: 'Chest Supported Row', rationale: 'Mid-back is 6 points under target over 14 days, and this is your most-kept exercise.' },
+          { id: 'demo_ohp', name: 'Seated Dumbbell Shoulder Press', rationale: 'Rounds out pressing without adding any leg load.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'Second pull to keep chipping at the back deficit.' },
+          { id: 'demo_curl', name: 'EZ-Bar Curl', rationale: 'Quick finisher that costs nothing from tomorrow\'s legs.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Your data disagrees with you: quads are 9 days stale and the weekly heavy-leg intent is unmet.',
+        summary: '5 exercises, ~45 min. Legs first, back deficit second.',
+        exercises: [
+          { id: 'demo_rdl', name: 'Romanian Deadlift', rationale: 'No hinge work in 9 days and your heavy-leg-day rule is unsatisfied this week.' },
+          { id: 'demo_legpress', name: 'Leg Press', rationale: 'Quads are 4 points under target with zero sets in 7 days.' },
+          { id: 'demo_row', name: 'Chest Supported Row', rationale: 'Mid-back carries the largest upper-body deficit at +6.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'Extra pull volume while chest sits at target already.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Cheap rear-delt work that has been absent for two weeks.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Cable-and-bodyweight upper day — patterns you almost never touch, legs still spared.',
+        summary: '5 exercises, ~40 min. Vertical pull and isolation variety.',
+        exercises: [
+          { id: 'demo_pullup', name: 'Pull-Up', rationale: 'You row weekly but never pull vertically — different lat stimulus, zero leg cost.' },
+          { id: 'demo_incline_db', name: 'Incline Dumbbell Press', rationale: 'Upper-chest angle you have not logged recently.' },
+          { id: 'demo_fly', name: 'Cable Fly', rationale: 'Constant-tension chest work as a change from pressing.' },
+          { id: 'demo_lateral', name: 'Cable Lateral Raise', rationale: 'Side delts get no direct work in your recent logs.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Arm finisher to replace the leg volume you skipped.' },
+        ],
+      },
+    ],
+    warnings: [
+      'Your one-heavy-leg-day rule is unmet this week and you asked to skip legs again. If you pass on the Data Driven option, plan a leg session before Sunday.',
+    ],
+  },
+}
+
+export const BODYBUILDER_EXAMPLE: FewShotExample = {
+  archetype: 'bodybuilder',
+  keywords: [
+    'hypertrophy', 'physique', 'aesthetic', 'pump', 'bigger', 'size',
+    'muscle', 'chest day', 'arm day', 'bro split', 'lean',
+  ],
+  timeBudgetMinutes: 60,
+  candidateIds: [
+    'demo_bench', 'demo_incline_db', 'demo_fly', 'demo_dips', 'demo_ohp_bb',
+    'demo_row_bb', 'demo_latpull', 'demo_pullover', 'demo_facepull',
+    'demo_lateral', 'demo_curl', 'demo_pushdown', 'demo_pullup', 'demo_db_row',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: Build a bigger chest and arms; Hypertrophy focus
+Intensity preference: hypertrophy
+Equipment: barbell, dumbbells, cable, machines
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+chest | 2d | 2d | 16 | 30 | 12% | 16% | -4% | over
+lats | 6d | never | 3 | 8 | 12% | 6% | +6% | neglected
+mid-back | 6d | never | 3 | 7 | 11% | 5% | +6% | neglected
+Movement calibration: horizontal_push ~185 (recent 175,180,180,185,185), 8-12 reps
+Reaction to past suggestions (30d): often deletes: quads
+Confident preferences — likes: demo_incline_db; dislikes: (none)
+
+CANDIDATE EXERCISES (14 shown)
+demo_bench | Barbell Bench Press | chest +triceps | barbell | horizontal_push | heavy | -
+demo_row_bb | Barbell Row | mid-back,lats | barbell | horizontal_pull | heavy | -
+demo_pullover | Cable Pullover | lats +chest | cable | isolation | light | -
+... (11 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 60 minutes -> 5 to 8 exercises per option
+Vibe: heavy — feeling strong, open to top-end loads
+Prioritize: "chest day"`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'The chest day you asked for, pressing heavy while you feel strong.',
+        summary: '6 exercises, ~55 min. Heavy presses first, isolation pump last.',
+        exercises: [
+          { id: 'demo_bench', name: 'Barbell Bench Press', rationale: 'You feel strong — work at or above your recent 185 top sets.' },
+          { id: 'demo_incline_db', name: 'Incline Dumbbell Press', rationale: 'Your most-liked press, hitting the upper chest next.' },
+          { id: 'demo_dips', name: 'Weighted Dip', rationale: 'Third press angle to fill out a true chest day.' },
+          { id: 'demo_fly', name: 'Cable Fly', rationale: 'Isolation volume once the heavy pressing is done.' },
+          { id: 'demo_lateral', name: 'Cable Lateral Raise', rationale: 'Side delts round out the pressing look you are after.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Triceps finisher after three pressing movements.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Chest is 4 points over target while lats and mid-back sit 6 under — this is a pull day.',
+        summary: '5 exercises, ~55 min. Heavy rows first, rear delts and arms last.',
+        exercises: [
+          { id: 'demo_row_bb', name: 'Barbell Row', rationale: 'Biggest deficit is mid-back and it has had no heavy work in 14 days.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'Lats are 6 points under target with 3 sets in 7 days.' },
+          { id: 'demo_pullup', name: 'Pull-Up', rationale: 'Second vertical pull to close the lat gap faster.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Rear delts balance two weeks of press-dominant training.' },
+          { id: 'demo_curl', name: 'EZ-Bar Curl', rationale: 'Arms still get direct work, so the day serves your goal too.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Chest-back superset day — presses stay, but every press is paired with a pull.',
+        summary: '5 exercises, ~55 min. Antagonist pairs keep the pump without deepening the imbalance.',
+        exercises: [
+          { id: 'demo_bench', name: 'Barbell Bench Press', rationale: 'Keep the heavy press, paired with a row between sets.' },
+          { id: 'demo_db_row', name: 'One-Arm Dumbbell Row', rationale: 'A row you never log — supersets cleanly with pressing.' },
+          { id: 'demo_incline_db', name: 'Incline Dumbbell Press', rationale: 'Second press of the pairing scheme.' },
+          { id: 'demo_pullover', name: 'Cable Pullover', rationale: 'Novel lat isolation that still stretches the chest.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Finisher for the rear delts both other options need.' },
+        ],
+      },
+    ],
+    warnings: [
+      'Chest has run 4 points over target for two weeks while your back sits 6 under. Another pure chest day widens that gap.',
+    ],
+  },
+}
+
+export const POWERLIFTER_EXAMPLE: FewShotExample = {
+  archetype: 'powerlifter',
+  keywords: [
+    'strength', 'stronger', 'bench', 'squat', 'deadlift', '1rm', 'pr',
+    'powerlifting', 'total', 'heavy single', 'top set',
+  ],
+  timeBudgetMinutes: 60,
+  candidateIds: [
+    'demo_bench', 'demo_cgbench', 'demo_pause_bench', 'demo_squat',
+    'demo_front_squat', 'demo_dl', 'demo_gm', 'demo_ohp_bb', 'demo_row_bb',
+    'demo_pullup', 'demo_facepull', 'demo_pushdown', 'demo_legpress',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: Add 30 lbs to my bench this year; Keep squat and deadlift moving
+Intensity preference: strength
+Equipment: barbell, cable, machines
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+chest | 3d | 3d | 9 | 18 | 10% | 11% | -1% | balanced
+quads | 8d | 8d | 2 | 7 | 10% | 5% | +5% | neglected
+Movement calibration: horizontal_push ~232 (recent 225,225,230,235,235), 3-5 reps @ RPE 8
+Movement calibration: squat ~315 (recent 305,315,315), 3-5 reps @ RPE 8, last 8d ago
+Goal progress: Add 30 lbs to my bench: progressing, 6 weeks observed (top sets 225 -> 235)
+
+CANDIDATE EXERCISES (13 shown)
+demo_bench | Barbell Bench Press | chest +triceps | barbell | horizontal_push | heavy | -
+demo_squat | Barbell Back Squat | quads,glutes +lower-back | barbell | squat | heavy | -
+demo_pause_bench | Paused Bench Press | chest +triceps | barbell | horizontal_push | heavy | -
+... (10 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 60 minutes -> 5 to 8 exercises per option
+Vibe: heavy — feeling strong, open to top-end loads
+Prioritize: "bench is moving well, want to push it"`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'Push the bench while it is moving — heavy top sets, then pressing support work.',
+        summary: '5 exercises, ~55 min. Bench-led strength day.',
+        exercises: [
+          { id: 'demo_bench', name: 'Barbell Bench Press', rationale: 'Six weeks of progress from 225 to 235 and you feel strong — earn a new top set.' },
+          { id: 'demo_cgbench', name: 'Close-Grip Bench Press', rationale: 'Triceps-biased back-off pressing to support the goal lift.' },
+          { id: 'demo_row_bb', name: 'Barbell Row', rationale: 'Heavy horizontal pull keeps your pressing base stable.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Shoulder health work behind a heavy press day.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Extra triceps volume where bench lockouts are won.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Squat pattern is 8 days stale and quads are 5 points under — the bench can wait two days.',
+        summary: '5 exercises, ~55 min. Heavy squat day with pulling balance.',
+        exercises: [
+          { id: 'demo_squat', name: 'Barbell Back Squat', rationale: 'Last squatted 8 days ago at 315 — longest gap of any main lift.' },
+          { id: 'demo_legpress', name: 'Leg Press', rationale: 'Quad volume without more spinal loading after squats.' },
+          { id: 'demo_gm', name: 'Good Morning', rationale: 'Hinge work keeps deadlift moving on a leg-focused day.' },
+          { id: 'demo_pullup', name: 'Pull-Up', rationale: 'Upper-body pull so the day is not legs alone.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Low-cost rear-delt work to finish.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Variation day — paused bench and front squat attack the same lifts from angles you never train.',
+        summary: '5 exercises, ~55 min. New stimulus for both goal lifts.',
+        exercises: [
+          { id: 'demo_pause_bench', name: 'Paused Bench Press', rationale: 'Builds strength off the chest, the slowest part of most benches.' },
+          { id: 'demo_front_squat', name: 'Front Squat', rationale: 'Squat stimulus with lighter loads while the pattern is stale.' },
+          { id: 'demo_ohp_bb', name: 'Overhead Press', rationale: 'Overhead work is absent from your recent logs and carries over to bench.' },
+          { id: 'demo_pullup', name: 'Pull-Up', rationale: 'Vertical pull to balance two pressing movements.' },
+          { id: 'demo_dl', name: 'Deadlift', rationale: 'One heavy pull keeps the third lift honest this week.' },
+        ],
+      },
+    ],
+    warnings: [
+      'If you take the bench-focused option, squat within the next 2 days — the pattern is 8 days stale and quads are your largest deficit.',
+    ],
+  },
+}
+
+export const BEGINNER_EXAMPLE: FewShotExample = {
+  archetype: 'beginner',
+  keywords: ['new', 'beginner', 'started', 'starting', 'first', 'learn', 'gym anxiety'],
+  timeBudgetMinutes: 30,
+  candidateIds: [
+    'demo_chest_press', 'demo_latpull', 'demo_legpress', 'demo_shoulder_press',
+    'demo_row_m', 'demo_curl_db', 'demo_legcurl', 'demo_goblet', 'demo_plank',
+    'demo_pushdown',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: Get comfortable in the gym; General fitness
+Equipment: machines, dumbbells, cable
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+chest | 4d | never | 3 | 5 | 10% | 11% | -1% | balanced
+quads | 4d | never | 3 | 5 | 10% | 10% | 0% | balanced
+No movement calibration yet (fewer than 3 logged sessions per pattern). Pick common, easy-to-learn movements and keep loads conservative.
+No suggestion history yet.
+Confident preferences: none yet — not enough data.
+
+CANDIDATE EXERCISES (10 shown)
+demo_chest_press | Machine Chest Press | chest +triceps | machines | horizontal_push | moderate | -
+demo_goblet | Goblet Squat | quads,glutes | dumbbells | squat | moderate | -
+demo_row_m | Seated Cable Row | mid-back,lats | cable | horizontal_pull | moderate | -
+... (7 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 30 minutes -> 3 to 5 exercises per option
+Vibe: easy — keep it light
+Prioritize: (none)
+Avoid/deprioritize: (none)`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'An easy machine-based session, matching the light day you asked for.',
+        summary: '4 exercises, ~30 min. Simple full body, nothing to overthink.',
+        exercises: [
+          { id: 'demo_chest_press', name: 'Machine Chest Press', rationale: 'Fixed path makes this easy to do well while you build the habit.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'Balances the press with a pull, same seat-and-go simplicity.' },
+          { id: 'demo_legpress', name: 'Leg Press', rationale: 'Leg work without needing barbell technique yet.' },
+          { id: 'demo_plank', name: 'Plank', rationale: 'Quick core finisher with zero setup.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Your logs are evenly balanced so far — this keeps every muscle group ticking.',
+        summary: '4 exercises, ~30 min. Full body with one free-weight movement to learn.',
+        exercises: [
+          { id: 'demo_goblet', name: 'Goblet Squat', rationale: 'The friendliest way to learn squatting — start light.' },
+          { id: 'demo_row_m', name: 'Seated Cable Row', rationale: 'Rowing keeps your back even with your pressing.' },
+          { id: 'demo_shoulder_press', name: 'Machine Shoulder Press', rationale: 'Adds an overhead angle your first sessions have not covered.' },
+          { id: 'demo_legcurl', name: 'Seated Leg Curl', rationale: 'Hamstrings get direct work the leg press does not give.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Dumbbell day — same effort, but you practice controlling free weights.',
+        summary: '4 exercises, ~30 min. A first step beyond the machines.',
+        exercises: [
+          { id: 'demo_goblet', name: 'Goblet Squat', rationale: 'Doubles as leg work and free-weight practice.' },
+          { id: 'demo_curl_db', name: 'Dumbbell Curl', rationale: 'Simple arm work most people enjoy early on.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Pairs with curls for an easy arm finish.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'One familiar machine so the day is not all new.' },
+        ],
+      },
+    ],
+    warnings: [],
+  },
+}
+
+export const RETURNING_EXAMPLE: FewShotExample = {
+  archetype: 'returning',
+  keywords: ['back at it', 'been a while', 'layoff', 'break', 'vacation', 'sick', 'rust'],
+  timeBudgetMinutes: 45,
+  candidateIds: [
+    'demo_legpress', 'demo_chest_press', 'demo_latpull', 'demo_row_m',
+    'demo_rdl_db', 'demo_goblet', 'demo_ohp_db', 'demo_curl', 'demo_pushdown',
+    'demo_plank', 'demo_bench', 'demo_squat',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: General strength; Stay consistent this time
+Equipment: barbell, dumbbells, cable, machines
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+chest | 22d | 22d | 0 | 0 | 10% | 0% | +10% | neglected
+mid-back | 22d | never | 0 | 0 | 11% | 0% | +11% | neglected
+quads | 24d | 24d | 0 | 0 | 10% | 0% | +10% | neglected
+(every muscle group: 0 sets in 14d)
+Movement calibration: horizontal_push ~150 (recent 145,150,150), 8-12 reps, last 22d ago
+
+CANDIDATE EXERCISES (12 shown)
+demo_chest_press | Machine Chest Press | chest +triceps | machines | horizontal_push | moderate | -
+demo_goblet | Goblet Squat | quads,glutes | dumbbells | squat | moderate | -
+... (10 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 45 minutes -> 4 to 6 exercises per option
+Vibe: easy — keep it light
+Prioritize: "first day back after three weeks off"`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'The easy re-entry you asked for — machines, moderate loads, full body.',
+        summary: '4 exercises, ~35 min. Low-stakes first day back.',
+        exercises: [
+          { id: 'demo_chest_press', name: 'Machine Chest Press', rationale: 'Pressing again without chasing your old 150 top sets yet.' },
+          { id: 'demo_row_m', name: 'Seated Cable Row', rationale: 'Every muscle group is at zero sets — a row covers the biggest gap.' },
+          { id: 'demo_legpress', name: 'Leg Press', rationale: 'Leg volume with less soreness risk than free squats after 24 days off.' },
+          { id: 'demo_plank', name: 'Plank', rationale: 'Gentle core work to close out the return session.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Three weeks of zeros everywhere — one balanced full-body session restarts every pattern at once.',
+        summary: '5 exercises, ~45 min. Squat, hinge, push, pull in one day.',
+        exercises: [
+          { id: 'demo_goblet', name: 'Goblet Squat', rationale: 'Reopens the squat pattern at self-limiting loads.' },
+          { id: 'demo_rdl_db', name: 'Dumbbell Romanian Deadlift', rationale: 'Light hinge so hamstrings are not wrecked by day one.' },
+          { id: 'demo_row_m', name: 'Seated Cable Row', rationale: 'Mid-back holds your largest deficit at +11.' },
+          { id: 'demo_ohp_db', name: 'Seated Dumbbell Shoulder Press', rationale: 'One press covers chest and shoulders for the restart week.' },
+          { id: 'demo_latpull', name: 'Lat Pulldown', rationale: 'Second pull — a two-to-one pull bias eases you back safely.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'A light pump day — arms and easy movements to make day one enjoyable, not punishing.',
+        summary: '4 exercises, ~35 min. Fun first, fitness follows.',
+        exercises: [
+          { id: 'demo_bench', name: 'Barbell Bench Press', rationale: 'One familiar barbell lift at well under your old numbers, just to reconnect.' },
+          { id: 'demo_curl', name: 'EZ-Bar Curl', rationale: 'Low-cost arm work that makes returning feel good.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Pairs with curls for an easy finish.' },
+          { id: 'demo_plank', name: 'Plank', rationale: 'Core re-entry without loading a cold spine.' },
+        ],
+      },
+    ],
+    warnings: [
+      'First session in over three weeks — every option trims volume, and your working weights will be below your last logged numbers. That is expected.',
+    ],
+  },
+}
+
+export const SHORT_SESSION_EXAMPLE: FewShotExample = {
+  archetype: 'short-session',
+  keywords: ['quick', 'short', 'lunch', 'squeeze', 'busy', 'only have'],
+  timeBudgetMinutes: 20,
+  candidateIds: [
+    'demo_curl', 'demo_hammer', 'demo_pushdown', 'demo_cgbench', 'demo_dips',
+    'demo_facepull', 'demo_lateral', 'demo_row_m', 'demo_farmer', 'demo_pullup',
+  ],
+  inputSnippet: `USER PROFILE
+Goals: Bigger arms; Train 4x per week around work
+Equipment: barbell, dumbbells, cable, machines
+
+TRAINING STATE (abridged)
+muscle | last | heavy | 7d | 14d | target | actual | deficit(+=under) | status
+biceps | 4d | never | 4 | 8 | 7% | 6% | +1% | balanced
+rear-delts | 12d | never | 0 | 2 | 6% | 2% | +4% | neglected
+mid-back | 6d | never | 5 | 9 | 11% | 7% | +4% | neglected
+
+CANDIDATE EXERCISES (10 shown)
+demo_curl | EZ-Bar Curl | biceps | barbell | isolation | light | -
+demo_row_m | Seated Cable Row | mid-back,lats | cable | horizontal_pull | moderate | -
+demo_farmer | Farmer Carry | forearms,traps +abs | dumbbells | carry | moderate | -
+... (7 more)
+
+TODAY'S REQUEST — user_preference must be built around this
+Time: 20 minutes -> 2 to 3 exercises per option
+Vibe: solid — normal working session
+Prioritize: "arms, in and out fast"`,
+  output: {
+    options: [
+      {
+        id: 'user_preference',
+        name: 'User Preference',
+        description: 'Pure arms, superset to fit the clock.',
+        summary: '3 exercises, ~20 min. Curl and pushdown back to back, hammer to finish.',
+        exercises: [
+          { id: 'demo_curl', name: 'EZ-Bar Curl', rationale: 'The arm focus you asked for — superset with pushdowns to save time.' },
+          { id: 'demo_pushdown', name: 'Rope Pushdown', rationale: 'Triceps half of the superset; no rest wasted.' },
+          { id: 'demo_hammer', name: 'Hammer Curl', rationale: 'Second biceps angle plus forearm work in one move.' },
+        ],
+      },
+      {
+        id: 'data_driven',
+        name: 'Data Driven',
+        description: 'Rear delts and mid-back are your real gaps — 20 minutes of pulling pays more than more curls.',
+        summary: '3 exercises, ~20 min. Dense pull circuit.',
+        exercises: [
+          { id: 'demo_row_m', name: 'Seated Cable Row', rationale: 'Mid-back is 4 points under target — biggest gap you can close today.' },
+          { id: 'demo_pullup', name: 'Pull-Up', rationale: 'Vertical pull doubles the back coverage and still hits biceps.' },
+          { id: 'demo_facepull', name: 'Face Pull', rationale: 'Rear delts have 2 sets in 14 days — this is the fix.' },
+        ],
+      },
+      {
+        id: 'wild_card',
+        name: 'Wild Card',
+        description: 'Arms by another route — dips and carries load the arms without a single curl.',
+        summary: '3 exercises, ~20 min. Heavy, simple, different.',
+        exercises: [
+          { id: 'demo_dips', name: 'Weighted Dip', rationale: 'More triceps growth per minute than any isolation move here.' },
+          { id: 'demo_farmer', name: 'Farmer Carry', rationale: 'Forearms and grip — arm size you cannot get from curls.' },
+          { id: 'demo_curl', name: 'EZ-Bar Curl', rationale: 'One direct biceps movement so the arm request is still honored.' },
+        ],
+      },
+    ],
+    warnings: [],
+  },
+}
+
+export const FEW_SHOT_EXAMPLES: readonly FewShotExample[] = [
+  CYCLIST_EXAMPLE,
+  BODYBUILDER_EXAMPLE,
+  POWERLIFTER_EXAMPLE,
+  BEGINNER_EXAMPLE,
+  RETURNING_EXAMPLE,
+  SHORT_SESSION_EXAMPLE,
+]
+
+/**
+ * Pick the single example that best matches this payload.
+ *
+ * Structural signals (data sparsity, layoff, very short session) beat
+ * keyword matches — they change what a correct answer LOOKS like, while
+ * keywords only change the topic. Falls back to the bodybuilder example
+ * (hypertrophy is the modal user).
+ */
+export function selectFewShotExample(
+  payload: SuggestWorkoutPayload,
+): FewShotExample {
+  const { training_state, ephemeral_context, durable_profile } = payload
+
+  if (training_state.per_movement_calibration.length === 0) {
+    return BEGINNER_EXAMPLE
+  }
+
+  const sessionGaps = training_state.per_fau
+    .map((f) => f.last_session_days_ago)
+    .filter((d): d is number => d !== null)
+  const freshest = sessionGaps.length > 0 ? Math.min(...sessionGaps) : null
+  if (freshest !== null && freshest >= 14) {
+    return RETURNING_EXAMPLE
+  }
+
+  if (ephemeral_context.time_budget_minutes <= 25) {
+    return SHORT_SESSION_EXAMPLE
+  }
+
+  const haystack = [
+    ...durable_profile.goal_sentences,
+    ephemeral_context.prioritize_freetext ?? '',
+    ephemeral_context.deprioritize_freetext ?? '',
+    durable_profile.default_intensity_preference ?? '',
+  ]
+    .join(' ')
+    .toLowerCase()
+
+  let best: FewShotExample = BODYBUILDER_EXAMPLE
+  let bestScore = 0
+  for (const example of FEW_SHOT_EXAMPLES) {
+    const score = example.keywords.filter((k) => haystack.includes(k)).length
+    if (score > bestScore) {
+      best = example
+      bestScore = score
+    }
+  }
+  return best
+}
+
+/**
+ * Render an example for inclusion at the top of the user message. The
+ * output JSON is compact (no whitespace) — cheap models imitate the
+ * format they see, and compact output halves output-token cost.
+ */
+export function renderFewShotExample(example: FewShotExample): string {
+  return [
+    `EXAMPLE (${example.archetype}) — format reference only. The exercises below are NOT in today's candidate list; never reuse their ids.`,
+    'Input (abridged):',
+    example.inputSnippet,
+    'Output:',
+    JSON.stringify(example.output),
+    'END EXAMPLE',
+  ].join('\n')
+}

--- a/lib/llm/prompts/suggest-workout/few-shot-examples.ts
+++ b/lib/llm/prompts/suggest-workout/few-shot-examples.ts
@@ -1,4 +1,4 @@
-import type { SuggestWorkoutPayload, SuggestionResponse } from './schemas'
+import type { SuggestionResponse, SuggestWorkoutPayload } from './schemas'
 
 /**
  * Few-shot examples for the Suggest Workout prompt.

--- a/lib/llm/prompts/suggest-workout/index.ts
+++ b/lib/llm/prompts/suggest-workout/index.ts
@@ -11,46 +11,13 @@
  * Design rationale: docs/SUGGEST_PROMPT_DESIGN.md
  */
 
-export {
-  buildSuggestionResponseSchema,
-  exerciseCountRange,
-  suggestionResponseBaseSchema,
-  suggestWorkoutPayloadSchema,
-  wildCardNoveltyFloor,
-  OPTION_IDS,
-  INTENSITY_VIBES,
-  type CandidateExercise,
-  type ExerciseCountRange,
-  type IntensityVibe,
-  type OptionId,
-  type SuggestedExercise,
-  type SuggestionResponse,
-  type SuggestWorkoutPayload,
-  type WeeklyIntent,
-  type WorkoutOption,
-} from './schemas'
-
-export {
-  assembleSuggestWorkoutPrompt,
-  estimateTokens,
-  SUGGEST_WORKOUT_SYSTEM_PROMPT,
-  type AssembledSuggestPrompt,
-  type AssembleOptions,
-} from './system-prompt'
 
 export {
   FEW_SHOT_EXAMPLES,
+  type FewShotExample,
   renderFewShotExample,
   selectFewShotExample,
-  type FewShotExample,
 } from './few-shot-examples'
-
-export {
-  buildSuggestRetryPrompt,
-  summarizeValidationError,
-  type SuggestRetryContext,
-} from './retry-prompt'
-
 export {
   buildAnthropicToolRequest,
   buildJsonModeRequest,
@@ -61,3 +28,33 @@ export {
   SUGGEST_TOOL_NAME,
   SUGGESTION_RESPONSE_JSON_SCHEMA,
 } from './provider-variants'
+export {
+  buildSuggestRetryPrompt,
+  type SuggestRetryContext,
+  summarizeValidationError,
+} from './retry-prompt'
+export {
+  buildSuggestionResponseSchema,
+  type CandidateExercise,
+  type ExerciseCountRange,
+  exerciseCountRange,
+  INTENSITY_VIBES,
+  type IntensityVibe,
+  OPTION_IDS,
+  type OptionId,
+  type SuggestedExercise,
+  type SuggestionResponse,
+  type SuggestWorkoutPayload,
+  suggestionResponseBaseSchema,
+  suggestWorkoutPayloadSchema,
+  type WeeklyIntent,
+  type WorkoutOption,
+  wildCardNoveltyFloor,
+} from './schemas'
+export {
+  type AssembledSuggestPrompt,
+  type AssembleOptions,
+  assembleSuggestWorkoutPrompt,
+  estimateTokens,
+  SUGGEST_WORKOUT_SYSTEM_PROMPT,
+} from './system-prompt'

--- a/lib/llm/prompts/suggest-workout/index.ts
+++ b/lib/llm/prompts/suggest-workout/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Suggest Workout prompt module. Typical worker usage:
+ *
+ *   const prompt = assembleSuggestWorkoutPrompt(payload)
+ *   const schema = buildSuggestionResponseSchema(prompt.candidateIds, prompt.countRange)
+ *   const result = await getLLMClient().callWithStructuredOutput(prompt.user, schema, { system: prompt.system })
+ *
+ * On LLMValidationError, make one focused retry with
+ * buildSuggestRetryPrompt (see retry-prompt.ts).
+ *
+ * Design rationale: docs/SUGGEST_PROMPT_DESIGN.md
+ */
+
+export {
+  buildSuggestionResponseSchema,
+  exerciseCountRange,
+  suggestionResponseBaseSchema,
+  suggestWorkoutPayloadSchema,
+  wildCardNoveltyFloor,
+  OPTION_IDS,
+  INTENSITY_VIBES,
+  type CandidateExercise,
+  type ExerciseCountRange,
+  type IntensityVibe,
+  type OptionId,
+  type SuggestedExercise,
+  type SuggestionResponse,
+  type SuggestWorkoutPayload,
+  type WeeklyIntent,
+  type WorkoutOption,
+} from './schemas'
+
+export {
+  assembleSuggestWorkoutPrompt,
+  estimateTokens,
+  SUGGEST_WORKOUT_SYSTEM_PROMPT,
+  type AssembledSuggestPrompt,
+  type AssembleOptions,
+} from './system-prompt'
+
+export {
+  FEW_SHOT_EXAMPLES,
+  renderFewShotExample,
+  selectFewShotExample,
+  type FewShotExample,
+} from './few-shot-examples'
+
+export {
+  buildSuggestRetryPrompt,
+  summarizeValidationError,
+  type SuggestRetryContext,
+} from './retry-prompt'
+
+export {
+  buildAnthropicToolRequest,
+  buildJsonModeRequest,
+  buildNoSchemaRequest,
+  buildOpenAIStructuredRequest,
+  buildThinkingModelRequest,
+  extractAnthropicToolInput,
+  SUGGEST_TOOL_NAME,
+  SUGGESTION_RESPONSE_JSON_SCHEMA,
+} from './provider-variants'

--- a/lib/llm/prompts/suggest-workout/provider-variants.ts
+++ b/lib/llm/prompts/suggest-workout/provider-variants.ts
@@ -1,0 +1,250 @@
+import type { AssembledSuggestPrompt } from './system-prompt'
+
+/**
+ * Provider-specific request builders for the Suggest Workout call.
+ *
+ * The shipped LLMClient (lib/llm/client.ts) speaks one dialect: chat
+ * completions + response_format json_object + cleanup + zod. That is
+ * the JSON-mode variant below and works on DeepInfra, Groq, Together,
+ * and OpenAI. The other builders exist so #880's worker can upgrade a
+ * provider to its strongest structured-output mechanism without
+ * touching the prompt content — every variant wraps the SAME assembled
+ * prompt.
+ *
+ * Reliability ladder (strongest first):
+ *   1. Anthropic tool-use (forced tool call — schema enforced server-side)
+ *   2. OpenAI structured outputs (json_schema strict)
+ *   3. JSON mode (json_object) — current LLMClient behavior
+ *   4. No schema support — prompt-only, lean on cleanup + retry
+ * Regardless of variant, ALWAYS run zod validation: provider-side
+ * schemas cannot check candidate-id membership, counts, or option
+ * distinctness.
+ */
+
+/**
+ * Hand-written (not zod-derived) so it stays inside the keyword subset
+ * that BOTH Anthropic tool schemas and OpenAI strict mode accept:
+ * type / properties / required / additionalProperties / enum / items /
+ * description. No min/max constraints here — zod owns fine validation.
+ */
+export const SUGGESTION_RESPONSE_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['options', 'warnings'],
+  properties: {
+    options: {
+      type: 'array',
+      description:
+        'Exactly three options in order: user_preference, data_driven, wild_card',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'name', 'description', 'summary', 'exercises'],
+        properties: {
+          id: {
+            type: 'string',
+            enum: ['user_preference', 'data_driven', 'wild_card'],
+          },
+          name: { type: 'string' },
+          description: {
+            type: 'string',
+            description: 'One sentence on what makes this option this option',
+          },
+          summary: {
+            type: 'string',
+            description: 'N exercises, ~M min, plus one line of character',
+          },
+          exercises: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['id', 'name', 'rationale'],
+              properties: {
+                id: {
+                  type: 'string',
+                  description:
+                    'Copied exactly from the CANDIDATE EXERCISES list',
+                },
+                name: { type: 'string' },
+                rationale: {
+                  type: 'string',
+                  description: 'One sentence grounded in the input data',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    warnings: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Empty array when there is nothing to warn about',
+    },
+  },
+} as const
+
+export const SUGGEST_TOOL_NAME = 'submit_workout_options'
+
+// ---------------------------------------------------------------------------
+// 1. Anthropic tool-use mode (native Messages API shape)
+// ---------------------------------------------------------------------------
+
+export interface AnthropicToolRequest {
+  model: string
+  max_tokens: number
+  system: string
+  messages: Array<{ role: 'user'; content: string }>
+  tools: Array<{
+    name: string
+    description: string
+    input_schema: typeof SUGGESTION_RESPONSE_JSON_SCHEMA
+  }>
+  tool_choice: { type: 'tool'; name: string }
+  temperature: number
+}
+
+export function buildAnthropicToolRequest(
+  prompt: AssembledSuggestPrompt,
+  opts: { model: string; maxTokens?: number; temperature?: number },
+): AnthropicToolRequest {
+  return {
+    model: opts.model,
+    max_tokens: opts.maxTokens ?? 3000,
+    system: prompt.system,
+    messages: [{ role: 'user', content: prompt.user }],
+    tools: [
+      {
+        name: SUGGEST_TOOL_NAME,
+        description:
+          'Submit exactly three workout options built from the candidate exercises.',
+        input_schema: SUGGESTION_RESPONSE_JSON_SCHEMA,
+      },
+    ],
+    // Forcing the tool means the model CANNOT reply with prose — the
+    // strongest schema-adherence mechanism available anywhere.
+    tool_choice: { type: 'tool', name: SUGGEST_TOOL_NAME },
+    temperature: opts.temperature ?? 0.2,
+  }
+}
+
+/** Pull the tool input out of an Anthropic Messages response. */
+export function extractAnthropicToolInput(response: unknown): unknown {
+  const content = (response as { content?: unknown })?.content
+  if (!Array.isArray(content)) return null
+  const block = content.find(
+    (b: unknown) =>
+      !!b &&
+      typeof b === 'object' &&
+      (b as { type?: string }).type === 'tool_use' &&
+      (b as { name?: string }).name === SUGGEST_TOOL_NAME,
+  )
+  return block ? (block as { input: unknown }).input : null
+}
+
+// ---------------------------------------------------------------------------
+// 2. OpenAI structured outputs (json_schema strict)
+// ---------------------------------------------------------------------------
+
+export interface OpenAIStructuredRequest {
+  model: string
+  messages: Array<{ role: 'system' | 'user'; content: string }>
+  response_format: {
+    type: 'json_schema'
+    json_schema: {
+      name: string
+      strict: true
+      schema: typeof SUGGESTION_RESPONSE_JSON_SCHEMA
+    }
+  }
+  temperature: number
+  max_tokens?: number
+}
+
+export function buildOpenAIStructuredRequest(
+  prompt: AssembledSuggestPrompt,
+  opts: { model: string; maxTokens?: number; temperature?: number },
+): OpenAIStructuredRequest {
+  return {
+    model: opts.model,
+    messages: [
+      { role: 'system', content: prompt.system },
+      { role: 'user', content: prompt.user },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'workout_options',
+        strict: true,
+        schema: SUGGESTION_RESPONSE_JSON_SCHEMA,
+      },
+    },
+    temperature: opts.temperature ?? 0.2,
+    max_tokens: opts.maxTokens,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. JSON mode (json_object) — what LLMClient does today
+// ---------------------------------------------------------------------------
+
+export interface JsonModeRequest {
+  system: string
+  user: string
+}
+
+/**
+ * The system prompt already contains the output skeleton, so JSON mode
+ * needs no extra scaffolding. Provided for symmetry; calling
+ * `llmClient.callWithStructuredOutput(prompt.user, schema, { system:
+ * prompt.system })` is equivalent.
+ */
+export function buildJsonModeRequest(
+  prompt: AssembledSuggestPrompt,
+): JsonModeRequest {
+  return { system: prompt.system, user: prompt.user }
+}
+
+// ---------------------------------------------------------------------------
+// 4. No schema support at all — prompt-only fallback
+// ---------------------------------------------------------------------------
+
+export function buildNoSchemaRequest(
+  prompt: AssembledSuggestPrompt,
+): JsonModeRequest {
+  return {
+    system: prompt.system,
+    user: `${prompt.user}\n\nYour entire reply must be the JSON object: the first character "{" and the last character "}".`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Thinking-model variant (DeepSeek-R1 class, o-series)
+// ---------------------------------------------------------------------------
+
+export interface ThinkingModelRequest extends JsonModeRequest {
+  /** Reasoning models are slow — the default 60s client timeout is too tight. */
+  recommendedTimeoutMs: number
+}
+
+/**
+ * Reasoning models emit deliberation before the answer, which breaks
+ * two assumptions of the standard path: response_format is often
+ * rejected, and cleanLLMOutput extracts the FIRST balanced JSON object
+ * — which may sit inside the visible reasoning. The added instruction
+ * keeps braces out of the reasoning so first-object extraction stays
+ * correct. Retry semantics change too: a validation failure on a
+ * thinking model is usually an extraction problem, not a comprehension
+ * problem, so the focused retry prompt (retry-prompt.ts) is the right
+ * second call — do not re-send the full payload.
+ */
+export function buildThinkingModelRequest(
+  prompt: AssembledSuggestPrompt,
+): ThinkingModelRequest {
+  return {
+    system: prompt.system,
+    user: `${prompt.user}\n\nThink through the selection first if you need to, but keep the reasoning free of braces or JSON fragments. End your reply with the final JSON object and nothing after it.`,
+    recommendedTimeoutMs: 180_000,
+  }
+}

--- a/lib/llm/prompts/suggest-workout/retry-prompt.ts
+++ b/lib/llm/prompts/suggest-workout/retry-prompt.ts
@@ -1,4 +1,4 @@
-import { type ExerciseCountRange } from './schemas'
+import type { ExerciseCountRange } from './schemas'
 
 /**
  * Worker-level retry prompt for the Suggest Workout call.

--- a/lib/llm/prompts/suggest-workout/retry-prompt.ts
+++ b/lib/llm/prompts/suggest-workout/retry-prompt.ts
@@ -1,0 +1,86 @@
+import { type ExerciseCountRange } from './schemas'
+
+/**
+ * Worker-level retry prompt for the Suggest Workout call.
+ *
+ * Two retry layers exist:
+ * 1. LLMClient's internal retry (lib/llm/client.ts) re-sends the FULL
+ *    original prompt plus the zod issues. The refinement messages in
+ *    buildSuggestionResponseSchema are written as repair instructions,
+ *    so that layer usually recovers on its own.
+ * 2. If the client still throws LLMValidationError, the worker makes
+ *    ONE more call with THIS prompt (#880: "one retry on validation
+ *    failure"). It is a focused repair request — no profile, no
+ *    training state — just the error, the rules, the valid ids, and
+ *    the previous output. Roughly 1/4 the tokens of a full re-ask, and
+ *    more reliable because the only task left is "fix the JSON".
+ */
+
+const MAX_PREVIOUS_OUTPUT_CHARS = 4000
+
+export interface SuggestRetryContext {
+  /** Human/model-readable summary of what failed validation. */
+  errorSummary: string
+  /** The raw text of the failed response. */
+  previousOutput: string
+  /** Full candidate id list for the request. */
+  candidateIds: readonly string[]
+  countRange: ExerciseCountRange
+}
+
+/**
+ * Flatten zod issues (or a parse error) into short, deduplicated,
+ * actionable lines. LLMValidationError exposes `issues: unknown`; this
+ * accepts anything and degrades to JSON.stringify.
+ */
+export function summarizeValidationError(issues: unknown): string {
+  if (typeof issues === 'string') return issues
+  if (Array.isArray(issues)) {
+    const lines = new Set<string>()
+    for (const issue of issues) {
+      if (issue && typeof issue === 'object' && 'message' in issue) {
+        const path = Array.isArray(
+          (issue as { path?: unknown[] }).path,
+        )
+          ? (issue as { path: unknown[] }).path.join('.')
+          : ''
+        const message = String((issue as { message: unknown }).message)
+        lines.add(path ? `${path}: ${message}` : message)
+      }
+    }
+    if (lines.size > 0) return [...lines].join('\n')
+  }
+  if (issues && typeof issues === 'object' && 'parseError' in issues) {
+    return `The response was not valid JSON: ${String((issues as { parseError: unknown }).parseError)}`
+  }
+  return JSON.stringify(issues)
+}
+
+export function buildSuggestRetryPrompt(ctx: SuggestRetryContext): string {
+  const truncated =
+    ctx.previousOutput.length > MAX_PREVIOUS_OUTPUT_CHARS
+      ? `${ctx.previousOutput.slice(0, MAX_PREVIOUS_OUTPUT_CHARS)}\n...(truncated)`
+      : ctx.previousOutput
+
+  return [
+    'Your previous workout suggestion failed validation.',
+    '',
+    'Errors:',
+    ctx.errorSummary,
+    '',
+    'Produce a corrected version of your previous response. Keep every part that was already valid — change only what the errors above require. Reply with the JSON object alone: no explanation, no markdown fences.',
+    '',
+    'Requirements:',
+    `- Exactly 3 options with "id" values "user_preference", "data_driven", "wild_card", in that order.`,
+    `- Between ${ctx.countRange.min} and ${ctx.countRange.max} exercises per option; no exercise twice in one option.`,
+    '- Every exercise "id" must be one of the VALID IDS below, copied exactly.',
+    '- Each option has "id", "name", "description", "summary", "exercises" (each exercise: "id", "name", "rationale").',
+    '- Top level has "options" and "warnings" (use [] when there are no warnings).',
+    '',
+    'VALID IDS:',
+    ctx.candidateIds.join(', '),
+    '',
+    'Your previous response:',
+    truncated,
+  ].join('\n')
+}

--- a/lib/llm/prompts/suggest-workout/schemas.ts
+++ b/lib/llm/prompts/suggest-workout/schemas.ts
@@ -1,0 +1,319 @@
+import { z } from 'zod'
+
+/**
+ * Zod schemas for the Suggest Workout LLM call.
+ *
+ * Input side: `suggestWorkoutPayloadSchema` validates the training-state
+ * builder's output (locked contract — issue #877 comment) BEFORE we spend
+ * LLM tokens on it. It is deliberately tolerant of extra keys so the
+ * payload can grow without breaking the prompt layer.
+ *
+ * Output side: `buildSuggestionResponseSchema` produces a per-request
+ * schema whose refinement messages are written FOR THE MODEL — the LLM
+ * client appends zod issues verbatim to its retry prompt, so every
+ * message here doubles as repair instructions.
+ */
+
+export const OPTION_IDS = ['user_preference', 'data_driven', 'wild_card'] as const
+export type OptionId = (typeof OPTION_IDS)[number]
+
+export const INTENSITY_VIBES = ['easy', 'solid', 'heavy'] as const
+export type IntensityVibe = (typeof INTENSITY_VIBES)[number]
+
+// ---------------------------------------------------------------------------
+// Input payload (training-state builder → prompt assembler)
+// ---------------------------------------------------------------------------
+
+/** Weekly intent discriminated union — mirrors issue #884. */
+export const weeklyIntentSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('heavy_session'),
+    muscle_group: z.enum(['legs', 'upper', 'pull', 'push']),
+    min_per_week: z.number().int().positive(),
+  }),
+  z.object({
+    type: z.literal('volume_tilt'),
+    toward: z.array(z.string()),
+    away_from: z.array(z.string()),
+    ratio: z.number(),
+  }),
+  z.object({
+    type: z.literal('movement_frequency'),
+    movement_pattern: z.string(),
+    min_per_week: z.number().int().positive(),
+  }),
+  z.object({
+    type: z.literal('free_text'),
+    text: z.string(),
+  }),
+])
+export type WeeklyIntent = z.infer<typeof weeklyIntentSchema>
+
+export const durableProfileSchema = z.object({
+  goal_sentences: z.array(z.string()),
+  weekly_intent: z.array(weeklyIntentSchema),
+  equipment_available: z.array(z.string()),
+  banned_exercise_ids: z.array(z.string()),
+  default_intensity_preference: z
+    .enum(['hypertrophy', 'strength', 'balanced'])
+    .nullable(),
+  ratio_targets: z.record(z.string(), z.number()),
+})
+
+export const ephemeralContextSchema = z.object({
+  time_budget_minutes: z.number().int().min(10).max(240),
+  intensity_vibe: z.enum(INTENSITY_VIBES).nullable(),
+  deprioritize_freetext: z.string().nullable(),
+  prioritize_freetext: z.string().nullable(),
+  equipment_override: z.array(z.string()).nullable(),
+})
+
+export const perFauStateSchema = z.object({
+  fau: z.string(),
+  last_session_days_ago: z.number().nullable(),
+  last_heavy_days_ago: z.number().nullable(),
+  rolling_7d_sets: z.number(),
+  rolling_14d_sets: z.number(),
+  target_share: z.number(),
+  actual_14d_share: z.number(),
+  /** Positive = under-trained relative to target. */
+  deficit_share: z.number(),
+  status: z.enum(['neglected', 'balanced', 'over']),
+})
+
+export const movementCalibrationSchema = z.object({
+  movement_pattern: z.string(),
+  current_ewma_top_weight_lbs: z.number(),
+  recent_observations: z.array(z.number()),
+  typical_rep_range: z.string(),
+  // Nullable (deviation from the #877 sample, which showed a bare number):
+  // RPE logging is opt-in, so the builder cannot always produce one.
+  typical_rpe: z.number().nullable(),
+  last_session_days_ago: z.number(),
+})
+
+export const weeklyIntentStatusSchema = z.object({
+  intent_summary: z.string(),
+  satisfied_this_week: z.boolean(),
+  /** Populated iff satisfied_this_week === true (spec rule 3). */
+  evidence: z.string().optional(),
+  /** Populated iff satisfied_this_week === false (spec rule 4). */
+  last_satisfied_days_ago: z.number().nullable().optional(),
+})
+
+export const goalProgressSchema = z.object({
+  goal: z.string(),
+  interpretation: z.string(),
+  recent_top_sets_lbs: z.array(z.number()),
+  trend: z.enum(['progressing', 'stalled', 'regressing', 'new']),
+  weeks_observed: z.number(),
+})
+
+export const recentFeedbackSchema = z.object({
+  suggestions_last_30d: z.number(),
+  swap_rate: z.number(),
+  common_swaps: z.array(
+    z.object({ from: z.string(), to: z.string(), count: z.number() }),
+  ),
+  common_additions_fau: z.array(z.string()),
+  common_deletions_fau: z.array(z.string()),
+})
+
+export const preferencesSummarySchema = z.object({
+  high_confidence_likes: z.array(z.string()),
+  high_confidence_dislikes: z.array(z.string()),
+  low_confidence_note: z.string().optional(),
+})
+
+export const trainingStateSchema = z.object({
+  now: z.string(),
+  today_dow: z.string(),
+  per_fau: z.array(perFauStateSchema),
+  per_movement_calibration: z.array(movementCalibrationSchema),
+  weekly_intent_status: z.array(weeklyIntentStatusSchema),
+  goal_progress: z.array(goalProgressSchema),
+  recent_feedback: recentFeedbackSchema,
+  preferences_summary: preferencesSummarySchema,
+})
+
+export const candidateExerciseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  primary_faus: z.array(z.string()),
+  secondary_faus: z.array(z.string()),
+  equipment: z.string(),
+  /** null = untagged; the LLM infers from name/FAUs (locked decision). */
+  movement_pattern: z.string().nullable(),
+  intensity_class: z.enum(['heavy', 'moderate', 'light']),
+  /** Present only when Beta-distribution confidence is high (spec rule 8). */
+  user_preference_score: z.number().optional(),
+  user_preference_confidence: z.literal('high').optional(),
+})
+export type CandidateExercise = z.infer<typeof candidateExerciseSchema>
+
+export const suggestWorkoutPayloadSchema = z.object({
+  durable_profile: durableProfileSchema,
+  ephemeral_context: ephemeralContextSchema,
+  training_state: trainingStateSchema,
+  candidate_exercises: z.array(candidateExerciseSchema).min(1),
+})
+export type SuggestWorkoutPayload = z.infer<typeof suggestWorkoutPayloadSchema>
+
+// ---------------------------------------------------------------------------
+// Exercise count budgeting (shared by prompt text AND output validation so
+// the instruction and the check can never drift apart)
+// ---------------------------------------------------------------------------
+
+export interface ExerciseCountRange {
+  min: number
+  max: number
+}
+
+/**
+ * Time budget → exercise count. Assumes ~8 minutes per exercise including
+ * rest and setup (v1 has no sets/reps — the user logs those live).
+ */
+export function exerciseCountRange(timeBudgetMinutes: number): ExerciseCountRange {
+  if (timeBudgetMinutes <= 20) return { min: 2, max: 3 }
+  if (timeBudgetMinutes <= 35) return { min: 3, max: 5 }
+  if (timeBudgetMinutes <= 50) return { min: 4, max: 6 }
+  if (timeBudgetMinutes <= 75) return { min: 5, max: 8 }
+  return { min: 6, max: 10 }
+}
+
+/**
+ * How many wild_card exercises must appear in neither other option.
+ * Short sessions get a lower bar — there isn't room for two novelties
+ * in a 2-exercise workout.
+ */
+export function wildCardNoveltyFloor(countRange: ExerciseCountRange): number {
+  return countRange.min <= 3 ? 1 : 2
+}
+
+// ---------------------------------------------------------------------------
+// LLM output
+// ---------------------------------------------------------------------------
+
+export const suggestedExerciseSchema = z.object({
+  id: z.string().min(1),
+  // The model echoes the candidate's name next to its id. This is a
+  // grounding device (binds attention to a real candidate row), not data —
+  // the transform step reads the canonical name from the DB. Presence-only
+  // validation: a paraphrased name must never fail a correct id.
+  name: z.string().min(1),
+  rationale: z.string().min(1).max(240),
+})
+export type SuggestedExercise = z.infer<typeof suggestedExerciseSchema>
+
+export const workoutOptionSchema = z.object({
+  id: z.enum(OPTION_IDS),
+  name: z.string().min(1).max(60),
+  description: z.string().min(1).max(240),
+  summary: z.string().min(1).max(240),
+  exercises: z.array(suggestedExerciseSchema).min(1),
+})
+export type WorkoutOption = z.infer<typeof workoutOptionSchema>
+
+/**
+ * Structure-only output schema. Use `buildSuggestionResponseSchema` for
+ * real calls — it adds the per-request semantic checks (candidate ids,
+ * counts, distinctness).
+ */
+export const suggestionResponseBaseSchema = z.object({
+  options: z.array(workoutOptionSchema).length(3),
+  // default([]) — a missing warnings key must not burn a retry.
+  warnings: z.array(z.string().min(1).max(300)).max(5).default([]),
+})
+export type SuggestionResponse = z.infer<typeof suggestionResponseBaseSchema>
+
+function setEquals(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const v of a) if (!b.has(v)) return false
+  return true
+}
+
+/**
+ * Per-request output schema. Every refinement message is phrased as a
+ * repair instruction because the LLM client feeds zod issues straight
+ * back to the model on its internal retry.
+ */
+export function buildSuggestionResponseSchema(
+  candidateIds: Iterable<string>,
+  countRange: ExerciseCountRange,
+): z.ZodType<SuggestionResponse> {
+  const validIds = new Set(candidateIds)
+  const noveltyFloor = wildCardNoveltyFloor(countRange)
+
+  return suggestionResponseBaseSchema.superRefine((res, ctx) => {
+    const idSets = res.options.map(
+      (o) => new Set(o.exercises.map((e) => e.id)),
+    )
+
+    res.options.forEach((option, i) => {
+      if (option.id !== OPTION_IDS[i]) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', i, 'id'],
+          message: `options[${i}].id must be "${OPTION_IDS[i]}". The three options must appear in this exact order: user_preference, data_driven, wild_card.`,
+        })
+      }
+
+      const unknown = option.exercises
+        .map((e) => e.id)
+        .filter((id) => !validIds.has(id))
+      if (unknown.length > 0) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', i, 'exercises'],
+          message: `These exercise ids do not exist: ${unknown.join(', ')}. Replace each with an id copied exactly from the CANDIDATE EXERCISES list. Do not invent ids.`,
+        })
+      }
+
+      const seen = new Set<string>()
+      const dupes = new Set<string>()
+      for (const e of option.exercises) {
+        if (seen.has(e.id)) dupes.add(e.id)
+        seen.add(e.id)
+      }
+      if (dupes.size > 0) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', i, 'exercises'],
+          message: `Duplicate exercises in ${option.id}: ${[...dupes].join(', ')}. Each exercise may appear at most once per option.`,
+        })
+      }
+
+      const n = option.exercises.length
+      if (n < countRange.min || n > countRange.max) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', i, 'exercises'],
+          message: `${option.id} has ${n} exercises but the time budget requires between ${countRange.min} and ${countRange.max}. Add or remove exercises to fit.`,
+        })
+      }
+    })
+
+    // Distinctness backstops. The option recipes in the system prompt do
+    // the real work; these catch collapse.
+    if (res.options.length === 3) {
+      if (setEquals(idSets[0], idSets[1])) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', 1, 'exercises'],
+          message:
+            'user_preference and data_driven contain the same exercises. data_driven must be built from training-state deficits and weekly intent, not from today\'s request — change at least two of its exercises.',
+        })
+      }
+      const novel = [...idSets[2]].filter(
+        (id) => !idSets[0].has(id) && !idSets[1].has(id),
+      )
+      if (novel.length < noveltyFloor) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['options', 2, 'exercises'],
+          message: `wild_card must include at least ${noveltyFloor} exercise(s) that appear in neither other option. Swap in something the user rarely does.`,
+        })
+      }
+    }
+  })
+}

--- a/lib/llm/prompts/suggest-workout/system-prompt.ts
+++ b/lib/llm/prompts/suggest-workout/system-prompt.ts
@@ -1,0 +1,369 @@
+import {
+  exerciseCountRange,
+  type CandidateExercise,
+  type ExerciseCountRange,
+  type SuggestWorkoutPayload,
+  type WeeklyIntent,
+} from './schemas'
+import {
+  renderFewShotExample,
+  selectFewShotExample,
+  type FewShotExample,
+} from './few-shot-examples'
+
+/**
+ * Suggest Workout prompt assembly.
+ *
+ * Layout (and why):
+ * - System prompt is 100% static → provider prompt caching works.
+ * - The payload is rendered as compact labeled text, not raw JSON.
+ *   Text costs ~40% fewer tokens and keeps "JSON" unambiguous: the only
+ *   JSON the model ever sees (example output, skeleton) looks like what
+ *   it must produce.
+ * - Candidates are a pipe table with the id in column one — the model
+ *   copies ids from the start of lines far more reliably than from
+ *   nested JSON.
+ * - TODAY'S REQUEST is the last section before the final instruction.
+ *   Cheap models weight the end of a long prompt heavily; this is the
+ *   defense against regressing to a generic workout that ignores the
+ *   session-specific input.
+ * - Exercise counts are precomputed from the time budget. The model
+ *   never does arithmetic.
+ */
+
+export const SUGGEST_WORKOUT_SYSTEM_PROMPT = `You are the workout planner inside Ripit Fitness, a strength training app. Each request gives you one user's profile, their recent training state, today's request, and a list of candidate exercises. You respond with exactly three workout options as a single JSON object.
+
+An option is an ordered list of exercises for one session (no sets or reps — the user logs those live). Order exercises as they should be performed: the most demanding compound work first, isolation and accessory work last.
+
+HARD RULES
+1. Every exercise "id" is copied character-for-character from the CANDIDATE EXERCISES list. No other ids exist.
+2. Exactly three options, with "id" values "user_preference", "data_driven", "wild_card", in that order.
+3. No exercise appears twice in the same option.
+4. Respond with the JSON object only — no markdown fences, no text before or after it.
+
+THE THREE OPTIONS
+user_preference — built around TODAY'S REQUEST. If the user named a focus, most exercises serve that focus. Anything they asked to avoid or deprioritize is fully respected. Fill remaining slots with their high-confidence likes and the movements they train most.
+data_driven — built from TRAINING STATE alone. Satisfy any unsatisfied weekly intent first, then attack the largest positive deficits and the stalest muscle groups. Today's stated mood and focus do NOT steer this option; only hard limits do: the time budget, available equipment, and any pain, soreness, or injury the user mentioned — safety always wins. When this option contradicts the request, say so plainly in its description.
+wild_card — a session the user would not have picked but a good coach could defend. Rotate to equipment, movement patterns, or exercises the user rarely or never uses, or use an unusual structure such as antagonist supersets. Keep it anchored: at least half its exercises still serve the user's goals or current deficits. Include at least two exercises that appear in neither other option. Never include high-confidence dislikes.
+
+If user_preference and data_driven would come out nearly identical because the request already matches the data, force them apart: keep user_preference tightly on the requested focus and make data_driven a broader rebalancing session, and let each description say what distinguishes it.
+
+SELECTION PRINCIPLES
+- When barbells, dumbbells, cables, or machines are available, build around them. Bands and bodyweight are fillers, not defaults — use them only when equipment limits or the request calls for them.
+- Use movement calibration to judge readiness: a pattern loaded heavy 1-2 days ago is not ready for more heavy work; 4 or more days is.
+- status "neglected" plus a large positive deficit is the strongest signal to include that muscle group.
+- Prefer high-confidence liked exercises in user_preference and data_driven. Avoid high-confidence dislikes in every option.
+- Honor weekly intents when time allows; when one cannot fit today, add a warning instead of forcing it.
+- Soreness or pain in the request overrides every deficit signal for the affected area.
+
+WRITING STYLE for description, summary, and rationale
+Write like a knowledgeable training partner: plain, direct, specific, one sentence each. Ground claims in the input data ("chest is 6 points under target over 14 days", "no hinge work in 9 days"). Use only numbers that appear in the input — never invent one. No emoji, no exclamation points, no hype words, no jargon the input does not use.
+
+WARNINGS
+Add a short warning string when an unsatisfied weekly intent cannot fit today's time budget, when today's request sharply contradicts the training data (state what the data says), or when an equipment override removes most relevant exercises. Otherwise "warnings" must be [].
+
+OUTPUT SHAPE — exactly this structure:
+{
+  "options": [
+    {
+      "id": "user_preference",
+      "name": "User Preference",
+      "description": "one sentence: how this follows today's request",
+      "summary": "N exercises, ~M min. One line on the session's character.",
+      "exercises": [
+        { "id": "copied from CANDIDATE EXERCISES", "name": "that exercise's name", "rationale": "one sentence" }
+      ]
+    },
+    { "id": "data_driven", "name": "Data Driven", "description": "...", "summary": "...", "exercises": [ ... ] },
+    { "id": "wild_card", "name": "Wild Card", "description": "...", "summary": "...", "exercises": [ ... ] }
+  ],
+  "warnings": []
+}`
+
+// ---------------------------------------------------------------------------
+// Section renderers (exported for tests)
+// ---------------------------------------------------------------------------
+
+function formatDays(days: number | null): string {
+  if (days === null) return 'never'
+  return `${days}d`
+}
+
+function formatShare(share: number): string {
+  return `${Math.round(share * 100)}%`
+}
+
+function formatDeficit(deficit: number): string {
+  const pts = Math.round(deficit * 100)
+  return `${pts >= 0 ? '+' : ''}${pts}%`
+}
+
+export function summarizeWeeklyIntent(intent: WeeklyIntent): string {
+  switch (intent.type) {
+    case 'heavy_session':
+      return `at least ${intent.min_per_week} heavy ${intent.muscle_group} session(s) per week`
+    case 'volume_tilt':
+      return `tilt volume toward ${intent.toward.join(', ')} and away from ${intent.away_from.join(', ')}`
+    case 'movement_frequency':
+      return `${intent.movement_pattern} at least ${intent.min_per_week}x per week`
+    case 'free_text':
+      return intent.text
+  }
+}
+
+export function renderDurableProfile(payload: SuggestWorkoutPayload): string {
+  const p = payload.durable_profile
+  const lines = ['USER PROFILE']
+  lines.push(
+    `Goals: ${p.goal_sentences.length > 0 ? p.goal_sentences.join('; ') : '(none stated)'}`,
+  )
+  if (p.weekly_intent.length > 0) {
+    lines.push(`Weekly intent: ${p.weekly_intent.map(summarizeWeeklyIntent).join('; ')}`)
+  }
+  if (p.default_intensity_preference) {
+    lines.push(`Intensity preference: ${p.default_intensity_preference}`)
+  }
+  const equipment =
+    payload.ephemeral_context.equipment_override ?? p.equipment_available
+  const overridden = payload.ephemeral_context.equipment_override !== null
+  lines.push(
+    `Equipment${overridden ? ' today (overrides profile)' : ''}: ${equipment.join(', ')}`,
+  )
+  // banned_exercise_ids and ratio_targets are intentionally NOT rendered:
+  // bans are already filtered out of candidates, and ratio targets are
+  // fully expressed by the per-FAU target/deficit columns.
+  return lines.join('\n')
+}
+
+export function renderTrainingState(payload: SuggestWorkoutPayload): string {
+  const t = payload.training_state
+  const sections: string[] = []
+
+  sections.push(`TRAINING STATE (as of ${t.today_dow} ${t.now.slice(0, 10)})`)
+
+  const fauLines = [
+    'Muscle groups — sets and share of total volume vs target:',
+    'muscle | last trained | last heavy | sets 7d | sets 14d | target | actual | deficit(+=under) | status',
+    ...t.per_fau.map((f) =>
+      [
+        f.fau,
+        formatDays(f.last_session_days_ago),
+        formatDays(f.last_heavy_days_ago),
+        f.rolling_7d_sets,
+        f.rolling_14d_sets,
+        formatShare(f.target_share),
+        formatShare(f.actual_14d_share),
+        formatDeficit(f.deficit_share),
+        f.status,
+      ].join(' | '),
+    ),
+  ]
+  sections.push(fauLines.join('\n'))
+
+  if (t.per_movement_calibration.length > 0) {
+    const calLines = [
+      'Movement calibration (top working weight, lb):',
+      ...t.per_movement_calibration.map((c) =>
+        `${c.movement_pattern}: ~${c.current_ewma_top_weight_lbs} (recent ${c.recent_observations.join(',')}), ${c.typical_rep_range} reps${c.typical_rpe !== null ? ` @ RPE ${c.typical_rpe}` : ''}, last ${formatDays(c.last_session_days_ago)} ago`,
+      ),
+    ]
+    sections.push(calLines.join('\n'))
+  } else {
+    sections.push(
+      'No movement calibration yet (fewer than 3 logged sessions per pattern). Pick common, easy-to-learn movements and keep loads conservative.',
+    )
+  }
+
+  if (t.weekly_intent_status.length > 0) {
+    const intentLines = [
+      'Weekly intent status (Mon-Sun week):',
+      ...t.weekly_intent_status.map((s) => {
+        if (s.satisfied_this_week) {
+          return `- satisfied: ${s.intent_summary}${s.evidence ? ` (${s.evidence})` : ''}`
+        }
+        const ago =
+          s.last_satisfied_days_ago !== null &&
+          s.last_satisfied_days_ago !== undefined
+            ? ` (last satisfied ${s.last_satisfied_days_ago}d ago)`
+            : ''
+        return `- NOT satisfied: ${s.intent_summary}${ago}`
+      }),
+    ]
+    sections.push(intentLines.join('\n'))
+  }
+
+  if (t.goal_progress.length > 0) {
+    const goalLines = [
+      'Goal progress:',
+      ...t.goal_progress.map(
+        (g) =>
+          `- ${g.goal}: ${g.trend}, ${g.weeks_observed} week(s) observed (top sets ${g.recent_top_sets_lbs.join(', ')})`,
+      ),
+    ]
+    sections.push(goalLines.join('\n'))
+  }
+
+  const fb = t.recent_feedback
+  if (fb.suggestions_last_30d > 0) {
+    const parts = [
+      `Reaction to past suggestions (30d): ${fb.suggestions_last_30d} suggestions, ${Math.round(fb.swap_rate * 100)}% of exercises swapped.`,
+    ]
+    if (fb.common_swaps.length > 0) {
+      parts.push(
+        `Swaps: ${fb.common_swaps.map((s) => `${s.from} -> ${s.to} (${s.count})`).join('; ')}.`,
+      )
+    }
+    if (fb.common_additions_fau.length > 0) {
+      parts.push(`Often adds: ${fb.common_additions_fau.join(', ')}.`)
+    }
+    if (fb.common_deletions_fau.length > 0) {
+      parts.push(`Often deletes: ${fb.common_deletions_fau.join(', ')}.`)
+    }
+    sections.push(parts.join(' '))
+  } else {
+    sections.push('No suggestion history yet.')
+  }
+
+  const prefs = t.preferences_summary
+  if (
+    prefs.high_confidence_likes.length > 0 ||
+    prefs.high_confidence_dislikes.length > 0
+  ) {
+    sections.push(
+      `Confident preferences — likes: ${prefs.high_confidence_likes.join(', ') || '(none)'}; dislikes: ${prefs.high_confidence_dislikes.join(', ') || '(none)'}. Everything else: not enough data.`,
+    )
+  } else {
+    sections.push('Confident preferences: none yet — not enough data.')
+  }
+
+  return sections.join('\n\n')
+}
+
+export function renderCandidateLine(c: CandidateExercise): string {
+  const targets =
+    c.secondary_faus.length > 0
+      ? `${c.primary_faus.join(',')} +${c.secondary_faus.join(',')}`
+      : c.primary_faus.join(',')
+  return [
+    c.id,
+    c.name,
+    targets,
+    c.equipment,
+    c.movement_pattern ?? '-',
+    c.intensity_class,
+    c.user_preference_score !== undefined
+      ? c.user_preference_score.toFixed(2)
+      : '-',
+  ].join(' | ')
+}
+
+export function renderCandidates(payload: SuggestWorkoutPayload): string {
+  const candidates = payload.candidate_exercises
+  return [
+    `CANDIDATE EXERCISES — the only ${candidates.length} exercise ids that exist:`,
+    'id | name | muscles | equipment | pattern | intensity | preference',
+    ...candidates.map(renderCandidateLine),
+  ].join('\n')
+}
+
+const VIBE_LABELS: Record<string, string> = {
+  easy: 'easy — keep it light',
+  solid: 'solid — normal working session',
+  heavy: 'heavy — feeling strong, open to top-end loads',
+}
+
+export function renderTodaysRequest(
+  payload: SuggestWorkoutPayload,
+  countRange: ExerciseCountRange,
+): string {
+  const e = payload.ephemeral_context
+  const lines = ["TODAY'S REQUEST — user_preference must be built around this"]
+  lines.push(
+    `Time: ${e.time_budget_minutes} minutes -> ${countRange.min} to ${countRange.max} exercises per option (~8 min each)`,
+  )
+  if (e.intensity_vibe) {
+    lines.push(`Vibe: ${VIBE_LABELS[e.intensity_vibe] ?? e.intensity_vibe}`)
+  }
+  lines.push(`Prioritize: ${e.prioritize_freetext ? `"${e.prioritize_freetext}"` : '(none)'}`)
+  lines.push(
+    `Avoid/deprioritize: ${e.deprioritize_freetext ? `"${e.deprioritize_freetext}"` : '(none)'}`,
+  )
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Assembly
+// ---------------------------------------------------------------------------
+
+export interface AssembledSuggestPrompt {
+  system: string
+  user: string
+  countRange: ExerciseCountRange
+  candidateIds: string[]
+  /** null when the example was dropped to stay inside the token budget. */
+  exampleArchetype: string | null
+  estimatedTokens: number
+}
+
+export interface AssembleOptions {
+  /**
+   * 'auto' (default) selects an archetype-matched example and drops it
+   * if the total estimate exceeds maxTotalTokens. Pass null to omit,
+   * or a specific example to pin one (used by evals).
+   */
+  example?: 'auto' | FewShotExample | null
+  /** Rough ceiling for system + user, in estimated tokens. */
+  maxTotalTokens?: number
+}
+
+const DEFAULT_MAX_TOTAL_TOKENS = 6000
+
+/** chars/4 — crude but consistent; used only for budget decisions. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function assembleSuggestWorkoutPrompt(
+  payload: SuggestWorkoutPayload,
+  options: AssembleOptions = {},
+): AssembledSuggestPrompt {
+  const maxTotalTokens = options.maxTotalTokens ?? DEFAULT_MAX_TOTAL_TOKENS
+  const countRange = exerciseCountRange(
+    payload.ephemeral_context.time_budget_minutes,
+  )
+
+  const body = [
+    renderDurableProfile(payload),
+    renderTrainingState(payload),
+    renderCandidates(payload),
+    renderTodaysRequest(payload, countRange),
+    `Return the JSON object now: exactly 3 options (user_preference, data_driven, wild_card), ${countRange.min} to ${countRange.max} exercises each, every id copied from CANDIDATE EXERCISES, "warnings" always present.`,
+  ].join('\n\n')
+
+  let example: FewShotExample | null
+  if (options.example === undefined || options.example === 'auto') {
+    example = selectFewShotExample(payload)
+  } else {
+    example = options.example
+  }
+
+  const systemTokens = estimateTokens(SUGGEST_WORKOUT_SYSTEM_PROMPT)
+  let user = body
+  if (example) {
+    const withExample = `${renderFewShotExample(example)}\n\n${body}`
+    if (systemTokens + estimateTokens(withExample) <= maxTotalTokens) {
+      user = withExample
+    } else {
+      example = null
+    }
+  }
+
+  return {
+    system: SUGGEST_WORKOUT_SYSTEM_PROMPT,
+    user,
+    countRange,
+    candidateIds: payload.candidate_exercises.map((c) => c.id),
+    exampleArchetype: example?.archetype ?? null,
+    estimatedTokens: systemTokens + estimateTokens(user),
+  }
+}

--- a/lib/llm/prompts/suggest-workout/system-prompt.ts
+++ b/lib/llm/prompts/suggest-workout/system-prompt.ts
@@ -1,15 +1,15 @@
 import {
-  exerciseCountRange,
+  type FewShotExample,
+  renderFewShotExample,
+  selectFewShotExample,
+} from './few-shot-examples'
+import {
   type CandidateExercise,
   type ExerciseCountRange,
+  exerciseCountRange,
   type SuggestWorkoutPayload,
   type WeeklyIntent,
 } from './schemas'
-import {
-  renderFewShotExample,
-  selectFewShotExample,
-  type FewShotExample,
-} from './few-shot-examples'
 
 /**
  * Suggest Workout prompt assembly.


### PR DESCRIPTION
## What this is

The complete prompt-engineering artifact for the Suggest Workout LLM call (milestone: Suggest Workout (LLM-powered), consumed by #880). Prompt assembly, zod schemas for both sides of the call, archetype-matched few-shot examples, provider variants, a focused retry prompt, and a design-rationale doc. Wires into the worker with three lines:

```typescript
const prompt = assembleSuggestWorkoutPrompt(payload)
const schema = buildSuggestionResponseSchema(prompt.candidateIds, prompt.countRange)
const result = await getLLMClient().callWithStructuredOutput(prompt.user, schema, { system: prompt.system })
```

## Files

- `lib/llm/prompts/suggest-workout/schemas.ts` — payload schema (locked contract on #877) + per-request output schema whose refinements check candidate-id membership, counts, option order, and distinctness
- `lib/llm/prompts/suggest-workout/system-prompt.ts` — static system prompt + payload-to-text renderer + assembly with token budgeting
- `lib/llm/prompts/suggest-workout/few-shot-examples.ts` — six archetypes (cyclist, bodybuilder, powerlifter, beginner, returning, short-session); exactly one included per request
- `lib/llm/prompts/suggest-workout/provider-variants.ts` — Anthropic forced-tool, OpenAI strict json_schema, JSON mode, no-schema fallback, thinking-model variant
- `lib/llm/prompts/suggest-workout/retry-prompt.ts` — worker-level focused retry (error + rules + valid ids + previous output, no payload re-send)
- `__tests__/lib/llm/suggest-workout-prompt.test.ts` — pins every example against the real schema + refinement/assembly behavior
- `docs/SUGGEST_PROMPT_DESIGN.md` — full rationale, failure-mode table, provider matrix, lint checklist

## Key design decisions

- **Static system prompt, dynamic user message** — byte-identical system prompt across all requests, so provider prompt caching works and behavior changes are attributable to the payload, not interpolation.
- **Payload rendered as compact labeled text, not raw JSON** — ~40% fewer tokens, and the only JSON the model ever sees is shaped like what it must produce (skeleton + example output), so it can't echo input structure.
- **Hallucinated-id defense in depth** (the primary failure mode per #880): id is the first token of each candidate line; the output echoes `name` next to `id` (grounding — validated for presence only); the refinement message lists offending ids as repair instructions, which the client's internal retry feeds back verbatim.
- **TODAY'S REQUEST is the last content section** — recency position so cheap models can't ignore the ephemeral input under a large payload.
- **Exercise counts precomputed** — `exerciseCountRange` maps time budget to a min–max band used by both the instruction and the zod check, so they can't drift. No model arithmetic.
- **Distinctness via procedures, not adjectives** — each option has a different construction recipe reading a different input section; schema backstops collapse (UP ≠ DD set-equality, wild-card novelty floor).
- **One few-shot example, archetype-matched** — structural signals first (no calibration → beginner, everything ≥14d stale → returning, ≤25 min → short-session), keywords second. `demo_`-prefixed ids so bleed is self-evident; auto-dropped if the payload pushes past the 6k estimated-token ceiling.
- **Two retry layers** — client-internal (full prompt + zod issues, already shipped) then one worker-level focused repair call at ~¼ the tokens. Then `failed`. Never loop.

## Findings worth flagging

1. **Issue-pointer drift (again)**: the locked payload spec comment lives on **#877**, not #876, and the History v2 design comment is on **#886**, not #885 — both #876 and #885 have zero comments. Any shared-context prose citing #876/#885 propagates the shuffle the #868 postmortem documented.
2. **Proposed amendments to the locked #877 contract** (called out in the doc):
   - `exercises[].name` added to the output shape (anti-hallucination grounding, ~80 output tokens, transform ignores it)
   - `per_movement_calibration[].typical_rpe` must be nullable — RPE logging is opt-in, so the builder can't always produce the bare number the spec sample shows
   - `exerciseCountRange` now defines the previously-unspecified "count fits time budget" check (~8 min/exercise)
3. **Token budget is a candidate-count problem, not an instruction problem**: fixed overhead (system + example) is ~2.1k estimated; candidates cost 20–25 tokens/line. A realistic 110-candidate payload assembles at ~5.7k estimated (real ~4.7k — chars/4 overestimates). If payloads outgrow the ceiling, tighten the deterministic candidate filter in the builder rather than shaving prompt sections.

## Verification

- `npm run type-check` clean
- All six few-shot example outputs validate against the real per-request schema (pinned by the new test — `npm test suggest-workout-prompt`)
- Assembly verified with a synthetic 110-candidate payload: example included, ephemeral section last, every candidate id present, under budget
- Not yet run against a live model — no `LLM_*` secrets in `dev_personal`. First live smoke test against Haiku/Llama-8B should happen as part of #880 wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)