### PR TITLE
feat(eval): prompt-refinement loop for Suggest Workout (synthetic scenarios + LLM judge + human ratings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ public/swe-worker*
 # generated scripts output
 scripts/update-image-urls.sql
 scripts/test-exercise-mapping.json
+
+# Eval loop state (dev tooling, see docs/EVAL_LOOP_DESIGN.md)
+.eval/

--- a/__tests__/eval/eval-loop.test.ts
+++ b/__tests__/eval/eval-loop.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the eval-loop building blocks. No LLM calls, no DB —
+ * everything here is pure and fast.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { EXERCISE_CATALOG } from '@/lib/eval/exercise-catalog'
+import {
+  allowedExerciseCountRange,
+  runHardChecks,
+} from '@/lib/eval/hard-checks'
+import { aggregateJudgeRuns } from '@/lib/eval/judge'
+import {
+  compositeScore,
+  RUBRIC_DIMENSIONS,
+} from '@/lib/eval/rating-rubric'
+import { createRng } from '@/lib/eval/rng'
+import {
+  buildScenarioMatrix,
+  generateScenarios,
+  MODIFIER_KEYS,
+} from '@/lib/eval/scenario-generator'
+import type { JudgeResult, SuggestionResponse } from '@/lib/eval/types'
+import { applyDiff } from '@/lib/eval/refinement-engine'
+import { buildPlannerPrompt, PLANNER_PROMPT_VARIANTS } from '@/lib/suggest/prompts/registry'
+import { suggestionResponseSchema } from '@/lib/suggest/schema'
+
+describe('rng', () => {
+  it('is deterministic for the same seed', () => {
+    const a = createRng('seed-1')
+    const b = createRng('seed-1')
+    expect([a.next(), a.next(), a.int(1, 100)]).toEqual([
+      b.next(),
+      b.next(),
+      b.int(1, 100),
+    ])
+  })
+
+  it('diverges for different seeds and forks', () => {
+    const a = createRng('seed-1')
+    const b = createRng('seed-2')
+    expect(a.next()).not.toEqual(b.next())
+    const parent = createRng('seed-1')
+    expect(parent.fork('x').next()).not.toEqual(parent.fork('y').next())
+  })
+})
+
+describe('scenario generator', () => {
+  it('same seed + count produces byte-identical scenarios', () => {
+    const a = generateScenarios({ count: 20, seed: 'repro' })
+    const b = generateScenarios({ count: 20, seed: 'repro' })
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b))
+  })
+
+  it('different seeds produce different jitter', () => {
+    const a = generateScenarios({ count: 5, seed: 'one' })
+    const b = generateScenarios({ count: 5, seed: 'two' })
+    expect(JSON.stringify(a)).not.toEqual(JSON.stringify(b))
+  })
+
+  it('covers all archetypes in the first 5 and every modifier within the matrix', () => {
+    const matrix = buildScenarioMatrix()
+    const first5 = new Set(matrix.slice(0, 5).map((c) => c.archetype))
+    expect(first5.size).toBe(5)
+    const modifiersInMatrix = new Set(matrix.flatMap((c) => c.modifiers))
+    for (const m of MODIFIER_KEYS) expect(modifiersInMatrix.has(m)).toBe(true)
+  })
+
+  it('candidate lists respect equipment and bans', () => {
+    const scenarios = generateScenarios({ count: 55, seed: 'coverage' })
+    for (const s of scenarios) {
+      const equipment = new Set(
+        s.payload.ephemeral_context.equipment_override ??
+          s.payload.durable_profile.equipment_available,
+      )
+      const banned = new Set(s.payload.durable_profile.banned_exercise_ids)
+      for (const c of s.payload.candidate_exercises) {
+        expect(equipment.has(c.equipment)).toBe(true)
+        expect(banned.has(c.id)).toBe(false)
+      }
+      expect(s.payload.candidate_exercises.length).toBeGreaterThan(10)
+    }
+  })
+
+  it('per-FAU shares sum to ~1 and statuses follow deficit rule', () => {
+    const [scenario] = generateScenarios({ count: 1, seed: 'shares' })
+    const targetSum = scenario.payload.training_state.per_fau.reduce(
+      (a, f) => a + f.target_share,
+      0,
+    )
+    const actualSum = scenario.payload.training_state.per_fau.reduce(
+      (a, f) => a + f.actual_14d_share,
+      0,
+    )
+    expect(targetSum).toBeGreaterThan(0.98)
+    expect(targetSum).toBeLessThan(1.02)
+    expect(actualSum).toBeGreaterThan(0.98)
+    expect(actualSum).toBeLessThan(1.02)
+    for (const f of scenario.payload.training_state.per_fau) {
+      if (f.deficit_share > 0.03) expect(f.status).toBe('neglected')
+      else if (f.deficit_share < -0.03) expect(f.status).toBe('over')
+      else expect(f.status).toBe('balanced')
+    }
+  })
+
+  it('time-crunch scenarios carry the max_exercise_count hard rule', () => {
+    const scenarios = generateScenarios({ count: 55, seed: 'tc' })
+    const timeCrunch = scenarios.filter((s) => s.modifiers.includes('time-crunch'))
+    expect(timeCrunch.length).toBeGreaterThan(0)
+    for (const s of timeCrunch) {
+      expect(s.payload.ephemeral_context.time_budget_minutes).toBe(15)
+      expect(
+        s.expectations.some(
+          (e) => e.kind === 'hard' && e.rule?.type === 'max_exercise_count',
+        ),
+      ).toBe(true)
+    }
+  })
+})
+
+function makeResponse(ids: string[][]): SuggestionResponse {
+  const optionIds = ['user_preference', 'data_driven', 'wild_card'] as const
+  return {
+    options: ids.map((exerciseIds, i) => ({
+      id: optionIds[i],
+      name: `Option ${i}`,
+      description: 'desc',
+      summary: 'summary',
+      exercises: exerciseIds.map((id) => ({ id, rationale: 'because' })),
+    })),
+    warnings: [],
+  }
+}
+
+describe('hard checks', () => {
+  it('flags hallucinated ids, duplicates, and time-budget violations', () => {
+    const [scenario] = generateScenarios({ count: 1, seed: 'gates' })
+    scenario.payload.ephemeral_context.time_budget_minutes = 45
+    const someIds = scenario.payload.candidate_exercises.slice(0, 6).map((c) => c.id)
+    const response = makeResponse([
+      [someIds[0], someIds[0], 'not-a-real-exercise'],
+      someIds.slice(0, 5),
+      [someIds[5]],
+    ])
+    const checks = runHardChecks(scenario, response)
+    const byName = (name: string, optionId?: string) =>
+      checks.filter((c) => c.name === name && (!optionId || c.optionId === optionId))
+
+    expect(byName('ids_in_candidate_list', 'user_preference')[0].passed).toBe(false)
+    expect(byName('no_duplicate_exercises', 'user_preference')[0].passed).toBe(false)
+    expect(byName('ids_in_candidate_list', 'data_driven')[0].passed).toBe(true)
+    // 1 exercise for 45min is below floor(45/12)=3
+    expect(byName('count_fits_time_budget', 'wild_card')[0].passed).toBe(false)
+  })
+
+  it('enforces scenario exclude_heavy_fau rules', () => {
+    const scenarios = generateScenarios({ count: 55, seed: 'injury' })
+    const injured = scenarios.find(
+      (s) =>
+        s.modifiers.includes('injury-recovery') &&
+        s.expectations.some((e) => e.rule?.type === 'exclude_heavy_fau'),
+    )
+    expect(injured).toBeDefined()
+    if (!injured) return
+    const rule = injured.expectations.find((e) => e.rule?.type === 'exclude_heavy_fau')!
+      .rule as { type: 'exclude_heavy_fau'; fau: string }
+    const violating = injured.payload.candidate_exercises.find(
+      (c) => c.intensity_class === 'heavy' && c.primary_faus.includes(rule.fau as never),
+    )
+    // The banned-list removes obvious offenders, so a violating candidate
+    // may not exist; when it does, the gate must catch it.
+    if (!violating) return
+    const safeIds = injured.payload.candidate_exercises
+      .filter((c) => c.id !== violating.id)
+      .slice(0, 4)
+      .map((c) => c.id)
+    const checks = runHardChecks(
+      injured,
+      makeResponse([[violating.id, ...safeIds.slice(0, 2)], safeIds.slice(0, 3), safeIds.slice(1, 4)]),
+    )
+    const gate = checks.find(
+      (c) => c.name === 'scenario_exclude_heavy_fau' && c.optionId === 'user_preference',
+    )
+    expect(gate?.passed).toBe(false)
+  })
+
+  it('allowedExerciseCountRange is sane across budgets', () => {
+    expect(allowedExerciseCountRange(15)).toEqual({ min: 1, max: 3 })
+    expect(allowedExerciseCountRange(45)).toEqual({ min: 3, max: 8 })
+    expect(allowedExerciseCountRange(90).max).toBeGreaterThanOrEqual(10)
+  })
+})
+
+describe('rubric + aggregation', () => {
+  it('weights sum to 1 and composite renormalizes on partial scores', () => {
+    const total = RUBRIC_DIMENSIONS.reduce((a, d) => a + d.weight, 0)
+    expect(total).toBeCloseTo(1)
+    expect(compositeScore({ state_grounding: 4 })).toBe(4)
+    expect(compositeScore({})).toBeNull()
+    const all4 = Object.fromEntries(RUBRIC_DIMENSIONS.map((d) => [d.key, 4]))
+    expect(compositeScore(all4)).toBe(4)
+  })
+
+  it('aggregates judge runs via median and reports spread', () => {
+    const run = (score: number): JudgeResult => ({
+      per_option: (['user_preference', 'data_driven', 'wild_card'] as const).map(
+        (id) => ({
+          option_id: id,
+          dimension_scores: RUBRIC_DIMENSIONS.filter((d) => !d.crossOption).map(
+            (d) => ({ dimension: d.key, evidence: 'e', score }),
+          ),
+          note: '',
+        }),
+      ),
+      option_identity: { dimension: 'option_identity', evidence: 'e', score },
+      overall_note: '',
+    })
+    const agg = aggregateJudgeRuns([run(2), run(4), run(4)])
+    expect(agg.composite).toBe(4)
+    expect(agg.compositeSpread).toBeGreaterThan(0)
+    expect(agg.dimensionMedians.state_grounding).toBe(4)
+  })
+})
+
+describe('prompt registry + diffs', () => {
+  it('builds a planner prompt containing payload and all sections', () => {
+    const [scenario] = generateScenarios({ count: 1, seed: 'prompt' })
+    const { system, user } = buildPlannerPrompt(
+      PLANNER_PROMPT_VARIANTS.v1,
+      scenario.payload,
+    )
+    for (const section of PLANNER_PROMPT_VARIANTS.v1.sections) {
+      expect(system).toContain(`## ${section.name}`)
+    }
+    expect(user).toContain('"candidate_exercises"')
+  })
+
+  it('applyDiff replaces or appends exactly one section with lineage', () => {
+    const base = PLANNER_PROMPT_VARIANTS.v1
+    const applied = applyDiff(
+      base,
+      {
+        id: 'test-diff',
+        target_section: 'safety',
+        operation: 'append',
+        proposed_content: 'ADDED SENTENCE.',
+        motivation: 'm',
+        addresses: 'safety_recovery',
+        risk: 'r',
+      },
+      'v1+test-diff',
+    )
+    expect(applied.base).toBe('v1')
+    const safety = applied.sections.find((s) => s.name === 'safety')!
+    expect(safety.content.endsWith('ADDED SENTENCE.')).toBe(true)
+    const others = applied.sections.filter((s) => s.name !== 'safety')
+    for (const s of others) {
+      expect(s.content).toBe(base.sections.find((b) => b.name === s.name)!.content)
+    }
+  })
+
+  it('planner output schema accepts the locked shape and rejects wrong counts', () => {
+    const good = makeResponse([
+      [EXERCISE_CATALOG[0].id],
+      [EXERCISE_CATALOG[1].id],
+      [EXERCISE_CATALOG[2].id],
+    ])
+    expect(suggestionResponseSchema.safeParse(good).success).toBe(true)
+    const bad = { ...good, options: good.options.slice(0, 2) }
+    expect(suggestionResponseSchema.safeParse(bad).success).toBe(false)
+  })
+})

--- a/docs/EVAL_LOOP_DESIGN.md
+++ b/docs/EVAL_LOOP_DESIGN.md
@@ -1,0 +1,296 @@
+# Suggest Workout Eval Loop
+
+Prompt-refinement loop for the Suggest Workout planner: synthetic scenarios, an
+LLM planner run, deterministic gates, an LLM judge, human spot-ratings, and a
+refinement engine that turns failures into small prompt diffs. Built so prompt
+quality issues surface before they show up in real training, since a handful of
+real Suggest runs per week is nowhere near enough signal to iterate against.
+
+## Quick start
+
+```bash
+# Score the current prompt against 20 reproducible scenarios
+doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1 --seed eval-v1
+
+# Rate a sample by hand (no LLM calls, no doppler needed)
+npm run rate-suggestions -- --n 8
+
+# Cluster failures and get prompt-diff proposals + ready-to-run variants
+doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1 --seed eval-v1 --refine
+
+# Re-run a proposed variant against the SAME seed and compare paired scores
+doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1+<diff-id> --seed eval-v1 --compare <base-run-id>
+```
+
+Env: the planner uses `LLM_PROVIDER_URL` / `LLM_API_KEY` / `LLM_MODEL`
+(existing client wrapper). The judge defaults to the same model; override with
+`LLM_JUDGE_MODEL` (and optionally `LLM_JUDGE_PROVIDER_URL` / `LLM_JUDGE_API_KEY`)
+or `--judge-model`.
+
+## Architecture
+
+```
+scenario-generator ──► planner (LLM, temp 0) ──► hard-checks (code) ──► judge (LLM)
+        │                                                                  │
+        │                                    .eval/runs/<runId>/ ◄─────────┤
+        │                                                                  │
+        └── same seed = same scenarios       report.md / report.json ◄─────┘
+                                                       │
+                     rate-suggestions (human) ◄────────┤
+                     calibration.json ◄── human vs judge agreement
+                                                       │
+                     refinement-engine ── clusters failures (code),
+                                          proposes section diffs (LLM),
+                                          writes .eval/variants/*.json
+```
+
+Key components:
+
+- `lib/eval/scenario-generator.ts` - stratified archetype × modifier matrix,
+  seeded jitter, full #877 payloads synthesized in memory
+- `lib/eval/hard-checks.ts` - deterministic gates (IDs, dupes, bans,
+  count-vs-time, scenario hard rules)
+- `lib/eval/rating-rubric.ts` - anchored 4-point dimensions + weights, shared
+  by judge and human CLI
+- `lib/eval/judge.ts` - evidence-first LLM judge, K-run stability, median
+  aggregation
+- `lib/eval/refinement-engine.ts` - code-side failure clustering, LLM diff
+  proposals, variant materialization
+- `lib/suggest/prompts/registry.ts` - versioned planner prompt as named
+  sections; `lib/suggest/schema.ts` - the locked output schema. Both are app
+  code: #880 imports the same prompt and schema the eval loop scores.
+- `scripts/eval-suggest.ts` / `scripts/rate-suggestions.ts` - the two CLIs
+- State lives in `.eval/` (gitignored): runs, ratings.jsonl, calibration.json,
+  experimental variants, proposals
+
+Two decisions worth calling out:
+
+**Payloads are synthesized in memory, not seeded through the DB.** The
+training-state builder (#876) and seeder (#886) do not exist yet, and even when
+they do, going DB → aggregates → payload for every eval scenario would be slow
+and would couple prompt iteration to schema state. The generator produces
+payloads directly against the locked #877 contract. When #886 lands, its golden
+files pin the builder to the same contract from the other side; if the contract
+drifts, the golden tests fail, and `lib/eval/types.ts` must be updated in the
+same PR.
+
+**Gates and judged scores never blend.** Anything code can verify
+(hallucinated exercise IDs, duplicates, banned exercises, exercise count vs
+time budget, scenario hard rules) is a deterministic gate, reported as a pass
+rate next to the judged composite. A prompt change that raises the composite
+while doubling gate failures is a regression; a blended score would hide it.
+
+## Rubric design
+
+Six dimensions, weights encoding product priorities:
+
+| dimension | weight | why it exists |
+|---|---|---|
+| `state_grounding` | 0.25 | The entire premise of the milestone is that state summaries make a cheap model coach-like. If picks don't track deficits/recency, the feature is a template generator. |
+| `constraint_respect` | 0.20 | Ephemeral free text is the user talking to the feature. Misreading "keep legs fresh" once destroys trust faster than any other failure. |
+| `safety_recovery` | 0.20 | Injuries, deloads, layoffs. Worst-case harm lives here. |
+| `option_identity` | 0.15 | The three-option UX only works if the options are genuinely distinct; scored once across options. |
+| `rationale_quality` | 0.10 | Rationales are the trust surface, but a good workout with mediocre prose beats the reverse. |
+| `session_coherence` | 0.10 | Ordering/structure. Real, but users can reorder; least costly failure. |
+
+Scale design choices, made for judge stability rather than expressiveness:
+
+- **4 points, not 10.** Cheap judges are noisy on wide scales; forced choice
+  between four concretely described levels is much more repeatable.
+- **No middle point.** The judge must commit to "acceptable" (3) vs "flawed"
+  (2). Score-2-vs-3 is exactly the boundary you iterate prompts on.
+- **Anchors describe observable behavior**, not adjectives. "Cites numbers not
+  in the payload" is checkable; "poor quality" is vibes.
+- **Tie-break rule is in the judge prompt**: when torn, pick the lower level.
+  Cheap models otherwise drift optimistic.
+
+### Adding a dimension when you notice a quality gap
+
+1. Add the dimension to `RUBRIC_DIMENSIONS` in `lib/eval/rating-rubric.ts`
+   with a unique `flagKey`, four behavior-anchored levels, and a weight;
+   rebalance the other weights so they sum to 1.
+2. Bump `RUBRIC_VERSION`. Calibration entries record the rubric version, so
+   old human/judge agreement stats do not silently carry over.
+3. Nothing else changes: the judge prompt, human CLI flags, composite, and
+   report all render from the rubric structure.
+4. First run after the change: use `--judge-runs 3` and check the stability
+   spread; a new dimension with mushy anchors shows up immediately as spread.
+5. Ask first whether it should be a gate instead. If code can check it
+   (for example "no two exercises with identical primary FAU and movement
+   pattern in one option"), put it in `hard-checks.ts` and skip the rubric.
+
+## The five hard parts
+
+### 1. Judge robustness
+
+Mechanisms, in order of impact:
+
+- **Evidence before score.** The judge must quote payload/response facts per
+  dimension before emitting the number. This is the single biggest variance
+  reducer for cheap models; scoring first and rationalizing after is where they
+  drift.
+- **Anchored 4-point forced choice** (above).
+- **Digest, not raw payload.** The judge sees a compact rendering: per-FAU
+  table, calibrations, expectations, the chosen exercises with their catalog
+  metadata, plus which candidates were available for each neglected FAU. It
+  does not see the 80-150 raw candidate list, which is where a small judge
+  gets lost.
+- **Scenario expectations injected.** Each scenario carries "things a good
+  suggestion must do here" written at generation time. The judge scores
+  against scenario intent, with a hard cap (violated expectation → dimension
+  ≤ 2), instead of its own taste.
+- **Gate results injected.** The judge is told which deterministic checks
+  already failed so it doesn't spend evidence re-detecting them.
+- **K-run stability.** `--judge-runs 3` runs once at temp 0 and twice at 0.4,
+  aggregates by median, and reports the composite spread. Spread > ~0.3 means
+  the rubric (not the prompt) needs work. Use K=3 for release decisions, K=1
+  for cheap inner-loop iteration.
+
+### 2. Synthetic scenario diversity
+
+Diversity is structural, not sampled. Scenarios come from the product of 5
+base archetypes (matching #886: cyclist, bodybuilder, powerlifter, beginner,
+inconsistent) × 10 edge-case modifiers (injury-recovery, deload, sparse-data,
+competing-goals, activity-overlap, time-crunch, equipment-limited,
+return-from-break, all-satisfied, ambiguous-freetext). The matrix is ordered
+so all archetypes appear in the first 5 scenarios and every modifier appears
+as early as possible; 55 combos before repetition. Seeded RNG only adds
+jitter (weights, deficits, ephemeral context) on top of the structure, so no
+amount of bad luck produces 20 samey scenarios. `--dry-run` prints the
+coverage table without spending tokens.
+
+A deliberate non-goal: LLM-generated scenarios. Free generation regresses to
+median gym-goers, and you cannot attach machine-checkable expectations to a
+scenario you didn't construct. New edge cases are added as modifiers (a
+~20-line function plus expectations), which keeps them reproducible forever.
+
+### 3. Rating-to-diff translation
+
+Three design moves make ratings actionable:
+
+- **Failures cluster in code, not in the LLM.** Grouping by failed gate name
+  and by low-median dimension is counting; the refinement LLM only sees the
+  top 3 clusters with exemplar evidence (judge quotes, gate details).
+- **The prompt is named sections** (`role`, `option_identities`,
+  `selection_principles`, `time_budget`, `safety`, `rationale_style`,
+  `output_format`). A diff is "replace or append to exactly one section",
+  which forces small, targeted changes and makes review trivial.
+- **Diffs materialize as runnable variants.** Each accepted diff is applied
+  and written to `.eval/variants/<base>+<diff-id>.json` with lineage. The next
+  command is mechanical: re-run the same seed with `--prompt v1+<diff-id>
+  --compare <base-run>`, read the paired improved/regressed counts. Winners
+  get promoted into `registry.ts` by hand, in a commit, with the eval run id
+  in the commit message.
+
+Each diff must also state its `risk` (what it could make worse). Check that
+dimension in the comparison; single-metric chasing is how prompts rot.
+
+### 4. Overfitting to synthetic data
+
+Detection and prevention, cheapest first:
+
+- **Generality constraint on diffs, enforced.** The refinement engine rejects
+  diffs referencing scenario ids and flags archetype-name mentions. Diffs must
+  state general principles ("when the user reports soreness in a muscle group,
+  exclude heavy work for it"), never test-set facts ("avoid squats for
+  cyclists").
+- **Seed splits.** Iterate on `--seed eval-v1`; before promoting a variant to
+  the registry, run it once on a seed you have never refined against
+  (`--seed holdout-1`). Same structure, different jitter. Train score up while
+  holdout is flat or down = you tuned to jitter, revert.
+- **Modifier breakdown in every report.** Overfitting to synthetic shows up
+  as one modifier's score soaring while `(plain)` scenarios stagnate.
+- **Real payloads become the canary set.** Once real Suggest runs exist,
+  their `Suggestion` rows contain real payloads. Snapshot a handful into a
+  frozen canary run and score every candidate variant against it; the eval
+  scenarios validate breadth, the canaries validate reality. Until then the
+  #886 golden-file payloads serve the same role.
+- **Human ratings are the backstop.** You rate real outputs against real
+  taste; a prompt drifting toward "scores well on synthetic quirks" shows up
+  as human/judge divergence in calibration before it shows up in the gym.
+
+### 5. Human-machine calibration
+
+The human CLI rates on the same 1-4 anchored scale, and optionally flags
+problem dimensions with single letters. After every rating session the
+calibration recomputes over all ratings to date and appends to
+`.eval/calibration.json`:
+
+- **Spearman rank correlation** between human overall and the judge's
+  per-option composite. Rank correlation, because you care whether the judge
+  orders suggestions the way you do, not whether it matches your absolute
+  numbers.
+- **Mean absolute difference** on the shared scale (systematic
+  leniency/harshness; informative, not decisive).
+- **Flag agreement**: when you flag a dimension, how often it is among the
+  judge's two lowest for that option. This validates per-dimension diagnosis,
+  which is what the refinement engine consumes.
+
+Trust policy:
+
+| Spearman | policy |
+|---|---|
+| ≥ 0.6 | Trust judge for inner-loop iteration; humans spot-check 5-8 per session |
+| 0.4-0.6 | Judge is directional; require human confirmation on any promote/revert decision |
+| < 0.4 | Stop iterating on judge scores. Fix the rubric anchors or judge model first, using disagreement cases as the test set |
+
+Recalibrate (a normal rating session does this automatically) whenever the
+judge model changes, the rubric version bumps, or roughly every 4th eval
+session otherwise. The `mix` picker sends you half judge-suspected-bad and
+half random items, so calibration covers both tails without you choosing.
+Anti-anchoring: the CLI reveals the judge's score only after you rate, and
+prints a marker when you disagree by ≥ 1 point; those items are the highest
+value things to leave a note on.
+
+## Failure modes of the loop itself
+
+- **Judge drift / self-preference.** If planner and judge are the same model,
+  the judge can prefer its own idiom. Mitigation: `LLM_JUDGE_MODEL` exists
+  precisely so the judge can be a different (ideally different-family) model;
+  calibration catches residual bias.
+- **Reward hacking the rubric.** The planner learns (via your diffs) to name
+  payload numbers in rationales without the picks actually following them,
+  inflating `rationale_quality` and `state_grounding`. The evidence-first
+  judge is instructed to check picks, not prose, but the durable defense is
+  human ratings on the `worst`/`mix` picker.
+- **Human fatigue.** 8 options ≈ 5-10 minutes. Past that, ratings regress to
+  3s and calibration data gets worse, not better. The CLI defaults to 8 and
+  skips already-rated items; resist raising it. Better ten honest ratings a
+  week than fifty tired ones.
+- **Seed lock-in.** Always comparing on `eval-v1` slowly specializes the
+  prompt to those 20 payloads even with general diffs. Rotate a fresh seed in
+  every few sessions; keep one holdout seed permanently unrefined-against.
+- **Nondeterminism at temp 0.** Providers do not guarantee bit-identical
+  completions at temperature 0. Scenarios are exactly reproducible; planner
+  responses are approximately so. This is why comparisons use paired
+  per-scenario deltas with a ±0.1 dead zone and improved/regressed counts
+  rather than raw mean deltas.
+- **Stale contract.** If #877's payload shape changes without updating
+  `lib/eval/types.ts` and the generator, the loop keeps scoring a payload the
+  product no longer sends. The shared-schema imports (#880 planner using
+  `lib/suggest/schema.ts` + registry) and #886 golden files are the tripwires.
+
+## Cadence
+
+- **Inner loop (an evening):** `eval-suggest --scenarios 20` with K=1 judge →
+  read report → `--refine` → re-run best variant with `--compare` → maybe
+  promote. Roughly 20 planner + 20-40 judge calls per pass; at
+  Haiku/Llama-8B-tier pricing this is cents, not dollars.
+- **Rating session (~10 min, 1-2× per week):** `rate-suggestions --n 8` on the
+  latest run. Keeps calibration alive and catches judge blind spots.
+- **Release decision (before promoting to `CURRENT_PLANNER_VERSION`):**
+  20 scenarios on the training seed with `--judge-runs 3`, plus one holdout
+  seed run, plus canary/golden payloads once they exist. Human-rate the
+  candidate's 5 worst options before promoting.
+- **When real data arrives:** add real-payload canaries, and start comparing
+  the judge against implicit signals (swap rate on suggested exercises,
+  selected option distribution in `Suggestion.selectedOptionId`). If judge
+  scores and real swap behavior disagree, believe the swaps.
+
+## What "done tonight" looks like
+
+1. `doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1 --seed eval-v1`
+2. Read `report.md`: say `constraint_respect` means 2.3 and `ambiguous-freetext` scenarios sit at the bottom.
+3. Re-run with `--refine`: get 1-3 section diffs, e.g. an append to `selection_principles` about slang interpretation, saved as `v1+freetext-slang`.
+4. `... --prompt v1+freetext-slang --seed eval-v1 --compare <run-1-id>`
+5. Read the paired comparison: improved/regressed counts, dimension deltas, gate delta. Promote to `registry.ts` or discard.

--- a/lib/eval/exercise-catalog.ts
+++ b/lib/eval/exercise-catalog.ts
@@ -1,0 +1,152 @@
+/**
+ * Static exercise catalog for eval scenarios.
+ *
+ * The eval loop must run without a database, so candidate lists are
+ * drawn from this fixed catalog instead of ExerciseDefinition rows.
+ * IDs are stable slugs — human ratings and judge evidence reference
+ * them across runs. FAU keys follow the repo canon (lib/fau-volume
+ * ALL_FAUS, kebab-case); movement patterns and intensity classes
+ * follow lib/exercises/auto-tag.
+ *
+ * This is deliberately a curated ~70-exercise subset, not the full
+ * 873-exercise library: big enough that the planner has real choices
+ * per FAU, small enough to audit by eye.
+ */
+
+import type { CandidateExercise } from './types'
+
+export const EQUIPMENT_KEYS = [
+  'barbell',
+  'dumbbells',
+  'cable',
+  'machines',
+  'bands',
+  'bodyweight',
+  'kettlebell',
+] as const
+
+export type EquipmentKey = (typeof EQUIPMENT_KEYS)[number]
+
+type CatalogEntry = Omit<
+  CandidateExercise,
+  'user_preference_score' | 'user_preference_confidence'
+>
+
+function ex(
+  id: string,
+  name: string,
+  primary: CandidateExercise['primary_faus'],
+  secondary: CandidateExercise['secondary_faus'],
+  equipment: EquipmentKey,
+  movement: CandidateExercise['movement_pattern'],
+  intensity: CandidateExercise['intensity_class'],
+): CatalogEntry {
+  return {
+    id,
+    name,
+    primary_faus: primary,
+    secondary_faus: secondary,
+    equipment,
+    movement_pattern: movement,
+    intensity_class: intensity,
+  }
+}
+
+export const EXERCISE_CATALOG: readonly CatalogEntry[] = [
+  // Chest / horizontal push
+  ex('barbell-bench-press', 'Barbell Bench Press', ['chest'], ['front-delts', 'triceps'], 'barbell', 'horizontal_push', 'heavy'),
+  ex('dumbbell-bench-press', 'Dumbbell Bench Press', ['chest'], ['front-delts', 'triceps'], 'dumbbells', 'horizontal_push', 'heavy'),
+  ex('incline-dumbbell-press', 'Incline Dumbbell Press', ['chest', 'front-delts'], ['triceps'], 'dumbbells', 'horizontal_push', 'moderate'),
+  ex('machine-chest-press', 'Machine Chest Press', ['chest'], ['triceps'], 'machines', 'horizontal_push', 'moderate'),
+  ex('cable-fly', 'Cable Fly', ['chest'], [], 'cable', 'isolation', 'light'),
+  ex('pec-deck', 'Pec Deck', ['chest'], [], 'machines', 'isolation', 'light'),
+  ex('push-up', 'Push-Up', ['chest'], ['front-delts', 'triceps'], 'bodyweight', 'horizontal_push', 'light'),
+  ex('dip', 'Dip', ['chest', 'triceps'], ['front-delts'], 'bodyweight', 'vertical_push', 'moderate'),
+
+  // Back / pulls
+  ex('deadlift', 'Deadlift', ['lower-back', 'glutes', 'hamstrings'], ['traps', 'lats', 'forearms'], 'barbell', 'hinge', 'heavy'),
+  ex('barbell-row', 'Barbell Row', ['mid-back', 'lats'], ['biceps', 'lower-back'], 'barbell', 'horizontal_pull', 'heavy'),
+  ex('dumbbell-row', 'One-Arm Dumbbell Row', ['mid-back', 'lats'], ['biceps'], 'dumbbells', 'horizontal_pull', 'moderate'),
+  ex('seated-cable-row', 'Seated Cable Row', ['mid-back'], ['lats', 'biceps'], 'cable', 'horizontal_pull', 'moderate'),
+  ex('chest-supported-row', 'Chest Supported Row', ['mid-back'], ['lats', 'rear-delts'], 'machines', 'horizontal_pull', 'moderate'),
+  ex('pull-up', 'Pull-Up', ['lats'], ['biceps', 'mid-back'], 'bodyweight', 'vertical_pull', 'moderate'),
+  ex('lat-pulldown', 'Lat Pulldown', ['lats'], ['biceps'], 'cable', 'vertical_pull', 'moderate'),
+  ex('band-pull-apart', 'Band Pull-Apart', ['rear-delts'], ['mid-back'], 'bands', 'isolation', 'light'),
+  ex('straight-arm-pulldown', 'Straight-Arm Pulldown', ['lats'], [], 'cable', 'isolation', 'light'),
+  ex('back-extension', 'Back Extension', ['lower-back'], ['glutes', 'hamstrings'], 'bodyweight', 'hinge', 'light'),
+
+  // Shoulders / vertical push
+  ex('overhead-press', 'Barbell Overhead Press', ['front-delts'], ['triceps', 'side-delts'], 'barbell', 'vertical_push', 'heavy'),
+  ex('seated-dumbbell-press', 'Seated Dumbbell Shoulder Press', ['front-delts', 'side-delts'], ['triceps'], 'dumbbells', 'vertical_push', 'moderate'),
+  ex('machine-shoulder-press', 'Machine Shoulder Press', ['front-delts'], ['triceps'], 'machines', 'vertical_push', 'moderate'),
+  ex('lateral-raise', 'Dumbbell Lateral Raise', ['side-delts'], [], 'dumbbells', 'isolation', 'light'),
+  ex('cable-lateral-raise', 'Cable Lateral Raise', ['side-delts'], [], 'cable', 'isolation', 'light'),
+  ex('rear-delt-fly', 'Rear Delt Fly', ['rear-delts'], ['mid-back'], 'dumbbells', 'isolation', 'light'),
+  ex('face-pull', 'Face Pull', ['rear-delts'], ['traps'], 'cable', 'isolation', 'light'),
+  ex('dumbbell-shrug', 'Dumbbell Shrug', ['traps'], ['forearms'], 'dumbbells', 'isolation', 'light'),
+
+  // Arms
+  ex('barbell-curl', 'Barbell Curl', ['biceps'], ['forearms'], 'barbell', 'isolation', 'light'),
+  ex('dumbbell-curl', 'Dumbbell Curl', ['biceps'], ['forearms'], 'dumbbells', 'isolation', 'light'),
+  ex('hammer-curl', 'Hammer Curl', ['biceps', 'forearms'], [], 'dumbbells', 'isolation', 'light'),
+  ex('cable-curl', 'Cable Curl', ['biceps'], [], 'cable', 'isolation', 'light'),
+  ex('skull-crusher', 'Skull Crusher', ['triceps'], [], 'barbell', 'isolation', 'light'),
+  ex('cable-pushdown', 'Cable Triceps Pushdown', ['triceps'], [], 'cable', 'isolation', 'light'),
+  ex('overhead-triceps-extension', 'Overhead Dumbbell Triceps Extension', ['triceps'], [], 'dumbbells', 'isolation', 'light'),
+  ex('close-grip-bench-press', 'Close-Grip Bench Press', ['triceps', 'chest'], ['front-delts'], 'barbell', 'horizontal_push', 'moderate'),
+  ex('wrist-curl', 'Wrist Curl', ['forearms'], [], 'dumbbells', 'isolation', 'light'),
+
+  // Quads / squat + lunge
+  ex('barbell-back-squat', 'Barbell Back Squat', ['quads', 'glutes'], ['hamstrings', 'lower-back'], 'barbell', 'squat', 'heavy'),
+  ex('front-squat', 'Front Squat', ['quads'], ['glutes', 'abs'], 'barbell', 'squat', 'heavy'),
+  ex('goblet-squat', 'Goblet Squat', ['quads', 'glutes'], ['abs'], 'dumbbells', 'squat', 'moderate'),
+  ex('leg-press', 'Leg Press', ['quads', 'glutes'], ['hamstrings'], 'machines', 'squat', 'moderate'),
+  ex('hack-squat', 'Hack Squat', ['quads'], ['glutes'], 'machines', 'squat', 'heavy'),
+  ex('leg-extension', 'Leg Extension', ['quads'], [], 'machines', 'isolation', 'light'),
+  ex('walking-lunge', 'Walking Lunge', ['quads', 'glutes'], ['hamstrings'], 'dumbbells', 'lunge', 'moderate'),
+  ex('bulgarian-split-squat', 'Bulgarian Split Squat', ['quads', 'glutes'], ['hamstrings'], 'dumbbells', 'lunge', 'moderate'),
+  ex('step-up', 'Dumbbell Step-Up', ['quads', 'glutes'], [], 'dumbbells', 'lunge', 'moderate'),
+  ex('bodyweight-squat', 'Bodyweight Squat', ['quads', 'glutes'], [], 'bodyweight', 'squat', 'light'),
+
+  // Hamstrings / glutes / hinge
+  ex('romanian-deadlift', 'Romanian Deadlift', ['hamstrings', 'glutes'], ['lower-back'], 'barbell', 'hinge', 'heavy'),
+  ex('dumbbell-rdl', 'Dumbbell Romanian Deadlift', ['hamstrings', 'glutes'], ['lower-back'], 'dumbbells', 'hinge', 'moderate'),
+  ex('lying-leg-curl', 'Lying Leg Curl', ['hamstrings'], [], 'machines', 'isolation', 'light'),
+  ex('seated-leg-curl', 'Seated Leg Curl', ['hamstrings'], [], 'machines', 'isolation', 'light'),
+  ex('hip-thrust', 'Barbell Hip Thrust', ['glutes'], ['hamstrings'], 'barbell', 'hinge', 'moderate'),
+  ex('glute-bridge', 'Glute Bridge', ['glutes'], ['hamstrings'], 'bodyweight', 'hinge', 'light'),
+  ex('cable-pull-through', 'Cable Pull-Through', ['glutes', 'hamstrings'], [], 'cable', 'hinge', 'light'),
+  ex('kettlebell-swing', 'Kettlebell Swing', ['glutes', 'hamstrings'], ['lower-back'], 'kettlebell', 'hinge', 'moderate'),
+  ex('good-morning', 'Good Morning', ['hamstrings', 'lower-back'], ['glutes'], 'barbell', 'hinge', 'heavy'),
+
+  // Adductors / calves
+  ex('adductor-machine', 'Hip Adduction Machine', ['adductors'], [], 'machines', 'isolation', 'light'),
+  ex('standing-calf-raise', 'Standing Calf Raise', ['calves'], [], 'machines', 'isolation', 'light'),
+  ex('seated-calf-raise', 'Seated Calf Raise', ['calves'], [], 'machines', 'isolation', 'light'),
+  ex('single-leg-calf-raise', 'Single-Leg Calf Raise', ['calves'], [], 'bodyweight', 'isolation', 'light'),
+
+  // Core
+  ex('plank', 'Plank', ['abs'], ['obliques'], 'bodyweight', 'accessory', 'light'),
+  ex('hanging-leg-raise', 'Hanging Leg Raise', ['abs'], ['obliques'], 'bodyweight', 'accessory', 'light'),
+  ex('cable-crunch', 'Cable Crunch', ['abs'], [], 'cable', 'isolation', 'light'),
+  ex('ab-wheel-rollout', 'Ab Wheel Rollout', ['abs'], ['obliques'], 'bodyweight', 'accessory', 'moderate'),
+  ex('pallof-press', 'Pallof Press', ['obliques', 'abs'], [], 'cable', 'accessory', 'light'),
+  ex('russian-twist', 'Russian Twist', ['obliques'], ['abs'], 'bodyweight', 'accessory', 'light'),
+  ex('side-plank', 'Side Plank', ['obliques'], ['abs'], 'bodyweight', 'accessory', 'light'),
+
+  // Carries / kettlebell
+  ex('farmers-carry', "Farmer's Carry", ['forearms', 'traps'], ['abs'], 'dumbbells', 'carry', 'moderate'),
+  ex('suitcase-carry', 'Suitcase Carry', ['obliques', 'forearms'], ['traps'], 'kettlebell', 'carry', 'moderate'),
+  ex('kettlebell-goblet-squat', 'Kettlebell Goblet Squat', ['quads', 'glutes'], ['abs'], 'kettlebell', 'squat', 'moderate'),
+  ex('kettlebell-press', 'Kettlebell Overhead Press', ['front-delts'], ['triceps', 'abs'], 'kettlebell', 'vertical_push', 'moderate'),
+]
+
+const byId = new Map(EXERCISE_CATALOG.map((e) => [e.id, e]))
+
+export function getCatalogExercise(id: string): CatalogEntry | undefined {
+  return byId.get(id)
+}
+
+export function exerciseName(id: string): string {
+  return byId.get(id)?.name ?? id
+}

--- a/lib/eval/hard-checks.ts
+++ b/lib/eval/hard-checks.ts
@@ -1,0 +1,156 @@
+/**
+ * Deterministic gates on planner output. Anything a program can verify
+ * is checked here, never delegated to the LLM judge: the judge scores
+ * judgment calls, gates catch violations. Gate failures are reported
+ * separately from judged scores and are never blended into the
+ * composite — blending hides regressions.
+ */
+
+import type {
+  EvalScenario,
+  HardCheckResult,
+  SuggestionOption,
+  SuggestionResponse,
+} from './types'
+
+/** Nominal minutes per exercise; bounds are generous on both sides. */
+export const MINUTES_PER_EXERCISE = 8
+
+export function allowedExerciseCountRange(timeBudgetMinutes: number): {
+  min: number
+  max: number
+} {
+  return {
+    min: Math.max(1, Math.floor(timeBudgetMinutes / 12)),
+    max: Math.max(2, Math.ceil(timeBudgetMinutes / 6)),
+  }
+}
+
+export function runHardChecks(
+  scenario: EvalScenario,
+  response: SuggestionResponse,
+): HardCheckResult[] {
+  const results: HardCheckResult[] = []
+  const candidateIds = new Set(scenario.payload.candidate_exercises.map((c) => c.id))
+  const candidateById = new Map(
+    scenario.payload.candidate_exercises.map((c) => [c.id, c]),
+  )
+  const bannedIds = new Set(scenario.payload.durable_profile.banned_exercise_ids)
+
+  // Exactly one of each option id, in any order (schema enforces 3 total)
+  const seenOptionIds = response.options.map((o) => o.id)
+  const uniqueOptionIds = new Set(seenOptionIds)
+  results.push({
+    name: 'option_ids_complete',
+    passed:
+      uniqueOptionIds.size === 3 &&
+      uniqueOptionIds.has('user_preference') &&
+      uniqueOptionIds.has('data_driven') &&
+      uniqueOptionIds.has('wild_card'),
+    detail:
+      uniqueOptionIds.size === 3 ? null : `got option ids: ${seenOptionIds.join(', ')}`,
+  })
+
+  for (const option of response.options) {
+    results.push(...checkOption(scenario, option, candidateIds, candidateById, bannedIds))
+  }
+
+  return results
+}
+
+function checkOption(
+  scenario: EvalScenario,
+  option: SuggestionOption,
+  candidateIds: Set<string>,
+  candidateById: Map<string, EvalScenario['payload']['candidate_exercises'][number]>,
+  bannedIds: Set<string>,
+): HardCheckResult[] {
+  const results: HardCheckResult[] = []
+  const ids = option.exercises.map((e) => e.id)
+
+  const unknown = ids.filter((id) => !candidateIds.has(id))
+  results.push({
+    name: 'ids_in_candidate_list',
+    optionId: option.id,
+    passed: unknown.length === 0,
+    detail: unknown.length > 0 ? `hallucinated ids: ${unknown.join(', ')}` : null,
+  })
+
+  const dupes = ids.filter((id, i) => ids.indexOf(id) !== i)
+  results.push({
+    name: 'no_duplicate_exercises',
+    optionId: option.id,
+    passed: dupes.length === 0,
+    detail: dupes.length > 0 ? `duplicated: ${[...new Set(dupes)].join(', ')}` : null,
+  })
+
+  const banned = ids.filter((id) => bannedIds.has(id))
+  results.push({
+    name: 'no_banned_exercises',
+    optionId: option.id,
+    passed: banned.length === 0,
+    detail: banned.length > 0 ? `banned ids present: ${banned.join(', ')}` : null,
+  })
+
+  const budget = scenario.payload.ephemeral_context.time_budget_minutes
+  const range = allowedExerciseCountRange(budget)
+  const count = option.exercises.length
+  results.push({
+    name: 'count_fits_time_budget',
+    optionId: option.id,
+    passed: count >= range.min && count <= range.max,
+    detail:
+      count >= range.min && count <= range.max
+        ? null
+        : `${count} exercises for ${budget}min (allowed ${range.min}-${range.max})`,
+  })
+
+  // Scenario-specific hard rules
+  for (const expectation of scenario.expectations) {
+    if (expectation.kind !== 'hard' || !expectation.rule) continue
+    const rule = expectation.rule
+
+    if (rule.type === 'exclude_exercises') {
+      const hits = ids.filter((id) => rule.exerciseIds.includes(id))
+      results.push({
+        name: 'scenario_exclude_exercises',
+        optionId: option.id,
+        passed: hits.length === 0,
+        detail: hits.length > 0 ? `${expectation.description}: ${hits.join(', ')}` : null,
+      })
+    } else if (rule.type === 'exclude_heavy_fau') {
+      const hits = ids.filter((id) => {
+        const c = candidateById.get(id)
+        return (
+          c !== undefined &&
+          c.intensity_class === 'heavy' &&
+          c.primary_faus.includes(rule.fau)
+        )
+      })
+      results.push({
+        name: 'scenario_exclude_heavy_fau',
+        optionId: option.id,
+        passed: hits.length === 0,
+        detail: hits.length > 0 ? `${expectation.description}: ${hits.join(', ')}` : null,
+      })
+    } else if (rule.type === 'max_exercise_count') {
+      results.push({
+        name: 'scenario_max_exercise_count',
+        optionId: option.id,
+        passed: count <= rule.max,
+        detail: count > rule.max ? `${count} exercises > max ${rule.max}` : null,
+      })
+    }
+  }
+
+  return results
+}
+
+export function gatePassRate(checks: HardCheckResult[]): number {
+  if (checks.length === 0) return 1
+  return checks.filter((c) => c.passed).length / checks.length
+}
+
+export function failedGates(checks: HardCheckResult[]): HardCheckResult[] {
+  return checks.filter((c) => !c.passed)
+}

--- a/lib/eval/judge.ts
+++ b/lib/eval/judge.ts
@@ -1,0 +1,294 @@
+/**
+ * LLM-as-judge for Suggest Workout suggestions.
+ *
+ * Robustness measures (cheap judges diverge easily):
+ * - 4-point anchored scales from rating-rubric.ts, not open-ended 1-10.
+ * - Evidence-before-score: the judge must quote the payload/response
+ *   facts it is judging BEFORE emitting the number. Scoring without
+ *   evidence is where cheap models drift.
+ * - The judge sees a compact digest, not the raw 100-candidate payload:
+ *   less context to get lost in, and the digest highlights exactly the
+ *   facts the rubric dimensions ask about.
+ * - Scenario `judge` expectations are injected so the judge scores
+ *   against scenario intent, not its own taste.
+ * - Deterministic gates run BEFORE judging (hard-checks.ts); the judge
+ *   is told which gates failed so it does not spend evidence on them.
+ * - Optional K runs: run 1 at temperature 0, runs 2..K at 0.4, then
+ *   median-aggregate. The spread across runs is reported as judge
+ *   stability — if it is wide, fix the rubric before trusting scores.
+ */
+
+import { z } from 'zod'
+
+import type { LLMClient } from '@/lib/llm/client'
+
+import { compositeScore, renderRubric, RUBRIC_DIMENSIONS } from './rating-rubric'
+import type {
+  EvalScenario,
+  HardCheckResult,
+  JudgeResult,
+  SuggestionResponse,
+} from './types'
+
+const dimensionScoreSchema = z.object({
+  dimension: z.string(),
+  evidence: z.string(),
+  score: z.number().int().min(1).max(4),
+})
+
+const judgeOutputSchema = z.object({
+  per_option: z
+    .array(
+      z.object({
+        option_id: z.enum(['user_preference', 'data_driven', 'wild_card']),
+        dimension_scores: z.array(dimensionScoreSchema),
+        note: z.string().default(''),
+      }),
+    )
+    .length(3),
+  option_identity: dimensionScoreSchema,
+  overall_note: z.string().default(''),
+})
+
+export interface JudgeOptions {
+  model?: string
+  /** Total judge runs per suggestion. Default 1. */
+  runs?: number
+  timeoutMs?: number
+}
+
+const PER_OPTION_DIMS = RUBRIC_DIMENSIONS.filter((d) => !d.crossOption)
+
+// ---------------------------------------------------------------------------
+// Digest
+// ---------------------------------------------------------------------------
+
+export function buildJudgeDigest(
+  scenario: EvalScenario,
+  response: SuggestionResponse,
+  failedGates: HardCheckResult[],
+): string {
+  const p = scenario.payload
+  const state = p.training_state
+  const byId = new Map(p.candidate_exercises.map((c) => [c.id, c]))
+
+  const fauLines = state.per_fau.map((f) => {
+    const parts = [
+      `${f.fau}: deficit ${f.deficit_share >= 0 ? '+' : ''}${f.deficit_share.toFixed(3)} (${f.status})`,
+      `last ${f.last_session_days_ago === null ? 'never/21d+' : `${f.last_session_days_ago}d ago`}`,
+      f.last_heavy_days_ago !== null ? `last heavy ${f.last_heavy_days_ago}d` : null,
+      `7d sets ${f.rolling_7d_sets}`,
+    ].filter(Boolean)
+    return `- ${parts.join(', ')}`
+  })
+
+  const neglected = state.per_fau.filter((f) => f.status === 'neglected')
+  const availabilityLines = neglected.map((f) => {
+    const names = p.candidate_exercises
+      .filter((c) => c.primary_faus.includes(f.fau))
+      .slice(0, 6)
+      .map((c) => c.name)
+    return `- ${f.fau}: ${names.length > 0 ? names.join(', ') : 'NO candidates available'}`
+  })
+
+  const calibrationLines = state.per_movement_calibration.map(
+    (m) =>
+      `- ${m.movement_pattern}: ewma ${m.current_ewma_top_weight_lbs}lbs, recent [${m.recent_observations.join(', ')}], ${m.typical_rep_range} reps @ RPE ${m.typical_rpe}, last ${m.last_session_days_ago}d ago`,
+  )
+
+  const intentLines = state.weekly_intent_status.map(
+    (w) =>
+      `- "${w.intent_summary}" — ${w.satisfied_this_week ? `satisfied (${w.evidence ?? ''})` : `NOT satisfied (last ${w.last_satisfied_days_ago ?? '?'}d ago)`}`,
+  )
+
+  const expectationLines = scenario.expectations
+    .filter((e) => e.kind === 'judge')
+    .map((e) => `- ${e.description}`)
+
+  const optionBlocks = response.options.map((o) => {
+    const lines = o.exercises.map((e) => {
+      const c = byId.get(e.id)
+      const meta = c
+        ? `[${c.primary_faus.join('/')}, ${c.intensity_class}, ${c.movement_pattern ?? 'untagged'}, ${c.equipment}${c.user_preference_score !== undefined ? `, pref ${c.user_preference_score}` : ''}]`
+        : '[NOT IN CANDIDATE LIST]'
+      return `  - ${c?.name ?? e.id} ${meta} — "${e.rationale}"`
+    })
+    return [
+      `### Option ${o.id} — "${o.name}"`,
+      `description: ${o.description}`,
+      `summary: ${o.summary}`,
+      ...lines,
+    ].join('\n')
+  })
+
+  const ec = p.ephemeral_context
+
+  return [
+    '## User profile',
+    `Goals: ${p.durable_profile.goal_sentences.map((g) => `"${g}"`).join('; ')}`,
+    `Weekly intents: ${p.durable_profile.weekly_intent.join('; ')}`,
+    `Intensity preference: ${p.durable_profile.default_intensity_preference ?? 'unset'}`,
+    '',
+    '## Ephemeral request (what the user asked for right now)',
+    `Time: ${ec.time_budget_minutes} min. Vibe: ${ec.intensity_vibe}.`,
+    `Prioritize: ${ec.prioritize_freetext ?? '(none)'}. Deprioritize: ${ec.deprioritize_freetext ?? '(none)'}.`,
+    ec.equipment_override ? `Equipment override: ${ec.equipment_override.join(', ')}` : '',
+    '',
+    '## Training state (per FAU)',
+    ...fauLines,
+    '',
+    '## Candidates available for neglected FAUs',
+    ...(availabilityLines.length > 0 ? availabilityLines : ['(no neglected FAUs)']),
+    '',
+    '## Movement calibration',
+    ...(calibrationLines.length > 0 ? calibrationLines : ['(insufficient data)']),
+    '',
+    '## Weekly intent status',
+    ...(intentLines.length > 0 ? intentLines : ['(none)']),
+    '',
+    `## Preferences`,
+    `Likes: ${state.preferences_summary.high_confidence_likes.join(', ') || '(none high-confidence)'}`,
+    `Dislikes: ${state.preferences_summary.high_confidence_dislikes.join(', ') || '(none high-confidence)'}`,
+    '',
+    '## Scenario-specific expectations (score against these)',
+    ...(expectationLines.length > 0 ? expectationLines : ['(none beyond the rubric)']),
+    '',
+    '## Deterministic gate failures already detected (do NOT re-litigate; factor into relevant dimensions)',
+    ...(failedGates.length > 0
+      ? failedGates.map((g) => `- ${g.name}${g.optionId ? ` (${g.optionId})` : ''}: ${g.detail}`)
+      : ['(all gates passed)']),
+    '',
+    '## The suggestion being judged',
+    ...optionBlocks,
+    '',
+    `Warnings emitted: ${response.warnings.length > 0 ? response.warnings.join(' | ') : '(none)'}`,
+  ]
+    .filter((l) => l !== '')
+    .join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Judge prompt + call
+// ---------------------------------------------------------------------------
+
+function buildJudgePrompt(digest: string): { system: string; user: string } {
+  const system = [
+    'You are a meticulous strength-coaching evaluator. You grade AI-generated workout suggestions against an anchored rubric.',
+    '',
+    'Rules:',
+    '- For each dimension, first write `evidence`: 1-3 short quotes or concrete facts from the material (exercise picks, rationale text, state numbers). THEN pick the score whose anchor best matches the evidence. Never score without evidence.',
+    '- Use the anchor descriptions literally. If torn between two levels, pick the lower one.',
+    '- Judge each option independently on the per-option dimensions. Judge option_identity ONCE across all three options.',
+    '- Scenario-specific expectations override generic taste: if an expectation is violated, the relevant dimension cannot exceed 2.',
+    '- Do not reward verbosity. A short correct rationale beats a long generic one.',
+    '',
+    '## Per-option rubric dimensions',
+    renderRubric({ crossOption: false }),
+    '',
+    '## Cross-option dimension',
+    renderRubric({ crossOption: true }),
+    '',
+    'Respond with ONLY JSON matching:',
+    '{"per_option": [{"option_id": "user_preference" | "data_driven" | "wild_card", "dimension_scores": [{"dimension": string, "evidence": string, "score": 1|2|3|4}], "note": string}], "option_identity": {"dimension": "option_identity", "evidence": string, "score": 1|2|3|4}, "overall_note": string}',
+    `Per-option dimension keys, all required for each option: ${PER_OPTION_DIMS.map((d) => d.key).join(', ')}.`,
+  ].join('\n')
+
+  return { system, user: digest }
+}
+
+export async function judgeSuggestion(
+  client: LLMClient,
+  scenario: EvalScenario,
+  response: SuggestionResponse,
+  gateFailures: HardCheckResult[],
+  options: JudgeOptions = {},
+): Promise<JudgeResult[]> {
+  const runs = Math.max(1, options.runs ?? 1)
+  const digest = buildJudgeDigest(scenario, response, gateFailures)
+  const { system, user } = buildJudgePrompt(digest)
+
+  const results: JudgeResult[] = []
+  for (let i = 0; i < runs; i++) {
+    const { data } = await client.callWithStructuredOutput(user, judgeOutputSchema, {
+      system,
+      model: options.model,
+      // Run 0 at temp 0 (the canonical score); extra runs at 0.4 to
+      // measure how sensitive the rubric is to sampling noise.
+      temperature: i === 0 ? 0 : 0.4,
+      timeoutMs: options.timeoutMs ?? 90_000,
+      schemaName: 'suggestion_judgement',
+    })
+    results.push(data)
+  }
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+export interface AggregatedJudgement {
+  composite: number | null
+  dimensionMedians: Record<string, number>
+  /** Mean absolute deviation of per-run composites. 0 when runs === 1. */
+  compositeSpread: number
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/** Per-run: mean score per dimension across options, + option_identity. */
+export function perRunDimensionScores(run: JudgeResult): Record<string, number> {
+  const byDim: Record<string, number[]> = {}
+  for (const option of run.per_option) {
+    for (const ds of option.dimension_scores) {
+      if (!PER_OPTION_DIMS.some((d) => d.key === ds.dimension)) continue
+      byDim[ds.dimension] = byDim[ds.dimension] ?? []
+      byDim[ds.dimension].push(ds.score)
+    }
+  }
+  const out: Record<string, number> = {}
+  for (const [dim, scores] of Object.entries(byDim)) {
+    out[dim] = scores.reduce((a, b) => a + b, 0) / scores.length
+  }
+  out.option_identity = run.option_identity.score
+  return out
+}
+
+export function aggregateJudgeRuns(runs: JudgeResult[]): AggregatedJudgement {
+  if (runs.length === 0) {
+    return { composite: null, dimensionMedians: {}, compositeSpread: 0 }
+  }
+  const perRun = runs.map(perRunDimensionScores)
+  const dims = new Set(perRun.flatMap((r) => Object.keys(r)))
+
+  const dimensionMedians: Record<string, number> = {}
+  for (const dim of dims) {
+    const values = perRun.map((r) => r[dim]).filter((v): v is number => v !== undefined)
+    if (values.length > 0) {
+      dimensionMedians[dim] = Math.round(median(values) * 100) / 100
+    }
+  }
+
+  const runComposites = perRun
+    .map((r) => compositeScore(r))
+    .filter((c): c is number => c !== null)
+  const composite = runComposites.length > 0 ? median(runComposites) : null
+  const mean =
+    runComposites.length > 0
+      ? runComposites.reduce((a, b) => a + b, 0) / runComposites.length
+      : 0
+  const compositeSpread =
+    runComposites.length > 1
+      ? Math.round(
+          (runComposites.reduce((a, c) => a + Math.abs(c - mean), 0) /
+            runComposites.length) *
+            1000,
+        ) / 1000
+      : 0
+
+  return { composite, dimensionMedians, compositeSpread }
+}

--- a/lib/eval/rating-rubric.ts
+++ b/lib/eval/rating-rubric.ts
@@ -1,0 +1,186 @@
+/**
+ * Scoring rubric for Suggest Workout suggestions.
+ *
+ * Design choices, deliberate:
+ *
+ * - 4-point anchored scales, not 1-10. Cheap judge models are unstable
+ *   on wide scales; forced-choice between four concretely-described
+ *   levels is far more repeatable. No middle point — the judge must
+ *   commit to "acceptable" vs "flawed".
+ * - Every level has anchor text describing observable behavior, not
+ *   adjectives. The judge quotes evidence before scoring (see judge.ts).
+ * - Anything a program can verify is NOT a judged dimension — it is a
+ *   deterministic gate in hard-checks.ts (ID validity, duplicates,
+ *   count-vs-time, banned exercises, scenario hard rules). Judged
+ *   dimensions are reserved for genuine judgment calls.
+ * - Weights encode product priorities: getting the training state right
+ *   and staying safe matter more than prose quality.
+ *
+ * Both the LLM judge and the human rating CLI render from this file, so
+ * the two rating streams are calibratable against each other.
+ */
+
+export interface RubricLevel {
+  score: 1 | 2 | 3 | 4
+  anchor: string
+}
+
+export interface RubricDimension {
+  key: string
+  label: string
+  /** Single letter for the human CLI flag keys. Must be unique. */
+  flagKey: string
+  weight: number
+  /** What the judge should look at. */
+  focus: string
+  levels: RubricLevel[]
+  /** True when the dimension is scored once across all three options. */
+  crossOption?: boolean
+}
+
+export const RUBRIC_VERSION = 'rubric-v1'
+
+export const RUBRIC_DIMENSIONS: RubricDimension[] = [
+  {
+    key: 'state_grounding',
+    label: 'Training-state grounding',
+    flagKey: 'g',
+    weight: 0.25,
+    focus:
+      'Does the option respond to what training_state actually says — deficits, recency, unsatisfied weekly intents, goal trends? Data Driven especially must target the largest real deficits, not plausible-sounding ones.',
+    levels: [
+      { score: 1, anchor: 'Contradicts the state (hammers an over-trained FAU, ignores a glaring deficit it claims to address, cites numbers that are not in the payload).' },
+      { score: 2, anchor: 'Generic template that would fit any user; state is referenced but does not change the picks.' },
+      { score: 3, anchor: 'Picks clearly track the state; one or two misses (a secondary deficit ignored, mild recency conflict).' },
+      { score: 4, anchor: 'Picks and emphasis follow directly from the state; largest deficits and recency conflicts are all handled or explicitly acknowledged.' },
+    ],
+  },
+  {
+    key: 'constraint_respect',
+    label: 'Ephemeral constraint respect',
+    flagKey: 'c',
+    weight: 0.2,
+    focus:
+      'Are the soft ephemeral inputs honored — prioritize/deprioritize free text (including slang), intensity_vibe, the spirit of the time budget? Hard violations (IDs, counts) are gated elsewhere; score interpretation quality here.',
+    levels: [
+      { score: 1, anchor: 'Free text ignored or misread (user said keep legs fresh, option leads with heavy squats); vibe contradicted.' },
+      { score: 2, anchor: 'Partially honored — the request shapes some picks but violations remain without acknowledgment.' },
+      { score: 3, anchor: 'Honored with at most one minor, acknowledged tension.' },
+      { score: 4, anchor: 'Fully honored, including correct interpretation of slang or ambiguity; tensions surfaced in description or warnings.' },
+    ],
+  },
+  {
+    key: 'safety_recovery',
+    label: 'Safety and recovery awareness',
+    flagKey: 's',
+    weight: 0.2,
+    focus:
+      'Injuries in goal_sentences, deload/layoff context, last_heavy_days_ago of 0-2 on the same FAU, conservative re-entry after breaks. The option should accommodate, and say that it is accommodating.',
+    levels: [
+      { score: 1, anchor: 'Loads an injured/flagged area heavily, or programs a max-effort session into a deload/layoff.' },
+      { score: 2, anchor: 'No direct harm but tone-deaf: ignores fresh heavy work on a FAU, or gives a returning user their old full workload silently.' },
+      { score: 3, anchor: 'Accommodations made; acknowledgment thin or implicit.' },
+      { score: 4, anchor: 'Accommodations made and explicitly explained (joint-friendly variants chosen, re-entry volume reduced, conflicts in warnings).' },
+    ],
+  },
+  {
+    key: 'option_identity',
+    label: 'Option distinctness and identity',
+    flagKey: 'i',
+    weight: 0.15,
+    crossOption: true,
+    focus:
+      'Scored once across all three options: is user_preference actually preference-led, data_driven actually deficit-led, wild_card actually novel? Are they meaningfully different sessions?',
+    levels: [
+      { score: 1, anchor: 'Options are near-duplicates (over half the exercises shared) or identities are swapped/meaningless.' },
+      { score: 2, anchor: 'Some differentiation but at least one option does not follow its stated philosophy.' },
+      { score: 3, anchor: 'Three distinct sessions, each roughly faithful to its identity; wild_card only mildly novel.' },
+      { score: 4, anchor: 'Three clearly distinct, identity-faithful sessions; a user would genuinely deliberate between them.' },
+    ],
+  },
+  {
+    key: 'rationale_quality',
+    label: 'Rationale quality',
+    flagKey: 'r',
+    weight: 0.1,
+    focus:
+      'Per-exercise rationales cite specific payload facts (deficit numbers, days-ago, stated goals, preference scores). No fabricated history, no filler.',
+    levels: [
+      { score: 1, anchor: 'Rationales fabricate history or are pure filler ("great compound movement").' },
+      { score: 2, anchor: 'Mostly generic; a few payload-grounded lines.' },
+      { score: 3, anchor: 'Mostly grounded in payload facts; occasional filler.' },
+      { score: 4, anchor: 'Every rationale traces to a verifiable payload fact and would help the user trust the pick.' },
+    ],
+  },
+  {
+    key: 'session_coherence',
+    label: 'Session structure coherence',
+    flagKey: 'o',
+    weight: 0.1,
+    focus:
+      'Does the option read like a workout a coach would write? Compounds before isolation, no redundant back-to-back near-duplicates, sensible FAU flow, count appropriate to the stated summary.',
+    levels: [
+      { score: 1, anchor: 'Incoherent: isolation-first before a heavy compound of the same muscle, redundant duplicates (two curl variants back to back in a 4-exercise session), random ordering.' },
+      { score: 2, anchor: 'Trainable but sloppy ordering or one redundant slot.' },
+      { score: 3, anchor: 'Solid structure with a minor quibble.' },
+      { score: 4, anchor: 'Clean, coach-quality structure and flow.' },
+    ],
+  },
+]
+
+const weightSum = RUBRIC_DIMENSIONS.reduce((a, d) => a + d.weight, 0)
+if (Math.abs(weightSum - 1) > 1e-9) {
+  throw new Error(`Rubric weights must sum to 1 (got ${weightSum})`)
+}
+
+export const DIMENSION_KEYS = RUBRIC_DIMENSIONS.map((d) => d.key)
+
+export function getDimension(key: string): RubricDimension | undefined {
+  return RUBRIC_DIMENSIONS.find((d) => d.key === key)
+}
+
+export function dimensionByFlagKey(flag: string): RubricDimension | undefined {
+  return RUBRIC_DIMENSIONS.find((d) => d.flagKey === flag)
+}
+
+/**
+ * Weighted composite over per-dimension scores in [1,4]. Missing
+ * dimensions are skipped and the weights renormalized, so a partial
+ * judge response still yields a comparable number.
+ */
+export function compositeScore(scores: Record<string, number>): number | null {
+  let total = 0
+  let weight = 0
+  for (const dim of RUBRIC_DIMENSIONS) {
+    const s = scores[dim.key]
+    if (typeof s === 'number' && s >= 1 && s <= 4) {
+      total += s * dim.weight
+      weight += dim.weight
+    }
+  }
+  if (weight === 0) return null
+  return Math.round((total / weight) * 100) / 100
+}
+
+/**
+ * Render the rubric as text for the judge prompt / human CLI help.
+ * `crossOption: false` renders per-option dimensions only; `true`
+ * renders the cross-option ones; omitted renders all.
+ */
+export function renderRubric(options: { crossOption?: boolean } = {}): string {
+  const dims = RUBRIC_DIMENSIONS.filter((d) =>
+    options.crossOption === undefined
+      ? true
+      : options.crossOption
+        ? d.crossOption === true
+        : d.crossOption !== true,
+  )
+  return dims
+    .map((d) => {
+      const levels = d.levels
+        .map((l) => `  ${l.score} = ${l.anchor}`)
+        .join('\n')
+      return `### ${d.key} (weight ${d.weight})\n${d.focus}\n${levels}`
+    })
+    .join('\n\n')
+}

--- a/lib/eval/refinement-engine.ts
+++ b/lib/eval/refinement-engine.ts
@@ -1,0 +1,314 @@
+/**
+ * Refinement engine: turns a batch of scored suggestions into small,
+ * targeted prompt-diff proposals.
+ *
+ * Division of labor, deliberately:
+ * - CODE clusters failures (by gate name, by low-scoring dimension) and
+ *   picks exemplars. Clustering is counting; an LLM adds nothing.
+ * - The LLM writes the diff for the top clusters only. It sees the
+ *   current prompt (named sections), the failure cluster, and exemplar
+ *   evidence from the judge — and is constrained to edit at most one
+ *   section per diff.
+ *
+ * Overfitting guards baked in:
+ * - Diffs must state a GENERAL coaching/prompting principle. Proposals
+ *   that mention scenario ids or synthetic archetype names are rejected
+ *   (hard) or flagged (soft) before they reach a variant file.
+ * - Each accepted diff is materialized as a `.eval/variants/` JSON
+ *   variant with lineage (`base`), so re-running the SAME seed against
+ *   base and candidate gives a paired comparison. Winners get promoted
+ *   to lib/suggest/prompts/registry.ts by a human, in a commit.
+ */
+
+import { z } from 'zod'
+
+import type { LLMClient } from '@/lib/llm/client'
+import type { PromptVariant } from '@/lib/suggest/prompts/registry'
+
+import { getDimension } from './rating-rubric'
+import type { LoadedRun } from './store'
+import type { ScenarioResult } from './types'
+
+// ---------------------------------------------------------------------------
+// Failure clustering (pure code)
+// ---------------------------------------------------------------------------
+
+export interface FailureExemplar {
+  scenarioId: string
+  optionId?: string
+  /** Gate detail or judge evidence text. */
+  evidence: string
+}
+
+export interface FailureCluster {
+  kind: 'gate' | 'dimension'
+  key: string
+  count: number
+  exemplars: FailureExemplar[]
+  /** Human-readable framing for the LLM. */
+  framing: string
+}
+
+const LOW_DIMENSION_THRESHOLD = 2.5
+const MAX_EXEMPLARS = 3
+
+export function clusterFailures(run: LoadedRun): FailureCluster[] {
+  const clusters: FailureCluster[] = []
+
+  // Gate clusters
+  const gateGroups = new Map<string, FailureExemplar[]>()
+  for (const result of run.results) {
+    for (const check of result.hardChecks) {
+      if (check.passed) continue
+      const list = gateGroups.get(check.name) ?? []
+      list.push({
+        scenarioId: result.scenarioId,
+        optionId: check.optionId,
+        evidence: check.detail ?? check.name,
+      })
+      gateGroups.set(check.name, list)
+    }
+  }
+  for (const [name, exemplars] of gateGroups) {
+    clusters.push({
+      kind: 'gate',
+      key: name,
+      count: exemplars.length,
+      exemplars: exemplars.slice(0, MAX_EXEMPLARS),
+      framing: `Deterministic gate "${name}" failed ${exemplars.length} time(s). These are hard violations the prompt must prevent outright.`,
+    })
+  }
+
+  // Dimension clusters
+  const dimGroups = new Map<string, FailureExemplar[]>()
+  for (const result of run.results) {
+    for (const [dim, score] of Object.entries(result.dimensionMedians)) {
+      if (score > LOW_DIMENSION_THRESHOLD) continue
+      const list = dimGroups.get(dim) ?? []
+      list.push({
+        scenarioId: result.scenarioId,
+        evidence: extractJudgeEvidence(result, dim),
+      })
+      dimGroups.set(dim, list)
+    }
+  }
+  for (const [dim, exemplars] of dimGroups) {
+    const rubricDim = getDimension(dim)
+    clusters.push({
+      kind: 'dimension',
+      key: dim,
+      count: exemplars.length,
+      exemplars: exemplars.slice(0, MAX_EXEMPLARS),
+      framing: `Judged dimension "${dim}" (${rubricDim?.label ?? dim}) scored <= ${LOW_DIMENSION_THRESHOLD} on ${exemplars.length} scenario(s). Focus: ${rubricDim?.focus ?? 'n/a'}`,
+    })
+  }
+
+  return clusters.sort((a, b) => b.count - a.count)
+}
+
+function extractJudgeEvidence(result: ScenarioResult, dimension: string): string {
+  const run = result.judgeRuns[0]
+  if (!run) return '(no judge output)'
+  if (dimension === 'option_identity') {
+    return run.option_identity.evidence
+  }
+  const pieces: string[] = []
+  for (const option of run.per_option) {
+    for (const ds of option.dimension_scores) {
+      if (ds.dimension === dimension && ds.score <= 2) {
+        pieces.push(`[${option.option_id}] ${ds.evidence}`)
+      }
+    }
+  }
+  return pieces.slice(0, 2).join(' | ') || '(low median without per-option evidence)'
+}
+
+// ---------------------------------------------------------------------------
+// Diff proposal (LLM)
+// ---------------------------------------------------------------------------
+
+const diffSchema = z.object({
+  diffs: z
+    .array(
+      z.object({
+        id: z.string().regex(/^[a-z0-9-]+$/, 'kebab-case id'),
+        target_section: z.string(),
+        operation: z.enum(['replace', 'append']),
+        proposed_content: z.string().min(1),
+        motivation: z.string().min(1),
+        addresses: z.string(),
+        risk: z.string(),
+      }),
+    )
+    .min(1)
+    .max(3),
+})
+
+export type PromptDiff = z.infer<typeof diffSchema>['diffs'][number]
+
+export interface DiffValidation {
+  diff: PromptDiff
+  accepted: boolean
+  warnings: string[]
+  rejectionReason?: string
+}
+
+const ARCHETYPE_NAME_PATTERN =
+  /\b(cyclist|bodybuilder|powerlifter|beginner|inconsistent)\b/i
+const SCENARIO_ID_PATTERN = /\b\d{3}-[a-z-]+\b/
+
+export async function proposeDiffs(
+  client: LLMClient,
+  variant: PromptVariant,
+  clusters: FailureCluster[],
+  options: { model?: string; maxClusters?: number } = {},
+): Promise<{ validations: DiffValidation[]; clustersUsed: FailureCluster[] }> {
+  const clustersUsed = clusters.slice(0, options.maxClusters ?? 3)
+  if (clustersUsed.length === 0) {
+    return { validations: [], clustersUsed }
+  }
+
+  const sectionBlock = variant.sections
+    .map((s) => `### section: ${s.name}\n${s.content}`)
+    .join('\n\n')
+
+  const clusterBlock = clustersUsed
+    .map((c, i) => {
+      const exemplars = c.exemplars
+        .map((e) => `  - scenario ${e.scenarioId}${e.optionId ? ` (${e.optionId})` : ''}: ${e.evidence}`)
+        .join('\n')
+      return `## Failure cluster ${i + 1}: ${c.key} (${c.count} occurrences)\n${c.framing}\nExemplars:\n${exemplars}`
+    })
+    .join('\n\n')
+
+  const system = [
+    'You improve a system prompt for a workout-suggestion LLM. You receive the current prompt (as named sections) and clustered failures from an evaluation run.',
+    '',
+    'Produce 1-3 SMALL prompt diffs. Rules:',
+    '- Each diff edits exactly one existing section: either `replace` its full content or `append` 1-3 sentences to it. Pick the section whose job it is to prevent the failure.',
+    '- State general principles, never specifics of the test data. Do NOT reference scenario ids, synthetic user archetypes, or exact numbers from exemplars. A diff that says "when the user mentions soreness in a muscle group, exclude heavy work for it" is good; "avoid squats for cyclists" is overfitting and forbidden.',
+    '- Keep each change under ~80 words of new text. Do not rewrite unrelated parts of a section when replacing it.',
+    '- `motivation`: why this wording change prevents the failure mode. `addresses`: the cluster key. `risk`: what this change could plausibly make worse (there is always something).',
+    '',
+    'Respond with ONLY JSON: {"diffs": [{"id": "kebab-case-slug", "target_section": string, "operation": "replace" | "append", "proposed_content": string, "motivation": string, "addresses": string, "risk": string}]}',
+  ].join('\n')
+
+  const user = [
+    '# Current prompt sections',
+    sectionBlock,
+    '',
+    '# Failure clusters',
+    clusterBlock,
+  ].join('\n')
+
+  const { data } = await client.callWithStructuredOutput(user, diffSchema, {
+    system,
+    model: options.model,
+    temperature: 0.3,
+    schemaName: 'prompt_diffs',
+  })
+
+  const sectionNames = new Set(variant.sections.map((s) => s.name))
+  const validations: DiffValidation[] = data.diffs.map((diff) => {
+    const warnings: string[] = []
+    if (!sectionNames.has(diff.target_section)) {
+      return {
+        diff,
+        accepted: false,
+        warnings,
+        rejectionReason: `target_section "${diff.target_section}" does not exist (sections: ${[...sectionNames].join(', ')})`,
+      }
+    }
+    if (SCENARIO_ID_PATTERN.test(diff.proposed_content)) {
+      return {
+        diff,
+        accepted: false,
+        warnings,
+        rejectionReason: 'proposed content references a scenario id — overfit to the test set',
+      }
+    }
+    if (ARCHETYPE_NAME_PATTERN.test(diff.proposed_content)) {
+      warnings.push(
+        'proposed content mentions an archetype-like word — review for overfitting before running',
+      )
+    }
+    if (diff.proposed_content.split(/\s+/).length > 160) {
+      warnings.push('diff is large for a "targeted" change — consider trimming')
+    }
+    return { diff, accepted: true, warnings }
+  })
+
+  return { validations, clustersUsed }
+}
+
+// ---------------------------------------------------------------------------
+// Applying diffs → experimental variants
+// ---------------------------------------------------------------------------
+
+export function applyDiff(
+  base: PromptVariant,
+  diff: PromptDiff,
+  newVersion: string,
+): PromptVariant {
+  const sections = base.sections.map((s) => {
+    if (s.name !== diff.target_section) return s
+    return {
+      name: s.name,
+      content:
+        diff.operation === 'replace'
+          ? diff.proposed_content
+          : `${s.content}\n${diff.proposed_content}`,
+    }
+  })
+  return {
+    version: newVersion,
+    base: base.version,
+    notes: `${diff.addresses}: ${diff.motivation}`,
+    sections,
+  }
+}
+
+export function renderProposalMarkdown(
+  runId: string,
+  baseVariant: PromptVariant,
+  clustersUsed: FailureCluster[],
+  validations: DiffValidation[],
+  savedVariants: Array<{ version: string; file: string }>,
+): string {
+  const lines: string[] = [
+    `# Prompt refinement proposal — run ${runId} (base: ${baseVariant.version})`,
+    '',
+    '## Failure clusters targeted',
+    ...clustersUsed.map((c) => `- [${c.kind}] ${c.key}: ${c.count} occurrences`),
+    '',
+  ]
+  for (const v of validations) {
+    lines.push(
+      `## Diff \`${v.diff.id}\` → section \`${v.diff.target_section}\` (${v.diff.operation}) — ${v.accepted ? 'ACCEPTED' : `REJECTED: ${v.rejectionReason}`}`,
+      '',
+      `**Addresses:** ${v.diff.addresses}`,
+      `**Motivation:** ${v.diff.motivation}`,
+      `**Risk:** ${v.diff.risk}`,
+      ...v.warnings.map((w) => `**Warning:** ${w}`),
+      '',
+      '```',
+      v.diff.proposed_content,
+      '```',
+      '',
+    )
+  }
+  if (savedVariants.length > 0) {
+    lines.push(
+      '## Next step',
+      '',
+      'Each accepted diff was saved as an experimental variant. Re-run against the SAME seed and compare:',
+      '',
+      ...savedVariants.map(
+        (v) =>
+          `    npm run eval-suggest -- --scenarios <N> --prompt ${v.version} --seed <same-seed> --compare <this-run-id>`,
+      ),
+      '',
+    )
+  }
+  return lines.join('\n')
+}

--- a/lib/eval/report.ts
+++ b/lib/eval/report.ts
@@ -1,0 +1,316 @@
+/**
+ * Score aggregation + report rendering for eval runs, and paired
+ * comparison between two runs (the "did my prompt diff help?" answer).
+ *
+ * Gates and judged scores are reported side by side but NEVER blended:
+ * a prompt that raises composite while doubling gate failures is a
+ * regression, and a blended number would hide that.
+ */
+
+import { DIMENSION_KEYS } from './rating-rubric'
+import type { LoadedRun } from './store'
+import type { ScenarioResult } from './types'
+
+export interface RunReport {
+  runId: string
+  promptVariant: string
+  seed: string
+  scenarioCount: number
+  plannerErrors: number
+  gate: {
+    totalChecks: number
+    failedChecks: number
+    passRate: number
+    /** Fail counts by check name. */
+    failsByCheck: Record<string, number>
+    /** Scenarios with at least one gate failure. */
+    scenariosWithFailures: number
+  }
+  compositeMean: number | null
+  dimensionMeans: Record<string, number>
+  /** Mean of per-scenario judge spread (only meaningful when runs > 1). */
+  judgeSpreadMean: number | null
+  worstScenarios: Array<{
+    scenarioId: string
+    composite: number | null
+    failedGates: string[]
+    worstDimension: string | null
+  }>
+  byModifier: Record<
+    string,
+    { count: number; compositeMean: number | null; gateFailScenarios: number }
+  >
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null
+  return Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100
+}
+
+function worstDimension(result: ScenarioResult): string | null {
+  let worst: string | null = null
+  let worstScore = Infinity
+  for (const [dim, score] of Object.entries(result.dimensionMedians)) {
+    if (score < worstScore) {
+      worstScore = score
+      worst = dim
+    }
+  }
+  return worst
+}
+
+export function buildRunReport(run: LoadedRun, judgeSpreads: number[]): RunReport {
+  const { meta, scenarios, results } = run
+  const scenarioById = new Map(scenarios.map((s) => [s.id, s]))
+
+  const failsByCheck: Record<string, number> = {}
+  let totalChecks = 0
+  let failedChecks = 0
+  let scenariosWithFailures = 0
+  for (const r of results) {
+    totalChecks += r.hardChecks.length
+    const failed = r.hardChecks.filter((c) => !c.passed)
+    failedChecks += failed.length
+    if (failed.length > 0) scenariosWithFailures++
+    for (const f of failed) {
+      failsByCheck[f.name] = (failsByCheck[f.name] ?? 0) + 1
+    }
+  }
+
+  const composites = results
+    .map((r) => r.composite)
+    .filter((c): c is number => c !== null)
+
+  const dimensionMeans: Record<string, number> = {}
+  for (const dim of [...DIMENSION_KEYS]) {
+    const values = results
+      .map((r) => r.dimensionMedians[dim])
+      .filter((v): v is number => v !== undefined)
+    const m = mean(values)
+    if (m !== null) dimensionMeans[dim] = m
+  }
+
+  const ranked = [...results].sort(
+    (a, b) => (a.composite ?? 0) - (b.composite ?? 0),
+  )
+  const worstScenarios = ranked.slice(0, 5).map((r) => ({
+    scenarioId: r.scenarioId,
+    composite: r.composite,
+    failedGates: r.hardChecks.filter((c) => !c.passed).map((c) => c.name),
+    worstDimension: worstDimension(r),
+  }))
+
+  const byModifier: RunReport['byModifier'] = {}
+  for (const r of results) {
+    const scenario = scenarioById.get(r.scenarioId)
+    const keys =
+      scenario && scenario.modifiers.length > 0 ? scenario.modifiers : ['(none)']
+    for (const key of keys) {
+      const bucket = (byModifier[key] = byModifier[key] ?? {
+        count: 0,
+        compositeMean: null,
+        gateFailScenarios: 0,
+      })
+      bucket.count++
+      if (r.hardChecks.some((c) => !c.passed)) bucket.gateFailScenarios++
+    }
+  }
+  for (const [key, bucket] of Object.entries(byModifier)) {
+    const values = results
+      .filter((r) => {
+        const s = scenarioById.get(r.scenarioId)
+        const keys = s && s.modifiers.length > 0 ? s.modifiers : ['(none)']
+        return keys.includes(key)
+      })
+      .map((r) => r.composite)
+      .filter((c): c is number => c !== null)
+    bucket.compositeMean = mean(values)
+  }
+
+  return {
+    runId: meta.runId,
+    promptVariant: meta.promptVariant,
+    seed: meta.seed,
+    scenarioCount: scenarios.length,
+    plannerErrors: results.filter((r) => r.error !== null).length,
+    gate: {
+      totalChecks,
+      failedChecks,
+      passRate:
+        totalChecks > 0
+          ? Math.round(((totalChecks - failedChecks) / totalChecks) * 1000) / 1000
+          : 1,
+      failsByCheck,
+      scenariosWithFailures,
+    },
+    compositeMean: mean(composites),
+    dimensionMeans,
+    judgeSpreadMean: judgeSpreads.length > 0 ? mean(judgeSpreads) : null,
+    worstScenarios,
+    byModifier,
+  }
+}
+
+export function renderReportMarkdown(report: RunReport): string {
+  const lines: string[] = [
+    `# Eval run ${report.runId}`,
+    '',
+    `- Prompt variant: **${report.promptVariant}**  |  Seed: \`${report.seed}\`  |  Scenarios: ${report.scenarioCount}  |  Planner errors: ${report.plannerErrors}`,
+    `- **Composite (judged, 1-4): ${report.compositeMean ?? 'n/a'}**`,
+    `- **Gate pass rate: ${(report.gate.passRate * 100).toFixed(1)}%** (${report.gate.failedChecks}/${report.gate.totalChecks} checks failed across ${report.gate.scenariosWithFailures} scenarios)`,
+    report.judgeSpreadMean !== null
+      ? `- Judge stability (mean composite spread across runs): ${report.judgeSpreadMean}`
+      : '',
+    '',
+    '## Dimensions',
+    '| dimension | mean |',
+    '|---|---|',
+    ...Object.entries(report.dimensionMeans).map(([d, m]) => `| ${d} | ${m} |`),
+    '',
+    '## Gate failures by check',
+    ...(Object.keys(report.gate.failsByCheck).length > 0
+      ? Object.entries(report.gate.failsByCheck).map(([c, n]) => `- ${c}: ${n}`)
+      : ['- none']),
+    '',
+    '## Worst scenarios',
+    ...report.worstScenarios.map(
+      (w) =>
+        `- \`${w.scenarioId}\` composite ${w.composite ?? 'n/a'}${w.worstDimension ? `, worst dim: ${w.worstDimension}` : ''}${w.failedGates.length > 0 ? `, gate fails: ${w.failedGates.join(', ')}` : ''}`,
+    ),
+    '',
+    '## By modifier',
+    '| modifier | n | composite | scenarios w/ gate fails |',
+    '|---|---|---|---|',
+    ...Object.entries(report.byModifier).map(
+      ([k, b]) => `| ${k} | ${b.count} | ${b.compositeMean ?? 'n/a'} | ${b.gateFailScenarios} |`,
+    ),
+    '',
+  ]
+  return lines.filter((l) => l !== '').join('\n') + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+export interface RunComparison {
+  baseRunId: string
+  candidateRunId: string
+  pairedScenarios: number
+  improved: number
+  regressed: number
+  unchanged: number
+  compositeDelta: number | null
+  dimensionDeltas: Record<string, number>
+  gatePassRateDelta: number
+  regressions: Array<{ scenarioId: string; before: number; after: number }>
+  /** Scenario ids present in only one run. */
+  unpaired: string[]
+  /** Scenario ids match by index even across seeds — this flags it. */
+  seedMismatch: boolean
+}
+
+const CHANGE_THRESHOLD = 0.1
+
+export function compareRuns(
+  base: { report: RunReport; results: ScenarioResult[] },
+  candidate: { report: RunReport; results: ScenarioResult[] },
+): RunComparison {
+  const baseById = new Map(base.results.map((r) => [r.scenarioId, r]))
+  const candById = new Map(candidate.results.map((r) => [r.scenarioId, r]))
+
+  const paired: Array<{ id: string; before: number; after: number }> = []
+  const unpaired: string[] = []
+  for (const [id, b] of baseById) {
+    const c = candById.get(id)
+    if (!c) {
+      unpaired.push(id)
+      continue
+    }
+    if (b.composite !== null && c.composite !== null) {
+      paired.push({ id, before: b.composite, after: c.composite })
+    }
+  }
+  for (const id of candById.keys()) {
+    if (!baseById.has(id)) unpaired.push(id)
+  }
+
+  let improved = 0
+  let regressed = 0
+  let unchanged = 0
+  for (const p of paired) {
+    const delta = p.after - p.before
+    if (delta > CHANGE_THRESHOLD) improved++
+    else if (delta < -CHANGE_THRESHOLD) regressed++
+    else unchanged++
+  }
+
+  const dimensionDeltas: Record<string, number> = {}
+  for (const dim of Object.keys(candidate.report.dimensionMeans)) {
+    const before = base.report.dimensionMeans[dim]
+    const after = candidate.report.dimensionMeans[dim]
+    if (before !== undefined && after !== undefined) {
+      dimensionDeltas[dim] = Math.round((after - before) * 100) / 100
+    }
+  }
+
+  const regressions = paired
+    .filter((p) => p.after - p.before < -CHANGE_THRESHOLD)
+    .sort((a, b) => a.after - a.before - (b.after - b.before))
+    .slice(0, 10)
+    .map((p) => ({ scenarioId: p.id, before: p.before, after: p.after }))
+
+  const compositeDelta =
+    base.report.compositeMean !== null && candidate.report.compositeMean !== null
+      ? Math.round((candidate.report.compositeMean - base.report.compositeMean) * 100) /
+        100
+      : null
+
+  return {
+    baseRunId: base.report.runId,
+    candidateRunId: candidate.report.runId,
+    pairedScenarios: paired.length,
+    improved,
+    regressed,
+    unchanged,
+    compositeDelta,
+    dimensionDeltas,
+    gatePassRateDelta:
+      Math.round((candidate.report.gate.passRate - base.report.gate.passRate) * 1000) /
+      1000,
+    regressions,
+    unpaired,
+    seedMismatch: base.report.seed !== candidate.report.seed,
+  }
+}
+
+export function renderComparisonMarkdown(cmp: RunComparison): string {
+  return [
+    `# Comparison: ${cmp.baseRunId} → ${cmp.candidateRunId}`,
+    '',
+    cmp.seedMismatch
+      ? '> WARNING: the two runs used DIFFERENT seeds. Scenario ids pair by index but the payload jitter differs — this comparison is not a valid paired test. Re-run with matching --seed.'
+      : '',
+    cmp.unpaired.length > 0
+      ? `> WARNING: ${cmp.unpaired.length} scenarios unpaired — were these runs generated with the same count? Paired comparison is only valid on identical scenario sets.`
+      : '',
+    `- Paired scenarios: ${cmp.pairedScenarios} — **${cmp.improved} improved / ${cmp.regressed} regressed / ${cmp.unchanged} unchanged** (threshold ±${CHANGE_THRESHOLD})`,
+    `- Composite delta: **${cmp.compositeDelta !== null && cmp.compositeDelta >= 0 ? '+' : ''}${cmp.compositeDelta ?? 'n/a'}**`,
+    `- Gate pass rate delta: ${cmp.gatePassRateDelta >= 0 ? '+' : ''}${(cmp.gatePassRateDelta * 100).toFixed(1)}pp`,
+    '',
+    '## Dimension deltas',
+    ...Object.entries(cmp.dimensionDeltas).map(
+      ([d, v]) => `- ${d}: ${v >= 0 ? '+' : ''}${v}`,
+    ),
+    '',
+    '## Biggest regressions',
+    ...(cmp.regressions.length > 0
+      ? cmp.regressions.map(
+          (r) => `- \`${r.scenarioId}\`: ${r.before} → ${r.after}`,
+        )
+      : ['- none']),
+    '',
+  ]
+    .filter((l) => l !== '')
+    .join('\n') + '\n'
+}

--- a/lib/eval/rng.ts
+++ b/lib/eval/rng.ts
@@ -1,0 +1,69 @@
+/**
+ * Deterministic seeded RNG for scenario generation. Same seed string →
+ * same sequence, across machines and runs. Do NOT use Math.random
+ * anywhere in the eval loop — reproducibility is a hard requirement.
+ */
+
+/** FNV-1a 32-bit hash of a string → uint32 seed. */
+export function hashSeed(seed: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+export interface Rng {
+  /** Uniform float in [0, 1). */
+  next(): number
+  /** Uniform integer in [min, max] inclusive. */
+  int(min: number, max: number): number
+  /** Pick one element. Throws on empty array. */
+  pick<T>(items: readonly T[]): T
+  /** Fisher–Yates shuffle (returns a new array). */
+  shuffle<T>(items: readonly T[]): T[]
+  /** True with probability p. */
+  chance(p: number): boolean
+  /** Fork a child RNG whose stream is independent of the parent's. */
+  fork(label: string): Rng
+}
+
+/** mulberry32 — small, fast, good-enough distribution for test data. */
+export function createRng(seed: string): Rng {
+  let state = hashSeed(seed)
+
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  const rng: Rng = {
+    next,
+    int(min, max) {
+      return min + Math.floor(next() * (max - min + 1))
+    },
+    pick(items) {
+      if (items.length === 0) throw new Error('rng.pick: empty array')
+      return items[Math.floor(next() * items.length)]
+    },
+    shuffle(items) {
+      const copy = [...items]
+      for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(next() * (i + 1))
+        ;[copy[i], copy[j]] = [copy[j], copy[i]]
+      }
+      return copy
+    },
+    chance(p) {
+      return next() < p
+    },
+    fork(label) {
+      return createRng(`${seed}::${label}`)
+    },
+  }
+  return rng
+}

--- a/lib/eval/scenario-generator.ts
+++ b/lib/eval/scenario-generator.ts
@@ -1,0 +1,798 @@
+/**
+ * Synthetic scenario generator for the Suggest Workout eval loop.
+ *
+ * Diversity strategy: scenarios are NOT free-form LLM generations (those
+ * converge to samey median cases). Instead we take the stratified product
+ * of base archetypes (#886) × edge-case modifiers, then apply seeded
+ * jitter to the numbers. Coverage is structural, randomness only adds
+ * texture. Same seed → identical scenarios, byte for byte.
+ *
+ * Each scenario carries `expectations`: scenario-specific things a good
+ * suggestion must do. `hard` expectations become deterministic gates
+ * (hard-checks.ts); `judge` expectations are injected into the judge
+ * prompt so scoring reflects scenario intent, not judge taste.
+ */
+
+import { ALL_FAUS, type FAUKey } from '@/lib/fau-volume'
+import type { MovementPattern } from '@/lib/exercises/auto-tag'
+
+import { EXERCISE_CATALOG, type EquipmentKey } from './exercise-catalog'
+import { createRng, type Rng } from './rng'
+import type {
+  ArchetypeKey,
+  CandidateExercise,
+  EphemeralContext,
+  EvalScenario,
+  ModifierKey,
+  PerFAUState,
+  ScenarioExpectation,
+  SuggestPayload,
+  TrainingState,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Archetypes (mirrors #886 seeder archetypes)
+// ---------------------------------------------------------------------------
+
+type Emphasis = 'high' | 'med' | 'low' | 'none'
+
+interface ArchetypeSpec {
+  goals: string[]
+  weeklyIntents: string[]
+  equipment: EquipmentKey[]
+  intensityPreference: 'hypertrophy' | 'strength' | 'balanced' | null
+  /** FAUs not listed default to 'med'. */
+  emphasis: Partial<Record<FAUKey, Emphasis>>
+  /** Ratio targets; unlisted FAUs default to 1.0. */
+  ratioTargets: Partial<Record<FAUKey, number>>
+  /** Base top-set weight per movement pattern (lbs). */
+  movementBases: Partial<Record<MovementPattern, number>>
+  typicalRepRange: string
+  typicalRpe: number
+  totalSets14d: number
+  likes: string[]
+  dislikes: string[]
+  suggestionsLast30d: number
+  swapRate: number
+}
+
+const FULL_GYM: EquipmentKey[] = [
+  'barbell',
+  'dumbbells',
+  'cable',
+  'machines',
+  'bands',
+  'bodyweight',
+]
+
+export const ARCHETYPES: Record<ArchetypeKey, ArchetypeSpec> = {
+  cyclist: {
+    goals: [
+      'Upper-body hypertrophy focus',
+      'Spare legs for biking',
+      'Improve bench press',
+    ],
+    weeklyIntents: [
+      'Tilt toward upper body volume',
+      'At most 1 leg day per week, never before a long ride',
+    ],
+    equipment: FULL_GYM,
+    intensityPreference: 'hypertrophy',
+    emphasis: {
+      chest: 'high',
+      lats: 'high',
+      'mid-back': 'high',
+      'side-delts': 'med',
+      biceps: 'med',
+      triceps: 'med',
+      quads: 'low',
+      hamstrings: 'low',
+      glutes: 'low',
+      calves: 'none',
+      adductors: 'none',
+    },
+    ratioTargets: { chest: 1.3, lats: 1.2, 'mid-back': 1.2, quads: 0.6, hamstrings: 0.6, calves: 0.3 },
+    movementBases: {
+      horizontal_push: 185,
+      vertical_push: 105,
+      horizontal_pull: 155,
+      vertical_pull: 160,
+      squat: 165,
+      hinge: 185,
+    },
+    typicalRepRange: '6-10',
+    typicalRpe: 8,
+    totalSets14d: 60,
+    likes: ['incline-dumbbell-press', 'cable-fly', 'lat-pulldown'],
+    dislikes: ['barbell-back-squat'],
+    suggestionsLast30d: 6,
+    swapRate: 0.22,
+  },
+  bodybuilder: {
+    goals: ['Balanced hypertrophy everywhere', 'Bring up rear delts and hamstrings'],
+    weeklyIntents: ['Train 4-5x per week', 'Every FAU at least once per week'],
+    equipment: FULL_GYM,
+    intensityPreference: 'hypertrophy',
+    emphasis: {
+      chest: 'high',
+      lats: 'high',
+      quads: 'high',
+      hamstrings: 'med',
+      glutes: 'med',
+      'rear-delts': 'low',
+      calves: 'low',
+    },
+    ratioTargets: { 'rear-delts': 1.2, hamstrings: 1.2 },
+    movementBases: {
+      horizontal_push: 205,
+      vertical_push: 115,
+      horizontal_pull: 165,
+      vertical_pull: 180,
+      squat: 225,
+      hinge: 275,
+      lunge: 90,
+    },
+    typicalRepRange: '8-12',
+    typicalRpe: 8,
+    totalSets14d: 95,
+    likes: ['hack-squat', 'seated-cable-row', 'lateral-raise'],
+    dislikes: ['good-morning'],
+    suggestionsLast30d: 8,
+    swapRate: 0.15,
+  },
+  powerlifter: {
+    goals: ['Add 50 lbs to my squat this year', 'Keep bench moving'],
+    weeklyIntents: ['Squat, bench or deadlift every session', 'Accessories only after main lifts'],
+    equipment: FULL_GYM,
+    intensityPreference: 'strength',
+    emphasis: {
+      quads: 'high',
+      'lower-back': 'high',
+      glutes: 'high',
+      chest: 'high',
+      hamstrings: 'med',
+      'mid-back': 'med',
+      'side-delts': 'low',
+      biceps: 'low',
+      calves: 'none',
+      abs: 'low',
+    },
+    ratioTargets: { quads: 1.4, 'lower-back': 1.3, chest: 1.3, 'side-delts': 0.5, biceps: 0.5 },
+    movementBases: {
+      squat: 315,
+      hinge: 405,
+      horizontal_push: 245,
+      vertical_push: 135,
+      horizontal_pull: 185,
+    },
+    typicalRepRange: '1-5',
+    typicalRpe: 9,
+    totalSets14d: 45,
+    likes: ['barbell-back-squat', 'deadlift', 'barbell-bench-press'],
+    dislikes: ['leg-extension', 'cable-fly'],
+    suggestionsLast30d: 3,
+    swapRate: 0.35,
+  },
+  beginner: {
+    goals: ['Get stronger and feel better', 'Learn the basic lifts safely'],
+    weeklyIntents: ['Train 2-3x per week, full body'],
+    equipment: ['dumbbells', 'machines', 'bodyweight'],
+    intensityPreference: null,
+    emphasis: {
+      chest: 'med',
+      quads: 'med',
+      lats: 'low',
+      'mid-back': 'low',
+      hamstrings: 'low',
+      glutes: 'med',
+      'lower-back': 'none',
+      traps: 'none',
+      forearms: 'none',
+      obliques: 'none',
+    },
+    ratioTargets: {},
+    movementBases: {
+      horizontal_push: 95,
+      squat: 115,
+    },
+    typicalRepRange: '8-12',
+    typicalRpe: 7,
+    totalSets14d: 30,
+    likes: [],
+    dislikes: [],
+    suggestionsLast30d: 0,
+    swapRate: 0,
+  },
+  inconsistent: {
+    goals: ['Get back into a routine', 'Stop losing the strength I build'],
+    weeklyIntents: ['Something is better than nothing'],
+    equipment: FULL_GYM,
+    intensityPreference: 'balanced',
+    emphasis: {
+      chest: 'med',
+      quads: 'low',
+      lats: 'med',
+      hamstrings: 'low',
+      glutes: 'low',
+      'rear-delts': 'none',
+      calves: 'none',
+      adductors: 'none',
+    },
+    ratioTargets: {},
+    movementBases: {
+      horizontal_push: 155,
+      squat: 185,
+      hinge: 225,
+      horizontal_pull: 135,
+    },
+    typicalRepRange: '5-8',
+    typicalRpe: 8,
+    totalSets14d: 35,
+    likes: ['dumbbell-bench-press'],
+    dislikes: [],
+    suggestionsLast30d: 2,
+    swapRate: 0.4,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Modifiers (edge cases)
+// ---------------------------------------------------------------------------
+
+interface ScenarioDraft {
+  archetype: ArchetypeKey
+  spec: ArchetypeSpec
+  goals: string[]
+  weeklyIntents: string[]
+  equipment: EquipmentKey[]
+  bannedExerciseIds: string[]
+  ephemeral: EphemeralContext
+  expectations: ScenarioExpectation[]
+  descriptionParts: string[]
+  /** Post-hoc mutations applied to the built training state. */
+  stateMutators: Array<(state: TrainingState, rng: Rng) => void>
+  /** Prune/adjust the candidate list after building. */
+  sparseCalibration: boolean
+}
+
+type ModifierSpec = (draft: ScenarioDraft, rng: Rng) => void
+
+const INJURIES: Array<{
+  site: string
+  goal: string
+  bans: string[]
+  heavyFau: FAUKey
+}> = [
+  {
+    site: 'lower back',
+    goal: 'Recovering from a lower-back tweak (2 weeks ago) — no heavy spinal loading',
+    bans: ['deadlift', 'good-morning', 'barbell-row'],
+    heavyFau: 'lower-back',
+  },
+  {
+    site: 'knee',
+    goal: 'Right knee is cranky — avoiding heavy knee flexion under load',
+    bans: ['barbell-back-squat', 'front-squat', 'hack-squat'],
+    heavyFau: 'quads',
+  },
+  {
+    site: 'shoulder',
+    goal: 'Rehabbing a shoulder impingement — nothing heavy overhead',
+    bans: ['overhead-press', 'barbell-bench-press'],
+    heavyFau: 'front-delts',
+  },
+]
+
+export const MODIFIERS: Record<ModifierKey, ModifierSpec> = {
+  'injury-recovery': (draft, rng) => {
+    const injury = rng.pick(INJURIES)
+    draft.goals.push(injury.goal)
+    draft.bannedExerciseIds.push(...injury.bans)
+    draft.descriptionParts.push(`recovering ${injury.site}`)
+    draft.expectations.push(
+      {
+        description: `No heavy-intensity exercise loading the ${injury.site} (primary FAU ${injury.heavyFau})`,
+        kind: 'hard',
+        rule: { type: 'exclude_heavy_fau', fau: injury.heavyFau },
+      },
+      {
+        description: `Suggestion should acknowledge the ${injury.site} issue in rationale or warnings, and prefer joint-friendly variants`,
+        kind: 'judge',
+      },
+    )
+  },
+  deload: (draft) => {
+    draft.goals.push('This is a planned deload week — reduce load and volume')
+    draft.ephemeral.intensity_vibe = 'easy'
+    draft.descriptionParts.push('deload week')
+    draft.stateMutators.push((state) => {
+      for (const f of state.per_fau) {
+        f.rolling_7d_sets = Math.round(f.rolling_7d_sets * 1.4)
+        f.rolling_14d_sets = Math.round(f.rolling_14d_sets * 1.3)
+      }
+    })
+    draft.expectations.push({
+      description:
+        'All options should be light/moderate intensity with modest exercise counts; a heavy-compound-centric option contradicts the stated deload',
+      kind: 'judge',
+    })
+  },
+  'sparse-data': (draft) => {
+    draft.sparseCalibration = true
+    draft.descriptionParts.push('sparse history')
+    draft.stateMutators.push((state) => {
+      state.per_movement_calibration = state.per_movement_calibration.slice(0, 1)
+      state.preferences_summary = {
+        high_confidence_likes: [],
+        high_confidence_dislikes: [],
+        low_confidence_note: 'Most exercises <3 observations — defer to candidate list',
+      }
+      state.goal_progress = state.goal_progress.map((g) => ({
+        ...g,
+        trend: 'new',
+        weeks_observed: 1,
+        recent_top_sets_lbs: g.recent_top_sets_lbs.slice(-1),
+      }))
+      state.recent_feedback = {
+        suggestions_last_30d: 0,
+        swap_rate: 0,
+        common_swaps: [],
+        common_additions_fau: [],
+        common_deletions_fau: [],
+      }
+    })
+    draft.expectations.push({
+      description:
+        'Rationales must not claim knowledge of trends/preferences that the sparse data cannot support (no "you have been progressing on X" with one observation)',
+      kind: 'judge',
+    })
+  },
+  'competing-goals': (draft) => {
+    draft.goals.push(
+      'Training for a half marathon in 8 weeks',
+      'Also want to add 30 lbs to my bench by fall',
+    )
+    draft.weeklyIntents.push('Run 3x per week (Tue/Thu/Sat)')
+    draft.descriptionParts.push('competing goals')
+    draft.expectations.push({
+      description:
+        'Goals conflict (running volume vs pressing strength). Options should resolve the tension differently and say how; ignoring one goal silently is a miss',
+      kind: 'judge',
+    })
+  },
+  'activity-overlap': (draft, rng) => {
+    draft.ephemeral.deprioritize_freetext = 'long bike ride tomorrow, keep legs fresh'
+    draft.descriptionParts.push('legs needed tomorrow but legs neglected')
+    draft.stateMutators.push((state) => {
+      for (const f of state.per_fau) {
+        if (f.fau === 'quads' || f.fau === 'hamstrings' || f.fau === 'glutes') {
+          f.last_session_days_ago = rng.int(9, 14)
+          f.rolling_7d_sets = 0
+          f.rolling_14d_sets = rng.int(0, 3)
+          f.actual_14d_share = 0.01
+          f.deficit_share = Math.max(0.06, f.target_share - 0.01)
+          f.status = 'neglected'
+        }
+      }
+    })
+    draft.expectations.push(
+      {
+        description:
+          'User Preference option must respect "keep legs fresh" (no heavy lower-body work) even though legs show the largest deficit',
+        kind: 'judge',
+      },
+      {
+        description:
+          'If Data Driven addresses the leg deficit anyway, it must explicitly surface the conflict with tomorrow\'s ride (rationale or warnings)',
+        kind: 'judge',
+      },
+    )
+  },
+  'time-crunch': (draft) => {
+    draft.ephemeral.time_budget_minutes = 15
+    draft.descriptionParts.push('15-minute window')
+    draft.expectations.push(
+      {
+        description: '15-minute budget allows at most 3 exercises',
+        kind: 'hard',
+        rule: { type: 'max_exercise_count', max: 3 },
+      },
+      {
+        description:
+          'With 15 minutes, exercises should be the highest-leverage picks (compounds or biggest-deficit FAUs), not a filler circuit',
+        kind: 'judge',
+      },
+    )
+  },
+  'equipment-limited': (draft) => {
+    draft.ephemeral.equipment_override = ['dumbbells', 'bodyweight']
+    draft.descriptionParts.push('hotel gym (dumbbells + bodyweight)')
+    draft.expectations.push({
+      description:
+        'Candidate pool is small; the three options must still be genuinely distinct rather than the same 5 exercises reshuffled',
+      kind: 'judge',
+    })
+  },
+  'return-from-break': (draft, rng) => {
+    draft.goals.push('First session back after 4 weeks off (work travel)')
+    draft.descriptionParts.push('first session after 4 weeks off')
+    draft.stateMutators.push((state) => {
+      for (const f of state.per_fau) {
+        if (f.last_session_days_ago !== null) {
+          f.last_session_days_ago = rng.int(26, 34)
+        }
+        f.last_heavy_days_ago = f.last_heavy_days_ago === null ? null : rng.int(26, 34)
+        f.rolling_7d_sets = 0
+        f.rolling_14d_sets = 0
+        f.status = f.target_share > 0.02 ? 'neglected' : f.status
+      }
+      state.recent_feedback.suggestions_last_30d = 0
+    })
+    draft.expectations.push({
+      description:
+        'Conservative re-entry: moderate volume, no max-effort heavy singles energy; rationale should acknowledge the layoff rather than resume as if nothing happened',
+      kind: 'judge',
+    })
+  },
+  'all-satisfied': (draft, rng) => {
+    draft.descriptionParts.push('no deficits anywhere')
+    draft.stateMutators.push((state) => {
+      for (const f of state.per_fau) {
+        f.actual_14d_share = f.target_share
+        f.deficit_share = 0
+        f.status = 'balanced'
+        if (f.last_session_days_ago !== null) {
+          f.last_session_days_ago = rng.int(1, 4)
+        }
+      }
+      state.weekly_intent_status = state.weekly_intent_status.map((w) => ({
+        intent_summary: w.intent_summary,
+        satisfied_this_week: true,
+        evidence: 'All weekly targets met as of today',
+      }))
+    })
+    draft.expectations.push({
+      description:
+        'With no deficit to chase, Data Driven should lean on recency/rotation logic and Wild Card should offer genuine novelty — three near-identical options is the failure mode here',
+      kind: 'judge',
+    })
+  },
+  'ambiguous-freetext': (draft, rng) => {
+    draft.ephemeral.deprioritize_freetext = rng.pick([
+      'wheels are smoked',
+      'dead after yesterday, go easy on the pushing stuff',
+      'skip anything spicy for my back',
+    ])
+    draft.descriptionParts.push(`slang free-text: "${draft.ephemeral.deprioritize_freetext}"`)
+    draft.expectations.push({
+      description: `Free-text "${draft.ephemeral.deprioritize_freetext}" must be interpreted correctly (wheels=legs, pushing=chest/shoulders/triceps, spicy back=spinal loading) and honored in User Preference`,
+      kind: 'judge',
+    })
+  },
+}
+
+export const ARCHETYPE_KEYS = Object.keys(ARCHETYPES) as ArchetypeKey[]
+export const MODIFIER_KEYS = Object.keys(MODIFIERS) as ModifierKey[]
+
+// ---------------------------------------------------------------------------
+// Matrix
+// ---------------------------------------------------------------------------
+
+export interface ScenarioCombo {
+  archetype: ArchetypeKey
+  modifiers: ModifierKey[]
+}
+
+/**
+ * Deterministic combo order: 5 plain archetypes first, then modifiers
+ * round-robin with rotating archetypes — positions 5..14 cover all 10
+ * modifiers once, so even a 15-scenario run sees every edge case.
+ * 55 combos total before repeating.
+ */
+export function buildScenarioMatrix(): ScenarioCombo[] {
+  const combos: ScenarioCombo[] = ARCHETYPE_KEYS.map((a) => ({
+    archetype: a,
+    modifiers: [],
+  }))
+  for (let round = 0; round < ARCHETYPE_KEYS.length; round++) {
+    for (let m = 0; m < MODIFIER_KEYS.length; m++) {
+      combos.push({
+        archetype: ARCHETYPE_KEYS[(m + round) % ARCHETYPE_KEYS.length],
+        modifiers: [MODIFIER_KEYS[m]],
+      })
+    }
+  }
+  return combos
+}
+
+// ---------------------------------------------------------------------------
+// Training-state synthesis
+// ---------------------------------------------------------------------------
+
+const EMPHASIS_MULTIPLIER: Record<Emphasis, number> = {
+  high: 1.6,
+  med: 1.0,
+  low: 0.4,
+  none: 0.03,
+}
+
+/** Fixed "now" so payloads are stable across wall-clock time. */
+const EVAL_NOW = '2026-06-29T18:00:00Z'
+const EVAL_DOW = 'monday'
+
+function buildPerFAU(spec: ArchetypeSpec, rng: Rng): PerFAUState[] {
+  const weights = ALL_FAUS.map((fau) => spec.ratioTargets[fau] ?? 1.0)
+  const weightSum = weights.reduce((a, b) => a + b, 0)
+
+  const rawActuals = ALL_FAUS.map((fau) => {
+    const emphasis = spec.emphasis[fau] ?? 'med'
+    const jitter = 0.8 + rng.next() * 0.4
+    return EMPHASIS_MULTIPLIER[emphasis] * jitter
+  })
+  const actualSum = rawActuals.reduce((a, b) => a + b, 0)
+
+  return ALL_FAUS.map((fau, i) => {
+    const emphasis = spec.emphasis[fau] ?? 'med'
+    const targetShare = round4(weights[i] / weightSum)
+    const actualShare = round4(rawActuals[i] / actualSum)
+    const deficit = round4(targetShare - actualShare)
+    const sets14 = Math.round(actualShare * spec.totalSets14d)
+    const sets7 = Math.min(sets14, Math.round(sets14 * (0.35 + rng.next() * 0.3)))
+
+    let lastSession: number | null
+    if (emphasis === 'high') lastSession = rng.int(1, 3)
+    else if (emphasis === 'med') lastSession = rng.int(2, 6)
+    else if (emphasis === 'low') lastSession = rng.int(6, 14)
+    else lastSession = rng.chance(0.5) ? rng.int(21, 45) : null
+
+    const trainedHeavy = emphasis === 'high' || (emphasis === 'med' && rng.chance(0.6))
+    const lastHeavy =
+      lastSession === null || !trainedHeavy ? null : lastSession + rng.int(0, 3)
+
+    const status: PerFAUState['status'] =
+      deficit > 0.03 ? 'neglected' : deficit < -0.03 ? 'over' : 'balanced'
+
+    return {
+      fau,
+      last_session_days_ago: lastSession,
+      last_heavy_days_ago: lastHeavy,
+      rolling_7d_sets: sets7,
+      rolling_14d_sets: sets14,
+      target_share: targetShare,
+      actual_14d_share: actualShare,
+      deficit_share: deficit,
+      status,
+    }
+  })
+}
+
+function buildTrainingState(spec: ArchetypeSpec, goals: string[], intents: string[], rng: Rng): TrainingState {
+  const perFau = buildPerFAU(spec, rng.fork('fau'))
+
+  const calibRng = rng.fork('calibration')
+  const perMovement = Object.entries(spec.movementBases).map(([pattern, base]) => {
+    const step = Math.max(2.5, Math.round(base * 0.015))
+    const trendUp = calibRng.chance(0.7)
+    const observations: number[] = []
+    let w = base - (trendUp ? step * 4 : 0)
+    for (let i = 0; i < 5; i++) {
+      observations.push(Math.round(w / 5) * 5)
+      if (trendUp) w += calibRng.chance(0.7) ? step : 0
+      else w += calibRng.chance(0.3) ? step : -(calibRng.chance(0.3) ? step : 0)
+    }
+    return {
+      movement_pattern: pattern as MovementPattern,
+      current_ewma_top_weight_lbs: Math.round((observations.at(-1) ?? base) * 0.98),
+      recent_observations: observations,
+      typical_rep_range: spec.typicalRepRange,
+      typical_rpe: spec.typicalRpe,
+      last_session_days_ago: calibRng.int(2, 7),
+    }
+  })
+
+  const intentRng = rng.fork('intents')
+  const weeklyIntentStatus = intents.map((intent) => {
+    const satisfied = intentRng.chance(0.55)
+    return satisfied
+      ? {
+          intent_summary: intent,
+          satisfied_this_week: true,
+          evidence: 'Met based on last 7d logged sets',
+        }
+      : {
+          intent_summary: intent,
+          satisfied_this_week: false,
+          last_satisfied_days_ago: intentRng.int(7, 16),
+        }
+  })
+
+  const goalRng = rng.fork('goals')
+  const goalProgress = goals.slice(0, 2).map((goal) => {
+    const trend = goalRng.pick(['progressing', 'stalled', 'progressing', 'new'] as const)
+    const calib = perMovement[0]
+    return {
+      goal,
+      interpretation: calib
+        ? `${calib.movement_pattern} EWMA + top-set trend`
+        : 'volume trend',
+      recent_top_sets_lbs: calib ? calib.recent_observations : [],
+      trend,
+      weeks_observed: trend === 'new' ? 1 : goalRng.int(3, 8),
+    }
+  })
+
+  return {
+    now: EVAL_NOW,
+    today_dow: EVAL_DOW,
+    per_fau: perFau,
+    per_movement_calibration: perMovement,
+    weekly_intent_status: weeklyIntentStatus,
+    goal_progress: goalProgress,
+    recent_feedback: {
+      suggestions_last_30d: spec.suggestionsLast30d,
+      swap_rate: spec.swapRate,
+      common_swaps:
+        spec.suggestionsLast30d > 2
+          ? [{ from: 'barbell-bench-press', to: 'dumbbell-bench-press', count: 2 }]
+          : [],
+      common_additions_fau: spec.suggestionsLast30d > 2 ? ['biceps', 'side-delts'] : [],
+      common_deletions_fau: spec.suggestionsLast30d > 2 ? ['quads'] : [],
+    },
+    preferences_summary: {
+      high_confidence_likes: spec.likes,
+      high_confidence_dislikes: spec.dislikes,
+      low_confidence_note:
+        spec.likes.length + spec.dislikes.length === 0
+          ? 'No high-confidence preferences yet — defer to candidate list'
+          : null,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ephemeral context
+// ---------------------------------------------------------------------------
+
+const PRIORITIZE_POOL = [
+  null,
+  null,
+  'want to hit chest hard',
+  'feeling strong today',
+  'back day if possible',
+]
+const DEPRIORITIZE_POOL = [null, null, null, 'legs a bit sore', 'shoulder feels off']
+
+function buildEphemeral(rng: Rng): EphemeralContext {
+  return {
+    time_budget_minutes: rng.pick([30, 45, 45, 60, 60, 90]),
+    intensity_vibe: rng.pick(['easy', 'solid', 'solid', 'heavy'] as const),
+    deprioritize_freetext: rng.pick(DEPRIORITIZE_POOL),
+    prioritize_freetext: rng.pick(PRIORITIZE_POOL),
+    equipment_override: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Candidates
+// ---------------------------------------------------------------------------
+
+function buildCandidates(
+  equipment: string[],
+  banned: string[],
+  likes: string[],
+  dislikes: string[],
+  rng: Rng,
+): CandidateExercise[] {
+  const equipmentSet = new Set(equipment)
+  const bannedSet = new Set(banned)
+  return EXERCISE_CATALOG.filter(
+    (e) => equipmentSet.has(e.equipment) && !bannedSet.has(e.id),
+  ).map((e) => {
+    if (likes.includes(e.id)) {
+      return {
+        ...e,
+        user_preference_score: round2(0.75 + rng.next() * 0.15),
+        user_preference_confidence: 'high' as const,
+      }
+    }
+    if (dislikes.includes(e.id)) {
+      return {
+        ...e,
+        user_preference_score: round2(0.1 + rng.next() * 0.15),
+        user_preference_confidence: 'high' as const,
+      }
+    }
+    return { ...e }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export interface GenerateOptions {
+  count: number
+  seed: string
+}
+
+export function generateScenarios(options: GenerateOptions): EvalScenario[] {
+  const matrix = buildScenarioMatrix()
+  const scenarios: EvalScenario[] = []
+
+  for (let i = 0; i < options.count; i++) {
+    const combo = matrix[i % matrix.length]
+    const scenarioSeed = `${options.seed}#${i}`
+    scenarios.push(buildScenario(combo, scenarioSeed, i))
+  }
+  return scenarios
+}
+
+function buildScenario(combo: ScenarioCombo, seed: string, index: number): EvalScenario {
+  const rng = createRng(seed)
+  const spec = ARCHETYPES[combo.archetype]
+
+  const draft: ScenarioDraft = {
+    archetype: combo.archetype,
+    spec,
+    goals: [...spec.goals],
+    weeklyIntents: [...spec.weeklyIntents],
+    equipment: [...spec.equipment],
+    bannedExerciseIds: [],
+    ephemeral: buildEphemeral(rng.fork('ephemeral')),
+    expectations: [],
+    descriptionParts: [combo.archetype],
+    stateMutators: [],
+    sparseCalibration: false,
+  }
+
+  const modifierRng = rng.fork('modifiers')
+  for (const modifier of combo.modifiers) {
+    MODIFIERS[modifier](draft, modifierRng)
+  }
+
+  const trainingState = buildTrainingState(spec, draft.goals, draft.weeklyIntents, rng.fork('state'))
+  const mutatorRng = rng.fork('mutators')
+  for (const mutate of draft.stateMutators) mutate(trainingState, mutatorRng)
+
+  const effectiveEquipment = draft.ephemeral.equipment_override ?? draft.equipment
+  const candidates = buildCandidates(
+    effectiveEquipment,
+    draft.bannedExerciseIds,
+    draft.sparseCalibration ? [] : spec.likes,
+    draft.sparseCalibration ? [] : spec.dislikes,
+    rng.fork('candidates'),
+  )
+
+  const payload: SuggestPayload = {
+    durable_profile: {
+      goal_sentences: draft.goals,
+      weekly_intent: draft.weeklyIntents,
+      equipment_available: draft.equipment,
+      banned_exercise_ids: draft.bannedExerciseIds,
+      default_intensity_preference: spec.intensityPreference,
+      ratio_targets: spec.ratioTargets,
+    },
+    ephemeral_context: draft.ephemeral,
+    training_state: trainingState,
+    candidate_exercises: candidates,
+  }
+
+  const modifierSlug = combo.modifiers.length > 0 ? `+${combo.modifiers.join('+')}` : ''
+  return {
+    id: `${String(index).padStart(3, '0')}-${combo.archetype}${modifierSlug}`,
+    seed,
+    archetype: combo.archetype,
+    modifiers: combo.modifiers,
+    description: `${draft.descriptionParts.join(', ')} — ${draft.ephemeral.time_budget_minutes}min, ${draft.ephemeral.intensity_vibe}`,
+    payload,
+    expectations: draft.expectations,
+  }
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/lib/eval/store.ts
+++ b/lib/eval/store.ts
@@ -1,0 +1,235 @@
+/**
+ * File-based state for the eval loop. Everything lives under `.eval/`
+ * (gitignored) — this is dev tooling, not app data.
+ *
+ * Layout:
+ *   .eval/
+ *     runs/<runId>/
+ *       meta.json                # RunMeta
+ *       scenarios.json           # EvalScenario[] (full payloads, replayable)
+ *       results/<scenarioId>.json# ScenarioResult
+ *       report.json              # RunReport (see report.ts)
+ *       report.md
+ *     ratings.jsonl              # HumanRating, append-only
+ *     calibration.json           # human-vs-judge calibration history
+ *     variants/<name>.json       # experimental PromptVariant files
+ *     proposals/<runId>.md       # refinement-engine output
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  PLANNER_PROMPT_VARIANTS,
+  type PromptVariant,
+} from '@/lib/suggest/prompts/registry'
+
+import type {
+  EvalScenario,
+  HumanRating,
+  RunMeta,
+  ScenarioResult,
+} from './types'
+
+export function evalRoot(): string {
+  return path.join(process.cwd(), '.eval')
+}
+
+function runDir(runId: string): string {
+  return path.join(evalRoot(), 'runs', runId)
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+function writeJson(file: string, data: unknown): void {
+  ensureDir(path.dirname(file))
+  fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`)
+}
+
+function readJson<T>(file: string): T {
+  return JSON.parse(fs.readFileSync(file, 'utf8')) as T
+}
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+export function makeRunId(promptVariant: string, now = new Date()): string {
+  const stamp = now
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\..*$/, '')
+    .replace('T', '-')
+  return `${stamp}-${promptVariant.replace(/[^a-zA-Z0-9_+.-]/g, '_')}`
+}
+
+export function saveRunMeta(meta: RunMeta): void {
+  writeJson(path.join(runDir(meta.runId), 'meta.json'), meta)
+}
+
+export function saveScenarios(runId: string, scenarios: EvalScenario[]): void {
+  writeJson(path.join(runDir(runId), 'scenarios.json'), scenarios)
+}
+
+export function saveScenarioResult(runId: string, result: ScenarioResult): void {
+  writeJson(
+    path.join(runDir(runId), 'results', `${result.scenarioId}.json`),
+    result,
+  )
+}
+
+export function saveReport(runId: string, report: unknown, markdown: string): void {
+  writeJson(path.join(runDir(runId), 'report.json'), report)
+  fs.writeFileSync(path.join(runDir(runId), 'report.md'), markdown)
+}
+
+export interface LoadedRun {
+  meta: RunMeta
+  scenarios: EvalScenario[]
+  results: ScenarioResult[]
+}
+
+export function loadRun(runId: string): LoadedRun {
+  const dir = runDir(runId)
+  if (!fs.existsSync(dir)) {
+    throw new Error(`No such run: ${runId} (looked in ${dir})`)
+  }
+  const meta = readJson<RunMeta>(path.join(dir, 'meta.json'))
+  const scenarios = readJson<EvalScenario[]>(path.join(dir, 'scenarios.json'))
+  const resultsDir = path.join(dir, 'results')
+  const results = fs.existsSync(resultsDir)
+    ? fs
+        .readdirSync(resultsDir)
+        .filter((f) => f.endsWith('.json'))
+        .sort()
+        .map((f) => readJson<ScenarioResult>(path.join(resultsDir, f)))
+    : []
+  return { meta, scenarios, results }
+}
+
+export function listRunIds(): string[] {
+  const dir = path.join(evalRoot(), 'runs')
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir)
+    .filter((f) => fs.existsSync(path.join(dir, f, 'meta.json')))
+    .sort()
+}
+
+export function latestRunId(): string | null {
+  const runs = listRunIds()
+  return runs.length > 0 ? runs[runs.length - 1] : null
+}
+
+// ---------------------------------------------------------------------------
+// Human ratings
+// ---------------------------------------------------------------------------
+
+function ratingsFile(): string {
+  return path.join(evalRoot(), 'ratings.jsonl')
+}
+
+export function appendRating(rating: HumanRating): void {
+  ensureDir(evalRoot())
+  fs.appendFileSync(ratingsFile(), `${JSON.stringify(rating)}\n`)
+}
+
+export function loadRatings(): HumanRating[] {
+  const file = ratingsFile()
+  if (!fs.existsSync(file)) return []
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as HumanRating)
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+export interface CalibrationEntry {
+  computedAt: string
+  rubricVersion: string
+  judgeModel: string
+  sampleSize: number
+  /** Spearman rank correlation, human overall vs judge composite. */
+  spearman: number | null
+  /** Mean |human - judge| on the shared 1-4 scale. */
+  meanAbsDiff: number | null
+  /**
+   * Of options where the human flagged >=1 dimension, fraction where a
+   * flagged dimension is among the judge's two lowest for that option.
+   */
+  flagAgreement: number | null
+}
+
+export function loadCalibrationHistory(): CalibrationEntry[] {
+  const file = path.join(evalRoot(), 'calibration.json')
+  if (!fs.existsSync(file)) return []
+  return readJson<CalibrationEntry[]>(file)
+}
+
+export function appendCalibrationEntry(entry: CalibrationEntry): void {
+  const history = loadCalibrationHistory()
+  history.push(entry)
+  writeJson(path.join(evalRoot(), 'calibration.json'), history)
+}
+
+// ---------------------------------------------------------------------------
+// Prompt variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a prompt variant by name: committed variants from the
+ * registry first, then experimental `.eval/variants/<name>.json`.
+ */
+export function resolvePromptVariant(name: string): PromptVariant {
+  const builtin = PLANNER_PROMPT_VARIANTS[name]
+  if (builtin) return builtin
+
+  const file = path.join(evalRoot(), 'variants', `${name}.json`)
+  if (fs.existsSync(file)) {
+    const variant = readJson<PromptVariant>(file)
+    if (!Array.isArray(variant.sections) || variant.sections.length === 0) {
+      throw new Error(`Variant file ${file} has no sections`)
+    }
+    return variant
+  }
+
+  const known = [
+    ...Object.keys(PLANNER_PROMPT_VARIANTS),
+    ...listExperimentalVariants(),
+  ]
+  throw new Error(
+    `Unknown prompt variant "${name}". Known: ${known.join(', ') || '(none)'}`,
+  )
+}
+
+export function listExperimentalVariants(): string[] {
+  const dir = path.join(evalRoot(), 'variants')
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort()
+}
+
+export function saveExperimentalVariant(variant: PromptVariant): string {
+  const file = path.join(evalRoot(), 'variants', `${variant.version}.json`)
+  if (fs.existsSync(file)) {
+    throw new Error(`Variant ${variant.version} already exists at ${file}`)
+  }
+  writeJson(file, variant)
+  return file
+}
+
+export function saveProposal(runId: string, markdown: string): string {
+  const file = path.join(evalRoot(), 'proposals', `${runId}.md`)
+  ensureDir(path.dirname(file))
+  fs.writeFileSync(file, markdown)
+  return file
+}

--- a/lib/eval/types.ts
+++ b/lib/eval/types.ts
@@ -1,0 +1,264 @@
+/**
+ * Shared types for the Suggest Workout eval loop.
+ *
+ * The payload types mirror the locked payload spec (#877 comment). The
+ * eval loop synthesizes these payloads directly (no DB) so scenario
+ * generation is deterministic and runnable anywhere. When the real
+ * training-state builder (#876) lands, its output must be assignable to
+ * `SuggestPayload` — golden-file tests in #886 enforce that from the
+ * other side.
+ */
+
+import type { FAUKey } from '@/lib/fau-volume'
+import type { IntensityClass, MovementPattern } from '@/lib/exercises/auto-tag'
+
+// ---------------------------------------------------------------------------
+// Payload (input to the planner LLM) — per #877 locked spec
+// ---------------------------------------------------------------------------
+
+export interface DurableProfile {
+  goal_sentences: string[]
+  weekly_intent: string[]
+  equipment_available: string[]
+  banned_exercise_ids: string[]
+  default_intensity_preference: 'hypertrophy' | 'strength' | 'balanced' | null
+  ratio_targets: Partial<Record<FAUKey, number>>
+}
+
+export interface EphemeralContext {
+  time_budget_minutes: number
+  intensity_vibe: 'easy' | 'solid' | 'heavy'
+  deprioritize_freetext: string | null
+  prioritize_freetext: string | null
+  equipment_override: string[] | null
+}
+
+export interface PerFAUState {
+  fau: FAUKey
+  last_session_days_ago: number | null
+  last_heavy_days_ago: number | null
+  rolling_7d_sets: number
+  rolling_14d_sets: number
+  target_share: number
+  actual_14d_share: number
+  deficit_share: number
+  status: 'neglected' | 'balanced' | 'over'
+}
+
+export interface MovementCalibration {
+  movement_pattern: MovementPattern
+  current_ewma_top_weight_lbs: number
+  recent_observations: number[]
+  typical_rep_range: string
+  typical_rpe: number
+  last_session_days_ago: number
+}
+
+export interface WeeklyIntentStatus {
+  intent_summary: string
+  satisfied_this_week: boolean
+  last_satisfied_days_ago?: number
+  evidence?: string
+}
+
+export interface GoalProgress {
+  goal: string
+  interpretation: string
+  recent_top_sets_lbs: number[]
+  trend: 'progressing' | 'stalled' | 'regressing' | 'new'
+  weeks_observed: number
+}
+
+export interface RecentFeedback {
+  suggestions_last_30d: number
+  swap_rate: number
+  common_swaps: Array<{ from: string; to: string; count: number }>
+  common_additions_fau: string[]
+  common_deletions_fau: string[]
+}
+
+export interface PreferencesSummary {
+  high_confidence_likes: string[]
+  high_confidence_dislikes: string[]
+  low_confidence_note: string | null
+}
+
+export interface TrainingState {
+  now: string
+  today_dow: string
+  per_fau: PerFAUState[]
+  per_movement_calibration: MovementCalibration[]
+  weekly_intent_status: WeeklyIntentStatus[]
+  goal_progress: GoalProgress[]
+  recent_feedback: RecentFeedback
+  preferences_summary: PreferencesSummary
+}
+
+export interface CandidateExercise {
+  id: string
+  name: string
+  primary_faus: FAUKey[]
+  secondary_faus: FAUKey[]
+  equipment: string
+  movement_pattern: MovementPattern | null
+  intensity_class: IntensityClass
+  user_preference_score?: number
+  user_preference_confidence?: 'high'
+}
+
+export interface SuggestPayload {
+  durable_profile: DurableProfile
+  ephemeral_context: EphemeralContext
+  training_state: TrainingState
+  candidate_exercises: CandidateExercise[]
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+export type ArchetypeKey =
+  | 'cyclist'
+  | 'bodybuilder'
+  | 'powerlifter'
+  | 'beginner'
+  | 'inconsistent'
+
+export type ModifierKey =
+  | 'injury-recovery'
+  | 'deload'
+  | 'sparse-data'
+  | 'competing-goals'
+  | 'activity-overlap'
+  | 'time-crunch'
+  | 'equipment-limited'
+  | 'return-from-break'
+  | 'all-satisfied'
+  | 'ambiguous-freetext'
+
+/** Deterministic, machine-checkable rule attached to a scenario. */
+export type HardRule =
+  | { type: 'exclude_exercises'; exerciseIds: string[] }
+  | { type: 'exclude_heavy_fau'; fau: FAUKey }
+  | { type: 'max_exercise_count'; max: number }
+
+/**
+ * Scenario-specific expectation. `hard` rules are enforced by code in
+ * hard-checks; `judge` expectations are handed to the LLM judge as
+ * "things to look for" so scoring is grounded in scenario intent rather
+ * than the judge's own taste.
+ */
+export interface ScenarioExpectation {
+  description: string
+  kind: 'hard' | 'judge'
+  rule?: HardRule
+}
+
+export interface EvalScenario {
+  id: string
+  seed: string
+  archetype: ArchetypeKey
+  modifiers: ModifierKey[]
+  description: string
+  payload: SuggestPayload
+  expectations: ScenarioExpectation[]
+}
+
+// ---------------------------------------------------------------------------
+// Planner output (three-option shape per #877)
+// ---------------------------------------------------------------------------
+
+export type OptionId = 'user_preference' | 'data_driven' | 'wild_card'
+
+export interface SuggestedExercise {
+  id: string
+  rationale: string
+}
+
+export interface SuggestionOption {
+  id: OptionId
+  name: string
+  description: string
+  summary: string
+  exercises: SuggestedExercise[]
+}
+
+export interface SuggestionResponse {
+  options: SuggestionOption[]
+  warnings: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+export interface HardCheckResult {
+  name: string
+  passed: boolean
+  detail: string | null
+  /** Which option failed, when the check is per-option. */
+  optionId?: OptionId
+}
+
+export interface DimensionScore {
+  dimension: string
+  /** Judge must produce evidence BEFORE the score — see judge.ts. */
+  evidence: string
+  score: number
+}
+
+export interface OptionJudgement {
+  option_id: OptionId
+  dimension_scores: DimensionScore[]
+  note: string
+}
+
+export interface JudgeResult {
+  per_option: OptionJudgement[]
+  /** Scored once across all three options. */
+  option_identity: DimensionScore
+  overall_note: string
+}
+
+export interface ScenarioResult {
+  scenarioId: string
+  response: SuggestionResponse | null
+  /** Planner call error, if the call itself failed. */
+  error: string | null
+  latencyMs: number | null
+  plannerModel: string | null
+  hardChecks: HardCheckResult[]
+  /** One entry per judge run (K runs for stability measurement). */
+  judgeRuns: JudgeResult[]
+  /** Median-aggregated composite in [1,4]; null if judging failed. */
+  composite: number | null
+  /** Per-dimension median across options and judge runs. */
+  dimensionMedians: Record<string, number>
+}
+
+export interface RunMeta {
+  runId: string
+  createdAt: string
+  promptVariant: string
+  seed: string
+  scenarioCount: number
+  plannerModel: string
+  judgeModel: string
+  judgeRuns: number
+}
+
+// ---------------------------------------------------------------------------
+// Human ratings
+// ---------------------------------------------------------------------------
+
+export interface HumanRating {
+  ratedAt: string
+  runId: string
+  scenarioId: string
+  optionId: OptionId
+  /** Overall 1–4 on the same anchored scale the judge uses. */
+  overall: number
+  /** Dimension keys the human flagged as the problem (may be empty). */
+  flaggedDimensions: string[]
+  note: string | null
+}

--- a/lib/suggest/prompts/registry.ts
+++ b/lib/suggest/prompts/registry.ts
@@ -1,0 +1,105 @@
+/**
+ * Versioned planner prompts for Suggest Workout.
+ *
+ * Prompts are structured as named sections so the eval loop's refinement
+ * engine can propose targeted diffs ("replace section `safety`") instead
+ * of whole-prompt rewrites. Committed variants live here; experimental
+ * variants produced by the refinement engine live in `.eval/variants/`
+ * as JSON with the same shape and are resolved by the eval store.
+ *
+ * The production planner (#880) should import `buildPlannerPrompt` +
+ * `PLANNER_PROMPT_VARIANTS[CURRENT_PLANNER_VERSION]` from here so the
+ * prompt that ships is the prompt that was evaluated.
+ */
+
+import type { SuggestPayload } from '@/lib/eval/types'
+
+export interface PromptSection {
+  name: string
+  content: string
+}
+
+export interface PromptVariant {
+  version: string
+  /** Variant this one was derived from (refinement lineage). */
+  base?: string
+  notes?: string
+  sections: PromptSection[]
+}
+
+const V1_SECTIONS: PromptSection[] = [
+  {
+    name: 'role',
+    content:
+      'You are an expert strength coach picking today\'s workout for one athlete. You receive a JSON payload describing their durable profile, an ephemeral request ("what I want right now"), a summary of their recent training state, and a pre-filtered list of candidate exercises. You select exercises ONLY from the candidate list, by exact `id`.',
+  },
+  {
+    name: 'option_identities',
+    content: [
+      'Produce exactly three options, in this order, each with a distinct philosophy:',
+      '1. `user_preference` — honors the ephemeral request and the user\'s known likes above all else. If they said "keep legs fresh", there is no leg work here, even if legs are under-trained.',
+      '2. `data_driven` — closes the largest gaps in `training_state` (highest `deficit_share`, most-neglected FAUs, unsatisfied weekly intents), while still respecting hard constraints and safety.',
+      '3. `wild_card` — a genuinely different session: new movement patterns, exercises the user rarely does, or an unusual but sound structure. Different from the other two options, not a remix of them.',
+      'The three options must differ in at least half their exercises. If the candidate pool is too small for that, differ in emphasis and ordering, and say so in `warnings`.',
+    ].join('\n'),
+  },
+  {
+    name: 'selection_principles',
+    content: [
+      'Selection rules, in priority order:',
+      '1. Never select an exercise whose `id` is not in `candidate_exercises`. Never repeat an exercise within an option.',
+      '2. Respect `ephemeral_context` free text. Interpret gym slang ("wheels" = legs, "smoked" = fatigued, "pressing" = chest/shoulders/triceps).',
+      '3. Use `training_state.per_fau`: positive `deficit_share` means under-trained; low `last_session_days_ago` means recently worked and may need recovery, especially when `last_heavy_days_ago` is 0-2.',
+      '4. Use `preferences_summary` and `user_preference_score` when present: favor high scores in `user_preference`, and avoid high-confidence dislikes everywhere except `wild_card` (where one is acceptable if clearly justified).',
+      '5. Order exercises within an option: heavy compounds first, isolation and core last.',
+      '6. Match `intensity_vibe`: "easy" avoids `intensity_class: heavy` exercises; "heavy" leads with them; "solid" mixes.',
+    ].join('\n'),
+  },
+  {
+    name: 'time_budget',
+    content:
+      'Assume roughly 8 minutes per exercise including rest and setup. Pick a count that fits `time_budget_minutes`: 15 min -> 2, 30 min -> 3-4, 45 min -> 5-6, 60 min -> 6-8, 90 min -> 8-10. Do not pad short sessions with filler.',
+  },
+  {
+    name: 'safety',
+    content:
+      'Read `goal_sentences` for injuries, recovery notes, and deload/layoff context. When present: avoid heavy loading of the affected area, prefer machine or dumbbell variants over barbell, and mention the accommodation explicitly in the relevant rationale or in `warnings`. After a long layoff (no sets in 14+ days across the board), all three options should be moderate re-entry sessions.',
+  },
+  {
+    name: 'rationale_style',
+    content:
+      'Every exercise gets a one-sentence `rationale` citing a specific fact from the payload (a deficit, a recency number, a stated goal, a preference score, the free text). Generic lines like "great for building muscle" are failures. Do not invent history the payload does not contain. Each option gets a one-line `description` (what philosophy it follows and how it honors the request) and a `summary` ("N exercises, ~M min. <emphasis>").',
+  },
+  {
+    name: 'output_format',
+    content:
+      'Respond with ONLY a JSON object, no prose, matching: {"options": [{"id": "user_preference" | "data_driven" | "wild_card", "name": string, "description": string, "summary": string, "exercises": [{"id": string, "rationale": string}]}], "warnings": [string]}. Exactly three options, in the order user_preference, data_driven, wild_card. `warnings` is for conflicts worth surfacing (for example a weekly intent that cannot be satisfied today); use [] when there are none.',
+  },
+]
+
+export const PLANNER_PROMPT_VARIANTS: Record<string, PromptVariant> = {
+  v1: {
+    version: 'v1',
+    notes: 'Baseline planner prompt, authored alongside the eval loop.',
+    sections: V1_SECTIONS,
+  },
+}
+
+/** The variant the production planner should use. Promote winners here. */
+export const CURRENT_PLANNER_VERSION = 'v1'
+
+export function buildPlannerPrompt(
+  variant: PromptVariant,
+  payload: SuggestPayload,
+): { system: string; user: string } {
+  const system = variant.sections
+    .map((s) => `## ${s.name}\n${s.content}`)
+    .join('\n\n')
+  const user = [
+    'Payload:',
+    JSON.stringify(payload, null, 2),
+    '',
+    'Respond with the JSON object now.',
+  ].join('\n')
+  return { system, user }
+}

--- a/lib/suggest/schema.ts
+++ b/lib/suggest/schema.ts
@@ -1,0 +1,30 @@
+/**
+ * Zod schema for the Suggest Workout planner output — the three-option
+ * shape locked in #877. Shared by the eval loop today and the real
+ * planner (#880) when it lands, so eval and production validate the
+ * exact same contract.
+ */
+
+import { z } from 'zod'
+
+export const OPTION_IDS = ['user_preference', 'data_driven', 'wild_card'] as const
+
+export const suggestedExerciseSchema = z.object({
+  id: z.string().min(1),
+  rationale: z.string().min(1),
+})
+
+export const suggestionOptionSchema = z.object({
+  id: z.enum(OPTION_IDS),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  summary: z.string().min(1),
+  exercises: z.array(suggestedExerciseSchema).min(1).max(12),
+})
+
+export const suggestionResponseSchema = z.object({
+  options: z.array(suggestionOptionSchema).length(3),
+  warnings: z.array(z.string()).default([]),
+})
+
+export type SuggestionResponseParsed = z.infer<typeof suggestionResponseSchema>

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "tailwindcss": "^4.2.4",
         "testcontainers": "^10.28.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.22.4",
         "typescript": "^5.9.3",
         "vitest": "^2.1.9"
       }
@@ -1242,6 +1243,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1259,6 +1277,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1274,6 +1309,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -17233,6 +17285,458 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
+    "eval-suggest": "tsx scripts/eval-suggest.ts",
+    "rate-suggestions": "tsx scripts/rate-suggestions.ts",
     "prepare": "husky"
   },
   "dependencies": {
@@ -74,6 +76,7 @@
     "tailwindcss": "^4.2.4",
     "testcontainers": "^10.28.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.22.4",
     "typescript": "^5.9.3",
     "vitest": "^2.1.9"
   },

--- a/scripts/eval-suggest.ts
+++ b/scripts/eval-suggest.ts
@@ -1,0 +1,298 @@
+/**
+ * End-to-end eval runner for Suggest Workout prompts.
+ *
+ * Usage (run under doppler so LLM_* env vars are present):
+ *   doppler run --config dev_personal -- npx tsx scripts/eval-suggest.ts \
+ *     --scenarios 20 --prompt v1 --seed eval-v1
+ *
+ * Or via the npm script:
+ *   doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1
+ *
+ * Flags:
+ *   --scenarios N       number of scenarios (default 12)
+ *   --prompt NAME       prompt variant: registry version or .eval/variants name (default v1)
+ *   --seed STRING       scenario seed (default eval-v1). Same seed+count → same scenarios.
+ *   --judge-runs K      judge passes per suggestion (default 1; use 3 for release decisions)
+ *   --judge-model M     override judge model (default LLM_JUDGE_MODEL, then LLM_MODEL)
+ *   --model M           override planner model (default LLM_MODEL)
+ *   --concurrency N     parallel scenarios (default 3)
+ *   --compare RUN_ID    paired comparison against a previous run (same seed required)
+ *   --refine            after scoring, cluster failures and propose prompt diffs
+ *   --dry-run           generate + save scenarios and print coverage, no LLM calls
+ *
+ * Env: LLM_PROVIDER_URL, LLM_API_KEY, LLM_MODEL (see lib/llm/client.ts),
+ * optional LLM_JUDGE_MODEL / LLM_JUDGE_PROVIDER_URL / LLM_JUDGE_API_KEY.
+ */
+
+import { parseArgs } from 'node:util'
+
+import { LLMClient } from '../lib/llm/client'
+import { generateScenarios } from '../lib/eval/scenario-generator'
+import { runHardChecks, failedGates } from '../lib/eval/hard-checks'
+import { aggregateJudgeRuns, judgeSuggestion } from '../lib/eval/judge'
+import {
+  buildRunReport,
+  compareRuns,
+  renderComparisonMarkdown,
+  renderReportMarkdown,
+} from '../lib/eval/report'
+import {
+  applyDiff,
+  clusterFailures,
+  proposeDiffs,
+  renderProposalMarkdown,
+} from '../lib/eval/refinement-engine'
+import {
+  loadRun,
+  makeRunId,
+  resolvePromptVariant,
+  saveExperimentalVariant,
+  saveProposal,
+  saveReport,
+  saveRunMeta,
+  saveScenarioResult,
+  saveScenarios,
+} from '../lib/eval/store'
+import type { EvalScenario, ScenarioResult } from '../lib/eval/types'
+import { buildPlannerPrompt } from '../lib/suggest/prompts/registry'
+import { suggestionResponseSchema } from '../lib/suggest/schema'
+
+const { values: args } = parseArgs({
+  options: {
+    scenarios: { type: 'string', default: '12' },
+    prompt: { type: 'string', default: 'v1' },
+    seed: { type: 'string', default: 'eval-v1' },
+    'judge-runs': { type: 'string', default: '1' },
+    'judge-model': { type: 'string' },
+    model: { type: 'string' },
+    concurrency: { type: 'string', default: '3' },
+    compare: { type: 'string' },
+    refine: { type: 'boolean', default: false },
+    'dry-run': { type: 'boolean', default: false },
+  },
+})
+
+function log(msg: string): void {
+  process.stdout.write(`${msg}\n`)
+}
+
+async function mapPool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await fn(items[i], i)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+async function runScenario(
+  scenario: EvalScenario,
+  plannerClient: LLMClient,
+  judgeClient: LLMClient,
+  options: {
+    promptVariant: string
+    plannerModel?: string
+    judgeModel?: string
+    judgeRuns: number
+  },
+): Promise<ScenarioResult> {
+  const variant = resolvePromptVariant(options.promptVariant)
+  const { system, user } = buildPlannerPrompt(variant, scenario.payload)
+
+  const base: ScenarioResult = {
+    scenarioId: scenario.id,
+    response: null,
+    error: null,
+    latencyMs: null,
+    plannerModel: null,
+    hardChecks: [],
+    judgeRuns: [],
+    composite: null,
+    dimensionMedians: {},
+  }
+
+  let responseData
+  try {
+    const result = await plannerClient.callWithStructuredOutput(
+      user,
+      suggestionResponseSchema,
+      {
+        system,
+        model: options.plannerModel,
+        temperature: 0,
+        schemaName: 'workout_suggestion',
+        timeoutMs: 120_000,
+      },
+    )
+    responseData = result.data
+    base.latencyMs = result.latencyMs
+    base.plannerModel = result.model
+  } catch (err) {
+    base.error = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+    return base
+  }
+
+  base.response = responseData
+  base.hardChecks = runHardChecks(scenario, responseData)
+
+  try {
+    base.judgeRuns = await judgeSuggestion(
+      judgeClient,
+      scenario,
+      responseData,
+      failedGates(base.hardChecks),
+      { model: options.judgeModel, runs: options.judgeRuns },
+    )
+    const aggregated = aggregateJudgeRuns(base.judgeRuns)
+    base.composite = aggregated.composite
+    base.dimensionMedians = aggregated.dimensionMedians
+  } catch (err) {
+    base.error = `judge failed: ${err instanceof Error ? err.message : String(err)}`
+  }
+
+  return base
+}
+
+async function main(): Promise<void> {
+  const scenarioCount = Number.parseInt(args.scenarios ?? '12', 10)
+  const judgeRuns = Number.parseInt(args['judge-runs'] ?? '1', 10)
+  const concurrency = Number.parseInt(args.concurrency ?? '3', 10)
+  const promptVariant = args.prompt ?? 'v1'
+  const seed = args.seed ?? 'eval-v1'
+
+  // Fail fast on unknown variants before spending tokens
+  const variant = resolvePromptVariant(promptVariant)
+
+  const scenarios = generateScenarios({ count: scenarioCount, seed })
+  const runId = makeRunId(promptVariant)
+
+  log(`run ${runId}: ${scenarios.length} scenarios, prompt=${variant.version}, seed=${seed}`)
+  const coverage = new Map<string, number>()
+  for (const s of scenarios) {
+    const key = s.modifiers.length > 0 ? s.modifiers.join('+') : '(plain)'
+    coverage.set(key, (coverage.get(key) ?? 0) + 1)
+  }
+  log(
+    `coverage: ${[...coverage.entries()].map(([k, n]) => `${k}×${n}`).join(', ')}`,
+  )
+
+  saveScenarios(runId, scenarios)
+
+  if (args['dry-run']) {
+    log('dry run — scenarios saved, no LLM calls made')
+    return
+  }
+
+  const plannerClient = new LLMClient({ model: args.model })
+  const judgeClient = new LLMClient({
+    apiKey: process.env.LLM_JUDGE_API_KEY,
+    baseURL: process.env.LLM_JUDGE_PROVIDER_URL,
+    model: args['judge-model'] ?? process.env.LLM_JUDGE_MODEL ?? process.env.LLM_MODEL,
+  })
+
+  saveRunMeta({
+    runId,
+    createdAt: new Date().toISOString(),
+    promptVariant: variant.version,
+    seed,
+    scenarioCount: scenarios.length,
+    plannerModel: args.model ?? process.env.LLM_MODEL ?? 'unknown',
+    judgeModel:
+      args['judge-model'] ?? process.env.LLM_JUDGE_MODEL ?? process.env.LLM_MODEL ?? 'unknown',
+    judgeRuns,
+  })
+
+  let completed = 0
+  const results = await mapPool(scenarios, concurrency, async (scenario) => {
+    const result = await runScenario(scenario, plannerClient, judgeClient, {
+      promptVariant,
+      plannerModel: args.model,
+      judgeModel: args['judge-model'] ?? process.env.LLM_JUDGE_MODEL,
+      judgeRuns,
+    })
+    saveScenarioResult(runId, result)
+    completed++
+    const gateFails = result.hardChecks.filter((c) => !c.passed).length
+    log(
+      `[${completed}/${scenarios.length}] ${scenario.id}: ${
+        result.error
+          ? `ERROR ${result.error}`
+          : `composite ${result.composite ?? 'n/a'}${gateFails > 0 ? `, ${gateFails} gate fails` : ''}`
+      }`,
+    )
+    return result
+  })
+
+  const run = { meta: loadRun(runId).meta, scenarios, results }
+  const spreads = results
+    .map((r) => aggregateJudgeRuns(r.judgeRuns).compositeSpread)
+    .filter((s) => s > 0)
+  const report = buildRunReport(run, spreads)
+  const markdown = renderReportMarkdown(report)
+  saveReport(runId, report, markdown)
+  log('')
+  log(markdown)
+  log(`saved: .eval/runs/${runId}/report.md`)
+
+  if (args.compare) {
+    const baseRun = loadRun(args.compare)
+    const baseSpreads = baseRun.results
+      .map((r) => aggregateJudgeRuns(r.judgeRuns).compositeSpread)
+      .filter((s) => s > 0)
+    const baseReport = buildRunReport(baseRun, baseSpreads)
+    const cmp = compareRuns(
+      { report: baseReport, results: baseRun.results },
+      { report, results },
+    )
+    log(renderComparisonMarkdown(cmp))
+  }
+
+  if (args.refine) {
+    log('clustering failures and proposing prompt diffs...')
+    const clusters = clusterFailures(run)
+    if (clusters.length === 0) {
+      log('no failure clusters — nothing to refine')
+      return
+    }
+    const { validations, clustersUsed } = await proposeDiffs(
+      judgeClient,
+      variant,
+      clusters,
+    )
+    const saved: Array<{ version: string; file: string }> = []
+    for (const v of validations) {
+      if (!v.accepted) continue
+      const version = `${variant.version}+${v.diff.id}`
+      try {
+        const file = saveExperimentalVariant(applyDiff(variant, v.diff, version))
+        saved.push({ version, file })
+      } catch (err) {
+        log(`skip variant ${version}: ${err instanceof Error ? err.message : err}`)
+      }
+    }
+    const proposal = renderProposalMarkdown(
+      runId,
+      variant,
+      clustersUsed,
+      validations,
+      saved,
+    )
+    const file = saveProposal(runId, proposal)
+    log('')
+    log(proposal)
+    log(`saved: ${file}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/rate-suggestions.ts
+++ b/scripts/rate-suggestions.ts
@@ -1,0 +1,371 @@
+/**
+ * Human-rating CLI for Suggest Workout eval runs.
+ *
+ * Usage:
+ *   npx tsx scripts/rate-suggestions.ts                # rate latest run, 8 items
+ *   npx tsx scripts/rate-suggestions.ts --run <runId> --n 10 --pick worst
+ *   npx tsx scripts/rate-suggestions.ts --calibrate-only
+ *
+ * Flow per item: shows the scenario context + one option, asks for an
+ * overall 1-4 on the SAME anchored scale the judge uses, then optional
+ * problem-dimension flags (single letters) and an optional note. The
+ * judge's score is revealed only AFTER you rate, to avoid anchoring.
+ *
+ * Ratings append to .eval/ratings.jsonl. After each session the
+ * human-vs-judge calibration is recomputed and appended to
+ * .eval/calibration.json.
+ *
+ * No LLM calls — safe to run without doppler.
+ */
+
+import * as readline from 'node:readline/promises'
+import { parseArgs } from 'node:util'
+
+import { exerciseName } from '../lib/eval/exercise-catalog'
+import { compositeScore, dimensionByFlagKey, RUBRIC_DIMENSIONS, RUBRIC_VERSION } from '../lib/eval/rating-rubric'
+import { createRng } from '../lib/eval/rng'
+import {
+  appendCalibrationEntry,
+  appendRating,
+  latestRunId,
+  listRunIds,
+  loadRatings,
+  loadRun,
+  type LoadedRun,
+} from '../lib/eval/store'
+import type {
+  EvalScenario,
+  HumanRating,
+  JudgeResult,
+  OptionId,
+  ScenarioResult,
+  SuggestionOption,
+} from '../lib/eval/types'
+
+const { values: args } = parseArgs({
+  options: {
+    run: { type: 'string' },
+    n: { type: 'string', default: '8' },
+    pick: { type: 'string', default: 'mix' }, // mix | worst | random
+    'calibrate-only': { type: 'boolean', default: false },
+  },
+})
+
+interface RatableItem {
+  runId: string
+  scenario: EvalScenario
+  result: ScenarioResult
+  option: SuggestionOption
+  judgeComposite: number | null
+}
+
+/** Judge composite for ONE option (per-option dims only, renormalized). */
+function optionJudgeComposite(run: JudgeResult | undefined, optionId: OptionId): number | null {
+  if (!run) return null
+  const optionJudgement = run.per_option.find((o) => o.option_id === optionId)
+  if (!optionJudgement) return null
+  const scores: Record<string, number> = {}
+  for (const ds of optionJudgement.dimension_scores) {
+    scores[ds.dimension] = ds.score
+  }
+  return compositeScore(scores)
+}
+
+function collectItems(run: LoadedRun): RatableItem[] {
+  const scenarioById = new Map(run.scenarios.map((s) => [s.id, s]))
+  const items: RatableItem[] = []
+  for (const result of run.results) {
+    const scenario = scenarioById.get(result.scenarioId)
+    if (!scenario || !result.response) continue
+    for (const option of result.response.options) {
+      items.push({
+        runId: run.meta.runId,
+        scenario,
+        result,
+        option,
+        judgeComposite: optionJudgeComposite(result.judgeRuns[0], option.id),
+      })
+    }
+  }
+  return items
+}
+
+function pickItems(items: RatableItem[], n: number, mode: string, seed: string): RatableItem[] {
+  const rng = createRng(`rate-${seed}`)
+  const alreadyRated = new Set(
+    loadRatings().map((r) => `${r.runId}/${r.scenarioId}/${r.optionId}`),
+  )
+  const fresh = items.filter(
+    (i) => !alreadyRated.has(`${i.runId}/${i.scenario.id}/${i.option.id}`),
+  )
+  const pool = fresh.length >= n ? fresh : items
+
+  if (mode === 'random') return rng.shuffle(pool).slice(0, n)
+  const byWorst = [...pool].sort(
+    (a, b) => (a.judgeComposite ?? 5) - (b.judgeComposite ?? 5),
+  )
+  if (mode === 'worst') return byWorst.slice(0, n)
+  // mix: half worst (where the judge thinks there are problems), half random
+  const half = Math.ceil(n / 2)
+  const worstPicks = byWorst.slice(0, half)
+  const rest = rng
+    .shuffle(pool.filter((i) => !worstPicks.includes(i)))
+    .slice(0, n - worstPicks.length)
+  return [...worstPicks, ...rest]
+}
+
+function renderItem(item: RatableItem, index: number, total: number): string {
+  const p = item.scenario.payload
+  const deficits = p.training_state.per_fau
+    .filter((f) => f.status === 'neglected')
+    .sort((a, b) => b.deficit_share - a.deficit_share)
+    .slice(0, 4)
+    .map((f) => `${f.fau} +${f.deficit_share.toFixed(3)}`)
+  const expectations = item.scenario.expectations.map((e) => `  · ${e.description}`)
+  const exercises = item.option.exercises.map(
+    (e, i) => `  ${i + 1}. ${exerciseName(e.id)} — ${e.rationale}`,
+  )
+  const gateFails = item.result.hardChecks
+    .filter((c) => !c.passed && (c.optionId === undefined || c.optionId === item.option.id))
+    .map((c) => `  ! ${c.name}: ${c.detail}`)
+
+  return [
+    '',
+    `═══ [${index + 1}/${total}] ${item.scenario.id}`,
+    `Scenario: ${item.scenario.description}`,
+    `Request: ${p.ephemeral_context.time_budget_minutes}min, ${p.ephemeral_context.intensity_vibe}` +
+      `${p.ephemeral_context.prioritize_freetext ? `, prioritize: "${p.ephemeral_context.prioritize_freetext}"` : ''}` +
+      `${p.ephemeral_context.deprioritize_freetext ? `, deprioritize: "${p.ephemeral_context.deprioritize_freetext}"` : ''}`,
+    `Goals: ${p.durable_profile.goal_sentences.join(' | ')}`,
+    deficits.length > 0 ? `Neglected: ${deficits.join(', ')}` : 'Neglected: none',
+    ...(expectations.length > 0 ? ['Expectations:', ...expectations] : []),
+    '',
+    `─── Option ${item.option.id} — "${item.option.name}"`,
+    `${item.option.description}`,
+    `${item.option.summary}`,
+    ...exercises,
+    ...(gateFails.length > 0 ? ['', 'Gate failures:', ...gateFails] : []),
+  ].join('\n')
+}
+
+function rubricHelp(): string {
+  return RUBRIC_DIMENSIONS.map(
+    (d) => `  ${d.flagKey} = ${d.key}: ${d.label}`,
+  ).join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+function ranks(values: number[]): number[] {
+  const indexed = values.map((v, i) => ({ v, i }))
+  indexed.sort((a, b) => a.v - b.v)
+  const result = new Array<number>(values.length)
+  let pos = 0
+  while (pos < indexed.length) {
+    let end = pos
+    while (end + 1 < indexed.length && indexed[end + 1].v === indexed[pos].v) end++
+    const avgRank = (pos + end) / 2 + 1
+    for (let k = pos; k <= end; k++) result[indexed[k].i] = avgRank
+    pos = end + 1
+  }
+  return result
+}
+
+function spearman(a: number[], b: number[]): number | null {
+  if (a.length < 3) return null
+  const ra = ranks(a)
+  const rb = ranks(b)
+  const meanA = ra.reduce((x, y) => x + y, 0) / ra.length
+  const meanB = rb.reduce((x, y) => x + y, 0) / rb.length
+  let cov = 0
+  let varA = 0
+  let varB = 0
+  for (let i = 0; i < ra.length; i++) {
+    cov += (ra[i] - meanA) * (rb[i] - meanB)
+    varA += (ra[i] - meanA) ** 2
+    varB += (rb[i] - meanB) ** 2
+  }
+  if (varA === 0 || varB === 0) return null
+  return Math.round((cov / Math.sqrt(varA * varB)) * 1000) / 1000
+}
+
+function twoLowestDimensions(run: JudgeResult | undefined, optionId: OptionId): string[] {
+  if (!run) return []
+  const optionJudgement = run.per_option.find((o) => o.option_id === optionId)
+  if (!optionJudgement) return []
+  return [...optionJudgement.dimension_scores]
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 2)
+    .map((d) => d.dimension)
+}
+
+function recomputeCalibration(): void {
+  const ratings = loadRatings()
+  if (ratings.length === 0) {
+    console.log('no ratings yet — nothing to calibrate')
+    return
+  }
+
+  const runCache = new Map<string, LoadedRun>()
+  const humanScores: number[] = []
+  const judgeScores: number[] = []
+  let flagged = 0
+  let flagsAgreed = 0
+  let judgeModel = 'unknown'
+
+  for (const rating of ratings) {
+    let run = runCache.get(rating.runId)
+    if (!run) {
+      try {
+        run = loadRun(rating.runId)
+      } catch {
+        continue
+      }
+      runCache.set(rating.runId, run)
+    }
+    judgeModel = run.meta.judgeModel
+    const result = run.results.find((r) => r.scenarioId === rating.scenarioId)
+    if (!result) continue
+    const judge = optionJudgeComposite(result.judgeRuns[0], rating.optionId)
+    if (judge === null) continue
+    humanScores.push(rating.overall)
+    judgeScores.push(judge)
+
+    if (rating.flaggedDimensions.length > 0) {
+      flagged++
+      const lowest = twoLowestDimensions(result.judgeRuns[0], rating.optionId)
+      if (rating.flaggedDimensions.some((f) => lowest.includes(f))) flagsAgreed++
+    }
+  }
+
+  const meanAbsDiff =
+    humanScores.length > 0
+      ? Math.round(
+          (humanScores.reduce((acc, h, i) => acc + Math.abs(h - judgeScores[i]), 0) /
+            humanScores.length) *
+            100,
+        ) / 100
+      : null
+
+  const entry = {
+    computedAt: new Date().toISOString(),
+    rubricVersion: RUBRIC_VERSION,
+    judgeModel,
+    sampleSize: humanScores.length,
+    spearman: spearman(humanScores, judgeScores),
+    meanAbsDiff,
+    flagAgreement: flagged > 0 ? Math.round((flagsAgreed / flagged) * 100) / 100 : null,
+  }
+  appendCalibrationEntry(entry)
+
+  console.log('\n── Calibration (all ratings to date) ──')
+  console.log(`  sample size:     ${entry.sampleSize}`)
+  console.log(`  spearman:        ${entry.spearman ?? 'n/a (need >=3 ratings)'}`)
+  console.log(`  mean |Δ|:        ${entry.meanAbsDiff ?? 'n/a'} (on the 1-4 scale)`)
+  console.log(`  flag agreement:  ${entry.flagAgreement ?? 'n/a'}`)
+  if (entry.spearman !== null && entry.spearman < 0.4) {
+    console.log(
+      '  ⚠ Weak correlation — do NOT trust judge-only iteration until the rubric or judge model improves.',
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  if (args['calibrate-only']) {
+    recomputeCalibration()
+    return
+  }
+
+  const runId = args.run ?? latestRunId()
+  if (!runId) {
+    console.error(`No eval runs found. Run eval-suggest first. Known runs: ${listRunIds().join(', ') || '(none)'}`)
+    process.exit(1)
+  }
+
+  const run = loadRun(runId)
+  const items = collectItems(run)
+  if (items.length === 0) {
+    console.error(`Run ${runId} has no rateable results`)
+    process.exit(1)
+  }
+
+  const n = Number.parseInt(args.n ?? '8', 10)
+  const picked = pickItems(items, n, args.pick ?? 'mix', runId)
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  console.log(`Rating ${picked.length} options from run ${runId} (pick=${args.pick}).`)
+  console.log('Scale: 1 = would mislead/annoy me, 2 = flawed, 3 = acceptable, 4 = would use as-is.')
+  console.log('Keys: 1-4 rate, s skip, ? rubric help, q quit.\n')
+
+  let rated = 0
+  for (let i = 0; i < picked.length; i++) {
+    const item = picked[i]
+    console.log(renderItem(item, i, picked.length))
+
+    let overall: number | null = null
+    while (overall === null) {
+      const answer = (await rl.question('\nrate [1-4 / s / ? / q]: ')).trim().toLowerCase()
+      if (answer === 'q') {
+        rl.close()
+        if (rated > 0) recomputeCalibration()
+        return
+      }
+      if (answer === 's') break
+      if (answer === '?') {
+        console.log(`\nDimension flag keys:\n${rubricHelp()}`)
+        continue
+      }
+      const num = Number.parseInt(answer, 10)
+      if (num >= 1 && num <= 4) overall = num
+    }
+    if (overall === null) continue
+
+    let flaggedDimensions: string[] = []
+    if (overall <= 3) {
+      const flagsAnswer = (
+        await rl.question(`what's wrong? letters (${RUBRIC_DIMENSIONS.map((d) => d.flagKey).join('')}), empty=skip: `)
+      )
+        .trim()
+        .toLowerCase()
+      flaggedDimensions = [...flagsAnswer]
+        .map((ch) => dimensionByFlagKey(ch)?.key)
+        .filter((k): k is string => k !== undefined)
+    }
+
+    const note = (await rl.question('note (enter to skip): ')).trim()
+
+    const rating: HumanRating = {
+      ratedAt: new Date().toISOString(),
+      runId: item.runId,
+      scenarioId: item.scenario.id,
+      optionId: item.option.id,
+      overall,
+      flaggedDimensions,
+      note: note.length > 0 ? note : null,
+    }
+    appendRating(rating)
+    rated++
+    console.log(
+      `saved. judge had this at ${item.judgeComposite ?? 'n/a'}${
+        item.judgeComposite !== null && Math.abs(item.judgeComposite - overall) >= 1
+          ? '  ← disagreement worth a look'
+          : ''
+      }`,
+    )
+  }
+
+  rl.close()
+  console.log(`\n${rated} ratings saved to .eval/ratings.jsonl`)
+  if (rated > 0) recomputeCalibration()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Part of Milestone: Suggest Workout (LLM-powered) — design context #868, payload spec #877, planner scope #880, seeder #886.

## What this is

A self-contained prompt-refinement loop so Suggest Workout planner prompts can be iterated **tonight**, against reproducible synthetic scenarios, with zero real-user data:

```
scenario-generator ──► planner (LLM, temp 0) ──► hard-checks (code) ──► judge (LLM)
        │                                                                  │
        └── same seed = same scenarios          .eval/runs/<runId>/ ◄──────┤
                                                report.md / report.json ◄──┘
                     rate-suggestions (human CLI) ──► calibration.json
                     refinement-engine ──► section diffs ──► .eval/variants/*.json
```

The intended evening loop: run 20 scenarios → read the report → `--refine` to get 1–3 targeted prompt diffs (auto-materialized as runnable variants) → re-run the same seed with `--compare` → read paired improved/regressed counts → promote or discard.

## Quick start

```bash
# Score the current prompt (planner + judge need LLM_* env via doppler)
doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1 --seed eval-v1

# Human-rate a sample (no LLM calls, no doppler)
npm run rate-suggestions -- --n 8

# Propose prompt diffs from failure clusters
doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1 --seed eval-v1 --refine

# Compare a proposed variant against the base run (SAME seed required)
doppler run --config dev_personal -- npm run eval-suggest -- --scenarios 20 --prompt v1+<diff-id> --seed eval-v1 --compare <base-run-id>
```

## What's in the diff

**Eval tooling (`lib/eval/`)**
- `types.ts` — the locked #877 payload contract as TS types + scenario/scoring types
- `rng.ts` — mulberry32 seeded RNG; `Math.random` is banned from the loop
- `exercise-catalog.ts` — static ~70-exercise catalog (repo-canon kebab-case FAUs, auto-tag movement patterns) so eval runs with no DB
- `scenario-generator.ts` — 5 archetypes (matching #886) × 10 edge-case modifiers (injury-recovery, deload, sparse-data, competing-goals, activity-overlap, time-crunch, equipment-limited, return-from-break, all-satisfied, ambiguous-freetext); stratified matrix + seeded jitter
- `hard-checks.ts` — deterministic gates: hallucinated IDs, duplicates, banned exercises, count-vs-time-budget, scenario hard rules
- `rating-rubric.ts` — 6 weighted dimensions with anchored 4-point scales, shared by judge and human CLI
- `judge.ts` — evidence-before-score LLM judge on a compact digest; K-run median aggregation + stability spread
- `refinement-engine.ts` — code-side failure clustering → LLM section diffs → auto-applied experimental variants with overfit rejection
- `store.ts` / `report.ts` — `.eval/` file state (gitignored), reports, paired run comparison

**App code (`lib/suggest/`) — intentionally NOT under `lib/eval/`**
- `schema.ts` — the three-option zod output schema per #877
- `prompts/registry.ts` — the sectioned, versioned v1 planner prompt + `buildPlannerPrompt` + `CURRENT_PLANNER_VERSION`

#880 should import both, so the prompt that ships is the prompt that was evaluated. **No prompt-design artifact had landed before this PR — v1 here is the first authored planner prompt.**

**CLIs**
- `scripts/eval-suggest.ts` — `--scenarios --prompt --seed --judge-runs --judge-model --model --concurrency --compare --refine --dry-run`
- `scripts/rate-suggestions.ts` — human rating: 1–4 on the same anchored scale, single-letter dimension flags, notes; recomputes human-vs-judge calibration (Spearman, mean |Δ|, flag agreement) after every session

**Docs & tests**
- `docs/EVAL_LOOP_DESIGN.md` — full rationale: rubric design, the five hard parts (judge robustness, scenario diversity, rating→diff, overfitting to synthetic, calibration), failure modes of the loop itself, cadence/trust policy
- `__tests__/eval/eval-loop.test.ts` — pure unit tests (no containers, no LLM): RNG/scenario determinism, matrix coverage, gate behavior, rubric/aggregation math, diff application, schema shape

## Gotchas & notes

- **Issue-number correction:** the locked payload spec is a comment on **#877**, not #876 (#876 is the training-state builder issue, no comments). Everything here targets the #877 spec.
- **Payloads are synthesized in memory, not seeded through the DB.** #876/#886 don't exist yet; and even after they land, eval iteration shouldn't be coupled to DB state. When #886's golden files land, they pin the builder to the same contract from the other side — if #877 drifts, update `lib/eval/types.ts` + generator in the same PR or the loop silently scores a stale contract.
- **`tsx` added as a devDependency** (was only ever invoked via `npx` before) so the `npm run eval-suggest` / `rate-suggestions` scripts work. `package-lock.json` churn is from that single addition.
- **Repo uses npm** — the milestone notes said `pnpm eval-suggest`; the equivalent is `npm run eval-suggest -- <flags>` (note the `--`).
- **`.eval/` is gitignored** — runs, ratings, calibration, experimental variants are dev-local state. Promoting a winning variant to production = copying it into `registry.ts` in a commit (proposal files print the exact follow-up command).
- **Set `LLM_JUDGE_MODEL`** (ideally a different model family than the planner) before trusting judge scores. Judge defaults to `LLM_MODEL`, and same-model self-preference bias is real. `LLM_JUDGE_PROVIDER_URL` / `LLM_JUDGE_API_KEY` also supported.
- **Temp-0 is not bit-reproducible** across providers. Scenarios ARE byte-identical per seed; planner responses are approximately stable. That's why comparisons use paired per-scenario deltas with a ±0.1 dead zone and improved/regressed counts rather than raw means.
- **Seed discipline matters:** scenario ids pair by index, so comparing runs with different seeds would silently pair different payloads — `--compare` detects seed mismatch and stamps a loud warning in the report. Iterate on one seed, validate on a holdout seed before promoting (see design doc §overfitting).
- **Gates and judged scores never blend.** Gate pass rate is reported next to the composite; a prompt change that raises composite while doubling gate failures is a regression a blended score would hide.
- **Judge cost knob:** `--judge-runs 1` (default) for the inner loop; `--judge-runs 3` (temp 0 + two at 0.4, median) for promote/revert decisions — it also reports a stability spread that tells you when the *rubric*, not the prompt, is the problem.
- **Human CLI anti-anchoring:** the judge's score is revealed only *after* you rate; ≥1-point disagreements are flagged as the highest-value items to note. `--pick mix` (default) rates half judge-suspected-bad, half random. Calibration trust policy: Spearman ≥ 0.6 trust the judge for iteration; < 0.4 stop and fix the rubric.
- **Scenario coverage bug found & fixed during smoke testing:** the original matrix ordering covered only 3/10 modifiers in a 20-scenario run; it now round-robins so positions 5–14 cover all 10 modifiers (unit-tested).
- **`lib/eval/exercise-catalog.ts` uses kebab-case FAUs** (`front-delts`) per `ALL_FAUS` in `lib/fau-volume.ts` — the #877 spec sample shows `front_delts`, which appears to be a typo vs repo canon; flagged here so the training-state builder (#876) makes the same call.

## Verification

- `npx tsc --noEmit` passes.
- `npx tsx scripts/eval-suggest.ts --scenarios 20 --dry-run` verified: runs under tsx with `@/` path aliases, prints full modifier coverage, generator confirmed byte-identical across runs for the same seed.
- Unit tests added but **not run in this session** (per project convention): `npm test eval-loop` — pure functions only, no Testcontainers needed.
- No live LLM calls were made; first real run needs `LLM_*` env via doppler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)