### PR TITLE
feat(profile): expand UserTrainingProfile — demographics, injuries, importance, rhythm

### DIFF
--- a/__tests__/api/user-training-profile.test.ts
+++ b/__tests__/api/user-training-profile.test.ts
@@ -1,12 +1,19 @@
 import type { PrismaClient } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { getDefaultMuscleBalanceTargets } from '@/lib/muscle-balance'
-import {
-  getOrCreateUserTrainingProfile,
-  normalizeUserTrainingProfile,
-} from '@/lib/user-training-profile'
 import { getTestDatabase } from '@/lib/test/database'
 import { createTestUser } from '@/lib/test/factories'
+import {
+  getOrCreateUserTrainingProfile,
+  normalizeFauImportance,
+  normalizeGoalCategories,
+  normalizeImportance,
+  normalizeInjuryAreas,
+  normalizeOtherActivities,
+  normalizePreferredDays,
+  normalizeUserTrainingProfile,
+  updateUserTrainingProfile,
+} from '@/lib/user-training-profile'
 
 describe('UserTrainingProfile normalization', () => {
   it('trims, dedupes, drops empties, and caps lengths', () => {
@@ -39,6 +46,150 @@ describe('UserTrainingProfile normalization', () => {
 
     expect(result.goalSentences).toEqual([])
     expect(result.defaultIntensityPreference).toBeNull()
+  })
+
+  it('defaults all expanded fields for a cold-start profile', () => {
+    const result = normalizeUserTrainingProfile(null)
+
+    expect(result.birthYear).toBeNull()
+    expect(result.biologicalSex).toBeNull()
+    expect(result.heightCm).toBeNull()
+    expect(result.weightKg).toBeNull()
+    expect(result.injuryAreas).toEqual([])
+    expect(result.goalCategories).toEqual([])
+    expect(result.otherActivities).toEqual([])
+    expect(result.fauImportance).toEqual({})
+    expect(result.targetSessionsPerWeek).toBeNull()
+    expect(result.targetMinutesPerSession).toBeNull()
+    expect(result.patternPreference).toBeNull()
+    expect(result.preferredDays).toEqual([])
+  })
+
+  it('normalizes demographics and rhythm, rejecting out-of-range values', () => {
+    const result = normalizeUserTrainingProfile({
+      goalSentences: [],
+      weeklyIntent: [],
+      equipmentAvailable: [],
+      bannedExerciseIds: [],
+      ratioTargets: {},
+      defaultIntensityPreference: null,
+      birthYear: 1990,
+      biologicalSex: 'prefer_not_to_say',
+      heightCm: 180.5,
+      weightKg: 9999,
+      targetSessionsPerWeek: 4,
+      targetMinutesPerSession: 2,
+      patternPreference: 'upper_lower',
+      preferredDays: ['friday', 'monday', 'bogusday'],
+    })
+
+    expect(result.birthYear).toBe(1990)
+    expect(result.biologicalSex).toBe('prefer_not_to_say')
+    expect(result.heightCm).toBeCloseTo(180.5)
+    expect(result.weightKg).toBeNull() // out of range
+    expect(result.targetSessionsPerWeek).toBe(4)
+    expect(result.targetMinutesPerSession).toBeNull() // below minimum
+    expect(result.patternPreference).toBe('upper_lower')
+    // Canonical day order, invalid entries dropped
+    expect(result.preferredDays).toEqual(['monday', 'friday'])
+  })
+})
+
+describe('injury normalization', () => {
+  it('keeps valid entries with notes and reportedAt, drops invalid ones', () => {
+    const result = normalizeInjuryAreas([
+      {
+        area: 'lower_back',
+        severity: 'avoid_loading',
+        notes: '  disc issue  ',
+        reportedAt: '2026-06-01T00:00:00.000Z',
+      },
+      { area: 'shoulder', severity: 'caution' },
+      { area: 'knee', severity: 'recovered', reportedAt: 'not a date' },
+      { area: 'shoulder', severity: 'caution' }, // duplicate area
+      { area: 'spleen', severity: 'caution' }, // invalid area
+      { area: 'hip', severity: 'sore' }, // invalid severity
+      'not an object',
+    ])
+
+    expect(result).toEqual([
+      {
+        area: 'lower_back',
+        severity: 'avoid_loading',
+        notes: 'disc issue',
+        reportedAt: '2026-06-01T00:00:00.000Z',
+      },
+      { area: 'shoulder', severity: 'caution' },
+      { area: 'knee', severity: 'recovered' },
+    ])
+  })
+
+  it('returns empty for non-array input', () => {
+    expect(normalizeInjuryAreas(null)).toEqual([])
+    expect(normalizeInjuryAreas({ area: 'knee' })).toEqual([])
+  })
+})
+
+describe('importance normalization', () => {
+  it('clamps importance to the 1-5 scale', () => {
+    expect(normalizeImportance(0)).toBe(1)
+    expect(normalizeImportance(3.6)).toBe(4)
+    expect(normalizeImportance(99)).toBe(5)
+    expect(normalizeImportance('3')).toBeNull()
+    expect(normalizeImportance(Number.NaN)).toBeNull()
+  })
+
+  it('normalizes goal categories, dropping invalid and duplicate entries', () => {
+    const result = normalizeGoalCategories([
+      { category: 'build_muscle', importance: 5 },
+      { category: 'build_muscle', importance: 2 },
+      { category: 'bogus', importance: 3 },
+      { category: 'lose_fat', importance: 'high' },
+      { category: 'get_stronger', importance: 7 },
+    ])
+
+    expect(result).toEqual([
+      { category: 'build_muscle', importance: 5 },
+      { category: 'get_stronger', importance: 5 },
+    ])
+  })
+
+  it('normalizes other activities with optional cadence', () => {
+    const result = normalizeOtherActivities([
+      { activity: 'cycling', importance: 5, cadence: ' 3x/week ' },
+      { activity: 'skydiving', importance: 3 },
+      { activity: 'yoga', importance: 2 },
+    ])
+
+    expect(result).toEqual([
+      { activity: 'cycling', importance: 5, cadence: '3x/week' },
+      { activity: 'yoga', importance: 2 },
+    ])
+  })
+
+  it('normalizes per-FAU importance, dropping unknown keys', () => {
+    const result = normalizeFauImportance({
+      chest: 5,
+      quads: 2.4,
+      spleen: 5,
+      lats: 'high',
+    })
+
+    expect(result).toEqual({ chest: 5, quads: 2 })
+  })
+
+  it('returns empty fauImportance for non-object input', () => {
+    expect(normalizeFauImportance(null)).toEqual({})
+    expect(normalizeFauImportance([1, 2])).toEqual({})
+  })
+})
+
+describe('preferred days normalization', () => {
+  it('dedupes and returns canonical order', () => {
+    expect(
+      normalizePreferredDays(['sunday', 'monday', 'monday', 'wednesday'])
+    ).toEqual(['monday', 'wednesday', 'sunday'])
+    expect(normalizePreferredDays('monday')).toEqual([])
   })
 })
 
@@ -95,5 +246,116 @@ describe('UserTrainingProfile persistence', () => {
     const profile = await getOrCreateUserTrainingProfile(prisma, userId)
     expect(profile.ratioTargets.chest).toBeCloseTo(1.5)
     expect(profile.ratioTargets.quads).toBeCloseTo(0.5)
+  })
+
+  it('defaults expanded fields on a freshly created profile', async () => {
+    const profile = await getOrCreateUserTrainingProfile(prisma, userId)
+
+    expect(profile.birthYear).toBeNull()
+    expect(profile.biologicalSex).toBeNull()
+    expect(profile.injuryAreas).toEqual([])
+    expect(profile.goalCategories).toEqual([])
+    expect(profile.otherActivities).toEqual([])
+    expect(profile.fauImportance).toEqual({})
+    expect(profile.targetSessionsPerWeek).toBeNull()
+    expect(profile.patternPreference).toBeNull()
+    expect(profile.preferredDays).toEqual([])
+  })
+
+  it('round-trips a full profile through updateUserTrainingProfile', async () => {
+    const updated = await updateUserTrainingProfile(prisma, userId, {
+      birthYear: 1988,
+      biologicalSex: 'female',
+      heightCm: 165,
+      weightKg: 62.5,
+      injuryAreas: [
+        {
+          area: 'lower_back',
+          severity: 'caution',
+          notes: 'tweaked deadlifting',
+          reportedAt: '2026-05-15T12:00:00.000Z',
+        },
+      ],
+      goalCategories: [{ category: 'get_stronger', importance: 5 }],
+      otherActivities: [
+        { activity: 'cycling', importance: 4, cadence: '2x/week' },
+      ],
+      fauImportance: { chest: 5, quads: 3 },
+      targetSessionsPerWeek: 3,
+      targetMinutesPerSession: 60,
+      patternPreference: 'full_body',
+      preferredDays: ['monday', 'wednesday', 'friday'],
+    })
+
+    const read = await getOrCreateUserTrainingProfile(prisma, userId)
+    expect(read).toEqual(updated)
+    expect(read.birthYear).toBe(1988)
+    expect(read.biologicalSex).toBe('female')
+    expect(read.heightCm).toBeCloseTo(165)
+    expect(read.weightKg).toBeCloseTo(62.5)
+    expect(read.injuryAreas).toEqual([
+      {
+        area: 'lower_back',
+        severity: 'caution',
+        notes: 'tweaked deadlifting',
+        reportedAt: '2026-05-15T12:00:00.000Z',
+      },
+    ])
+    expect(read.goalCategories).toEqual([
+      { category: 'get_stronger', importance: 5 },
+    ])
+    expect(read.otherActivities).toEqual([
+      { activity: 'cycling', importance: 4, cadence: '2x/week' },
+    ])
+    expect(read.fauImportance).toEqual({ chest: 5, quads: 3 })
+    expect(read.targetSessionsPerWeek).toBe(3)
+    expect(read.targetMinutesPerSession).toBe(60)
+    expect(read.patternPreference).toBe('full_body')
+    expect(read.preferredDays).toEqual(['monday', 'wednesday', 'friday'])
+  })
+
+  it('supports partial updates without clobbering other fields', async () => {
+    await updateUserTrainingProfile(prisma, userId, {
+      goalSentences: ['bench 225'],
+      birthYear: 1995,
+    })
+
+    const after = await updateUserTrainingProfile(prisma, userId, {
+      targetSessionsPerWeek: 4,
+    })
+
+    expect(after.goalSentences).toEqual(['bench 225'])
+    expect(after.birthYear).toBe(1995)
+    expect(after.targetSessionsPerWeek).toBe(4)
+  })
+
+  it('allows clearing fields by writing null', async () => {
+    await updateUserTrainingProfile(prisma, userId, { birthYear: 1995 })
+    const cleared = await updateUserTrainingProfile(prisma, userId, {
+      birthYear: null,
+      injuryAreas: [],
+    })
+
+    expect(cleared.birthYear).toBeNull()
+    expect(cleared.injuryAreas).toEqual([])
+  })
+
+  it('bumps updatedAt on profile writes (profile_age_days freshness)', async () => {
+    await getOrCreateUserTrainingProfile(prisma, userId)
+    const before = await prisma.userTrainingProfile.findUniqueOrThrow({
+      where: { userId },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await updateUserTrainingProfile(prisma, userId, {
+      targetSessionsPerWeek: 5,
+    })
+
+    const after = await prisma.userTrainingProfile.findUniqueOrThrow({
+      where: { userId },
+    })
+    expect(after.updatedAt.getTime()).toBeGreaterThan(
+      before.updatedAt.getTime()
+    )
   })
 })

--- a/lib/user-training-profile.ts
+++ b/lib/user-training-profile.ts
@@ -1,8 +1,9 @@
 import type { Prisma, PrismaClient } from '@prisma/client'
+import { ALL_FAUS, type FAUKey } from '@/lib/fau-volume'
 import {
   getDefaultMuscleBalanceTargets,
-  normalizeMuscleBalanceTargets,
   type MuscleBalanceTargets,
+  normalizeMuscleBalanceTargets,
 } from '@/lib/muscle-balance'
 
 export const INTENSITY_PREFERENCES = [
@@ -12,12 +13,124 @@ export const INTENSITY_PREFERENCES = [
 ] as const
 export type IntensityPreference = (typeof INTENSITY_PREFERENCES)[number]
 
+export const BIOLOGICAL_SEXES = ['female', 'male', 'prefer_not_to_say'] as const
+export type BiologicalSex = (typeof BIOLOGICAL_SEXES)[number]
+
+export const PATTERN_PREFERENCES = [
+  'no_preference',
+  'full_body',
+  'upper_lower',
+  'push_pull_legs',
+  'body_part_split',
+  'custom',
+] as const
+export type PatternPreference = (typeof PATTERN_PREFERENCES)[number]
+
+/**
+ * Injury body areas. Joint/region-level so the injury -> ban-list mapping can
+ * key off ExerciseDefinition.movementPattern + FAU taxonomy (e.g. lower_back
+ * -> hinge patterns / 'lower-back' FAU; shoulder -> vertical_push / delts).
+ */
+export const INJURY_AREAS = [
+  'neck',
+  'shoulder',
+  'elbow',
+  'wrist',
+  'upper_back',
+  'lower_back',
+  'hip',
+  'knee',
+  'ankle',
+] as const
+export type InjuryArea = (typeof INJURY_AREAS)[number]
+
+// avoid_loading: don't load this area at all; caution: allow but flag;
+// recovered: historical context only.
+export const INJURY_SEVERITIES = [
+  'avoid_loading',
+  'caution',
+  'recovered',
+] as const
+export type InjurySeverity = (typeof INJURY_SEVERITIES)[number]
+
+export const GOAL_CATEGORIES = [
+  'build_muscle',
+  'get_stronger',
+  'lose_fat',
+  'general_fitness',
+  'sport_performance',
+  'rehabilitation',
+  'aesthetic_specific',
+  'other',
+] as const
+export type GoalCategory = (typeof GOAL_CATEGORIES)[number]
+
+export const OTHER_ACTIVITIES = [
+  'cycling',
+  'running',
+  'hiking',
+  'climbing',
+  'yoga',
+  'team_sports',
+  'manual_labor',
+  'other',
+] as const
+export type OtherActivity = (typeof OTHER_ACTIVITIES)[number]
+
+export const PREFERRED_DAYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const
+export type PreferredDay = (typeof PREFERRED_DAYS)[number]
+
 export const MAX_GOAL_SENTENCES = 10
 export const MAX_GOAL_SENTENCE_LENGTH = 280
 export const MAX_WEEKLY_INTENTS = 10
 export const MAX_WEEKLY_INTENT_LENGTH = 280
 export const MAX_EQUIPMENT_ITEMS = 32
 export const MAX_BANNED_EXERCISE_IDS = 500
+export const MAX_INJURY_ENTRIES = INJURY_AREAS.length
+export const MAX_INJURY_NOTE_LENGTH = 500
+
+export const MIN_IMPORTANCE = 1
+export const MAX_IMPORTANCE = 5
+
+export const MIN_BIRTH_YEAR = 1900
+export const MIN_HEIGHT_CM = 50
+export const MAX_HEIGHT_CM = 300
+export const MIN_WEIGHT_KG = 10
+export const MAX_WEIGHT_KG = 500
+export const MIN_SESSIONS_PER_WEEK = 1
+export const MAX_SESSIONS_PER_WEEK = 14
+export const MIN_MINUTES_PER_SESSION = 5
+export const MAX_MINUTES_PER_SESSION = 480
+export const MAX_ACTIVITY_CADENCE_LENGTH = 120
+
+export type InjuryEntry = {
+  area: InjuryArea
+  severity: InjurySeverity
+  notes?: string
+  /** ISO 8601 timestamp of when the user reported the injury. */
+  reportedAt?: string
+}
+
+export type GoalCategoryEntry = {
+  category: GoalCategory
+  importance: number
+}
+
+export type OtherActivityEntry = {
+  activity: OtherActivity
+  importance: number
+  cadence?: string
+}
+
+export type FauImportance = Partial<Record<FAUKey, number>>
 
 export type UserTrainingProfileDTO = {
   goalSentences: string[]
@@ -26,15 +139,70 @@ export type UserTrainingProfileDTO = {
   bannedExerciseIds: string[]
   ratioTargets: MuscleBalanceTargets
   defaultIntensityPreference: IntensityPreference | null
+  // Demographics
+  birthYear: number | null
+  biologicalSex: BiologicalSex | null
+  heightCm: number | null
+  weightKg: number | null
+  // Injuries
+  injuryAreas: InjuryEntry[]
+  // Importance ratings
+  goalCategories: GoalCategoryEntry[]
+  otherActivities: OtherActivityEntry[]
+  fauImportance: FauImportance
+  // Training rhythm
+  targetSessionsPerWeek: number | null
+  targetMinutesPerSession: number | null
+  patternPreference: PatternPreference | null
+  preferredDays: PreferredDay[]
+}
+
+function normalizeEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[]
+): T | null {
+  if (typeof value !== 'string') return null
+  return (allowed as readonly string[]).includes(value) ? (value as T) : null
 }
 
 export function normalizeIntensityPreference(
   value: unknown
 ): IntensityPreference | null {
-  if (typeof value !== 'string') return null
-  return (INTENSITY_PREFERENCES as readonly string[]).includes(value)
-    ? (value as IntensityPreference)
-    : null
+  return normalizeEnum(value, INTENSITY_PREFERENCES)
+}
+
+export function normalizeBiologicalSex(value: unknown): BiologicalSex | null {
+  return normalizeEnum(value, BIOLOGICAL_SEXES)
+}
+
+export function normalizePatternPreference(
+  value: unknown
+): PatternPreference | null {
+  return normalizeEnum(value, PATTERN_PREFERENCES)
+}
+
+function clampInt(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const rounded = Math.round(value)
+  if (rounded < min || rounded > max) return null
+  return rounded
+}
+
+function clampFloat(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value < min || value > max) return null
+  return value
+}
+
+export function normalizeBirthYear(value: unknown): number | null {
+  return clampInt(value, MIN_BIRTH_YEAR, new Date().getUTCFullYear())
+}
+
+/** Clamp an importance rating into the 1-5 scale; null if not a number. */
+export function normalizeImportance(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const rounded = Math.round(value)
+  return Math.min(MAX_IMPORTANCE, Math.max(MIN_IMPORTANCE, rounded))
 }
 
 function normalizeStringList(
@@ -58,18 +226,117 @@ function normalizeStringList(
   return result
 }
 
-export function normalizeUserTrainingProfile(
-  profile:
-    | {
-        goalSentences: string[]
-        weeklyIntent: string[]
-        equipmentAvailable: string[]
-        bannedExerciseIds: string[]
-        ratioTargets: Prisma.JsonValue
-        defaultIntensityPreference: string | null
+export function normalizeInjuryAreas(value: unknown): InjuryEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: InjuryEntry[] = []
+  const seenAreas = new Set<InjuryArea>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const record = raw as Record<string, unknown>
+    const area = normalizeEnum(record.area, INJURY_AREAS)
+    const severity = normalizeEnum(record.severity, INJURY_SEVERITIES)
+    if (!area || !severity) continue
+    if (seenAreas.has(area)) continue
+    seenAreas.add(area)
+    const entry: InjuryEntry = { area, severity }
+    if (typeof record.notes === 'string') {
+      const notes = record.notes.trim().slice(0, MAX_INJURY_NOTE_LENGTH)
+      if (notes) entry.notes = notes
+    }
+    if (typeof record.reportedAt === 'string') {
+      const parsed = Date.parse(record.reportedAt)
+      if (!Number.isNaN(parsed)) {
+        entry.reportedAt = new Date(parsed).toISOString()
       }
-    | null
-    | undefined
+    }
+    result.push(entry)
+    if (result.length >= MAX_INJURY_ENTRIES) break
+  }
+  return result
+}
+
+export function normalizeGoalCategories(value: unknown): GoalCategoryEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: GoalCategoryEntry[] = []
+  const seen = new Set<GoalCategory>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const record = raw as Record<string, unknown>
+    const category = normalizeEnum(record.category, GOAL_CATEGORIES)
+    const importance = normalizeImportance(record.importance)
+    if (!category || importance == null) continue
+    if (seen.has(category)) continue
+    seen.add(category)
+    result.push({ category, importance })
+  }
+  return result
+}
+
+export function normalizeOtherActivities(value: unknown): OtherActivityEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: OtherActivityEntry[] = []
+  const seen = new Set<OtherActivity>()
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue
+    const record = raw as Record<string, unknown>
+    const activity = normalizeEnum(record.activity, OTHER_ACTIVITIES)
+    const importance = normalizeImportance(record.importance)
+    if (!activity || importance == null) continue
+    if (seen.has(activity)) continue
+    seen.add(activity)
+    const entry: OtherActivityEntry = { activity, importance }
+    if (typeof record.cadence === 'string') {
+      const cadence = record.cadence.trim().slice(0, MAX_ACTIVITY_CADENCE_LENGTH)
+      if (cadence) entry.cadence = cadence
+    }
+    result.push(entry)
+  }
+  return result
+}
+
+export function normalizeFauImportance(value: unknown): FauImportance {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const record = value as Record<string, unknown>
+  const result: FauImportance = {}
+  for (const fau of ALL_FAUS) {
+    const importance = normalizeImportance(record[fau])
+    if (importance != null) result[fau] = importance
+  }
+  return result
+}
+
+export function normalizePreferredDays(value: unknown): PreferredDay[] {
+  if (!Array.isArray(value)) return []
+  const result: PreferredDay[] = []
+  for (const day of PREFERRED_DAYS) {
+    if (value.includes(day)) result.push(day)
+  }
+  return result
+}
+
+type ProfileLike = {
+  goalSentences: string[]
+  weeklyIntent: string[]
+  equipmentAvailable: string[]
+  bannedExerciseIds: string[]
+  ratioTargets: Prisma.JsonValue
+  defaultIntensityPreference: string | null
+  birthYear?: number | null
+  biologicalSex?: string | null
+  heightCm?: number | null
+  weightKg?: number | null
+  injuryAreas?: Prisma.JsonValue
+  goalCategories?: Prisma.JsonValue
+  otherActivities?: Prisma.JsonValue
+  fauImportance?: Prisma.JsonValue
+  targetSessionsPerWeek?: number | null
+  targetMinutesPerSession?: number | null
+  patternPreference?: string | null
+  preferredDays?: string[]
+}
+
+export function normalizeUserTrainingProfile(
+  profile: ProfileLike | null | undefined
 ): UserTrainingProfileDTO {
   return {
     goalSentences: normalizeStringList(
@@ -96,6 +363,36 @@ export function normalizeUserTrainingProfile(
     defaultIntensityPreference: normalizeIntensityPreference(
       profile?.defaultIntensityPreference ?? null
     ),
+    birthYear: normalizeBirthYear(profile?.birthYear ?? null),
+    biologicalSex: normalizeBiologicalSex(profile?.biologicalSex ?? null),
+    heightCm: clampFloat(
+      profile?.heightCm ?? null,
+      MIN_HEIGHT_CM,
+      MAX_HEIGHT_CM
+    ),
+    weightKg: clampFloat(
+      profile?.weightKg ?? null,
+      MIN_WEIGHT_KG,
+      MAX_WEIGHT_KG
+    ),
+    injuryAreas: normalizeInjuryAreas(profile?.injuryAreas),
+    goalCategories: normalizeGoalCategories(profile?.goalCategories),
+    otherActivities: normalizeOtherActivities(profile?.otherActivities),
+    fauImportance: normalizeFauImportance(profile?.fauImportance),
+    targetSessionsPerWeek: clampInt(
+      profile?.targetSessionsPerWeek ?? null,
+      MIN_SESSIONS_PER_WEEK,
+      MAX_SESSIONS_PER_WEEK
+    ),
+    targetMinutesPerSession: clampInt(
+      profile?.targetMinutesPerSession ?? null,
+      MIN_MINUTES_PER_SESSION,
+      MAX_MINUTES_PER_SESSION
+    ),
+    patternPreference: normalizePatternPreference(
+      profile?.patternPreference ?? null
+    ),
+    preferredDays: normalizePreferredDays(profile?.preferredDays),
   }
 }
 
@@ -139,4 +436,122 @@ export async function getOrCreateUserTrainingProfile(
   })
 
   return normalizeUserTrainingProfile(created)
+}
+
+/**
+ * Fields writable via {@link updateUserTrainingProfile}. Every field is
+ * optional — omitted fields are left untouched. Values are normalized before
+ * persisting; invalid values normalize to null/empty rather than throwing.
+ */
+export type UserTrainingProfileUpdate = Partial<
+  Omit<UserTrainingProfileDTO, 'ratioTargets'> & {
+    ratioTargets: Prisma.JsonValue
+  }
+>
+
+/**
+ * Update the user's training profile (creating it first if needed) and return
+ * the normalized result. Only the provided fields are written, so `updatedAt`
+ * reflects the most recent user-driven change (the payload's
+ * `profile_age_days` freshness signal reads from it).
+ */
+export async function updateUserTrainingProfile(
+  prisma: PrismaClient,
+  userId: string,
+  update: UserTrainingProfileUpdate
+): Promise<UserTrainingProfileDTO> {
+  // Ensure the row exists (also seeds ratioTargets on first touch).
+  await getOrCreateUserTrainingProfile(prisma, userId)
+
+  const data: Prisma.UserTrainingProfileUpdateInput = {}
+
+  if ('goalSentences' in update) {
+    data.goalSentences = normalizeStringList(
+      update.goalSentences,
+      MAX_GOAL_SENTENCES,
+      MAX_GOAL_SENTENCE_LENGTH
+    )
+  }
+  if ('weeklyIntent' in update) {
+    data.weeklyIntent = normalizeStringList(
+      update.weeklyIntent,
+      MAX_WEEKLY_INTENTS,
+      MAX_WEEKLY_INTENT_LENGTH
+    )
+  }
+  if ('equipmentAvailable' in update) {
+    data.equipmentAvailable = normalizeStringList(
+      update.equipmentAvailable,
+      MAX_EQUIPMENT_ITEMS,
+      64
+    )
+  }
+  if ('bannedExerciseIds' in update) {
+    data.bannedExerciseIds = normalizeStringList(
+      update.bannedExerciseIds,
+      MAX_BANNED_EXERCISE_IDS,
+      64
+    )
+  }
+  if ('ratioTargets' in update) {
+    data.ratioTargets = normalizeMuscleBalanceTargets(update.ratioTargets)
+  }
+  if ('defaultIntensityPreference' in update) {
+    data.defaultIntensityPreference = normalizeIntensityPreference(
+      update.defaultIntensityPreference
+    )
+  }
+  if ('birthYear' in update) {
+    data.birthYear = normalizeBirthYear(update.birthYear)
+  }
+  if ('biologicalSex' in update) {
+    data.biologicalSex = normalizeBiologicalSex(update.biologicalSex)
+  }
+  if ('heightCm' in update) {
+    data.heightCm = clampFloat(update.heightCm, MIN_HEIGHT_CM, MAX_HEIGHT_CM)
+  }
+  if ('weightKg' in update) {
+    data.weightKg = clampFloat(update.weightKg, MIN_WEIGHT_KG, MAX_WEIGHT_KG)
+  }
+  if ('injuryAreas' in update) {
+    data.injuryAreas = normalizeInjuryAreas(update.injuryAreas)
+  }
+  if ('goalCategories' in update) {
+    data.goalCategories = normalizeGoalCategories(update.goalCategories)
+  }
+  if ('otherActivities' in update) {
+    data.otherActivities = normalizeOtherActivities(update.otherActivities)
+  }
+  if ('fauImportance' in update) {
+    data.fauImportance = normalizeFauImportance(update.fauImportance)
+  }
+  if ('targetSessionsPerWeek' in update) {
+    data.targetSessionsPerWeek = clampInt(
+      update.targetSessionsPerWeek,
+      MIN_SESSIONS_PER_WEEK,
+      MAX_SESSIONS_PER_WEEK
+    )
+  }
+  if ('targetMinutesPerSession' in update) {
+    data.targetMinutesPerSession = clampInt(
+      update.targetMinutesPerSession,
+      MIN_MINUTES_PER_SESSION,
+      MAX_MINUTES_PER_SESSION
+    )
+  }
+  if ('patternPreference' in update) {
+    data.patternPreference = normalizePatternPreference(
+      update.patternPreference
+    )
+  }
+  if ('preferredDays' in update) {
+    data.preferredDays = normalizePreferredDays(update.preferredDays)
+  }
+
+  const updated = await prisma.userTrainingProfile.update({
+    where: { userId },
+    data,
+  })
+
+  return normalizeUserTrainingProfile(updated)
 }

--- a/prisma/migrations/20260702033143_expand_user_training_profile/migration.sql
+++ b/prisma/migrations/20260702033143_expand_user_training_profile/migration.sql
@@ -1,0 +1,17 @@
+-- Expand UserTrainingProfile with demographics, injuries, importance ratings,
+-- and training rhythm (#915). Purely additive — no changes to existing columns,
+-- so updatedAt semantics are preserved for existing rows.
+
+ALTER TABLE "UserTrainingProfile"
+  ADD COLUMN "birthYear" INTEGER,
+  ADD COLUMN "biologicalSex" TEXT,
+  ADD COLUMN "heightCm" DOUBLE PRECISION,
+  ADD COLUMN "weightKg" DOUBLE PRECISION,
+  ADD COLUMN "injuryAreas" JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "goalCategories" JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "otherActivities" JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "fauImportance" JSONB NOT NULL DEFAULT '{}',
+  ADD COLUMN "targetSessionsPerWeek" INTEGER,
+  ADD COLUMN "targetMinutesPerSession" INTEGER,
+  ADD COLUMN "patternPreference" TEXT,
+  ADD COLUMN "preferredDays" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -370,6 +370,37 @@ model UserTrainingProfile {
   bannedExerciseIds           String[] @default([])
   ratioTargets                Json
   defaultIntensityPreference  String?
+
+  // Demographics (all optional, skippable)
+  birthYear                   Int?
+  // biologicalSex: female | male | prefer_not_to_say
+  biologicalSex               String?
+  heightCm                    Float?
+  weightKg                    Float?
+
+  // Injuries: [{ area, severity, notes?, reportedAt? }]
+  // area: neck | shoulder | elbow | wrist | upper_back | lower_back | hip | knee | ankle
+  // severity: avoid_loading | caution | recovered
+  // Source for the injury -> exercise ban-list mapping (areas align with
+  // ExerciseDefinition.movementPattern / FAU taxonomy).
+  injuryAreas                 Json     @default("[]")
+
+  // Importance ratings (1-5)
+  // goalCategories: [{ category, importance }]
+  goalCategories              Json     @default("[]")
+  // otherActivities: [{ activity, importance, cadence? }]
+  otherActivities             Json     @default("[]")
+  // fauImportance: { [fauKey]: 1..5 } — per-FAU weighting (keys from lib/fau-volume ALL_FAUS)
+  fauImportance               Json     @default("{}")
+
+  // Training rhythm
+  targetSessionsPerWeek       Int?
+  targetMinutesPerSession     Int?
+  // patternPreference: no_preference | full_body | upper_lower | push_pull_legs | body_part_split | custom
+  patternPreference           String?
+  // preferredDays: monday..sunday
+  preferredDays               String[] @default([])
+
   createdAt                   DateTime @default(now())
   updatedAt                   DateTime @updatedAt
 


### PR DESCRIPTION
Fixes #915

Additive schema expansion of `UserTrainingProfile` + typed accessor updates.

## Changes
- **Demographics**: `birthYear` (freshness-proof vs stored age), `biologicalSex` (female/male/prefer_not_to_say), `heightCm`, `weightKg` — all optional.
- **Injuries**: `injuryAreas` JSON list `{ area, severity, notes?, reportedAt? }`. Areas are joint/region-level (neck..ankle) for the injury→ban-list mapping onto movementPattern/FAU taxonomy. Severity per #915 spec: `avoid_loading | caution | recovered`.
- **Importance (1–5)**: `goalCategories`, `otherActivities` (names match payload spec #909), plus `fauImportance` map for per-FAU weighting (e.g. bench priority for the cyclist archetype).
- **Rhythm**: `targetSessionsPerWeek`, `targetMinutesPerSession`, `patternPreference`, `preferredDays`.
- New `updateUserTrainingProfile()` accessor: partial, normalized writes; `updatedAt` bumps only on user-driven writes (feeds `profile_age_days`).
- Migration is purely additive; `weeklyIntent` stays `String[]` (shape change from old #897 draft intentionally dropped — not in #915 scope).

## Reconciliation notes
- Injury severity taxonomy follows #915 (`avoid_loading/caution/recovered`), not the #897 draft / payload-spec doc (`past/mindful/active`) — the spec doc (PR #911) will need that one-word mapping updated.

## Testing
- 20 tests pass (`user-training-profile`): normalization edge cases, cold-start defaults, round-trip read/write, partial updates, clearing, updatedAt freshness.
- type-check + lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)