### PR TITLE
feat(learning): UserExercisePreference table + decayed-Beta accessor

### DIFF
--- a/__tests__/lib/preference-store.test.ts
+++ b/__tests__/lib/preference-store.test.ts
@@ -1,0 +1,152 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { UNIFORM_PRIOR, betaMean } from '@/lib/learning/math'
+import {
+  elapsedWeeks,
+  readPreference,
+  updatePreference,
+} from '@/lib/learning/preference-store'
+import { getTestDatabase } from '@/lib/test/database'
+import { createTestExerciseDefinition, createTestUser } from '@/lib/test/factories'
+
+describe('elapsedWeeks', () => {
+  it('returns whole weeks between two instants', () => {
+    const from = new Date('2026-01-01T00:00:00Z')
+    const to = new Date('2026-01-15T00:00:00Z') // 14 days = 2 weeks
+    expect(elapsedWeeks(from, to)).toBeCloseTo(2, 10)
+  })
+
+  it('clamps negative gaps (future stamp / clock skew) to zero', () => {
+    const from = new Date('2026-02-01T00:00:00Z')
+    const to = new Date('2026-01-01T00:00:00Z')
+    expect(elapsedWeeks(from, to)).toBe(0)
+  })
+})
+
+describe('preference-store (DB-backed)', () => {
+  let prisma: PrismaClient
+  let userId: string
+  let exerciseDefinitionId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+
+    const user = await createTestUser()
+    userId = user.id
+    const def = await createTestExerciseDefinition(prisma, { userId })
+    exerciseDefinitionId = def.id
+  })
+
+  describe('readPreference', () => {
+    it('returns the uniform prior when no row exists', async () => {
+      const result = await readPreference(prisma.userExercisePreference, userId, exerciseDefinitionId)
+      expect(result.exists).toBe(false)
+      expect(result.alpha).toBe(UNIFORM_PRIOR.alpha)
+      expect(result.beta).toBe(UNIFORM_PRIOR.beta)
+      expect(result.decayedWeeks).toBe(0)
+    })
+
+    it('applies decay based on elapsed weeks since lastUpdatedAt', async () => {
+      const writtenAt = new Date('2026-01-01T00:00:00Z')
+      // Strong preference evidence stamped in the past.
+      await updatePreference(prisma.userExercisePreference, userId, exerciseDefinitionId, 20, 0, writtenAt)
+
+      const stored = await readPreference(
+        prisma.userExercisePreference,
+        userId,
+        exerciseDefinitionId,
+        writtenAt // read at the same instant: no decay
+      )
+      expect(stored.decayedWeeks).toBe(0)
+      expect(stored.alpha).toBeCloseTo(21, 6)
+
+      // Read ~46 weeks later (roughly the decay half-life).
+      const halfLifeLater = new Date(writtenAt.getTime() + 46 * 7 * 24 * 60 * 60 * 1000)
+      const decayed = await readPreference(
+        prisma.userExercisePreference,
+        userId,
+        exerciseDefinitionId,
+        halfLifeLater
+      )
+      expect(decayed.decayedWeeks).toBeCloseTo(46, 6)
+      // Evidence above the prior should be roughly halved, and the mean pulled
+      // back toward the uniform prior (0.5).
+      expect(decayed.alpha).toBeLessThan(stored.alpha)
+      expect(decayed.alpha - UNIFORM_PRIOR.alpha).toBeCloseTo((stored.alpha - UNIFORM_PRIOR.alpha) / 2, 1)
+      expect(betaMean(decayed)).toBeLessThan(betaMean(stored))
+      expect(betaMean(decayed)).toBeGreaterThan(0.5)
+    })
+  })
+
+  describe('updatePreference', () => {
+    it('creates a row on first write and stamps lastUpdatedAt', async () => {
+      const now = new Date('2026-03-01T00:00:00Z')
+      const result = await updatePreference(
+        prisma.userExercisePreference,
+        userId,
+        exerciseDefinitionId,
+        3,
+        1,
+        now
+      )
+      expect(result.alpha).toBeCloseTo(4, 6) // prior 1 + 3 accepts
+      expect(result.beta).toBeCloseTo(2, 6) // prior 1 + 1 reject
+
+      const row = await prisma.userExercisePreference.findUniqueOrThrow({
+        where: { userId_exerciseDefinitionId: { userId, exerciseDefinitionId } },
+      })
+      expect(row.alpha).toBeCloseTo(4, 6)
+      expect(row.beta).toBeCloseTo(2, 6)
+      expect(row.lastUpdatedAt.getTime()).toBe(now.getTime())
+    })
+
+    it('is idempotent in structure: repeated writes update one row, never duplicate', async () => {
+      const t0 = new Date('2026-04-01T00:00:00Z')
+      await updatePreference(prisma.userExercisePreference, userId, exerciseDefinitionId, 2, 0, t0)
+      const t1 = new Date('2026-04-08T00:00:00Z') // one week later
+      await updatePreference(prisma.userExercisePreference, userId, exerciseDefinitionId, 2, 0, t1)
+
+      const rows = await prisma.userExercisePreference.findMany({
+        where: { userId, exerciseDefinitionId },
+      })
+      expect(rows).toHaveLength(1)
+      // Second write decays the first week's evidence before adding new accepts,
+      // so alpha is below the naive 1 + 2 + 2 = 5.
+      expect(rows[0].alpha).toBeGreaterThan(4)
+      expect(rows[0].alpha).toBeLessThan(5)
+      expect(rows[0].lastUpdatedAt.getTime()).toBe(t1.getTime())
+    })
+
+    it('with zero evidence only decays and re-stamps, inventing no signal', async () => {
+      const t0 = new Date('2026-05-01T00:00:00Z')
+      await updatePreference(prisma.userExercisePreference, userId, exerciseDefinitionId, 10, 0, t0)
+      const t1 = new Date(t0.getTime() + 10 * 7 * 24 * 60 * 60 * 1000)
+      const result = await updatePreference(
+        prisma.userExercisePreference,
+        userId,
+        exerciseDefinitionId,
+        0,
+        0,
+        t1
+      )
+      // Alpha decayed toward the prior but stays above it.
+      expect(result.alpha).toBeLessThan(11)
+      expect(result.alpha).toBeGreaterThan(1)
+    })
+  })
+
+  describe('unique constraint', () => {
+    it('rejects a duplicate (userId, exerciseDefinitionId) row', async () => {
+      await prisma.userExercisePreference.create({
+        data: { userId, exerciseDefinitionId, alpha: 2, beta: 1 },
+      })
+      await expect(
+        prisma.userExercisePreference.create({
+          data: { userId, exerciseDefinitionId, alpha: 3, beta: 1 },
+        })
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/lib/learning/preference-store.ts
+++ b/lib/learning/preference-store.ts
@@ -1,0 +1,124 @@
+/**
+ * Persistence + accessor layer for per-user, per-exercise preference learning.
+ *
+ * The Beta math (evidence update, weekly decay) lives in ./math. This module is
+ * the thin I/O layer over the UserExercisePreference table:
+ *
+ *   - readPreference applies decay-on-read: stored (alpha, beta) are decayed by
+ *     the elapsed weeks since lastUpdatedAt, so a preference that hasn't been
+ *     touched in months relaxes toward the uniform prior automatically.
+ *   - updatePreference decays the stored evidence to "now", applies the new
+ *     accept/reject counts, writes the result, and stamps lastUpdatedAt. This
+ *     keeps decay and update in one atomic upsert so repeated writes compose
+ *     correctly instead of double-counting or double-decaying.
+ *
+ * No callers are wired yet — implicit-feedback hooks (writers) and the
+ * training-state builder (reader) consume this in later issues. See issue #913.
+ */
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+import {
+  type BetaParams,
+  UNIFORM_PRIOR,
+  WEEKLY_DECAY_FACTOR,
+  decayBeta,
+  updateBeta,
+} from './math'
+
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+
+/** Minimal Prisma surface so tests can pass a client or a transaction handle. */
+type PreferenceDelegate = Pick<
+  PrismaClient['userExercisePreference'],
+  'findUnique' | 'upsert'
+>
+
+export interface PreferenceReadResult extends BetaParams {
+  /** Whether a stored row existed. When false, the uniform prior is returned. */
+  exists: boolean
+  /** Weeks of decay applied to the stored evidence (0 when no row exists). */
+  decayedWeeks: number
+}
+
+/**
+ * Elapsed whole-and-fractional weeks between two instants, clamped to >= 0.
+ * A negative gap (clock skew, future stamp) is treated as no elapsed time so
+ * decayBeta never receives a negative exponent.
+ */
+export function elapsedWeeks(from: Date, to: Date): number {
+  return Math.max(0, (to.getTime() - from.getTime()) / MS_PER_WEEK)
+}
+
+/**
+ * Read a user's decayed preference for an exercise. Applies weekly decay based
+ * on elapsed time since lastUpdatedAt. Returns the uniform prior when no row
+ * exists, so callers always get a valid Beta to sample/rank from.
+ */
+export async function readPreference(
+  db: PreferenceDelegate,
+  userId: string,
+  exerciseDefinitionId: string,
+  now: Date = new Date(),
+  factor: number = WEEKLY_DECAY_FACTOR
+): Promise<PreferenceReadResult> {
+  const row = await db.findUnique({
+    where: { userId_exerciseDefinitionId: { userId, exerciseDefinitionId } },
+  })
+
+  if (!row) {
+    return { ...UNIFORM_PRIOR, exists: false, decayedWeeks: 0 }
+  }
+
+  const weeks = elapsedWeeks(row.lastUpdatedAt, now)
+  const decayed = decayBeta({ alpha: row.alpha, beta: row.beta }, weeks, factor)
+  return { ...decayed, exists: true, decayedWeeks: weeks }
+}
+
+/**
+ * Record new accept/reject evidence for a user's exercise preference.
+ *
+ * The stored evidence is first decayed to `now` (so stale evidence has faded
+ * before the fresh signal lands), then updated with the new counts, then
+ * written back with lastUpdatedAt stamped to `now`. Idempotent in structure:
+ * calling with accepts=rejects=0 collapses the stored evidence toward the prior
+ * by the elapsed decay and re-stamps, without inventing signal.
+ */
+export async function updatePreference(
+  db: PreferenceDelegate,
+  userId: string,
+  exerciseDefinitionId: string,
+  accepts: number,
+  rejects: number,
+  now: Date = new Date(),
+  factor: number = WEEKLY_DECAY_FACTOR
+): Promise<BetaParams> {
+  const existing = await db.findUnique({
+    where: { userId_exerciseDefinitionId: { userId, exerciseDefinitionId } },
+  })
+
+  const base: BetaParams = existing
+    ? decayBeta(
+        { alpha: existing.alpha, beta: existing.beta },
+        elapsedWeeks(existing.lastUpdatedAt, now),
+        factor
+      )
+    : { ...UNIFORM_PRIOR }
+
+  const next = updateBeta(base, accepts, rejects)
+
+  const created: Prisma.UserExercisePreferenceCreateInput = {
+    userId,
+    alpha: next.alpha,
+    beta: next.beta,
+    lastUpdatedAt: now,
+    exerciseDefinition: { connect: { id: exerciseDefinitionId } },
+  }
+
+  await db.upsert({
+    where: { userId_exerciseDefinitionId: { userId, exerciseDefinitionId } },
+    create: created,
+    update: { alpha: next.alpha, beta: next.beta, lastUpdatedAt: now },
+  })
+
+  return next
+}

--- a/prisma/migrations/20260702161111_add_user_exercise_preference/migration.sql
+++ b/prisma/migrations/20260702161111_add_user_exercise_preference/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "UserExercisePreference" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "exerciseDefinitionId" TEXT NOT NULL,
+  "alpha" DOUBLE PRECISION NOT NULL DEFAULT 1,
+  "beta" DOUBLE PRECISION NOT NULL DEFAULT 1,
+  "lastUpdatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "UserExercisePreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UserExercisePreference_userId_idx" ON "UserExercisePreference"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserExercisePreference_exerciseDefinitionId_idx" ON "UserExercisePreference"("exerciseDefinitionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserExercisePreference_userId_exerciseDefinitionId_key" ON "UserExercisePreference"("userId", "exerciseDefinitionId");
+
+-- AddForeignKey
+ALTER TABLE "UserExercisePreference" ADD CONSTRAINT "UserExercisePreference_exerciseDefinitionId_fkey" FOREIGN KEY ("exerciseDefinitionId") REFERENCES "ExerciseDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,7 @@ model ExerciseDefinition {
   taggedAt        DateTime?
   taggedBy        String?
   exercises      Exercise[]
+  userPreferences UserExercisePreference[]
 
   @@index([normalizedName])
   @@index([isSystem])
@@ -105,6 +106,29 @@ model ExerciseDefinition {
   @@index([userId])
   @@index([movementPattern])
   @@index([intensityClass])
+}
+
+// Per-user, per-exercise preference learning (decayed Beta distribution).
+// Written by implicit-feedback hooks; read (with decay-on-read) by the
+// training-state builder. See lib/learning/math.ts and lib/learning/preference-store.ts.
+model UserExercisePreference {
+  id                   String             @id @default(cuid())
+  userId               String
+  exerciseDefinitionId String
+  // Beta(alpha, beta) evidence counts. Both > 0 (relax toward the uniform
+  // prior on decay rather than collapsing below 1).
+  alpha                Float              @default(1)
+  beta                 Float              @default(1)
+  // Drives decay-on-read: elapsed weeks since this stamp determine how far the
+  // stored evidence has decayed toward the prior.
+  lastUpdatedAt        DateTime           @default(now())
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
+  exerciseDefinition   ExerciseDefinition @relation(fields: [exerciseDefinitionId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, exerciseDefinitionId])
+  @@index([userId])
+  @@index([exerciseDefinitionId])
 }
 
 model Exercise {


### PR DESCRIPTION
## Summary

Adds persistent storage for per-user, per-exercise preference learning (issue #913). This is the table + accessor layer; the Beta math already lives in `lib/learning/math.ts` (#907).

- **Prisma model `UserExercisePreference`**: `userId` + `exerciseDefinitionId` (unique together), `alpha`/`beta` floats (default 1 = uniform prior), `lastUpdatedAt` (drives decay-on-read), `createdAt`/`updatedAt`, FK to `ExerciseDefinition` (cascade delete).
- **`lib/learning/preference-store.ts`** accessor:
  - `readPreference` applies weekly decay via `math.decayBeta` based on elapsed weeks since `lastUpdatedAt`; returns the uniform prior when no row exists so callers always get a valid Beta.
  - `updatePreference` decays stored evidence to `now`, applies new accept/reject counts, upserts, and re-stamps `lastUpdatedAt` — keeping decay + update atomic so repeated writes compose correctly.
  - `elapsedWeeks` helper clamps negative gaps (clock skew) to 0.
- Migration committed alongside the schema change (CI migration check).

## Out of scope

- Feedback hooks that write evidence (wave 2).
- Payload assembly that reads preferences (training-state builder).
- No callers wired yet.

## Testing

`__tests__/lib/preference-store.test.ts` (8 tests, all passing via Testcontainers):
- decay applied on read after simulated elapsed time (~half-life check)
- uniform prior returned when no row exists
- create-on-first-write with `lastUpdatedAt` stamping
- upsert idempotent in structure (repeated writes update one row, never duplicate)
- zero-evidence write only decays + re-stamps
- unique constraint enforced on `(userId, exerciseDefinitionId)`

type-check and lint pass for the changed files (pre-existing lint errors in `FollowAlongTabs.tsx` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)