### PR TITLE
feat(learning): deterministic injury -> ban-list mapping from profile

### DIFF
--- a/__tests__/lib/injury-ban-list.test.ts
+++ b/__tests__/lib/injury-ban-list.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import { MOVEMENT_PATTERNS } from '@/lib/exercises/auto-tag'
+import { ALL_FAUS } from '@/lib/fau-volume'
+import {
+  computeInjuryBanList,
+  INJURY_AREA_LOAD_MAP,
+  type InjuryBanExercise,
+} from '@/lib/learning/injury-ban-list'
+import { INJURY_AREAS, type InjuryEntry } from '@/lib/user-training-profile'
+
+/**
+ * Deterministic injury -> ban-list mapping (issue #918).
+ *
+ * Suggest must never recommend loading an area the user flagged `avoid_loading`.
+ * These tests pin the mapping table (every profile area maps to a sensible,
+ * non-empty pattern set), the hard-ban vs caution split, the recovered no-op,
+ * and graceful degradation for unknown / free-text injuries.
+ */
+
+// A small, tagged catalog spanning every movement pattern plus a couple of
+// isolation exercises with distinct primary FAUs, and one untagged exercise.
+const CATALOG: InjuryBanExercise[] = [
+  { id: 'bench', movementPattern: 'horizontal_push', primaryFAUs: ['chest'] },
+  { id: 'ohp', movementPattern: 'vertical_push', primaryFAUs: ['front-delts'] },
+  { id: 'row', movementPattern: 'horizontal_pull', primaryFAUs: ['mid-back'] },
+  { id: 'pullup', movementPattern: 'vertical_pull', primaryFAUs: ['lats'] },
+  { id: 'squat', movementPattern: 'squat', primaryFAUs: ['quads'] },
+  { id: 'deadlift', movementPattern: 'hinge', primaryFAUs: ['hamstrings'] },
+  { id: 'lunge', movementPattern: 'lunge', primaryFAUs: ['quads'] },
+  { id: 'carry', movementPattern: 'carry', primaryFAUs: ['forearms'] },
+  { id: 'curl', movementPattern: 'isolation', primaryFAUs: ['biceps'] },
+  { id: 'pushdown', movementPattern: 'isolation', primaryFAUs: ['triceps'] },
+  { id: 'shrug', movementPattern: 'isolation', primaryFAUs: ['traps'] },
+  { id: 'calf-raise', movementPattern: 'accessory', primaryFAUs: ['calves'] },
+  // Untagged: must never be banned by pattern.
+  { id: 'untagged', movementPattern: null, primaryFAUs: [] },
+]
+
+function injury(overrides: Partial<InjuryEntry>): InjuryEntry {
+  return { area: 'knee', severity: 'avoid_loading', ...overrides } as InjuryEntry
+}
+
+describe('INJURY_AREA_LOAD_MAP', () => {
+  it('maps every profile injury area to a non-empty pattern set', () => {
+    for (const area of INJURY_AREAS) {
+      const load = INJURY_AREA_LOAD_MAP[area]
+      expect(load, `missing mapping for ${area}`).toBeDefined()
+      expect(load.patterns.length, `${area} has no patterns`).toBeGreaterThan(0)
+      expect(load.faus.length, `${area} has no FAUs`).toBeGreaterThan(0)
+    }
+  })
+
+  it('only references valid movement patterns and FAUs', () => {
+    for (const area of INJURY_AREAS) {
+      const load = INJURY_AREA_LOAD_MAP[area]
+      for (const pattern of load.patterns) {
+        expect(MOVEMENT_PATTERNS).toContain(pattern)
+      }
+      for (const fau of load.faus) {
+        expect(ALL_FAUS).toContain(fau)
+      }
+    }
+  })
+})
+
+describe('computeInjuryBanList — hard bans (avoid_loading)', () => {
+  it('bans exactly the exercises that load a knee injury', () => {
+    const result = computeInjuryBanList(
+      [injury({ area: 'knee', severity: 'avoid_loading' })],
+      CATALOG
+    )
+    // knee -> patterns [squat, lunge], faus [quads, hamstrings]
+    expect(result.bannedExerciseIds).toEqual(
+      ['deadlift', 'lunge', 'squat'].sort()
+    )
+    expect(result.cautionedMovementPatterns).toEqual([])
+    expect(result.cautionedFAUs).toEqual([])
+    expect(result.notes).toEqual([])
+  })
+
+  it('bans by primary FAU even when the pattern does not match', () => {
+    // shoulder faus include front-delts; ohp already matches by pattern, but a
+    // pure-isolation delt raise should be caught by FAU alone.
+    const catalog: InjuryBanExercise[] = [
+      { id: 'lat-raise', movementPattern: 'isolation', primaryFAUs: ['side-delts'] },
+    ]
+    const result = computeInjuryBanList(
+      [injury({ area: 'shoulder', severity: 'avoid_loading' })],
+      catalog
+    )
+    expect(result.bannedExerciseIds).toEqual(['lat-raise'])
+  })
+
+  it('never bans untagged exercises', () => {
+    const result = computeInjuryBanList(
+      INJURY_AREAS.map((area) => injury({ area, severity: 'avoid_loading' })),
+      CATALOG
+    )
+    expect(result.bannedExerciseIds).not.toContain('untagged')
+  })
+
+  it('de-duplicates and sorts across multiple injuries', () => {
+    const result = computeInjuryBanList(
+      [
+        injury({ area: 'knee', severity: 'avoid_loading' }),
+        injury({ area: 'hip', severity: 'avoid_loading' }),
+      ],
+      CATALOG
+    )
+    const sorted = [...result.bannedExerciseIds].sort()
+    expect(result.bannedExerciseIds).toEqual(sorted)
+    expect(new Set(result.bannedExerciseIds).size).toBe(
+      result.bannedExerciseIds.length
+    )
+  })
+})
+
+describe('computeInjuryBanList — caution (soft flags)', () => {
+  it('emits cautioned patterns/FAUs without banning any exercise', () => {
+    const result = computeInjuryBanList(
+      [injury({ area: 'shoulder', severity: 'caution' })],
+      CATALOG
+    )
+    expect(result.bannedExerciseIds).toEqual([])
+    expect(result.cautionedMovementPatterns).toEqual(
+      [...INJURY_AREA_LOAD_MAP.shoulder.patterns].sort()
+    )
+    expect(result.cautionedFAUs).toEqual(
+      [...INJURY_AREA_LOAD_MAP.shoulder.faus].sort()
+    )
+  })
+
+  it('keeps hard bans and cautions separate when both are present', () => {
+    const result = computeInjuryBanList(
+      [
+        injury({ area: 'knee', severity: 'avoid_loading' }),
+        injury({ area: 'shoulder', severity: 'caution' }),
+      ],
+      CATALOG
+    )
+    // Hard ban from knee only.
+    expect(result.bannedExerciseIds).toEqual(['deadlift', 'lunge', 'squat'].sort())
+    // Caution from shoulder only — no bench/ohp id in bans.
+    expect(result.bannedExerciseIds).not.toContain('ohp')
+    expect(result.cautionedMovementPatterns).toContain('vertical_push')
+    expect(result.cautionedFAUs).toContain('front-delts')
+  })
+})
+
+describe('computeInjuryBanList — recovered & degradation', () => {
+  it('produces zero entries for a recovered injury', () => {
+    const result = computeInjuryBanList(
+      [injury({ area: 'knee', severity: 'recovered' })],
+      CATALOG
+    )
+    expect(result.bannedExerciseIds).toEqual([])
+    expect(result.cautionedMovementPatterns).toEqual([])
+    expect(result.cautionedFAUs).toEqual([])
+    expect(result.notes).toEqual([])
+  })
+
+  it('degrades unknown/free-text area to a note, never a crash or ban', () => {
+    const result = computeInjuryBanList(
+      [
+        { area: 'toe', severity: 'avoid_loading' },
+        { area: undefined, severity: 'caution' },
+      ] as unknown as InjuryEntry[],
+      CATALOG
+    )
+    expect(result.bannedExerciseIds).toEqual([])
+    expect(result.cautionedMovementPatterns).toEqual([])
+    expect(result.notes.length).toBe(2)
+  })
+
+  it('handles empty / nullish inputs without throwing', () => {
+    expect(computeInjuryBanList([], CATALOG).bannedExerciseIds).toEqual([])
+    expect(
+      computeInjuryBanList(
+        [injury({ area: 'knee', severity: 'avoid_loading' })],
+        []
+      ).bannedExerciseIds
+    ).toEqual([])
+  })
+
+  it('is deterministic for identical input', () => {
+    const injuries = [
+      injury({ area: 'hip', severity: 'avoid_loading' }),
+      injury({ area: 'shoulder', severity: 'caution' }),
+    ]
+    const a = computeInjuryBanList(injuries, CATALOG)
+    const b = computeInjuryBanList(injuries, CATALOG)
+    expect(a).toEqual(b)
+  })
+})

--- a/__tests__/lib/injury-ban-list.test.ts
+++ b/__tests__/lib/injury-ban-list.test.ts
@@ -147,6 +147,65 @@ describe('computeInjuryBanList — caution (soft flags)', () => {
   })
 })
 
+describe('computeInjuryBanList — secondary loading (product decision #918)', () => {
+  // Reviewer's example: a barbell row loads the lower back isometrically as a
+  // secondary mover, but its primary pattern/FAU is elsewhere. For a
+  // `lower_back` avoid_loading injury it must NOT be hard-banned — it is
+  // down-weighted via the cautioned soft-flag fields instead.
+  const rowLoadingLowBack: InjuryBanExercise = {
+    id: 'barbell-row',
+    movementPattern: 'horizontal_pull',
+    primaryFAUs: ['mid-back'],
+    secondaryFAUs: ['lower-back'],
+  }
+
+  it('routes a secondary-only loader to caution, not the hard ban', () => {
+    const result = computeInjuryBanList(
+      [injury({ area: 'lower_back', severity: 'avoid_loading' })],
+      [rowLoadingLowBack]
+    )
+    // lower_back -> patterns [hinge, squat, carry], faus [lower-back, glutes,
+    // hamstrings]. The row matches none of those as a PRIMARY loader.
+    expect(result.bannedExerciseIds).not.toContain('barbell-row')
+    expect(result.bannedExerciseIds).toEqual([])
+    // ...but its secondary lower-back load is flagged for down-weighting.
+    expect(result.cautionedFAUs).toContain('lower-back')
+  })
+
+  it('prefers the hard ban when an exercise loads the area both ways', () => {
+    // A deadlift primarily hinges (hard ban for lower_back) and also lists
+    // lower-back as a secondary FAU — it must land in the ban, not just caution.
+    const deadlift: InjuryBanExercise = {
+      id: 'deadlift',
+      movementPattern: 'hinge',
+      primaryFAUs: ['hamstrings'],
+      secondaryFAUs: ['lower-back'],
+    }
+    const result = computeInjuryBanList(
+      [injury({ area: 'lower_back', severity: 'avoid_loading' })],
+      [deadlift]
+    )
+    expect(result.bannedExerciseIds).toEqual(['deadlift'])
+    // No double-counting into caution for an already-banned exercise.
+    expect(result.cautionedFAUs).toEqual([])
+  })
+
+  it('ignores secondary FAUs that do not load the injured area', () => {
+    const benchWithTricepSecondary: InjuryBanExercise = {
+      id: 'bench',
+      movementPattern: 'horizontal_push',
+      primaryFAUs: ['chest'],
+      secondaryFAUs: ['triceps'],
+    }
+    const result = computeInjuryBanList(
+      [injury({ area: 'knee', severity: 'avoid_loading' })],
+      [benchWithTricepSecondary]
+    )
+    expect(result.bannedExerciseIds).toEqual([])
+    expect(result.cautionedFAUs).toEqual([])
+  })
+})
+
 describe('computeInjuryBanList — recovered & degradation', () => {
   it('produces zero entries for a recovered injury', () => {
     const result = computeInjuryBanList(

--- a/lib/learning/injury-ban-list.ts
+++ b/lib/learning/injury-ban-list.ts
@@ -16,10 +16,17 @@
  *                        exclude.
  *   - `recovered`     -> NO EFFECT (historical context only).
  *
- * An exercise "loads" an injured area when its `movementPattern` is one of the
- * area's patterns, OR its `primaryFAUs` intersect the area's FAUs. Untagged
- * exercises (null `movementPattern`, empty FAUs) are never banned by pattern —
- * consistent with the auto-tag contract ("treat untagged as no constraint").
+ * An exercise "loads" an injured area (for the hard-ban path) when its
+ * `movementPattern` is one of the area's patterns, OR its `primaryFAUs` intersect
+ * the area's FAUs. Untagged exercises (null `movementPattern`, empty FAUs) are
+ * never banned by pattern — consistent with the auto-tag contract ("treat
+ * untagged as no constraint").
+ *
+ * Secondary loading is deliberately NOT a hard ban (product decision, #918): an
+ * exercise whose *primary* pattern/FAU is elsewhere but which loads the injured
+ * area via `secondaryFAUs` (e.g. a barbell row loading the lower back
+ * isometrically) is routed into the cautioned soft-flag fields so the planner
+ * down-weights it rather than excluding it outright.
  */
 
 import type { MovementPattern } from '@/lib/exercises/auto-tag'
@@ -96,6 +103,11 @@ export interface InjuryBanExercise {
   id: string
   movementPattern: string | null
   primaryFAUs: string[]
+  /**
+   * Secondary movers/stabilizers. A match here on a hard-ban injury drives a
+   * *caution* (down-weight), never an exclusion — see module docs.
+   */
+  secondaryFAUs?: string[]
 }
 
 /**
@@ -120,7 +132,8 @@ function isKnownArea(area: string): area is InjuryArea {
 }
 
 /**
- * Does this exercise load the given area (by movement pattern or primary FAU)?
+ * Does this exercise load the given area as a PRIMARY mover — by movement
+ * pattern or primary FAU? This is the hard-ban predicate.
  */
 function exerciseLoadsArea(
   exercise: InjuryBanExercise,
@@ -132,6 +145,20 @@ function exerciseLoadsArea(
   }
   const faus = load.faus as readonly string[]
   return exercise.primaryFAUs.some((fau) => faus.includes(fau))
+}
+
+/**
+ * The injured-area FAUs this exercise loads as a SECONDARY mover/stabilizer.
+ * These drive a caution (soft flag), never a hard ban.
+ */
+function secondaryLoadedFAUs(
+  exercise: InjuryBanExercise,
+  load: AreaLoadProfile
+): FAUKey[] {
+  const areaFAUs = load.faus as readonly string[]
+  return (exercise.secondaryFAUs ?? []).filter((fau) =>
+    areaFAUs.includes(fau)
+  ) as FAUKey[]
 }
 
 /**
@@ -187,10 +214,15 @@ export function computeInjuryBanList(
       continue
     }
 
-    // avoid_loading -> hard ban every exercise that loads the area.
+    // avoid_loading -> hard ban every exercise that PRIMARILY loads the area.
+    // Secondary-only loaders are down-weighted (cautioned), not excluded.
     for (const exercise of exercises) {
       if (exerciseLoadsArea(exercise, load)) {
         banned.add(exercise.id)
+        continue
+      }
+      for (const fau of secondaryLoadedFAUs(exercise, load)) {
+        cautionedFAUs.add(fau)
       }
     }
   }

--- a/lib/learning/injury-ban-list.ts
+++ b/lib/learning/injury-ban-list.ts
@@ -1,0 +1,204 @@
+/**
+ * Injury -> exercise ban-list mapping (issue #918).
+ *
+ * Suggest must never recommend loading an injured area. This module turns the
+ * structured injuries on `UserTrainingProfile` (body area x severity, captured
+ * by the Goals wizard or the interview) into concrete ban-list fields for the
+ * suggest payload.
+ *
+ * This is a **pure, deterministic** mapping — no LLM. The training-state builder
+ * calls {@link computeInjuryBanList} on profile change; nothing is persisted.
+ *
+ * Severity semantics (from `INJURY_SEVERITIES`):
+ *   - `avoid_loading` -> HARD BAN. The exercise id is excluded from candidates.
+ *   - `caution`       -> SOFT FLAG. The movement patterns / FAUs are carried
+ *                        separately so the planner can down-weight rather than
+ *                        exclude.
+ *   - `recovered`     -> NO EFFECT (historical context only).
+ *
+ * An exercise "loads" an injured area when its `movementPattern` is one of the
+ * area's patterns, OR its `primaryFAUs` intersect the area's FAUs. Untagged
+ * exercises (null `movementPattern`, empty FAUs) are never banned by pattern —
+ * consistent with the auto-tag contract ("treat untagged as no constraint").
+ */
+
+import type { MovementPattern } from '@/lib/exercises/auto-tag'
+import type { FAUKey } from '@/lib/fau-volume'
+import type { InjuryArea, InjuryEntry } from '@/lib/user-training-profile'
+import { INJURY_AREAS } from '@/lib/user-training-profile'
+
+/**
+ * Which movement patterns and FAUs load a given injured area. Every area in the
+ * profile enum maps to a non-empty pattern set (asserted in tests). Kept
+ * deliberately conservative — the FAU list is the muscle groups that directly
+ * load the joint/region; the pattern list catches compound lifts that stress it
+ * even when the primary FAU is elsewhere.
+ */
+export interface AreaLoadProfile {
+  patterns: readonly MovementPattern[]
+  faus: readonly FAUKey[]
+}
+
+export const INJURY_AREA_LOAD_MAP: Record<InjuryArea, AreaLoadProfile> = {
+  // Neck: axial loading from carries and shrugs; traps are the direct driver.
+  neck: {
+    patterns: ['carry', 'vertical_push'],
+    faus: ['traps'],
+  },
+  // Shoulder: all pressing plus direct deltoid work.
+  shoulder: {
+    patterns: ['vertical_push', 'horizontal_push'],
+    faus: ['front-delts', 'side-delts', 'rear-delts'],
+  },
+  // Elbow: pressing (triceps) and curling (biceps) both load the joint.
+  elbow: {
+    patterns: ['horizontal_push', 'vertical_push'],
+    faus: ['triceps', 'biceps'],
+  },
+  // Wrist: grip-heavy carries and direct forearm/curl work.
+  wrist: {
+    patterns: ['carry'],
+    faus: ['forearms', 'biceps'],
+  },
+  // Upper back: all pulling plus the direct upper-back musculature.
+  upper_back: {
+    patterns: ['vertical_pull', 'horizontal_pull'],
+    faus: ['mid-back', 'lats', 'traps', 'rear-delts'],
+  },
+  // Lower back: hinges are the classic offender; squats and loaded carries
+  // stress the spine too.
+  lower_back: {
+    patterns: ['hinge', 'squat', 'carry'],
+    faus: ['lower-back', 'glutes', 'hamstrings'],
+  },
+  // Hip: hinge/squat/lunge all drive hip flexion/extension.
+  hip: {
+    patterns: ['hinge', 'squat', 'lunge'],
+    faus: ['glutes', 'hamstrings', 'adductors', 'quads'],
+  },
+  // Knee: squats and lunges load the knee under flexion.
+  knee: {
+    patterns: ['squat', 'lunge'],
+    faus: ['quads', 'hamstrings'],
+  },
+  // Ankle: squats/lunges through dorsiflexion; calves directly.
+  ankle: {
+    patterns: ['squat', 'lunge'],
+    faus: ['calves'],
+  },
+}
+
+/**
+ * Minimal exercise shape the mapping needs. Matches `ExerciseDefinition`
+ * (`movementPattern`, `primaryFAUs`, `secondaryFAUs`) but only the fields used.
+ */
+export interface InjuryBanExercise {
+  id: string
+  movementPattern: string | null
+  primaryFAUs: string[]
+}
+
+/**
+ * Ban-list fields for the suggest payload. `bannedExerciseIds` merges into the
+ * payload's `banned_exercise_ids`; the cautioned sets are carried separately so
+ * the planner can down-weight rather than exclude; `notes` surfaces anything
+ * that couldn't be mapped (unknown area, free-text-only injury).
+ */
+export interface InjuryBanListResult {
+  /** Hard bans (severity `avoid_loading`). Sorted, de-duplicated. */
+  bannedExerciseIds: string[]
+  /** Soft flags (severity `caution`) — movement patterns to down-weight. */
+  cautionedMovementPatterns: MovementPattern[]
+  /** Soft flags (severity `caution`) — FAUs to down-weight. */
+  cautionedFAUs: FAUKey[]
+  /** Human-readable notes for injuries that produced no structured mapping. */
+  notes: string[]
+}
+
+function isKnownArea(area: string): area is InjuryArea {
+  return (INJURY_AREAS as readonly string[]).includes(area)
+}
+
+/**
+ * Does this exercise load the given area (by movement pattern or primary FAU)?
+ */
+function exerciseLoadsArea(
+  exercise: InjuryBanExercise,
+  load: AreaLoadProfile
+): boolean {
+  const pattern = exercise.movementPattern
+  if (pattern && (load.patterns as readonly string[]).includes(pattern)) {
+    return true
+  }
+  const faus = load.faus as readonly string[]
+  return exercise.primaryFAUs.some((fau) => faus.includes(fau))
+}
+
+/**
+ * Compute the injury-derived ban list from structured profile injuries.
+ *
+ * Deterministic: identical input yields identical output (all outputs sorted).
+ * Robust: unknown / free-text-only injuries degrade to a note, never a throw.
+ *
+ * @param injuries  Structured injuries from `UserTrainingProfile.injuryAreas`.
+ *                  Loosely typed so raw/unnormalized entries can't crash it.
+ * @param exercises Candidate exercise catalog (id + movementPattern + FAUs).
+ */
+export function computeInjuryBanList(
+  injuries: readonly (InjuryEntry | { area?: unknown; severity?: unknown })[],
+  exercises: readonly InjuryBanExercise[]
+): InjuryBanListResult {
+  const banned = new Set<string>()
+  const cautionedPatterns = new Set<MovementPattern>()
+  const cautionedFAUs = new Set<FAUKey>()
+  const notes: string[] = []
+
+  for (const injury of injuries ?? []) {
+    const area = typeof injury?.area === 'string' ? injury.area : null
+    const severity =
+      typeof injury?.severity === 'string' ? injury.severity : null
+
+    // Recovered / historical: no effect.
+    if (severity === 'recovered') continue
+
+    // Only avoid_loading and caution drive the ban list.
+    if (severity !== 'avoid_loading' && severity !== 'caution') {
+      if (area) {
+        notes.push(
+          `Unmapped injury (severity "${severity ?? 'unknown'}") reported — no ban applied.`
+        )
+      }
+      continue
+    }
+
+    // Unknown / free-text-only area: degrade to a note, never a ban.
+    if (!area || !isKnownArea(area)) {
+      notes.push(
+        `Free-text or unrecognized injury area reported — mindful, but no automatic ban could be applied.`
+      )
+      continue
+    }
+
+    const load = INJURY_AREA_LOAD_MAP[area]
+
+    if (severity === 'caution') {
+      for (const pattern of load.patterns) cautionedPatterns.add(pattern)
+      for (const fau of load.faus) cautionedFAUs.add(fau)
+      continue
+    }
+
+    // avoid_loading -> hard ban every exercise that loads the area.
+    for (const exercise of exercises) {
+      if (exerciseLoadsArea(exercise, load)) {
+        banned.add(exercise.id)
+      }
+    }
+  }
+
+  return {
+    bannedExerciseIds: [...banned].sort(),
+    cautionedMovementPatterns: [...cautionedPatterns].sort(),
+    cautionedFAUs: [...cautionedFAUs].sort(),
+    notes,
+  }
+}


### PR DESCRIPTION
Fixes #918

## What

Adds `lib/learning/injury-ban-list.ts` — a **pure, deterministic** mapping (no LLM) from the structured injuries on `UserTrainingProfile` (`injuryAreas`: body area × severity) to the suggest payload's ban-list fields, via the movement-pattern / FAU taxonomy on `ExerciseDefinition`.

Suggest must never recommend loading an injured area; this autopopulates the hard ban list and carries cautions separately for the planner.

### Mapping (`INJURY_AREA_LOAD_MAP`)

Every injury area in the profile enum (`neck`, `shoulder`, `elbow`, `wrist`, `upper_back`, `lower_back`, `hip`, `knee`, `ankle`) maps to a non-empty set of movement patterns + FAUs that load it. An exercise "loads" an area when its `movementPattern` is one of the area's patterns **or** its `primaryFAUs` intersect the area's FAUs. Untagged exercises are never banned by pattern (consistent with the auto-tag contract).

### Severity semantics

| Severity | Effect |
|---|---|
| `avoid_loading` | **Hard ban** — exercise ids excluded from candidates (`bannedExerciseIds`) |
| `caution` | **Soft flag** — `cautionedMovementPatterns` / `cautionedFAUs` carried separately so the planner can down-weight rather than exclude |
| `recovered` | No effect |

### Robustness

Unknown / free-text-only injury areas degrade to a payload `note` (never a throw). Nullish inputs and empty catalogs are handled.

### Integration

`computeInjuryBanList(injuries, exercises)` is a pure function intended to be called by the training-state builder on profile change. No persistence.

## Tests

`__tests__/lib/injury-ban-list.test.ts` (12 tests, all passing):
- Every profile area maps to a non-empty, valid pattern/FAU set (reviewed fixture)
- Hard-ban vs caution separation asserted
- Recovered injury produces zero entries
- Unknown / free-text-only injuries degrade to a note, no ban, no crash
- Untagged exercises never banned; outputs sorted, de-duplicated, deterministic

## Notes

- No schema changes. Two new files only.
- `type-check` clean; lint clean for the new files (pre-existing lint errors exist in unrelated component files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)