### PR TITLE
feat: gap-decayed EWMA + Beta preference helpers (lib/learning/math.ts)

### DIFF
--- a/__tests__/lib/learning-math.test.ts
+++ b/__tests__/lib/learning-math.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest'
+import {
+  betaCredibleInterval,
+  betaMean,
+  betaVariance,
+  DEFAULT_EWMA_ALPHA,
+  decayBeta,
+  effectiveAlpha,
+  epleyE1RM,
+  gapDecayedEwma,
+  sampleBeta,
+  UNIFORM_PRIOR,
+  updateBeta,
+  WEEKLY_DECAY_FACTOR,
+} from '@/lib/learning/math'
+
+/** Deterministic LCG for reproducible sampling tests. */
+function seededRng(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return (state + 1) / 4294967297 // in (0, 1)
+  }
+}
+
+describe('gapDecayedEwma', () => {
+  it('returns nulls for zero observations', () => {
+    const result = gapDecayedEwma([])
+    expect(result.estimateLbs).toBeNull()
+    expect(result.estimateStalenessDays).toBeNull()
+    expect(result.observationCount).toBe(0)
+  })
+
+  it('returns the single observation weight and its staleness', () => {
+    const result = gapDecayedEwma([{ weightLbs: 185, daysAgo: 12 }])
+    expect(result.estimateLbs).toBe(185)
+    expect(result.estimateStalenessDays).toBe(12)
+    expect(result.observationCount).toBe(1)
+  })
+
+  it('processes observations oldest-first regardless of input order', () => {
+    const asc = gapDecayedEwma([
+      { weightLbs: 185, daysAgo: 14 },
+      { weightLbs: 190, daysAgo: 7 },
+      { weightLbs: 195, daysAgo: 0 },
+    ])
+    const shuffled = gapDecayedEwma([
+      { weightLbs: 195, daysAgo: 0 },
+      { weightLbs: 185, daysAgo: 14 },
+      { weightLbs: 190, daysAgo: 7 },
+    ])
+    expect(shuffled.estimateLbs).toBe(asc.estimateLbs)
+    expect(shuffled.estimateStalenessDays).toBe(0)
+  })
+
+  it('gap decay: a 21-day layoff stream leans harder on the newest observation than a fresh stream', () => {
+    // Same weights; only the gap before the final observation differs.
+    const fresh = gapDecayedEwma([
+      { weightLbs: 200, daysAgo: 10 },
+      { weightLbs: 200, daysAgo: 7 },
+      { weightLbs: 170, daysAgo: 0 }, // 7-day gap (typical)
+    ])
+    const layoff = gapDecayedEwma([
+      { weightLbs: 200, daysAgo: 24 },
+      { weightLbs: 200, daysAgo: 21 },
+      { weightLbs: 170, daysAgo: 0 }, // 21-day gap
+    ])
+    // Post-layoff, the lighter comeback observation should pull the estimate
+    // down much further than in the fresh stream.
+    expect(layoff.estimateLbs).toBeLessThan(fresh.estimateLbs as number)
+    // With alpha 0.3 / typical 7: fresh final step alpha' = 0.3;
+    // layoff final step alpha' = 1 - 0.7^3 = 0.657.
+    expect(fresh.estimateLbs).toBeCloseTo(0.3 * 170 + 0.7 * 200, 5)
+    expect(layoff.estimateLbs).toBeCloseTo(0.657 * 170 + 0.343 * 200, 5)
+  })
+
+  it('emits staleness reflecting the newest observation, not the stream shape', () => {
+    const stale = gapDecayedEwma([
+      { weightLbs: 200, daysAgo: 28 },
+      { weightLbs: 205, daysAgo: 21 },
+    ])
+    expect(stale.estimateStalenessDays).toBe(21)
+  })
+
+  it('throws on warmup observations', () => {
+    expect(() =>
+      gapDecayedEwma([{ weightLbs: 135, daysAgo: 0, isWarmup: true }])
+    ).toThrow(/warmup/)
+  })
+
+  it('throws on bodyweight-exercise observations', () => {
+    expect(() =>
+      gapDecayedEwma([{ weightLbs: 0, daysAgo: 0, isBodyweight: true }])
+    ).toThrow(/bodyweight/)
+  })
+
+  it('throws on invalid weights and daysAgo', () => {
+    expect(() => gapDecayedEwma([{ weightLbs: -5, daysAgo: 0 }])).toThrow(
+      /weightLbs/
+    )
+    expect(() => gapDecayedEwma([{ weightLbs: NaN, daysAgo: 0 }])).toThrow(
+      /weightLbs/
+    )
+    expect(() => gapDecayedEwma([{ weightLbs: 100, daysAgo: -1 }])).toThrow(
+      /daysAgo/
+    )
+  })
+})
+
+describe('effectiveAlpha', () => {
+  it('reproduces base alpha at the typical gap', () => {
+    expect(effectiveAlpha(0.3, 7, 7)).toBeCloseTo(0.3, 10)
+  })
+
+  it('increases monotonically with gap size', () => {
+    const a1 = effectiveAlpha(0.3, 7, 7)
+    const a2 = effectiveAlpha(0.3, 14, 7)
+    const a3 = effectiveAlpha(0.3, 21, 7)
+    expect(a2).toBeGreaterThan(a1)
+    expect(a3).toBeGreaterThan(a2)
+    expect(a3).toBeCloseTo(1 - 0.7 ** 3, 10)
+  })
+
+  it('clamps same-day gaps to 1 day so observations are not ignored', () => {
+    expect(effectiveAlpha(0.3, 0, 7)).toBeCloseTo(
+      1 - 0.7 ** (1 / 7),
+      10
+    )
+    expect(effectiveAlpha(0.3, 0, 7)).toBeGreaterThan(0)
+  })
+
+  it('rejects invalid parameters', () => {
+    expect(() => effectiveAlpha(0, 7, 7)).toThrow(/alpha/)
+    expect(() => effectiveAlpha(1, 7, 7)).toThrow(/alpha/)
+    expect(() => effectiveAlpha(0.3, 7, 0)).toThrow(/typicalGapDays/)
+  })
+
+  it('exports a sane default alpha', () => {
+    expect(DEFAULT_EWMA_ALPHA).toBeGreaterThan(0)
+    expect(DEFAULT_EWMA_ALPHA).toBeLessThan(1)
+  })
+})
+
+describe('epleyE1RM', () => {
+  it('returns weight for a single rep', () => {
+    expect(epleyE1RM(225, 1)).toBe(225)
+  })
+
+  it('applies weight * (1 + reps/30)', () => {
+    expect(epleyE1RM(200, 5)).toBeCloseTo(200 * (1 + 5 / 30), 10)
+  })
+
+  it('rejects non-positive reps', () => {
+    expect(() => epleyE1RM(200, 0)).toThrow(/reps/)
+  })
+})
+
+describe('updateBeta', () => {
+  it('adds accept/reject evidence to the counts', () => {
+    const posterior = updateBeta(UNIFORM_PRIOR, 3, 1)
+    expect(posterior).toEqual({ alpha: 4, beta: 2 })
+  })
+
+  it('rejects negative evidence and invalid params', () => {
+    expect(() => updateBeta(UNIFORM_PRIOR, -1, 0)).toThrow(/counts/)
+    expect(() => updateBeta({ alpha: 0, beta: 1 }, 1, 1)).toThrow(/alpha/)
+  })
+})
+
+describe('decayBeta', () => {
+  it('is identity at zero weeks', () => {
+    const params = { alpha: 10, beta: 4 }
+    expect(decayBeta(params, 0)).toEqual(params)
+  })
+
+  it('halves evidence above the prior at the ~46-week half-life of 0.985/week', () => {
+    const halfLifeWeeks = Math.log(0.5) / Math.log(WEEKLY_DECAY_FACTOR)
+    expect(halfLifeWeeks).toBeCloseTo(45.86, 1)
+
+    const params = { alpha: 11, beta: 5 } // evidence: 10 accepts, 4 rejects
+    const decayed = decayBeta(params, halfLifeWeeks)
+    expect(decayed.alpha).toBeCloseTo(1 + 10 / 2, 6)
+    expect(decayed.beta).toBeCloseTo(1 + 4 / 2, 6)
+  })
+
+  it('relaxes toward the prior (never below valid Beta parameters) as weeks grow', () => {
+    const decayed = decayBeta({ alpha: 20, beta: 2 }, 10_000)
+    expect(decayed.alpha).toBeCloseTo(UNIFORM_PRIOR.alpha, 6)
+    expect(decayed.beta).toBeCloseTo(UNIFORM_PRIOR.beta, 6)
+    expect(decayed.alpha).toBeGreaterThan(0)
+    expect(decayed.beta).toBeGreaterThan(0)
+  })
+
+  it('fades an ancient dislike behind recent signal', () => {
+    // A year-old pile of rejects, decayed, then updated with recent accepts.
+    const ancientDislike = updateBeta(UNIFORM_PRIOR, 0, 10)
+    const afterYear = decayBeta(ancientDislike, 52)
+    const withRecentAccepts = updateBeta(afterYear, 4, 0)
+    expect(betaMean(withRecentAccepts)).toBeGreaterThan(0.4)
+    // Without decay the old rejects dominate.
+    expect(betaMean(updateBeta(ancientDislike, 4, 0))).toBeLessThan(0.35)
+  })
+
+  it('rejects invalid inputs', () => {
+    expect(() => decayBeta({ alpha: 2, beta: 2 }, -1)).toThrow(/weeks/)
+    expect(() => decayBeta({ alpha: 2, beta: 2 }, 1, 1.5)).toThrow(/factor/)
+  })
+})
+
+describe('betaMean / betaVariance / betaCredibleInterval', () => {
+  it('computes mean and variance', () => {
+    expect(betaMean({ alpha: 3, beta: 1 })).toBeCloseTo(0.75, 10)
+    // Beta(2,2): mean 0.5, var = 4/(16*5) = 0.05
+    expect(betaVariance({ alpha: 2, beta: 2 })).toBeCloseTo(0.05, 10)
+  })
+
+  it('produces a clamped interval around the mean', () => {
+    const wide = betaCredibleInterval(UNIFORM_PRIOR)
+    expect(wide.lower).toBeGreaterThanOrEqual(0)
+    expect(wide.upper).toBeLessThanOrEqual(1)
+    expect(wide.lower).toBeLessThan(wide.upper)
+
+    const tight = betaCredibleInterval({ alpha: 300, beta: 100 })
+    expect(tight.lower).toBeGreaterThan(0.7)
+    expect(tight.upper).toBeLessThan(0.8)
+    expect(betaMean({ alpha: 300, beta: 100 })).toBeGreaterThan(tight.lower)
+    expect(betaMean({ alpha: 300, beta: 100 })).toBeLessThan(tight.upper)
+  })
+})
+
+describe('sampleBeta', () => {
+  it('draws values in (0, 1) and converges near the mean', () => {
+    const rng = seededRng(42)
+    const params = { alpha: 8, beta: 2 } // mean 0.8
+    const draws: number[] = []
+    for (let i = 0; i < 2000; i++) {
+      const x = sampleBeta(params, rng)
+      expect(x).toBeGreaterThan(0)
+      expect(x).toBeLessThan(1)
+      draws.push(x)
+    }
+    const avg = draws.reduce((s, x) => s + x, 0) / draws.length
+    expect(avg).toBeCloseTo(betaMean(params), 1)
+  })
+
+  it('handles shape parameters below 1 (boosted gamma path)', () => {
+    const rng = seededRng(7)
+    for (let i = 0; i < 200; i++) {
+      const x = sampleBeta({ alpha: 0.5, beta: 0.5 }, rng)
+      expect(x).toBeGreaterThan(0)
+      expect(x).toBeLessThan(1)
+    }
+  })
+
+  it('is deterministic with a seeded rng', () => {
+    const a = sampleBeta({ alpha: 3, beta: 5 }, seededRng(123))
+    const b = sampleBeta({ alpha: 3, beta: 5 }, seededRng(123))
+    expect(a).toBe(b)
+  })
+})

--- a/lib/learning/math.ts
+++ b/lib/learning/math.ts
@@ -1,0 +1,291 @@
+/**
+ * Pure-math helpers for strength calibration and exercise preference learning.
+ *
+ * - Gap-decayed EWMA for strength estimates (calendar-time aware, so layoffs
+ *   decay the estimate toward uncertainty instead of freezing it).
+ * - Beta-distribution preference helpers with weekly exponential decay so
+ *   ancient dislikes don't drown out recent signal.
+ *
+ * This module is intentionally free of I/O: no Prisma, no fetch, no fs.
+ * Input hygiene (warmup exclusion, bodyweight exclusion, lbs normalization)
+ * is the callers' contract, but violations are asserted here loudly.
+ *
+ * See docs/data-signal-audit.md (finding 3 / "gap-blind EWMA" and the
+ * preference-decay recommendation) and issue #907.
+ */
+
+// ---------------------------------------------------------------------------
+// Gap-decayed EWMA
+// ---------------------------------------------------------------------------
+
+export interface StrengthObservation {
+  /** Weight in lbs. Callers must pre-normalize via normalizeWeightToLbs. */
+  weightLbs: number
+  /** Days before "now" this set was performed. 0 = today. */
+  daysAgo: number
+  /** Must be false/undefined — warmup sets are excluded from calibration. */
+  isWarmup?: boolean
+  /**
+   * Must be false/undefined — bodyweight-exercise weights (often logged as 0)
+   * are excluded from weight EWMAs (ExerciseDefinition.isBodyweight).
+   */
+  isBodyweight?: boolean
+}
+
+export interface EwmaOptions {
+  /** Base smoothing factor applied when the gap equals typicalGapDays. */
+  alpha?: number
+  /** Expected days between observations of this movement (default weekly). */
+  typicalGapDays?: number
+}
+
+export interface StrengthEstimate {
+  /** Gap-decayed EWMA of observed weights (lbs), or null with no data. */
+  estimateLbs: number | null
+  /** Days since the most recent observation, or null with no data. */
+  estimateStalenessDays: number | null
+  observationCount: number
+}
+
+export const DEFAULT_EWMA_ALPHA = 0.3
+export const DEFAULT_TYPICAL_GAP_DAYS = 7
+
+/**
+ * Effective smoothing factor for a given calendar gap:
+ *   alpha' = 1 - (1 - alpha)^(gapDays / typicalGapDays)
+ *
+ * gap == typicalGapDays reproduces the base alpha; longer gaps weight the new
+ * observation more heavily (a 3x-typical gap with alpha 0.3 gives ~0.66).
+ * Gaps are clamped to a minimum of 1 day so same-day observations still
+ * contribute instead of being ignored (alpha' of 0).
+ */
+export function effectiveAlpha(
+  alpha: number,
+  gapDays: number,
+  typicalGapDays: number
+): number {
+  if (alpha <= 0 || alpha >= 1) {
+    throw new Error(`alpha must be in (0, 1), got ${alpha}`)
+  }
+  if (typicalGapDays <= 0) {
+    throw new Error(`typicalGapDays must be > 0, got ${typicalGapDays}`)
+  }
+  const clampedGap = Math.max(gapDays, 1)
+  return 1 - (1 - alpha) ** (clampedGap / typicalGapDays)
+}
+
+function assertObservationHygiene(obs: StrengthObservation): void {
+  if (obs.isWarmup === true) {
+    throw new Error('gapDecayedEwma: warmup sets must be excluded by callers')
+  }
+  if (obs.isBodyweight === true) {
+    throw new Error(
+      'gapDecayedEwma: bodyweight-exercise observations must be excluded by callers'
+    )
+  }
+  if (!Number.isFinite(obs.weightLbs) || obs.weightLbs < 0) {
+    throw new Error(
+      `gapDecayedEwma: weightLbs must be a finite non-negative number, got ${obs.weightLbs}`
+    )
+  }
+  if (!Number.isFinite(obs.daysAgo) || obs.daysAgo < 0) {
+    throw new Error(
+      `gapDecayedEwma: daysAgo must be a finite non-negative number, got ${obs.daysAgo}`
+    )
+  }
+}
+
+/**
+ * Gap-decayed exponentially weighted moving average of strength observations.
+ *
+ * Observations may be provided in any order; they are processed oldest-first.
+ * The smoothing factor for each step scales with the calendar gap since the
+ * previous observation (see effectiveAlpha), so a stream with a 3-week layoff
+ * leans much harder on the post-layoff observation than a fresh stream does.
+ *
+ * Always emits estimateStalenessDays (days since the newest observation) so
+ * downstream consumers can decay confidence in the estimate itself.
+ */
+export function gapDecayedEwma(
+  observations: StrengthObservation[],
+  options: EwmaOptions = {}
+): StrengthEstimate {
+  const alpha = options.alpha ?? DEFAULT_EWMA_ALPHA
+  const typicalGapDays = options.typicalGapDays ?? DEFAULT_TYPICAL_GAP_DAYS
+
+  for (const obs of observations) {
+    assertObservationHygiene(obs)
+  }
+
+  if (observations.length === 0) {
+    return { estimateLbs: null, estimateStalenessDays: null, observationCount: 0 }
+  }
+
+  // Oldest first (largest daysAgo first).
+  const ordered = [...observations].sort((a, b) => b.daysAgo - a.daysAgo)
+
+  let estimate = ordered[0].weightLbs
+  for (let i = 1; i < ordered.length; i++) {
+    const gapDays = ordered[i - 1].daysAgo - ordered[i].daysAgo
+    const a = effectiveAlpha(alpha, gapDays, typicalGapDays)
+    estimate = a * ordered[i].weightLbs + (1 - a) * estimate
+  }
+
+  return {
+    estimateLbs: estimate,
+    estimateStalenessDays: ordered[ordered.length - 1].daysAgo,
+    observationCount: ordered.length,
+  }
+}
+
+/**
+ * Estimated 1RM via the Epley formula: weight * (1 + reps / 30).
+ * Epley is the project-wide e1RM choice (see lib/stats/exercise-performance.ts);
+ * duplicated here rather than imported to keep this module free of files that
+ * touch Prisma types.
+ */
+export function epleyE1RM(weightLbs: number, reps: number): number {
+  if (reps <= 0) throw new Error(`epleyE1RM: reps must be >= 1, got ${reps}`)
+  if (reps === 1) return weightLbs
+  return weightLbs * (1 + reps / 30)
+}
+
+// ---------------------------------------------------------------------------
+// Beta-distribution preference helpers
+// ---------------------------------------------------------------------------
+
+export interface BetaParams {
+  alpha: number
+  beta: number
+}
+
+/** Uninformative Beta(1, 1) prior. */
+export const UNIFORM_PRIOR: BetaParams = { alpha: 1, beta: 1 }
+
+/** Weekly multiplicative decay on evidence counts (~10-month half-life). */
+export const WEEKLY_DECAY_FACTOR = 0.985
+
+function assertBetaParams(params: BetaParams, context: string): void {
+  if (!Number.isFinite(params.alpha) || params.alpha <= 0) {
+    throw new Error(`${context}: alpha must be > 0, got ${params.alpha}`)
+  }
+  if (!Number.isFinite(params.beta) || params.beta <= 0) {
+    throw new Error(`${context}: beta must be > 0, got ${params.beta}`)
+  }
+}
+
+/** Standard conjugate Beta update from accept/reject-style evidence counts. */
+export function updateBeta(
+  params: BetaParams,
+  accepts: number,
+  rejects: number
+): BetaParams {
+  assertBetaParams(params, 'updateBeta')
+  if (accepts < 0 || rejects < 0) {
+    throw new Error(
+      `updateBeta: evidence counts must be >= 0, got accepts=${accepts} rejects=${rejects}`
+    )
+  }
+  return { alpha: params.alpha + accepts, beta: params.beta + rejects }
+}
+
+/**
+ * Exponentially decay accumulated evidence: counts above the prior shrink by
+ * factor^weeks (default 0.985/week, half-life ~46 weeks). The decay applies to
+ * evidence only — parameters relax toward the prior rather than below 1, which
+ * a raw `Beta_old * factor^weeks` multiply would eventually do (an invalid,
+ * bimodal Beta). At the half-life, the influence of old accepts/rejects is
+ * halved, so ancient dislikes fade behind recent signal.
+ */
+export function decayBeta(
+  params: BetaParams,
+  weeks: number,
+  factor: number = WEEKLY_DECAY_FACTOR,
+  prior: BetaParams = UNIFORM_PRIOR
+): BetaParams {
+  assertBetaParams(params, 'decayBeta')
+  assertBetaParams(prior, 'decayBeta prior')
+  if (weeks < 0) throw new Error(`decayBeta: weeks must be >= 0, got ${weeks}`)
+  if (factor <= 0 || factor > 1) {
+    throw new Error(`decayBeta: factor must be in (0, 1], got ${factor}`)
+  }
+  const f = factor ** weeks
+  return {
+    alpha: prior.alpha + (params.alpha - prior.alpha) * f,
+    beta: prior.beta + (params.beta - prior.beta) * f,
+  }
+}
+
+/** Posterior mean: alpha / (alpha + beta). */
+export function betaMean(params: BetaParams): number {
+  assertBetaParams(params, 'betaMean')
+  return params.alpha / (params.alpha + params.beta)
+}
+
+/** Posterior variance. */
+export function betaVariance(params: BetaParams): number {
+  assertBetaParams(params, 'betaVariance')
+  const { alpha: a, beta: b } = params
+  const n = a + b
+  return (a * b) / (n * n * (n + 1))
+}
+
+/** z-scores for common two-sided credible-interval levels. */
+export const Z_90 = 1.6449
+export const Z_95 = 1.96
+
+/**
+ * Approximate central credible interval via the normal approximation
+ * (mean +/- z * sd), clamped to [0, 1]. Good enough for ranking/eligibility
+ * decisions downstream; avoids shipping an incomplete-beta inverse.
+ */
+export function betaCredibleInterval(
+  params: BetaParams,
+  z: number = Z_90
+): { lower: number; upper: number } {
+  const mean = betaMean(params)
+  const sd = Math.sqrt(betaVariance(params))
+  return {
+    lower: Math.max(0, mean - z * sd),
+    upper: Math.min(1, mean + z * sd),
+  }
+}
+
+/** Marsaglia–Tsang gamma sampler (shape only; scale 1). */
+function sampleGamma(shape: number, rng: () => number): number {
+  if (shape < 1) {
+    // Boost: Gamma(shape) = Gamma(shape + 1) * U^(1/shape)
+    return sampleGamma(shape + 1, rng) * rng() ** (1 / shape)
+  }
+  const d = shape - 1 / 3
+  const c = 1 / Math.sqrt(9 * d)
+  for (;;) {
+    let x: number
+    let v: number
+    do {
+      // Box–Muller standard normal
+      const u1 = rng()
+      const u2 = rng()
+      x = Math.sqrt(-2 * Math.log(u1 || Number.MIN_VALUE)) * Math.cos(2 * Math.PI * u2)
+      v = 1 + c * x
+    } while (v <= 0)
+    v = v * v * v
+    const u = rng()
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v
+  }
+}
+
+/**
+ * Draw a sample from Beta(alpha, beta) — e.g. for Thompson sampling over
+ * exercise preferences. Pass a seeded rng for deterministic tests.
+ */
+export function sampleBeta(
+  params: BetaParams,
+  rng: () => number = Math.random
+): number {
+  assertBetaParams(params, 'sampleBeta')
+  const x = sampleGamma(params.alpha, rng)
+  const y = sampleGamma(params.beta, rng)
+  return x / (x + y)
+}


### PR DESCRIPTION
Fixes #907

## Summary

New pure-math module `lib/learning/math.ts` (291 lines) — the foundation for strength calibration and exercise preference learning. No DB, no I/O, no `@prisma/client` imports.

### Gap-decayed EWMA
- `gapDecayedEwma(observations, options)` over timestamped `{ weightLbs, daysAgo }` observations. Effective alpha scales with the calendar gap since the previous observation: `alpha' = 1 - (1-alpha)^(days_gap / typical_gap_days)`, so a 3-week layoff leans heavily on the comeback observation instead of freezing a stale-high estimate (data-signal-audit finding 3).
- Emits `estimateStalenessDays` (days since newest observation) with every estimate.
- Input hygiene asserted loudly: throws on `isWarmup: true`, `isBodyweight: true`, non-finite/negative weights or `daysAgo`. Callers pre-normalize to lbs via `normalizeWeightToLbs`.
- Same-day gaps clamp to 1 day so repeat observations still contribute (raw formula would give alpha' = 0).
- `epleyE1RM` included locally (Epley is the project-wide e1RM choice per `lib/stats/exercise-performance.ts`); duplicated rather than imported to keep the module free of Prisma-touching files.

### Beta preference helpers
- `updateBeta` — standard conjugate update from accept/reject counts.
- `decayBeta` — weekly exponential decay (`0.985^weeks`, half-life ~46 weeks) applied to evidence **above the prior**, relaxing toward Beta(1,1). Note: a raw `Beta_old * factor^weeks` multiply on the parameters themselves would eventually drop below 1 (an invalid, bimodal Beta); decaying evidence-above-prior preserves the intended semantics — the influence of old accepts/rejects halves at the half-life so ancient dislikes fade behind recent signal.
- `betaMean`, `betaVariance`, `betaCredibleInterval` (normal approximation, clamped to [0,1], `Z_90`/`Z_95` constants), and `sampleBeta` (Marsaglia–Tsang gamma sampler, injectable rng for deterministic tests) for Thompson-sampling downstream.

## Testing

28 unit tests in `__tests__/lib/learning-math.test.ts`, all passing:
- Gap decay: fresh (7-day cadence) vs 21-day-layoff streams produce different estimates; exact closed-form checks.
- Staleness emission for stale streams; order-independence of input.
- Warmup / bodyweight / degenerate input assertions (0 observations, 1 observation, NaN, negatives).
- Beta decay half-life math (evidence halves at ~45.86 weeks), long-horizon relaxation to prior, ancient-dislike-fades scenario.
- Sampler: draws in (0,1), converges to mean over 2000 seeded draws, sub-1 shape path, determinism with seeded rng.

Type-check passes; lint issues in the repo are pre-existing in unrelated files (none in the new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)