### PR TITLE
chore(msv): point msv at milestone 16

### DIFF
--- a/.msv.yaml
+++ b/.msv.yaml
@@ -1,4 +1,4 @@
 owner: aptx-health
 repo: ripit-fitness
-milestone: Suggest Workout (LLM-powered)
-graph_file: milestones/suggest-workout.md
+milestone: "Suggest Workout: build phase"
+graph_file: milestones/suggest-workout-build.md


### PR DESCRIPTION
Repoints `.msv.yaml` to milestone 16 (Suggest Workout: build phase) and its graph file `milestones/suggest-workout-build.md` (gitignored, local). M15 is closed; see discussion #905 for M16 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)