### PR TITLE
feat(learning): session-relative weekly intent evaluator (#908)

### DIFF
--- a/__tests__/lib/weekly-intent.test.ts
+++ b/__tests__/lib/weekly-intent.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it } from 'vitest'
+import {
+  determineMovementHeavy,
+  type EvaluatedSession,
+  evaluateWeeklyIntent,
+  evaluateWeeklyIntents,
+  HEAVY_EFFORT_RPE,
+  isSessionHeavyForPatterns,
+  MIN_EWMA_OBSERVATIONS,
+  type MovementEwmaMap,
+  normalizedEffort,
+  type SessionMovement,
+  WINDOW_DAYS,
+} from '@/lib/learning/weekly-intent'
+import type { WeeklyIntent } from '@/lib/llm/prompts/suggest-workout/schemas'
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+/** A squat EWMA that is well-calibrated (enough observations to trust). */
+const CALIBRATED_SQUAT_EWMA: MovementEwmaMap = {
+  squat: { ewmaE1RMLbs: 400, observationCount: 6 },
+}
+
+function squatSession(
+  daysAgo: number,
+  sets: SessionMovement['sets'],
+  extra: Partial<SessionMovement> = {}
+): EvaluatedSession {
+  return {
+    daysAgo,
+    movements: [{ movementPattern: 'squat', sets, ...extra }],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Effort normalization
+// ---------------------------------------------------------------------------
+
+describe('normalizedEffort', () => {
+  it('uses RPE directly when present', () => {
+    expect(normalizedEffort({ weightLbs: 100, reps: 5, rpe: 8 })).toBe(8)
+  })
+
+  it('normalizes RIR to the RPE scale (RIR 2 => RPE 8)', () => {
+    expect(normalizedEffort({ weightLbs: 100, reps: 5, rir: 2 })).toBe(8)
+    expect(normalizedEffort({ weightLbs: 100, reps: 5, rir: 0 })).toBe(10)
+  })
+
+  it('prefers RPE over RIR when both are present', () => {
+    expect(normalizedEffort({ weightLbs: 100, reps: 5, rpe: 9, rir: 4 })).toBe(9)
+  })
+
+  it('returns null when neither is logged', () => {
+    expect(normalizedEffort({ weightLbs: 100, reps: 5 })).toBeNull()
+    expect(
+      normalizedEffort({ weightLbs: 100, reps: 5, rpe: null, rir: null })
+    ).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session-relative heavy determination — EWMA branch
+// ---------------------------------------------------------------------------
+
+describe('determineMovementHeavy — EWMA branch', () => {
+  it('is heavy when the top-set e1RM is >= 85% of the EWMA e1RM', () => {
+    // 350x1 = 350 e1RM = 87.5% of 400 -> heavy
+    const result = determineMovementHeavy(
+      { movementPattern: 'squat', sets: [{ weightLbs: 350, reps: 1 }] },
+      CALIBRATED_SQUAT_EWMA.squat
+    )
+    expect(result.isHeavy).toBe(true)
+    expect(result.reason).toBe('ewma')
+  })
+
+  it('is NOT heavy when the top-set e1RM is below 85% and effort is unlogged', () => {
+    // 300x1 = 300 e1RM = 75% of 400 -> not heavy
+    const result = determineMovementHeavy(
+      { movementPattern: 'squat', sets: [{ weightLbs: 300, reps: 1 }] },
+      CALIBRATED_SQUAT_EWMA.squat
+    )
+    expect(result.isHeavy).toBe(false)
+    expect(result.reason).toBe('none')
+  })
+
+  it('is heavy via effort even when load is light (RPE >= 8)', () => {
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        sets: [{ weightLbs: 135, reps: 5, rpe: HEAVY_EFFORT_RPE }],
+      },
+      CALIBRATED_SQUAT_EWMA.squat
+    )
+    expect(result.isHeavy).toBe(true)
+    expect(result.reason).toBe('effort')
+  })
+
+  it('ignores the intensityClass tag when the EWMA branch is active', () => {
+    // Tagged heavy, but light load and no effort logged -> not heavy.
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        intensityClass: 'heavy',
+        sets: [{ weightLbs: 135, reps: 5 }],
+      },
+      CALIBRATED_SQUAT_EWMA.squat
+    )
+    expect(result.isHeavy).toBe(false)
+  })
+
+  it('excludes warmup sets from the top-set computation', () => {
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        sets: [
+          { weightLbs: 400, reps: 1, isWarmup: true },
+          { weightLbs: 200, reps: 1 },
+        ],
+      },
+      CALIBRATED_SQUAT_EWMA.squat
+    )
+    // Only the 200x1 working set counts -> 50% of EWMA -> not heavy.
+    expect(result.isHeavy).toBe(false)
+    expect(result.topSetE1RM).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session-relative heavy determination — intensityClass fallback branch
+// ---------------------------------------------------------------------------
+
+describe('determineMovementHeavy — intensityClass fallback', () => {
+  it('falls back to the heavy tag when there are < 3 EWMA observations', () => {
+    const coldStart = { ewmaE1RMLbs: 400, observationCount: MIN_EWMA_OBSERVATIONS - 1 }
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        intensityClass: 'heavy',
+        sets: [{ weightLbs: 135, reps: 5 }],
+      },
+      coldStart
+    )
+    expect(result.isHeavy).toBe(true)
+    expect(result.reason).toBe('tag')
+  })
+
+  it('falls back when there is no EWMA entry at all', () => {
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        intensityClass: 'heavy',
+        sets: [{ weightLbs: 135, reps: 5 }],
+      },
+      undefined
+    )
+    expect(result.isHeavy).toBe(true)
+    expect(result.reason).toBe('tag')
+  })
+
+  it('is NOT heavy in the fallback branch for a non-heavy tag', () => {
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        intensityClass: 'moderate',
+        sets: [{ weightLbs: 135, reps: 5 }],
+      },
+      undefined
+    )
+    expect(result.isHeavy).toBe(false)
+  })
+
+  it('still honors logged effort during cold start (effort beats the tag)', () => {
+    const result = determineMovementHeavy(
+      {
+        movementPattern: 'squat',
+        intensityClass: 'moderate',
+        sets: [{ weightLbs: 200, reps: 5, rir: 1 }], // RIR 1 => RPE 9
+      },
+      undefined
+    )
+    expect(result.isHeavy).toBe(true)
+    expect(result.reason).toBe('effort')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Golden fixtures — old (tag-based) vs new (session-relative) disagree
+// ---------------------------------------------------------------------------
+
+describe('golden fixtures: tag-based vs session-relative definitions disagree', () => {
+  it('empty-bar heavy-tagged movement: old=heavy, NEW=not heavy', () => {
+    // Deadlift tagged intensityClass:heavy but trained near-empty, well
+    // calibrated -> the static tag says heavy, session-relative says no.
+    const ewma: MovementEwmaMap = {
+      hinge: { ewmaE1RMLbs: 500, observationCount: 8 },
+    }
+    const movement: SessionMovement = {
+      movementPattern: 'hinge',
+      intensityClass: 'heavy',
+      sets: [{ weightLbs: 135, reps: 5 }], // ~157 e1RM = 31% of 500
+    }
+    const oldTagBased = movement.intensityClass === 'heavy'
+    const newSessionRelative = determineMovementHeavy(movement, ewma.hinge).isHeavy
+
+    expect(oldTagBased).toBe(true)
+    expect(newSessionRelative).toBe(false)
+  })
+
+  it('brutal 5x5 on a moderate-tagged machine: old=not heavy, NEW=heavy', () => {
+    const ewma: MovementEwmaMap = {
+      horizontal_push: { ewmaE1RMLbs: 250, observationCount: 8 },
+    }
+    const movement: SessionMovement = {
+      movementPattern: 'horizontal_push',
+      intensityClass: 'moderate',
+      sets: [{ weightLbs: 240, reps: 5, rpe: 9 }], // effort + ~280 e1RM
+    }
+    const oldTagBased = movement.intensityClass === 'heavy'
+    const newSessionRelative = determineMovementHeavy(
+      movement,
+      ewma.horizontal_push
+    ).isHeavy
+
+    expect(oldTagBased).toBe(false)
+    expect(newSessionRelative).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isSessionHeavyForPatterns — muscle-group mapping
+// ---------------------------------------------------------------------------
+
+describe('isSessionHeavyForPatterns', () => {
+  it('matches any pattern in the muscle group', () => {
+    const session: EvaluatedSession = {
+      daysAgo: 0,
+      movements: [
+        { movementPattern: 'lunge', sets: [{ weightLbs: 100, reps: 8, rpe: 9 }] },
+      ],
+    }
+    expect(isSessionHeavyForPatterns(session, ['squat', 'hinge', 'lunge'], {})).toBe(
+      true
+    )
+  })
+
+  it('ignores untagged movements and patterns outside the group', () => {
+    const session: EvaluatedSession = {
+      daysAgo: 0,
+      movements: [
+        { movementPattern: null, sets: [{ weightLbs: 100, reps: 5, rpe: 10 }] },
+        {
+          movementPattern: 'horizontal_push',
+          sets: [{ weightLbs: 100, reps: 5, rpe: 10 }],
+        },
+      ],
+    }
+    expect(isSessionHeavyForPatterns(session, ['squat', 'hinge', 'lunge'], {})).toBe(
+      false
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// heavy_session intent — rolling window + last_satisfied_days_ago
+// ---------------------------------------------------------------------------
+
+const HEAVY_LEGS: WeeklyIntent = {
+  type: 'heavy_session',
+  muscle_group: 'legs',
+  min_per_week: 1,
+}
+
+describe('evaluateWeeklyIntent — heavy_session rolling window', () => {
+  it('is satisfied when a heavy leg session is within the last 7 days', () => {
+    const sessions = [squatSession(2, [{ weightLbs: 360, reps: 1 }])]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(true)
+    expect(verdict.lastSatisfiedDaysAgo).toBe(0)
+    expect(verdict.evidence).toContain('heavy legs')
+  })
+
+  it('populates last_satisfied_days_ago while satisfied (state-agnostic)', () => {
+    const sessions = [squatSession(3, [{ weightLbs: 360, reps: 1 }])]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(true)
+    // satisfied now => 0
+    expect(verdict.lastSatisfiedDaysAgo).toBe(0)
+  })
+
+  it('reports last_satisfied_days_ago when currently unsatisfied', () => {
+    // Heavy session 9 days ago: outside the current window, inside the window
+    // ending 3 days ago ([3, 10)).
+    const sessions = [squatSession(9, [{ weightLbs: 360, reps: 1 }])]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(false)
+    expect(verdict.lastSatisfiedDaysAgo).toBe(3)
+  })
+
+  it('returns null last_satisfied_days_ago when never satisfied', () => {
+    // Only light sessions ever logged.
+    const sessions = [
+      squatSession(2, [{ weightLbs: 135, reps: 5 }]),
+      squatSession(20, [{ weightLbs: 135, reps: 5 }]),
+    ]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(false)
+    expect(verdict.lastSatisfiedDaysAgo).toBeNull()
+    expect(verdict.evidence).toBeUndefined()
+  })
+
+  it('honors min_per_week > 1', () => {
+    const intent: WeeklyIntent = {
+      type: 'heavy_session',
+      muscle_group: 'legs',
+      min_per_week: 2,
+    }
+    const oneHeavy = evaluateWeeklyIntent(
+      intent,
+      [squatSession(1, [{ weightLbs: 360, reps: 1 }])],
+      CALIBRATED_SQUAT_EWMA
+    )
+    expect(oneHeavy.satisfiedLast7d).toBe(false)
+
+    const twoHeavy = evaluateWeeklyIntent(
+      intent,
+      [
+        squatSession(1, [{ weightLbs: 360, reps: 1 }]),
+        squatSession(4, [{ weightLbs: 360, reps: 1 }]),
+      ],
+      CALIBRATED_SQUAT_EWMA
+    )
+    expect(twoHeavy.satisfiedLast7d).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rolling-window edge cases
+// ---------------------------------------------------------------------------
+
+describe('rolling-window edge cases', () => {
+  it('a session exactly 7 days ago is OUTSIDE the current window', () => {
+    const sessions = [squatSession(WINDOW_DAYS, [{ weightLbs: 360, reps: 1 }])]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(false)
+    // It IS inside the window ending 1 day ago ([1, 8)).
+    expect(verdict.lastSatisfiedDaysAgo).toBe(1)
+  })
+
+  it('a session 6 days ago is INSIDE the current window', () => {
+    const sessions = [squatSession(WINDOW_DAYS - 1, [{ weightLbs: 360, reps: 1 }])]
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, sessions, CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(true)
+    expect(verdict.lastSatisfiedDaysAgo).toBe(0)
+  })
+
+  it('an empty session history is unsatisfied with null last_satisfied', () => {
+    const verdict = evaluateWeeklyIntent(HEAVY_LEGS, [], CALIBRATED_SQUAT_EWMA)
+    expect(verdict.satisfiedLast7d).toBe(false)
+    expect(verdict.lastSatisfiedDaysAgo).toBeNull()
+    expect(verdict.evidence).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// movement_frequency, volume_tilt, free_text
+// ---------------------------------------------------------------------------
+
+describe('evaluateWeeklyIntent — movement_frequency', () => {
+  const intent: WeeklyIntent = {
+    type: 'movement_frequency',
+    movement_pattern: 'horizontal_pull',
+    min_per_week: 2,
+  }
+
+  it('counts sessions containing the pattern regardless of heaviness', () => {
+    const row = (daysAgo: number): EvaluatedSession => ({
+      daysAgo,
+      movements: [
+        { movementPattern: 'horizontal_pull', sets: [{ weightLbs: 100, reps: 10 }] },
+      ],
+    })
+    const verdict = evaluateWeeklyIntent(intent, [row(1), row(4)])
+    expect(verdict.satisfiedLast7d).toBe(true)
+    expect(verdict.lastSatisfiedDaysAgo).toBe(0)
+  })
+
+  it('is unsatisfied below the frequency target', () => {
+    const verdict = evaluateWeeklyIntent(intent, [
+      {
+        daysAgo: 1,
+        movements: [
+          { movementPattern: 'horizontal_pull', sets: [{ weightLbs: 100, reps: 10 }] },
+        ],
+      },
+    ])
+    expect(verdict.satisfiedLast7d).toBe(false)
+  })
+})
+
+describe('evaluateWeeklyIntent — volume_tilt', () => {
+  const intent: WeeklyIntent = {
+    type: 'volume_tilt',
+    toward: ['back'],
+    away_from: ['chest'],
+    ratio: 2,
+  }
+
+  it('is satisfied when toward/away set ratio meets the target', () => {
+    const session: EvaluatedSession = {
+      daysAgo: 1,
+      movements: [
+        {
+          movementPattern: 'horizontal_pull',
+          faus: ['back'],
+          sets: [
+            { weightLbs: 100, reps: 10 },
+            { weightLbs: 100, reps: 10 },
+            { weightLbs: 100, reps: 10 },
+            { weightLbs: 100, reps: 10 },
+          ],
+        },
+        {
+          movementPattern: 'horizontal_push',
+          faus: ['chest'],
+          sets: [{ weightLbs: 100, reps: 10 }, { weightLbs: 100, reps: 10 }],
+        },
+      ],
+    }
+    const verdict = evaluateWeeklyIntent(intent, [session])
+    // 4 back / 2 chest = 2.0 >= 2 -> satisfied
+    expect(verdict.satisfiedLast7d).toBe(true)
+  })
+
+  it('is unsatisfied when the ratio is not met', () => {
+    const session: EvaluatedSession = {
+      daysAgo: 1,
+      movements: [
+        { movementPattern: 'horizontal_pull', faus: ['back'], sets: [{ weightLbs: 100, reps: 10 }] },
+        { movementPattern: 'horizontal_push', faus: ['chest'], sets: [{ weightLbs: 100, reps: 10 }] },
+      ],
+    }
+    const verdict = evaluateWeeklyIntent(intent, [session])
+    expect(verdict.satisfiedLast7d).toBe(false)
+  })
+})
+
+describe('evaluateWeeklyIntent — free_text', () => {
+  it('is not evaluable and carries neither evidence nor last_satisfied', () => {
+    const intent: WeeklyIntent = { type: 'free_text', text: 'feel athletic' }
+    const verdict = evaluateWeeklyIntent(intent, [
+      squatSession(1, [{ weightLbs: 360, reps: 1 }]),
+    ])
+    expect(verdict.evaluable).toBe(false)
+    expect(verdict.satisfiedLast7d).toBe(false)
+    expect(verdict.lastSatisfiedDaysAgo).toBeNull()
+    expect(verdict.evidence).toBeUndefined()
+  })
+})
+
+describe('evaluateWeeklyIntents', () => {
+  it('evaluates a mixed profile of intents', () => {
+    const intents: WeeklyIntent[] = [
+      HEAVY_LEGS,
+      { type: 'free_text', text: 'stay consistent' },
+    ]
+    const verdicts = evaluateWeeklyIntents(
+      intents,
+      [squatSession(1, [{ weightLbs: 360, reps: 1 }])],
+      CALIBRATED_SQUAT_EWMA
+    )
+    expect(verdicts).toHaveLength(2)
+    expect(verdicts[0].satisfiedLast7d).toBe(true)
+    expect(verdicts[1].evaluable).toBe(false)
+  })
+})

--- a/lib/learning/weekly-intent.ts
+++ b/lib/learning/weekly-intent.ts
@@ -1,0 +1,436 @@
+/**
+ * Weekly-intent evaluator with a **session-relative** definition of "heavy".
+ *
+ * Risk 4 from the Suggest Workout risk audit: the milestone conflated
+ * `ExerciseDefinition.intensityClass: heavy` (a static property of the movement
+ * — its typical systemic fatigue cost) with "the user actually trained heavy
+ * this session." An empty-bar deadlift is `intensityClass: heavy`; a brutal 5x5
+ * on a "moderate"-tagged machine is not. That mismatch produces confidently
+ * wrong copy on the exact surfaces meant to build trust ("you haven't had a
+ * heavy leg day this week" to someone still sore from Tuesday).
+ *
+ * This module fixes that by defining heaviness relative to the user's own
+ * calibration (movement-pattern EWMA e1RM) and logged effort, falling back to
+ * the `intensityClass` tag only during cold start (< 3 EWMA observations).
+ *
+ * Like `lib/learning/math.ts`, this module is intentionally free of I/O: no
+ * Prisma, no fetch, no fs. Callers pre-fetch sessions and EWMA estimates and
+ * hand normalized inputs in. Warmup exclusion and lbs normalization are the
+ * caller's contract.
+ *
+ * Out of scope (see issue #908): aggregates persistence (wave 2) and the prompt
+ * copy that consumes these verdicts.
+ *
+ * See docs/data-signal-audit.md (finding 5), docs/SUGGEST_PAYLOAD_SPEC.md
+ * (`weekly_intent_status[]`, `per_fau.last_heavy_days_ago`), the risk audit
+ * (Risk 4) and issue #908.
+ */
+
+import type { WeeklyIntent } from '@/lib/llm/prompts/suggest-workout/schemas'
+import { epleyE1RM } from './math'
+
+export type { WeeklyIntent }
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Rolling satisfaction window. Deliberately NOT a Mon–Sun calendar week — the
+ * calendar boundary made every intent read unsatisfied on Monday mornings
+ * (M16 decision 3). A session is "in the last 7 days" iff `daysAgo < 7`, i.e.
+ * `daysAgo` in [0, 7); a session exactly 7 days ago falls just outside. */
+export const WINDOW_DAYS = 7
+
+/** Top working-set e1RM at or above this fraction of the movement-pattern EWMA
+ * e1RM counts the session as heavy for that pattern. */
+export const HEAVY_E1RM_FRACTION = 0.85
+
+/** Normalized effort (RPE-equivalent) at or above this counts as heavy. RPE 8
+ * ⇔ RIR 2 on the `effort = rpe ?? (10 − rir)` scale. */
+export const HEAVY_EFFORT_RPE = 8
+
+/** Minimum EWMA observations before the EWMA branch is trusted; below this we
+ * fall back to the static `intensityClass` tag (cold start only). */
+export const MIN_EWMA_OBSERVATIONS = 3
+
+/** muscle_group → movement patterns that count toward a "heavy X day". Movement
+ * patterns follow ExerciseDefinition.movementPattern (see schema.prisma). */
+export const MUSCLE_GROUP_PATTERNS: Record<string, string[]> = {
+  legs: ['squat', 'hinge', 'lunge'],
+  push: ['horizontal_push', 'vertical_push'],
+  pull: ['horizontal_pull', 'vertical_pull'],
+  upper: ['horizontal_push', 'vertical_push', 'horizontal_pull', 'vertical_pull'],
+}
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/** A single logged working set. Warmups are excluded by the caller; a stray
+ * warmup is guarded against below. Weight is lbs (caller-normalized). */
+export interface IntentLoggedSet {
+  weightLbs: number
+  reps: number
+  /** RPE, if the user logs RPE. Takes precedence over `rir` when both present. */
+  rpe?: number | null
+  /** RIR, if the user logs RIR (the default per UserSettings.defaultIntensityRating). */
+  rir?: number | null
+  /** Guard only — warmups must be excluded by the caller. */
+  isWarmup?: boolean
+}
+
+/** One movement pattern's work within a single session. */
+export interface SessionMovement {
+  /** ExerciseDefinition.movementPattern, or null when untagged. */
+  movementPattern: string | null
+  /** ExerciseDefinition.intensityClass tag ('heavy' | 'moderate' | 'light').
+   * Used only as the cold-start fallback. */
+  intensityClass?: string | null
+  /** FAUs this movement contributes to (for volume_tilt attribution). */
+  faus?: string[]
+  /** Working sets logged for this movement in this session. */
+  sets: IntentLoggedSet[]
+}
+
+/** A completed training session, at whole-day granularity. */
+export interface EvaluatedSession {
+  /** Whole days before `now`. 0 = today. Must be a finite non-negative number. */
+  daysAgo: number
+  movements: SessionMovement[]
+}
+
+/** Gap-decayed EWMA estimate for one movement pattern (from lib/learning/math). */
+export interface MovementEwma {
+  /** EWMA of top-set e1RM (lbs). Null when no usable observations. */
+  ewmaE1RMLbs: number | null
+  /** Observation count that fed the EWMA — drives the cold-start fallback. */
+  observationCount: number
+}
+
+/** movement pattern → its EWMA estimate. */
+export type MovementEwmaMap = Record<string, MovementEwma | undefined>
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+export interface WeeklyIntentVerdict {
+  intent: WeeklyIntent
+  /** Satisfied over the rolling 7-day window ending at `now`. */
+  satisfiedLast7d: boolean
+  /**
+   * Days-ago of the most recent rolling-7d window in which this intent was
+   * satisfied (0 = satisfied now). `null` when never satisfied within the
+   * provided history, or when the intent is not evaluable (`free_text`).
+   *
+   * Populated **regardless** of `satisfiedLast7d` — downstream deload detection
+   * needs the value even while the intent is currently satisfied. The payload
+   * builder is responsible for only emitting it when unsatisfied.
+   */
+  lastSatisfiedDaysAgo: number | null
+  /** Human-readable evidence; present only when `satisfiedLast7d` is true. */
+  evidence?: string
+  /** False for intents this module cannot evaluate (`free_text`). */
+  evaluable: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Effort normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize logged effort to the RPE-equivalent scale: `effort = rpe ?? (10 −
+ * rir)`. RPE 8 ⇔ RIR 2. Returns null when neither is logged (intensity logging
+ * is opt-in). RPE takes precedence when both are present.
+ */
+export function normalizedEffort(set: IntentLoggedSet): number | null {
+  if (set.rpe != null && Number.isFinite(set.rpe)) return set.rpe
+  if (set.rir != null && Number.isFinite(set.rir)) return 10 - set.rir
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Session-relative "heavy" determination
+// ---------------------------------------------------------------------------
+
+export interface HeavyDetermination {
+  isHeavy: boolean
+  /** Which signal fired: 'ewma' | 'effort' | 'tag' | 'none'. */
+  reason: 'ewma' | 'effort' | 'tag' | 'none'
+  /** Top working-set e1RM observed for the pattern in this session, or null. */
+  topSetE1RM: number | null
+  /** Peak normalized effort observed, or null when no effort was logged. */
+  peakEffort: number | null
+}
+
+function workingSets(movement: SessionMovement): IntentLoggedSet[] {
+  return movement.sets.filter((s) => s.isWarmup !== true)
+}
+
+function peakEffortOf(sets: IntentLoggedSet[]): number | null {
+  let peak: number | null = null
+  for (const set of sets) {
+    const e = normalizedEffort(set)
+    if (e != null && (peak == null || e > peak)) peak = e
+  }
+  return peak
+}
+
+function topSetE1RMOf(sets: IntentLoggedSet[]): number | null {
+  let top: number | null = null
+  for (const set of sets) {
+    if (!Number.isFinite(set.weightLbs) || set.weightLbs <= 0) continue
+    if (!Number.isFinite(set.reps) || set.reps <= 0) continue
+    const e1rm = epleyE1RM(set.weightLbs, set.reps)
+    if (top == null || e1rm > top) top = e1rm
+  }
+  return top
+}
+
+/**
+ * Decide whether a session's work in a single movement pattern counts as heavy.
+ *
+ * Session-relative rule (issue #908 / Risk 4):
+ * - **EWMA branch** (≥ 3 observations): heavy iff the top working-set e1RM is
+ *   ≥ 85% of the movement-pattern EWMA e1RM, OR any working set logged effort
+ *   ≥ RPE-8-equivalent.
+ * - **Effort** is always a valid signal — a measured RPE ≥ 8 means the user
+ *   trained heavy regardless of calibration data.
+ * - **Fallback branch** (< 3 observations, cold start): heavy iff effort fired,
+ *   OR the movement's static `intensityClass` tag is 'heavy'.
+ */
+export function determineMovementHeavy(
+  movement: SessionMovement,
+  ewma: MovementEwma | undefined
+): HeavyDetermination {
+  const sets = workingSets(movement)
+  const peakEffort = peakEffortOf(sets)
+  const topSetE1RM = topSetE1RMOf(sets)
+
+  // Effort is a direct, calibration-free signal; check it first.
+  if (peakEffort != null && peakEffort >= HEAVY_EFFORT_RPE) {
+    return { isHeavy: true, reason: 'effort', topSetE1RM, peakEffort }
+  }
+
+  const hasEwma =
+    ewma != null &&
+    ewma.ewmaE1RMLbs != null &&
+    ewma.ewmaE1RMLbs > 0 &&
+    ewma.observationCount >= MIN_EWMA_OBSERVATIONS
+
+  if (hasEwma) {
+    // EWMA branch: compare measured load against the user's own estimate.
+    if (
+      topSetE1RM != null &&
+      topSetE1RM >= HEAVY_E1RM_FRACTION * (ewma!.ewmaE1RMLbs as number)
+    ) {
+      return { isHeavy: true, reason: 'ewma', topSetE1RM, peakEffort }
+    }
+    return { isHeavy: false, reason: 'none', topSetE1RM, peakEffort }
+  }
+
+  // Cold-start fallback: static intensityClass tag.
+  if (movement.intensityClass === 'heavy') {
+    return { isHeavy: true, reason: 'tag', topSetE1RM, peakEffort }
+  }
+
+  return { isHeavy: false, reason: 'none', topSetE1RM, peakEffort }
+}
+
+/**
+ * Whether a session counts as heavy for ANY of the given movement patterns.
+ * Untagged movements (null pattern) can never match a pattern filter.
+ */
+export function isSessionHeavyForPatterns(
+  session: EvaluatedSession,
+  patterns: string[],
+  ewmaMap: MovementEwmaMap
+): boolean {
+  const wanted = new Set(patterns)
+  for (const movement of session.movements) {
+    if (movement.movementPattern == null || !wanted.has(movement.movementPattern)) {
+      continue
+    }
+    if (determineMovementHeavy(movement, ewmaMap[movement.movementPattern]).isHeavy) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Whether a session contains any working set for one of the given patterns. */
+function sessionHasPattern(session: EvaluatedSession, patterns: string[]): boolean {
+  const wanted = new Set(patterns)
+  return session.movements.some(
+    (m) =>
+      m.movementPattern != null &&
+      wanted.has(m.movementPattern) &&
+      workingSets(m).length > 0
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Rolling-window satisfaction
+// ---------------------------------------------------------------------------
+
+/** Sessions whose `daysAgo` falls in the 7-day window ending `endDaysAgo` days
+ * ago, i.e. `daysAgo` in [endDaysAgo, endDaysAgo + WINDOW_DAYS). */
+function sessionsInWindow(
+  sessions: EvaluatedSession[],
+  endDaysAgo: number
+): EvaluatedSession[] {
+  return sessions.filter(
+    (s) => s.daysAgo >= endDaysAgo && s.daysAgo < endDaysAgo + WINDOW_DAYS
+  )
+}
+
+/**
+ * Find the most-recent (smallest) window-end offset at which `predicate` holds,
+ * scanning windows ending 0..maxDaysAgo days ago. Returns null if none.
+ */
+function findLastSatisfiedDaysAgo(
+  sessions: EvaluatedSession[],
+  predicate: (windowSessions: EvaluatedSession[]) => boolean
+): number | null {
+  const maxDaysAgo = sessions.reduce((m, s) => Math.max(m, s.daysAgo), 0)
+  for (let d = 0; d <= maxDaysAgo; d++) {
+    if (predicate(sessionsInWindow(sessions, d))) return d
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Intent evaluation
+// ---------------------------------------------------------------------------
+
+function evaluateHeavySession(
+  intent: Extract<WeeklyIntent, { type: 'heavy_session' }>,
+  sessions: EvaluatedSession[],
+  ewmaMap: MovementEwmaMap
+): WeeklyIntentVerdict {
+  const patterns = MUSCLE_GROUP_PATTERNS[intent.muscle_group] ?? []
+  const predicate = (windowSessions: EvaluatedSession[]) =>
+    windowSessions.filter((s) => isSessionHeavyForPatterns(s, patterns, ewmaMap))
+      .length >= intent.min_per_week
+
+  const current = sessionsInWindow(sessions, 0)
+  const heavyNow = current.filter((s) =>
+    isSessionHeavyForPatterns(s, patterns, ewmaMap)
+  ).length
+  const satisfiedLast7d = heavyNow >= intent.min_per_week
+
+  return {
+    intent,
+    satisfiedLast7d,
+    lastSatisfiedDaysAgo: findLastSatisfiedDaysAgo(sessions, predicate),
+    evidence: satisfiedLast7d
+      ? `${heavyNow} heavy ${intent.muscle_group} session${heavyNow === 1 ? '' : 's'} in the last ${WINDOW_DAYS} days (target ${intent.min_per_week})`
+      : undefined,
+    evaluable: true,
+  }
+}
+
+function evaluateMovementFrequency(
+  intent: Extract<WeeklyIntent, { type: 'movement_frequency' }>,
+  sessions: EvaluatedSession[]
+): WeeklyIntentVerdict {
+  const patterns = [intent.movement_pattern]
+  const predicate = (windowSessions: EvaluatedSession[]) =>
+    windowSessions.filter((s) => sessionHasPattern(s, patterns)).length >=
+    intent.min_per_week
+
+  const current = sessionsInWindow(sessions, 0)
+  const countNow = current.filter((s) => sessionHasPattern(s, patterns)).length
+  const satisfiedLast7d = countNow >= intent.min_per_week
+
+  return {
+    intent,
+    satisfiedLast7d,
+    lastSatisfiedDaysAgo: findLastSatisfiedDaysAgo(sessions, predicate),
+    evidence: satisfiedLast7d
+      ? `${countNow} ${intent.movement_pattern} session${countNow === 1 ? '' : 's'} in the last ${WINDOW_DAYS} days (target ${intent.min_per_week})`
+      : undefined,
+    evaluable: true,
+  }
+}
+
+/** Count working sets in a window attributed to any of the given FAUs. */
+function fauSetVolume(windowSessions: EvaluatedSession[], faus: string[]): number {
+  const wanted = new Set(faus)
+  let total = 0
+  for (const session of windowSessions) {
+    for (const movement of session.movements) {
+      if (!movement.faus || !movement.faus.some((f) => wanted.has(f))) continue
+      total += workingSets(movement).length
+    }
+  }
+  return total
+}
+
+function evaluateVolumeTilt(
+  intent: Extract<WeeklyIntent, { type: 'volume_tilt' }>,
+  sessions: EvaluatedSession[]
+): WeeklyIntentVerdict {
+  const predicate = (windowSessions: EvaluatedSession[]) => {
+    const toward = fauSetVolume(windowSessions, intent.toward)
+    const away = fauSetVolume(windowSessions, intent.away_from)
+    if (toward === 0) return false
+    // away === 0 with toward > 0 is an unbounded tilt toward — satisfied.
+    return away === 0 || toward / away >= intent.ratio
+  }
+
+  const current = sessionsInWindow(sessions, 0)
+  const satisfiedLast7d = predicate(current)
+  const towardNow = fauSetVolume(current, intent.toward)
+  const awayNow = fauSetVolume(current, intent.away_from)
+
+  return {
+    intent,
+    satisfiedLast7d,
+    lastSatisfiedDaysAgo: findLastSatisfiedDaysAgo(sessions, predicate),
+    evidence: satisfiedLast7d
+      ? `${towardNow} set(s) toward vs ${awayNow} away in the last ${WINDOW_DAYS} days (target ratio ${intent.ratio})`
+      : undefined,
+    evaluable: true,
+  }
+}
+
+/**
+ * Evaluate a single weekly intent against a user's recent sessions.
+ *
+ * @param intent   The structured intent (see WeeklyIntent union).
+ * @param sessions Completed sessions with whole-day `daysAgo` and per-movement
+ *                 working sets. Warmups should be pre-excluded by the caller.
+ * @param ewmaMap  movement pattern → gap-decayed EWMA e1RM estimate.
+ */
+export function evaluateWeeklyIntent(
+  intent: WeeklyIntent,
+  sessions: EvaluatedSession[],
+  ewmaMap: MovementEwmaMap = {}
+): WeeklyIntentVerdict {
+  switch (intent.type) {
+    case 'heavy_session':
+      return evaluateHeavySession(intent, sessions, ewmaMap)
+    case 'movement_frequency':
+      return evaluateMovementFrequency(intent, sessions)
+    case 'volume_tilt':
+      return evaluateVolumeTilt(intent, sessions)
+    case 'free_text':
+      // Free text is not machine-evaluable; the LLM reads it verbatim.
+      return {
+        intent,
+        satisfiedLast7d: false,
+        lastSatisfiedDaysAgo: null,
+        evaluable: false,
+      }
+  }
+}
+
+/** Evaluate every intent in a user's profile. */
+export function evaluateWeeklyIntents(
+  intents: WeeklyIntent[],
+  sessions: EvaluatedSession[],
+  ewmaMap: MovementEwmaMap = {}
+): WeeklyIntentVerdict[] {
+  return intents.map((intent) => evaluateWeeklyIntent(intent, sessions, ewmaMap))
+}


### PR DESCRIPTION
## Summary

Adds `lib/learning/weekly-intent.ts` — a pure, I/O-free evaluator for a user's weekly training intents. This fixes **Risk 4** from the Suggest Workout risk audit: the milestone conflated `ExerciseDefinition.intensityClass: heavy` (a *static* property of the movement) with "the user actually trained heavy this session," producing confidently-wrong copy on the exact surfaces meant to build trust ("you haven't had a heavy leg day this week" to someone still sore from Tuesday).

## Session-relative "heavy" definition

A session is heavy for a movement pattern when **either**:
- its top working-set e1RM (Epley) is ≥ **85%** of the movement-pattern EWMA e1RM, **or**
- any working set logged effort ≥ **RPE-8-equivalent**.

**Effort normalization:** `effort = rpe ?? (10 − rir)` (RPE 8 ⇔ RIR 2); RPE takes precedence when both present. RIR is the default per `UserSettings.defaultIntensityRating`.

**Cold-start fallback:** when a pattern has < 3 EWMA observations (or no estimate), fall back to the static `intensityClass` tag. Measured effort still counts in this branch.

## Satisfaction semantics

- Evaluated over a **rolling 7-day window** (`daysAgo` in [0, 7)), not Mon–Sun calendar weeks.
- `lastSatisfiedDaysAgo` is populated **regardless** of current satisfied state (downstream deload detection needs it); the payload builder is responsible for only emitting it when unsatisfied.

Covers all four intent types: `heavy_session`, `movement_frequency`, `volume_tilt`, `free_text` (non-evaluable). Reuses the existing `WeeklyIntent` union from `lib/llm/prompts/suggest-workout/schemas.ts` and `epleyE1RM` from `lib/learning/math.ts`.

## Out of scope

- Aggregates persistence (wave 2).
- Prompt copy that consumes the verdicts.

## Tests (`__tests__/lib/weekly-intent.test.ts`, 31 tests, all passing)

- **Both heavy branches:** EWMA-based path and `intensityClass` fallback path.
- **Golden fixtures where old (tag-based) and new (session-relative) disagree:**
  - empty-bar heavy-tagged deadlift → old=heavy, **new=not heavy**;
  - brutal 5×5 on a moderate-tagged machine → old=not heavy, **new=heavy**.
- **Rolling-window edges:** session exactly 7 days ago (outside current window), 6 days ago (inside), empty history.
- **`lastSatisfiedDaysAgo`** asserted in both satisfied (0) and unsatisfied (prior window) states, plus `null` when never satisfied.
- Effort normalization, warmup exclusion, min_per_week > 1, muscle-group mapping.

Fixes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)