### PR TITLE
feat: UserTrainingAggregates precompute + recompute job (#919)

### DIFF
--- a/__tests__/api/aggregates-queue.test.ts
+++ b/__tests__/api/aggregates-queue.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression guard for the aggregates recompute publisher (#919 / PR #939).
+ *
+ * The publisher uses a stable per-user jobId to coalesce bursts. A retained
+ * terminal job under that id would make BullMQ silently ignore every later
+ * enqueue for the user, so aggregates would freeze after the first recompute.
+ * These tests exercise the real Queue + Worker against a Testcontainers Redis
+ * (no Postgres — the compute core is tested separately) and assert that a
+ * completed job does NOT block the next enqueue.
+ */
+
+import { type Job, QueueEvents, Worker } from 'bullmq'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  AGGREGATES_QUEUE_NAME,
+  closeAggregatesJobsQueue,
+  publishAggregatesRecomputeJob,
+} from '@/lib/queue/aggregates-jobs'
+import { startRedisContainer, stopRedisContainer } from '@/lib/test/redis-container'
+
+interface AggregatesRecomputeJob {
+  userId: string
+}
+
+function getConnection() {
+  const parsed = new URL(process.env.REDIS_URL!)
+  return {
+    host: parsed.hostname,
+    port: parseInt(parsed.port || '6379', 10),
+    password: parsed.password || undefined,
+    maxRetriesPerRequest: null as null,
+  }
+}
+
+/** Poll until `predicate` is true or the timeout elapses. */
+async function waitUntil(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitUntil timed out after ${timeoutMs}ms`)
+    }
+    await new Promise((r) => setTimeout(r, 25))
+  }
+}
+
+describe('Aggregates recompute queue', () => {
+  let worker: Worker<AggregatesRecomputeJob>
+  let queueEvents: QueueEvents
+  // Every completed job id, in order — a stable jobId repeats across recomputes.
+  let completed: string[] = []
+
+  beforeAll(async () => {
+    await startRedisContainer()
+
+    queueEvents = new QueueEvents(AGGREGATES_QUEUE_NAME, { connection: getConnection() })
+    worker = new Worker<AggregatesRecomputeJob>(
+      AGGREGATES_QUEUE_NAME,
+      // No-op processor: we're testing publish/dedup/retention semantics, not compute.
+      async (job: Job<AggregatesRecomputeJob>) => {
+        completed.push(job.id!)
+      },
+      { connection: getConnection(), concurrency: 1 }
+    )
+    await worker.waitUntilReady()
+    await queueEvents.waitUntilReady()
+  }, 60000)
+
+  afterAll(async () => {
+    await worker.close()
+    await queueEvents.close()
+    await closeAggregatesJobsQueue()
+    await stopRedisContainer()
+  }, 15000)
+
+  afterEach(() => {
+    completed = []
+  })
+
+  it('re-enqueues a fresh job after the previous one completes (retention regression)', async () => {
+    completed = []
+    const userId = 'queue-user-retention'
+
+    // First completion -> first recompute job runs to completion.
+    await publishAggregatesRecomputeJob({ userId })
+    await waitUntil(() => completed.length === 1)
+
+    // A later completion must enqueue and run AGAIN, despite sharing the jobId.
+    // With removeOnComplete retaining the terminal job, BullMQ would ignore this
+    // add and the count would stay at 1.
+    await publishAggregatesRecomputeJob({ userId })
+    await waitUntil(() => completed.length === 2)
+
+    expect(completed).toEqual([`aggregates-${userId}`, `aggregates-${userId}`])
+  })
+
+  it('processes distinct users independently', async () => {
+    completed = []
+    await publishAggregatesRecomputeJob({ userId: 'queue-user-a' })
+    await publishAggregatesRecomputeJob({ userId: 'queue-user-b' })
+    await waitUntil(() => completed.length === 2)
+
+    expect(new Set(completed)).toEqual(
+      new Set(['aggregates-queue-user-a', 'aggregates-queue-user-b'])
+    )
+  })
+})

--- a/__tests__/api/user-training-aggregates.test.ts
+++ b/__tests__/api/user-training-aggregates.test.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { recomputeUserAggregates } from '@/lib/aggregates/recompute'
+import { computeUserAggregates, recomputeUserAggregates } from '@/lib/aggregates/recompute'
 import { getTestDatabase } from '@/lib/test/database'
 import { createTestUser } from '@/lib/test/factories'
 
@@ -126,6 +126,35 @@ describe('UserTrainingAggregates recompute', () => {
     expect(row).not.toBeNull()
     expect(row?.dataMaturity).toBe('cold_start')
     expect(row?.perFau).toEqual([])
+  })
+
+  it('computeUserAggregates returns aggregates without persisting (dry run)', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    for (const daysAgo of [2, 5, 9]) {
+      await seedSession(prisma, userId, chest, { daysAgo, sets: chestSets(7) })
+    }
+
+    const agg = await computeUserAggregates(prisma, userId, NOW)
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.rolling_14d_sets).toBe(21)
+
+    // Nothing written.
+    const row = await prisma.userTrainingAggregates.findUnique({ where: { userId } })
+    expect(row).toBeNull()
+  })
+
+  it('honors threshold overrides from the options object', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // 3 sessions, 20 sets -> low_data false at defaults...
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 9, sets: chestSets(6) })
+
+    const dflt = await computeUserAggregates(prisma, userId, NOW)
+    expect(dflt.perFau.find((f) => f.fau === 'chest')?.low_data).toBe(false)
+
+    // ...but low_data true when the set floor is raised past 20.
+    const strict = await computeUserAggregates(prisma, userId, NOW, { lowDataMinSets: 25 })
+    expect(strict.perFau.find((f) => f.fau === 'chest')?.low_data).toBe(true)
   })
 
   it('is idempotent — a double run yields an identical row', async () => {

--- a/__tests__/api/user-training-aggregates.test.ts
+++ b/__tests__/api/user-training-aggregates.test.ts
@@ -1,0 +1,324 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { recomputeUserAggregates } from '@/lib/aggregates/recompute'
+import { getTestDatabase } from '@/lib/test/database'
+import { createTestUser } from '@/lib/test/factories'
+
+const DAY = 24 * 60 * 60 * 1000
+// Wednesday 2026-07-01 — current partial ISO week is Mon 06-29 .. now.
+const NOW = new Date('2026-07-01T12:00:00Z')
+
+let defCounter = 0
+
+async function createDef(
+  prisma: PrismaClient,
+  opts: {
+    primaryFAUs: string[]
+    movementPattern?: string | null
+    isBodyweight?: boolean
+  }
+): Promise<string> {
+  defCounter += 1
+  const name = `Test Def ${defCounter}`
+  const def = await prisma.exerciseDefinition.create({
+    data: {
+      name,
+      normalizedName: `test def ${defCounter}`,
+      aliases: [],
+      equipment: opts.isBodyweight ? ['bodyweight'] : ['barbell'],
+      primaryFAUs: opts.primaryFAUs,
+      secondaryFAUs: [],
+      isSystem: true,
+      userId: '00000000-0000-0000-0000-000000000000',
+      movementPattern: opts.movementPattern ?? null,
+      isBodyweight: opts.isBodyweight ?? false,
+    },
+  })
+  return def.id
+}
+
+interface SetSpec {
+  weight?: number
+  weightUnit?: string
+  reps?: number
+  rpe?: number | null
+  rir?: number | null
+  isWarmup?: boolean
+}
+
+async function seedSession(
+  prisma: PrismaClient,
+  userId: string,
+  defId: string,
+  opts: { daysAgo: number; status?: string; sets: SetSpec[] }
+): Promise<void> {
+  const completedAt = new Date(NOW.getTime() - opts.daysAgo * DAY)
+  const completion = await prisma.workoutCompletion.create({
+    data: {
+      userId,
+      status: opts.status ?? 'completed',
+      completedAt,
+      isAdHoc: true,
+    },
+  })
+  const exercise = await prisma.exercise.create({
+    data: {
+      name: 'Test Exercise',
+      exerciseDefinitionId: defId,
+      order: 0,
+      userId,
+      workoutCompletionId: completion.id,
+    },
+  })
+  let setNumber = 1
+  for (const s of opts.sets) {
+    await prisma.loggedSet.create({
+      data: {
+        completionId: completion.id,
+        exerciseId: exercise.id,
+        userId,
+        setNumber: setNumber++,
+        reps: s.reps ?? 5,
+        weight: s.weight ?? 100,
+        weightUnit: s.weightUnit ?? 'lbs',
+        rpe: s.rpe ?? null,
+        rir: s.rir ?? null,
+        isWarmup: s.isWarmup ?? false,
+      },
+    })
+  }
+}
+
+/** N working sets of a chest press. */
+function chestSets(n: number, over: SetSpec = {}): SetSpec[] {
+  return Array.from({ length: n }, () => ({ weight: 185, reps: 5, rir: 2, ...over }))
+}
+
+describe('UserTrainingAggregates recompute', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('produces a valid row with nulls for a zero-history user (no crash)', async () => {
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+
+    expect(agg.dataMaturity).toBe('cold_start')
+    expect(agg.sessionsLast7d).toBe(0)
+    expect(agg.daysSinceAnySession).toBeNull()
+    expect(agg.lastSessionAt).toBeNull()
+    expect(agg.firstSessionAt).toBeNull()
+    expect(agg.qualifyingSessionsTotal).toBe(0)
+    expect(agg.totalWeeklySetsBaseline).toBeNull()
+    expect(agg.acuteChronicRatio).toBeNull()
+    expect(agg.detrainingGapDays).toBeNull()
+    expect(agg.perFau).toEqual([])
+    expect(agg.perMovementCalibration).toEqual([])
+
+    // Persisted and retrievable.
+    const row = await prisma.userTrainingAggregates.findUnique({ where: { userId } })
+    expect(row).not.toBeNull()
+    expect(row?.dataMaturity).toBe('cold_start')
+    expect(row?.perFau).toEqual([])
+  })
+
+  it('is idempotent — a double run yields an identical row', async () => {
+    const chest = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    for (const daysAgo of [2, 5, 9, 16, 23]) {
+      await seedSession(prisma, userId, chest, { daysAgo, sets: chestSets(4) })
+    }
+
+    const first = await recomputeUserAggregates(prisma, userId, NOW)
+    const rowA = await prisma.userTrainingAggregates.findUnique({ where: { userId } })
+    const second = await recomputeUserAggregates(prisma, userId, NOW)
+    const rowB = await prisma.userTrainingAggregates.findUnique({ where: { userId } })
+
+    expect(second).toEqual(first)
+    expect(rowB).toEqual(rowA)
+  })
+
+  it('flags low_data on the session/set boundary', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+
+    // Exactly 3 sessions, exactly 20 effective sets in 14d -> NOT low_data.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 9, sets: chestSets(6) })
+
+    const ok = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(ok.perFau.find((f) => f.fau === 'chest')?.low_data).toBe(false)
+  })
+
+  it('flags low_data when under 20 effective sets in 14d', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // 3 sessions but only 19 sets -> low_data.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(6) })
+    await seedSession(prisma, userId, chest, { daysAgo: 9, sets: chestSets(6) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.low_data).toBe(true)
+  })
+
+  it('flags low_data when fewer than 3 sessions in 14d', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // 2 sessions, plenty of sets -> still low_data (session floor).
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(15) })
+    await seedSession(prisma, userId, chest, { daysAgo: 6, sets: chestSets(15) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.low_data).toBe(true)
+  })
+
+  it('computes a deload acute:chronic ratio below 1', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // 28d span established via an older session; last 7d is a light deload.
+    await seedSession(prisma, userId, chest, { daysAgo: 3, sets: chestSets(4) }) // deload week
+    await seedSession(prisma, userId, chest, { daysAgo: 10, sets: chestSets(10) })
+    await seedSession(prisma, userId, chest, { daysAgo: 17, sets: chestSets(10) })
+    await seedSession(prisma, userId, chest, { daysAgo: 24, sets: chestSets(10) })
+    await seedSession(prisma, userId, chest, { daysAgo: 35, sets: chestSets(8) }) // >28d: sets first-session span
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    // sets7d = 4, sets28d = 4+10+10+10 = 34 -> 4 / (34/4) = 0.47
+    expect(agg.acuteChronicRatio).toBeCloseTo(4 / (34 / 4), 2)
+    expect(agg.acuteChronicRatio!).toBeLessThan(1)
+  })
+
+  it('returns null ACR until a 28-day span with >= 20 sets exists', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // Only ~2 weeks of history, first session < 28d ago.
+    await seedSession(prisma, userId, chest, { daysAgo: 3, sets: chestSets(10) })
+    await seedSession(prisma, userId, chest, { daysAgo: 10, sets: chestSets(10) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.acuteChronicRatio).toBeNull()
+  })
+
+  it('populates detraining_gap after an 11-day gap with prior training', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    for (const daysAgo of [11, 15, 20]) {
+      await seedSession(prisma, userId, chest, { daysAgo, sets: chestSets(5) })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.daysSinceAnySession).toBe(11)
+    expect(agg.sessionsLast7d).toBe(0)
+    expect(agg.detrainingGapDays).toBe(11)
+  })
+
+  it('leaves detraining_gap null with fewer than 3 prior sessions', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    await seedSession(prisma, userId, chest, { daysAgo: 11, sets: chestSets(5) })
+    await seedSession(prisma, userId, chest, { daysAgo: 15, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.daysSinceAnySession).toBe(11)
+    expect(agg.detrainingGapDays).toBeNull()
+  })
+
+  it('leaves detraining_gap null when the most recent session is within 10 days', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    for (const daysAgo of [3, 8, 14]) {
+      await seedSession(prisma, userId, chest, { daysAgo, sets: chestSets(5) })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.detrainingGapDays).toBeNull()
+  })
+
+  it('aggregates effort on the RPE-equivalent scale for an RIR-logging user', async () => {
+    const chest = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    // RIR-only user: rpe null, rir 2 -> effort 8 on the RPE-equivalent scale.
+    for (const daysAgo of [3, 7, 12, 20]) {
+      await seedSession(prisma, userId, chest, {
+        daysAgo,
+        sets: [{ weight: 185, reps: 5, rpe: null, rir: 2 }],
+      })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const cal = agg.perMovementCalibration.find((c) => c.movement_pattern === 'horizontal_push')
+    expect(cal).toBeDefined()
+    expect(cal?.observation_count).toBe(4)
+    expect(cal?.avg_effort_rpe_equiv).toBe(8)
+  })
+
+  it('excludes bodyweight weights from calibration but counts their FAU volume', async () => {
+    const pushup = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+      isBodyweight: true,
+    })
+    // Bodyweight pushups logged with weight 0.
+    for (const daysAgo of [2, 5, 9]) {
+      await seedSession(prisma, userId, pushup, {
+        daysAgo,
+        sets: [{ weight: 0, reps: 15, rir: 2 }],
+      })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    // FAU volume counts the bodyweight sets.
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.rolling_14d_sets).toBe(3)
+    // No calibration entry — bodyweight weights are excluded from EWMAs.
+    expect(agg.perMovementCalibration).toEqual([])
+  })
+
+  it('computes a full established-user row across the spec fields', async () => {
+    const chest = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    // One chest session per complete week for 8 weeks (5 sets each)...
+    for (const daysAgo of [4, 11, 18, 25, 32, 39, 46, 53]) {
+      await seedSession(prisma, userId, chest, { daysAgo, sets: chestSets(5) })
+    }
+    // ...plus a recent session (current partial week) and a 10th session to
+    // cross the established threshold.
+    await seedSession(prisma, userId, chest, { daysAgo: 1, sets: chestSets(6) })
+    await seedSession(prisma, userId, chest, { daysAgo: 6, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+
+    expect(agg.qualifyingSessionsTotal).toBe(10)
+    expect(agg.dataMaturity).toBe('established')
+    expect(agg.daysSinceAnySession).toBe(1)
+    expect(agg.sessionsLast7d).toBe(3) // daysAgo 1, 4, 6
+    // 8 complete weeks, current partial week excluded -> weekly median 5.
+    expect(agg.totalWeeklySetsBaseline).toBe(5)
+
+    const chestFau = agg.perFau.find((f) => f.fau === 'chest')
+    expect(chestFau).toBeDefined()
+    expect(chestFau?.low_data).toBe(false)
+    expect(chestFau?.baseline_weekly_sets).toBe(5)
+    expect(chestFau?.rolling_7d_sets).toBe(16) // 6 + 5 + 5
+    expect(chestFau?.rolling_14d_sets).toBe(21) // + daysAgo 11
+
+    const cal = agg.perMovementCalibration.find((c) => c.movement_pattern === 'horizontal_push')
+    expect(cal).toBeDefined()
+    expect(cal?.observation_count).toBe(6) // sessions within 30d
+    expect(cal?.typical_rep_range).toBe('5')
+    expect(cal?.avg_effort_rpe_equiv).toBe(8)
+    expect(cal?.estimate_staleness_days).toBe(1)
+    expect(cal?.recent_observations).toHaveLength(5)
+    // e1RM(185, 5) = 215.8; gap-decayed EWMA sits near it.
+    expect(cal?.ewma_e1rm_lbs).toBeGreaterThan(200)
+    expect(cal?.ewma_e1rm_lbs).toBeLessThan(230)
+    // oldest -> newest ordering.
+    const daysAgoSeries = cal!.recent_observations.map((o) => o.days_ago)
+    expect(daysAgoSeries).toEqual([...daysAgoSeries].sort((a, b) => b - a))
+  })
+})

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -3,6 +3,7 @@ import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { recordEvent } from '@/lib/events'
 import { logger } from '@/lib/logger'
+import { enqueueAggregatesRecompute } from '@/lib/queue/aggregates-jobs'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 
@@ -162,6 +163,8 @@ export async function POST(
     })
 
     recordEvent(user.id, 'workout_completed', { workoutId })
+    // Refresh the Suggest training-state layer off the request path (#919).
+    void enqueueAggregatesRecompute(user.id)
 
     let rollup = null
     try {

--- a/app/api/workouts/adhoc/[completionId]/complete/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/complete/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db'
 import { findAdHocCompletion } from '@/lib/db/adhoc-completion'
 import { recordEvent } from '@/lib/events'
 import { logger } from '@/lib/logger'
+import { enqueueAggregatesRecompute } from '@/lib/queue/aggregates-jobs'
 import { checkRateLimit, workoutActionLimiter } from '@/lib/rate-limit'
 import { computeWorkoutRollup } from '@/lib/stats/workout-rollup'
 
@@ -50,6 +51,8 @@ export async function POST(
     })
 
     recordEvent(user.id, 'adhoc_workout_completed', { completionId })
+    // Refresh the Suggest training-state layer off the request path (#919).
+    void enqueueAggregatesRecompute(user.id)
 
     logger.info(
       { userId: user.id, completionId, setCount },

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -1,12 +1,17 @@
 import http from 'node:http'
 import { PrismaClient } from '@prisma/client'
 import { type Job, Worker } from 'bullmq'
+import { recomputeUserAggregates } from '@/lib/aggregates/recompute'
 // Shared code from the repo root lib/ — resolved via the @/* path alias
 // (see tsconfig.json). Proves worker containers can consume lib/ modules.
 import { logger } from '@/lib/logger'
 import { cloneStrengthProgramData, type ProgramCloneJob } from './cloning'
 
 const QUEUE_NAME = 'program-clone-jobs'
+// Second queue served by this same worker container (issue #919, topology
+// option A). Recompute is short and DB-bound; it shares the direct-Postgres
+// connection the clone worker already uses.
+const AGGREGATES_QUEUE_NAME = 'user-training-aggregates'
 const LOG_LEVEL = process.env.CLONE_WORKER_LOG_LEVEL || 'info' // 'debug' for heartbeat + redis lifecycle
 const HEARTBEAT_INTERVAL = LOG_LEVEL === 'debug' ? 30_000 : 300_000 // 30s debug, 5min otherwise
 
@@ -193,6 +198,42 @@ if (LOG_LEVEL === 'debug') {
   })
 }
 
+// ---------------------------------------------------------------------------
+// UserTrainingAggregates recompute worker (issue #919)
+// ---------------------------------------------------------------------------
+
+interface AggregatesRecomputeJob {
+  userId: string
+}
+
+async function processAggregatesJob(job: Job<AggregatesRecomputeJob>): Promise<void> {
+  const { userId } = job.data
+  if (!userId) {
+    throw new Error('Invalid aggregates job payload: missing userId')
+  }
+  console.log(`[aggregates ${job.id}] recomputing for user=${userId}`)
+  await recomputeUserAggregates(prisma, userId)
+  console.log(`[aggregates ${job.id}] done user=${userId}`)
+}
+
+const aggregatesWorker = new Worker(AGGREGATES_QUEUE_NAME, processAggregatesJob, {
+  connection: connectionOpts,
+  concurrency: 3,
+})
+
+aggregatesWorker.on('ready', () => {
+  console.log('[aggregates] connected to Redis, polling for jobs')
+})
+
+aggregatesWorker.on('failed', (job, error) => {
+  const attempt = job ? `attempt ${job.attemptsMade}/${job.opts.attempts}` : 'unknown attempt'
+  console.error(`[aggregates] job ${job?.id} failed (${attempt}): ${error.message}`)
+})
+
+aggregatesWorker.on('error', (error) => {
+  console.error('[aggregates] worker error:', error.message || error)
+})
+
 // Catch unhandled errors that could silently kill the worker loop
 process.on('unhandledRejection', (reason) => {
   console.error('[process] unhandledRejection:', reason)
@@ -269,7 +310,7 @@ healthServer.listen(port, () => {
 // Graceful shutdown
 async function shutdown() {
   console.log('[shutdown] shutting down clone worker...')
-  await worker.close()
+  await Promise.all([worker.close(), aggregatesWorker.close()])
   healthServer.close()
   await prisma.$disconnect()
   process.exit(0)

--- a/lib/aggregates/compute.ts
+++ b/lib/aggregates/compute.ts
@@ -1,0 +1,366 @@
+/**
+ * Pure compute for the UserTrainingAggregates layer (issue #919).
+ *
+ * I/O-free: takes fetched, pre-filtered session rows plus `now` and returns the
+ * stored row shape. All measurement rules follow docs/SUGGEST_PAYLOAD_SPEC.md:
+ *   - effective set = non-warmup logged set (abandoned sessions count)
+ *   - weights normalized to lbs; bodyweight-exercise weights excluded from EWMAs
+ *   - effort on the RPE-equivalent scale: effort = rpe ?? (10 - rir)
+ *
+ * The recompute orchestrator (lib/aggregates/recompute.ts) owns all DB access
+ * and passes only qualifying sessions (completed|abandoned with >= 1 non-warmup
+ * set) into this function.
+ */
+
+import { ALL_FAUS } from '@/lib/fau-volume'
+import { epleyE1RM, gapDecayedEwma } from '@/lib/learning/math'
+import { normalizeWeightToLbs } from '@/lib/stats/exercise-performance'
+import type {
+  AggregateSessionInput,
+  AggregateSetInput,
+  CalibrationObservation,
+  ComputeInput,
+  DataMaturity,
+  MovementCalibration,
+  PerFauAggregate,
+  TrainingAggregates,
+} from './types'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const CALIBRATION_WINDOW_DAYS = 30
+const CALIBRATION_MIN_OBSERVATIONS = 3
+const BASELINE_WEEKS = 8
+const DETRAINING_MIN_DAYS = 10
+const DETRAINING_MIN_PRIOR_SESSIONS = 3
+const LOW_DATA_MIN_SESSIONS = 3
+const LOW_DATA_MIN_SETS = 20
+const ACR_MIN_28D_SETS = 20
+const ESTABLISHED_MIN_SESSIONS = 10
+const COLD_START_MIN_SESSIONS = 3
+const MATURITY_MIN_SPAN_DAYS = 28
+
+/** Days between an earlier date and `now` (float, non-negative). */
+function ageDays(now: Date, when: Date): number {
+  return (now.getTime() - when.getTime()) / DAY_MS
+}
+
+/** RPE-equivalent effort for a set, or null when neither RPE nor RIR was logged. */
+function setEffort(set: AggregateSetInput): number | null {
+  if (set.rpe != null) return set.rpe
+  if (set.rir != null) return 10 - set.rir
+  return null
+}
+
+/** Non-warmup sets — the "effective sets" that count toward volume. */
+function effectiveSets(session: AggregateSessionInput): AggregateSetInput[] {
+  return session.sets.filter((s) => !s.isWarmup)
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+function round(value: number, decimals = 1): number {
+  const f = 10 ** decimals
+  return Math.round(value * f) / f
+}
+
+/** Start (00:00:00.000 UTC) of the Monday-based week containing `d`. */
+function startOfIsoWeekUtc(d: Date): Date {
+  const out = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+  const dow = out.getUTCDay() // 0 = Sunday .. 6 = Saturday
+  const daysFromMonday = (dow + 6) % 7
+  out.setUTCDate(out.getUTCDate() - daysFromMonday)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Per-FAU
+// ---------------------------------------------------------------------------
+
+/** Count effective sets per FAU (primary attribution) for the given sessions. */
+function tallyFauSets(sessions: AggregateSessionInput[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const session of sessions) {
+    for (const set of effectiveSets(session)) {
+      for (const fau of set.primaryFAUs) {
+        counts.set(fau, (counts.get(fau) ?? 0) + 1)
+      }
+    }
+  }
+  return counts
+}
+
+function computePerFau(
+  input: ComputeInput,
+  lowData: boolean,
+  eightWeekStart: Date,
+  currentWeekStart: Date
+): PerFauAggregate[] {
+  const { now, detailSessions } = input
+
+  const within = (days: number) =>
+    detailSessions.filter((s) => ageDays(now, s.completedAt) <= days)
+
+  const sets7d = tallyFauSets(within(7))
+  const sets14d = tallyFauSets(within(14))
+
+  // Sessions in rolling 14d that trained each FAU (>= 1 effective set).
+  const sessions14dByFau = new Map<string, number>()
+  for (const session of within(14)) {
+    const fausInSession = new Set<string>()
+    for (const set of effectiveSets(session)) {
+      for (const fau of set.primaryFAUs) fausInSession.add(fau)
+    }
+    for (const fau of fausInSession) {
+      sessions14dByFau.set(fau, (sessions14dByFau.get(fau) ?? 0) + 1)
+    }
+  }
+
+  // Per-FAU weekly set totals across the 8 complete Mon-Sun weeks (zero weeks
+  // excluded from the baseline median).
+  const weekFauCounts: Map<string, number>[] = Array.from(
+    { length: BASELINE_WEEKS },
+    () => new Map<string, number>()
+  )
+  for (const session of detailSessions) {
+    const t = session.completedAt.getTime()
+    if (t < eightWeekStart.getTime() || t >= currentWeekStart.getTime()) continue
+    const weekIndex = Math.floor((t - eightWeekStart.getTime()) / (7 * DAY_MS))
+    if (weekIndex < 0 || weekIndex >= BASELINE_WEEKS) continue
+    for (const set of effectiveSets(session)) {
+      for (const fau of set.primaryFAUs) {
+        const wk = weekFauCounts[weekIndex]
+        wk.set(fau, (wk.get(fau) ?? 0) + 1)
+      }
+    }
+  }
+
+  // A FAU is present if it has >= 1 effective set in the trailing 8 weeks
+  // (including the current partial week — recent activity should not omit it).
+  const presentFaus = new Set<string>()
+  for (const session of detailSessions) {
+    if (session.completedAt.getTime() < eightWeekStart.getTime()) continue
+    for (const set of effectiveSets(session)) {
+      for (const fau of set.primaryFAUs) presentFaus.add(fau)
+    }
+  }
+
+  const order = new Map(ALL_FAUS.map((f, i) => [f as string, i]))
+  const result: PerFauAggregate[] = []
+  for (const fau of presentFaus) {
+    const weekly: number[] = []
+    for (const wk of weekFauCounts) {
+      const c = wk.get(fau) ?? 0
+      if (c > 0) weekly.push(c)
+    }
+    const baseline = weekly.length >= 2 ? median(weekly) : null
+    result.push({
+      fau,
+      rolling_7d_sets: sets7d.get(fau) ?? 0,
+      rolling_14d_sets: sets14d.get(fau) ?? 0,
+      sessions_14d: sessions14dByFau.get(fau) ?? 0,
+      baseline_weekly_sets: baseline,
+      low_data: lowData,
+    })
+  }
+
+  // Stable order: known FAUs by taxonomy order, then any unknown keys alphabetically.
+  result.sort((a, b) => {
+    const ai = order.get(a.fau) ?? Number.MAX_SAFE_INTEGER
+    const bi = order.get(b.fau) ?? Number.MAX_SAFE_INTEGER
+    return ai !== bi ? ai - bi : a.fau.localeCompare(b.fau)
+  })
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Per-movement calibration
+// ---------------------------------------------------------------------------
+
+interface TopSetObservation {
+  daysAgo: number
+  weightLbs: number
+  e1rm: number
+  reps: number
+  effort: number | null
+}
+
+function computeCalibration(input: ComputeInput): MovementCalibration[] {
+  const { now, detailSessions } = input
+
+  // Per movement pattern: the top (max-e1RM) qualifying set from each session.
+  const byPattern = new Map<string, TopSetObservation[]>()
+
+  for (const session of detailSessions) {
+    if (ageDays(now, session.completedAt) > CALIBRATION_WINDOW_DAYS) continue
+    const daysAgo = ageDays(now, session.completedAt)
+
+    // Best set per pattern within this single session.
+    const sessionBest = new Map<string, TopSetObservation>()
+    for (const set of session.sets) {
+      if (set.isWarmup || set.isBodyweight) continue
+      if (!set.movementPattern) continue
+      if (set.reps < 1) continue
+      const weightLbs = normalizeWeightToLbs(set.weight, set.weightUnit)
+      if (!(weightLbs > 0)) continue
+      const e1rm = epleyE1RM(weightLbs, set.reps)
+      const existing = sessionBest.get(set.movementPattern)
+      if (!existing || e1rm > existing.e1rm) {
+        sessionBest.set(set.movementPattern, {
+          daysAgo,
+          weightLbs,
+          e1rm,
+          reps: set.reps,
+          effort: setEffort(set),
+        })
+      }
+    }
+    for (const [pattern, obs] of sessionBest) {
+      const list = byPattern.get(pattern) ?? []
+      list.push(obs)
+      byPattern.set(pattern, list)
+    }
+  }
+
+  const result: MovementCalibration[] = []
+  for (const [pattern, observations] of byPattern) {
+    if (observations.length < CALIBRATION_MIN_OBSERVATIONS) continue
+
+    const estimate = gapDecayedEwma(
+      observations.map((o) => ({ weightLbs: o.e1rm, daysAgo: o.daysAgo }))
+    )
+    // Guaranteed non-null: observations.length >= 3.
+    const ewma = estimate.estimateLbs ?? 0
+    const staleness = estimate.estimateStalenessDays ?? 0
+
+    const efforts = observations.map((o) => o.effort).filter((e): e is number => e != null)
+    const avgEffort = efforts.length > 0 ? round(efforts.reduce((a, b) => a + b, 0) / efforts.length) : null
+
+    const reps = observations.map((o) => o.reps)
+    const minReps = Math.min(...reps)
+    const maxReps = Math.max(...reps)
+    const repRange = minReps === maxReps ? String(minReps) : `${minReps}-${maxReps}`
+
+    // Last <= 5 observations, oldest -> newest.
+    const recent: CalibrationObservation[] = [...observations]
+      .sort((a, b) => b.daysAgo - a.daysAgo)
+      .slice(-5)
+      .map((o) => ({ weight_lbs: round(o.weightLbs), days_ago: Math.floor(o.daysAgo) }))
+
+    result.push({
+      movement_pattern: pattern,
+      ewma_e1rm_lbs: round(ewma),
+      estimate_staleness_days: Math.floor(staleness),
+      avg_effort_rpe_equiv: avgEffort,
+      typical_rep_range: repRange,
+      observation_count: observations.length,
+      recent_observations: recent,
+      last_session_days_ago: Math.floor(Math.min(...observations.map((o) => o.daysAgo))),
+    })
+  }
+
+  result.sort((a, b) => a.movement_pattern.localeCompare(b.movement_pattern))
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+function computeDataMaturity(
+  now: Date,
+  qualifyingSessionsTotal: number,
+  firstSessionAt: Date | null
+): DataMaturity {
+  if (qualifyingSessionsTotal < COLD_START_MIN_SESSIONS) return 'cold_start'
+  const spanDays = firstSessionAt ? ageDays(now, firstSessionAt) : 0
+  if (qualifyingSessionsTotal >= ESTABLISHED_MIN_SESSIONS && spanDays >= MATURITY_MIN_SPAN_DAYS) {
+    return 'established'
+  }
+  return 'partial'
+}
+
+/**
+ * Compute the full aggregates row for a user.
+ *
+ * `input.detailSessions` must be the trailing detail-window (>= ~70d) qualifying
+ * sessions; `input.allTime` carries the all-time first/last/count needed for
+ * freshness and maturity that may reach beyond that window.
+ */
+export function computeAggregates(input: ComputeInput): TrainingAggregates {
+  const { now, detailSessions, allTime } = input
+
+  const within = (days: number) =>
+    detailSessions.filter((s) => ageDays(now, s.completedAt) <= days)
+
+  const countEffective = (sessions: AggregateSessionInput[]) =>
+    sessions.reduce((sum, s) => sum + effectiveSets(s).length, 0)
+
+  const sessions7d = within(7)
+  const sessions14d = within(14)
+  const sessions28d = within(28)
+
+  const sets7d = countEffective(sessions7d)
+  const sets28d = countEffective(sessions28d)
+  const sets14d = countEffective(sessions14d)
+
+  // Whole-body low-data flag (shared across all per-FAU rows).
+  const lowData = sessions14d.length < LOW_DATA_MIN_SESSIONS || sets14d < LOW_DATA_MIN_SETS
+
+  // Freshness.
+  const daysSinceAnySession = allTime.lastSessionAt
+    ? Math.floor(ageDays(now, allTime.lastSessionAt))
+    : null
+
+  // Detraining gap: only when the gap is real and there was prior training.
+  const detrainingGapDays =
+    daysSinceAnySession != null &&
+    daysSinceAnySession >= DETRAINING_MIN_DAYS &&
+    allTime.qualifyingSessionsTotal >= DETRAINING_MIN_PRIOR_SESSIONS
+      ? daysSinceAnySession
+      : null
+
+  // Calendar-week windows for the 8-week baselines.
+  const currentWeekStart = startOfIsoWeekUtc(now)
+  const eightWeekStart = new Date(currentWeekStart.getTime() - BASELINE_WEEKS * 7 * DAY_MS)
+
+  // Whole-body weekly totals across the 8 complete weeks (zero weeks excluded).
+  const weekTotals = new Array<number>(BASELINE_WEEKS).fill(0)
+  for (const session of detailSessions) {
+    const t = session.completedAt.getTime()
+    if (t < eightWeekStart.getTime() || t >= currentWeekStart.getTime()) continue
+    const weekIndex = Math.floor((t - eightWeekStart.getTime()) / (7 * DAY_MS))
+    if (weekIndex < 0 || weekIndex >= BASELINE_WEEKS) continue
+    weekTotals[weekIndex] += effectiveSets(session).length
+  }
+  const nonZeroWeeks = weekTotals.filter((c) => c > 0)
+  const totalWeeklySetsBaseline = nonZeroWeeks.length >= 2 ? median(nonZeroWeeks) : null
+
+  // Acute:chronic ratio — null until the chronic denominator is meaningful.
+  const firstSessionSpanDays = allTime.firstSessionAt ? ageDays(now, allTime.firstSessionAt) : 0
+  const acuteChronicRatio =
+    sets28d < ACR_MIN_28D_SETS || firstSessionSpanDays < MATURITY_MIN_SPAN_DAYS
+      ? null
+      : round(sets7d / (sets28d / 4), 2)
+
+  const perFau = computePerFau(input, lowData, eightWeekStart, currentWeekStart)
+  const perMovementCalibration = computeCalibration(input)
+
+  return {
+    computedAt: now,
+    sessionsLast7d: sessions7d.length,
+    daysSinceAnySession,
+    lastSessionAt: allTime.lastSessionAt,
+    firstSessionAt: allTime.firstSessionAt,
+    qualifyingSessionsTotal: allTime.qualifyingSessionsTotal,
+    totalWeeklySetsBaseline,
+    acuteChronicRatio,
+    detrainingGapDays,
+    dataMaturity: computeDataMaturity(now, allTime.qualifyingSessionsTotal, allTime.firstSessionAt),
+    perFau,
+    perMovementCalibration,
+  }
+}

--- a/lib/aggregates/compute.ts
+++ b/lib/aggregates/compute.ts
@@ -13,11 +13,17 @@
  */
 
 import { ALL_FAUS } from '@/lib/fau-volume'
-import { epleyE1RM, gapDecayedEwma } from '@/lib/learning/math'
+import {
+  DEFAULT_EWMA_ALPHA,
+  DEFAULT_TYPICAL_GAP_DAYS,
+  epleyE1RM,
+  gapDecayedEwma,
+} from '@/lib/learning/math'
 import { normalizeWeightToLbs } from '@/lib/stats/exercise-performance'
 import type {
   AggregateSessionInput,
   AggregateSetInput,
+  AggregatesOptions,
   CalibrationObservation,
   ComputeInput,
   DataMaturity,
@@ -27,17 +33,37 @@ import type {
 } from './types'
 
 const DAY_MS = 24 * 60 * 60 * 1000
-const CALIBRATION_WINDOW_DAYS = 30
-const CALIBRATION_MIN_OBSERVATIONS = 3
-const BASELINE_WEEKS = 8
-const DETRAINING_MIN_DAYS = 10
-const DETRAINING_MIN_PRIOR_SESSIONS = 3
-const LOW_DATA_MIN_SESSIONS = 3
-const LOW_DATA_MIN_SETS = 20
-const ACR_MIN_28D_SETS = 20
-const ESTABLISHED_MIN_SESSIONS = 10
-const COLD_START_MIN_SESSIONS = 3
-const MATURITY_MIN_SPAN_DAYS = 28
+
+/**
+ * Production threshold defaults. These are today's values; #937 will override
+ * individual fields from an admin-editable config. Change behavior here, not by
+ * editing call sites.
+ */
+export const DEFAULT_AGGREGATES_OPTIONS: AggregatesOptions = {
+  lowDataMinSessions: 3,
+  lowDataMinSets: 20,
+  detrainingMinDays: 10,
+  detrainingMinPriorSessions: 3,
+  acrMin28dSets: 20,
+  baselineWeeks: 8,
+  calibrationWindowDays: 30,
+  calibrationMinObservations: 3,
+  ewmaAlpha: DEFAULT_EWMA_ALPHA,
+  ewmaTypicalGapDays: DEFAULT_TYPICAL_GAP_DAYS,
+  coldStartMinSessions: 3,
+  establishedMinSessions: 10,
+  maturityMinSpanDays: 28,
+}
+
+/** Merge caller overrides over the production defaults. */
+export function resolveAggregatesOptions(
+  overrides?: Partial<AggregatesOptions>
+): AggregatesOptions {
+  return overrides ? { ...DEFAULT_AGGREGATES_OPTIONS, ...overrides } : DEFAULT_AGGREGATES_OPTIONS
+}
+
+/** Minimum non-zero weeks required before a baseline median is emitted (structural). */
+const BASELINE_MIN_NONZERO_WEEKS = 2
 
 /** Days between an earlier date and `now` (float, non-negative). */
 function ageDays(now: Date, when: Date): number {
@@ -95,11 +121,13 @@ function tallyFauSets(sessions: AggregateSessionInput[]): Map<string, number> {
 
 function computePerFau(
   input: ComputeInput,
+  opts: AggregatesOptions,
   lowData: boolean,
   eightWeekStart: Date,
   currentWeekStart: Date
 ): PerFauAggregate[] {
   const { now, detailSessions } = input
+  const baselineWeeks = opts.baselineWeeks
 
   const within = (days: number) =>
     detailSessions.filter((s) => ageDays(now, s.completedAt) <= days)
@@ -122,14 +150,14 @@ function computePerFau(
   // Per-FAU weekly set totals across the 8 complete Mon-Sun weeks (zero weeks
   // excluded from the baseline median).
   const weekFauCounts: Map<string, number>[] = Array.from(
-    { length: BASELINE_WEEKS },
+    { length: baselineWeeks },
     () => new Map<string, number>()
   )
   for (const session of detailSessions) {
     const t = session.completedAt.getTime()
     if (t < eightWeekStart.getTime() || t >= currentWeekStart.getTime()) continue
     const weekIndex = Math.floor((t - eightWeekStart.getTime()) / (7 * DAY_MS))
-    if (weekIndex < 0 || weekIndex >= BASELINE_WEEKS) continue
+    if (weekIndex < 0 || weekIndex >= baselineWeeks) continue
     for (const set of effectiveSets(session)) {
       for (const fau of set.primaryFAUs) {
         const wk = weekFauCounts[weekIndex]
@@ -156,7 +184,7 @@ function computePerFau(
       const c = wk.get(fau) ?? 0
       if (c > 0) weekly.push(c)
     }
-    const baseline = weekly.length >= 2 ? median(weekly) : null
+    const baseline = weekly.length >= BASELINE_MIN_NONZERO_WEEKS ? median(weekly) : null
     result.push({
       fau,
       rolling_7d_sets: sets7d.get(fau) ?? 0,
@@ -188,14 +216,17 @@ interface TopSetObservation {
   effort: number | null
 }
 
-function computeCalibration(input: ComputeInput): MovementCalibration[] {
+function computeCalibration(
+  input: ComputeInput,
+  opts: AggregatesOptions
+): MovementCalibration[] {
   const { now, detailSessions } = input
 
   // Per movement pattern: the top (max-e1RM) qualifying set from each session.
   const byPattern = new Map<string, TopSetObservation[]>()
 
   for (const session of detailSessions) {
-    if (ageDays(now, session.completedAt) > CALIBRATION_WINDOW_DAYS) continue
+    if (ageDays(now, session.completedAt) > opts.calibrationWindowDays) continue
     const daysAgo = ageDays(now, session.completedAt)
 
     // Best set per pattern within this single session.
@@ -227,10 +258,11 @@ function computeCalibration(input: ComputeInput): MovementCalibration[] {
 
   const result: MovementCalibration[] = []
   for (const [pattern, observations] of byPattern) {
-    if (observations.length < CALIBRATION_MIN_OBSERVATIONS) continue
+    if (observations.length < opts.calibrationMinObservations) continue
 
     const estimate = gapDecayedEwma(
-      observations.map((o) => ({ weightLbs: o.e1rm, daysAgo: o.daysAgo }))
+      observations.map((o) => ({ weightLbs: o.e1rm, daysAgo: o.daysAgo })),
+      { alpha: opts.ewmaAlpha, typicalGapDays: opts.ewmaTypicalGapDays }
     )
     // Guaranteed non-null: observations.length >= 3.
     const ewma = estimate.estimateLbs ?? 0
@@ -273,25 +305,32 @@ function computeCalibration(input: ComputeInput): MovementCalibration[] {
 function computeDataMaturity(
   now: Date,
   qualifyingSessionsTotal: number,
-  firstSessionAt: Date | null
+  firstSessionAt: Date | null,
+  opts: AggregatesOptions
 ): DataMaturity {
-  if (qualifyingSessionsTotal < COLD_START_MIN_SESSIONS) return 'cold_start'
+  if (qualifyingSessionsTotal < opts.coldStartMinSessions) return 'cold_start'
   const spanDays = firstSessionAt ? ageDays(now, firstSessionAt) : 0
-  if (qualifyingSessionsTotal >= ESTABLISHED_MIN_SESSIONS && spanDays >= MATURITY_MIN_SPAN_DAYS) {
+  if (qualifyingSessionsTotal >= opts.establishedMinSessions && spanDays >= opts.maturityMinSpanDays) {
     return 'established'
   }
   return 'partial'
 }
 
 /**
- * Compute the full aggregates row for a user.
+ * Compute the full aggregates row for a user. Pure and I/O-free — the same core
+ * serves both the persisting recompute job and #937's dry-run payload preview.
  *
  * `input.detailSessions` must be the trailing detail-window (>= ~70d) qualifying
  * sessions; `input.allTime` carries the all-time first/last/count needed for
- * freshness and maturity that may reach beyond that window.
+ * freshness and maturity that may reach beyond that window. `options` overrides
+ * individual thresholds; omit for today's production defaults.
  */
-export function computeAggregates(input: ComputeInput): TrainingAggregates {
+export function computeAggregates(
+  input: ComputeInput,
+  options?: Partial<AggregatesOptions>
+): TrainingAggregates {
   const { now, detailSessions, allTime } = input
+  const opts = resolveAggregatesOptions(options)
 
   const within = (days: number) =>
     detailSessions.filter((s) => ageDays(now, s.completedAt) <= days)
@@ -308,7 +347,7 @@ export function computeAggregates(input: ComputeInput): TrainingAggregates {
   const sets14d = countEffective(sessions14d)
 
   // Whole-body low-data flag (shared across all per-FAU rows).
-  const lowData = sessions14d.length < LOW_DATA_MIN_SESSIONS || sets14d < LOW_DATA_MIN_SETS
+  const lowData = sessions14d.length < opts.lowDataMinSessions || sets14d < opts.lowDataMinSets
 
   // Freshness.
   const daysSinceAnySession = allTime.lastSessionAt
@@ -318,36 +357,37 @@ export function computeAggregates(input: ComputeInput): TrainingAggregates {
   // Detraining gap: only when the gap is real and there was prior training.
   const detrainingGapDays =
     daysSinceAnySession != null &&
-    daysSinceAnySession >= DETRAINING_MIN_DAYS &&
-    allTime.qualifyingSessionsTotal >= DETRAINING_MIN_PRIOR_SESSIONS
+    daysSinceAnySession >= opts.detrainingMinDays &&
+    allTime.qualifyingSessionsTotal >= opts.detrainingMinPriorSessions
       ? daysSinceAnySession
       : null
 
-  // Calendar-week windows for the 8-week baselines.
+  // Calendar-week windows for the baseline (default 8 complete Mon-Sun weeks).
   const currentWeekStart = startOfIsoWeekUtc(now)
-  const eightWeekStart = new Date(currentWeekStart.getTime() - BASELINE_WEEKS * 7 * DAY_MS)
+  const eightWeekStart = new Date(currentWeekStart.getTime() - opts.baselineWeeks * 7 * DAY_MS)
 
-  // Whole-body weekly totals across the 8 complete weeks (zero weeks excluded).
-  const weekTotals = new Array<number>(BASELINE_WEEKS).fill(0)
+  // Whole-body weekly totals across the complete weeks (zero weeks excluded).
+  const weekTotals = new Array<number>(opts.baselineWeeks).fill(0)
   for (const session of detailSessions) {
     const t = session.completedAt.getTime()
     if (t < eightWeekStart.getTime() || t >= currentWeekStart.getTime()) continue
     const weekIndex = Math.floor((t - eightWeekStart.getTime()) / (7 * DAY_MS))
-    if (weekIndex < 0 || weekIndex >= BASELINE_WEEKS) continue
+    if (weekIndex < 0 || weekIndex >= opts.baselineWeeks) continue
     weekTotals[weekIndex] += effectiveSets(session).length
   }
   const nonZeroWeeks = weekTotals.filter((c) => c > 0)
-  const totalWeeklySetsBaseline = nonZeroWeeks.length >= 2 ? median(nonZeroWeeks) : null
+  const totalWeeklySetsBaseline =
+    nonZeroWeeks.length >= BASELINE_MIN_NONZERO_WEEKS ? median(nonZeroWeeks) : null
 
   // Acute:chronic ratio — null until the chronic denominator is meaningful.
   const firstSessionSpanDays = allTime.firstSessionAt ? ageDays(now, allTime.firstSessionAt) : 0
   const acuteChronicRatio =
-    sets28d < ACR_MIN_28D_SETS || firstSessionSpanDays < MATURITY_MIN_SPAN_DAYS
+    sets28d < opts.acrMin28dSets || firstSessionSpanDays < opts.maturityMinSpanDays
       ? null
       : round(sets7d / (sets28d / 4), 2)
 
-  const perFau = computePerFau(input, lowData, eightWeekStart, currentWeekStart)
-  const perMovementCalibration = computeCalibration(input)
+  const perFau = computePerFau(input, opts, lowData, eightWeekStart, currentWeekStart)
+  const perMovementCalibration = computeCalibration(input, opts)
 
   return {
     computedAt: now,
@@ -359,7 +399,12 @@ export function computeAggregates(input: ComputeInput): TrainingAggregates {
     totalWeeklySetsBaseline,
     acuteChronicRatio,
     detrainingGapDays,
-    dataMaturity: computeDataMaturity(now, allTime.qualifyingSessionsTotal, allTime.firstSessionAt),
+    dataMaturity: computeDataMaturity(
+      now,
+      allTime.qualifyingSessionsTotal,
+      allTime.firstSessionAt,
+      opts
+    ),
     perFau,
     perMovementCalibration,
   }

--- a/lib/aggregates/recompute.ts
+++ b/lib/aggregates/recompute.ts
@@ -1,0 +1,154 @@
+/**
+ * Orchestrator for the UserTrainingAggregates recompute (issue #919).
+ *
+ * Owns all DB access: fetches a user's qualifying training history, hands it to
+ * the pure compute layer, and upserts the single per-user row. Full recompute
+ * every run (no incremental bookkeeping) — idempotent for a fixed `now`.
+ *
+ * Called from the BullMQ aggregates worker on workout completion; safe to call
+ * directly (integration tests do).
+ */
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+import { logger } from '@/lib/logger'
+import { computeAggregates } from './compute'
+import type { AggregateSessionInput, TrainingAggregates } from './types'
+
+/**
+ * Detail-fetch window. Covers everything the rolling (7/14/28d) and 8-week
+ * Mon-Sun baseline computations need (worst case ~62 days back) with margin.
+ * All-time first/last/count are fetched separately and reach beyond this.
+ */
+const DETAIL_WINDOW_DAYS = 75
+const QUALIFYING_STATUSES = ['completed', 'abandoned']
+
+function toJson(value: unknown): Prisma.InputJsonValue {
+  return value as unknown as Prisma.InputJsonValue
+}
+
+/**
+ * Recompute and persist the aggregates row for a single user.
+ * Returns the computed aggregates (also useful for tests).
+ */
+export async function recomputeUserAggregates(
+  prisma: PrismaClient,
+  userId: string,
+  now: Date = new Date()
+): Promise<TrainingAggregates> {
+  const detailWindowStart = new Date(now.getTime() - DETAIL_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+
+  // Detailed sessions in the trailing window: full set data + exercise tags.
+  const detailCompletions = await prisma.workoutCompletion.findMany({
+    where: {
+      userId,
+      isArchived: false,
+      status: { in: QUALIFYING_STATUSES },
+      completedAt: { gte: detailWindowStart, lte: now },
+    },
+    select: {
+      completedAt: true,
+      status: true,
+      loggedSets: {
+        select: {
+          weight: true,
+          weightUnit: true,
+          reps: true,
+          rpe: true,
+          rir: true,
+          isWarmup: true,
+          exercise: {
+            select: {
+              exerciseDefinition: {
+                select: { movementPattern: true, isBodyweight: true, primaryFAUs: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const detailSessions: AggregateSessionInput[] = detailCompletions
+    .map((c) => ({
+      completedAt: c.completedAt,
+      status: c.status,
+      sets: c.loggedSets.map((s) => ({
+        weight: s.weight,
+        weightUnit: s.weightUnit,
+        reps: s.reps,
+        rpe: s.rpe,
+        rir: s.rir,
+        isWarmup: s.isWarmup,
+        movementPattern: s.exercise.exerciseDefinition.movementPattern,
+        isBodyweight: s.exercise.exerciseDefinition.isBodyweight,
+        primaryFAUs: s.exercise.exerciseDefinition.primaryFAUs,
+      })),
+    }))
+    // Qualifying session = >= 1 non-warmup ("effective") set.
+    .filter((s) => s.sets.some((set) => !set.isWarmup))
+
+  // All-time qualifying-session summary (freshness + data maturity may reach
+  // well beyond the detail window). Lightweight: one probe set per completion.
+  const allTimeCompletions = await prisma.workoutCompletion.findMany({
+    where: {
+      userId,
+      isArchived: false,
+      status: { in: QUALIFYING_STATUSES },
+      completedAt: { lte: now },
+    },
+    select: {
+      completedAt: true,
+      loggedSets: { where: { isWarmup: false }, select: { id: true }, take: 1 },
+    },
+  })
+  const qualifyingTimes = allTimeCompletions
+    .filter((c) => c.loggedSets.length > 0)
+    .map((c) => c.completedAt.getTime())
+
+  const firstSessionAt = qualifyingTimes.length ? new Date(Math.min(...qualifyingTimes)) : null
+  const lastSessionAt = qualifyingTimes.length ? new Date(Math.max(...qualifyingTimes)) : null
+
+  const aggregates = computeAggregates({
+    now,
+    detailSessions,
+    allTime: {
+      firstSessionAt,
+      lastSessionAt,
+      qualifyingSessionsTotal: qualifyingTimes.length,
+    },
+  })
+
+  const row = {
+    computedAt: aggregates.computedAt,
+    sessionsLast7d: aggregates.sessionsLast7d,
+    daysSinceAnySession: aggregates.daysSinceAnySession,
+    lastSessionAt: aggregates.lastSessionAt,
+    firstSessionAt: aggregates.firstSessionAt,
+    qualifyingSessionsTotal: aggregates.qualifyingSessionsTotal,
+    totalWeeklySetsBaseline: aggregates.totalWeeklySetsBaseline,
+    acuteChronicRatio: aggregates.acuteChronicRatio,
+    detrainingGapDays: aggregates.detrainingGapDays,
+    dataMaturity: aggregates.dataMaturity,
+    perFau: toJson(aggregates.perFau),
+    perMovementCalibration: toJson(aggregates.perMovementCalibration),
+  }
+
+  await prisma.userTrainingAggregates.upsert({
+    where: { userId },
+    create: { userId, ...row },
+    update: row,
+  })
+
+  logger.info(
+    {
+      userId,
+      qualifyingSessions: aggregates.qualifyingSessionsTotal,
+      dataMaturity: aggregates.dataMaturity,
+      faus: aggregates.perFau.length,
+      patterns: aggregates.perMovementCalibration.length,
+    },
+    'Recomputed user training aggregates'
+  )
+
+  return aggregates
+}

--- a/lib/aggregates/recompute.ts
+++ b/lib/aggregates/recompute.ts
@@ -1,9 +1,13 @@
 /**
- * Orchestrator for the UserTrainingAggregates recompute (issue #919).
+ * Orchestrator for the UserTrainingAggregates layer (issue #919).
  *
- * Owns all DB access: fetches a user's qualifying training history, hands it to
- * the pure compute layer, and upserts the single per-user row. Full recompute
- * every run (no incremental bookkeeping) — idempotent for a fixed `now`.
+ * Two seams:
+ *   - computeUserAggregates: fetches a user's qualifying history and runs the
+ *     pure compute core, returning the aggregates WITHOUT persisting. This is
+ *     the dry-run path #937 (TuningConfig + payload preview) needs.
+ *   - recomputeUserAggregates: the thin persisting wrapper — calls the above
+ *     and upserts the single per-user row. Full recompute every run (no
+ *     incremental bookkeeping); idempotent for a fixed `now`.
  *
  * Called from the BullMQ aggregates worker on workout completion; safe to call
  * directly (integration tests do).
@@ -11,15 +15,9 @@
 
 import type { Prisma, PrismaClient } from '@prisma/client'
 import { logger } from '@/lib/logger'
-import { computeAggregates } from './compute'
-import type { AggregateSessionInput, TrainingAggregates } from './types'
+import { computeAggregates, resolveAggregatesOptions } from './compute'
+import type { AggregateSessionInput, AggregatesOptions, TrainingAggregates } from './types'
 
-/**
- * Detail-fetch window. Covers everything the rolling (7/14/28d) and 8-week
- * Mon-Sun baseline computations need (worst case ~62 days back) with margin.
- * All-time first/last/count are fetched separately and reach beyond this.
- */
-const DETAIL_WINDOW_DAYS = 75
 const QUALIFYING_STATUSES = ['completed', 'abandoned']
 
 function toJson(value: unknown): Prisma.InputJsonValue {
@@ -27,15 +25,28 @@ function toJson(value: unknown): Prisma.InputJsonValue {
 }
 
 /**
- * Recompute and persist the aggregates row for a single user.
- * Returns the computed aggregates (also useful for tests).
+ * Trailing detail-fetch window (days). Must cover the rolling (7/14/28d) and
+ * baseline (N complete Mon-Sun weeks) computations with margin for the current
+ * partial week; all-time first/last/count are fetched separately and reach
+ * beyond it. Derived from the resolved baseline width so a config override that
+ * widens the baseline also widens the fetch.
  */
-export async function recomputeUserAggregates(
+function detailWindowDays(opts: AggregatesOptions): number {
+  return Math.max(35, opts.baselineWeeks * 7 + 14, opts.calibrationWindowDays + 7)
+}
+
+/**
+ * Fetch a user's qualifying history and compute their aggregates in-memory.
+ * Does NOT persist — see recomputeUserAggregates for the writing wrapper.
+ */
+export async function computeUserAggregates(
   prisma: PrismaClient,
   userId: string,
-  now: Date = new Date()
+  now: Date = new Date(),
+  options?: Partial<AggregatesOptions>
 ): Promise<TrainingAggregates> {
-  const detailWindowStart = new Date(now.getTime() - DETAIL_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+  const opts = resolveAggregatesOptions(options)
+  const detailWindowStart = new Date(now.getTime() - detailWindowDays(opts) * 24 * 60 * 60 * 1000)
 
   // Detailed sessions in the trailing window: full set data + exercise tags.
   const detailCompletions = await prisma.workoutCompletion.findMany({
@@ -108,15 +119,31 @@ export async function recomputeUserAggregates(
   const firstSessionAt = qualifyingTimes.length ? new Date(Math.min(...qualifyingTimes)) : null
   const lastSessionAt = qualifyingTimes.length ? new Date(Math.max(...qualifyingTimes)) : null
 
-  const aggregates = computeAggregates({
-    now,
-    detailSessions,
-    allTime: {
-      firstSessionAt,
-      lastSessionAt,
-      qualifyingSessionsTotal: qualifyingTimes.length,
+  return computeAggregates(
+    {
+      now,
+      detailSessions,
+      allTime: {
+        firstSessionAt,
+        lastSessionAt,
+        qualifyingSessionsTotal: qualifyingTimes.length,
+      },
     },
-  })
+    opts
+  )
+}
+
+/**
+ * Recompute and persist the aggregates row for a single user (the BullMQ
+ * processor's thin wrapper). Returns the computed aggregates.
+ */
+export async function recomputeUserAggregates(
+  prisma: PrismaClient,
+  userId: string,
+  now: Date = new Date(),
+  options?: Partial<AggregatesOptions>
+): Promise<TrainingAggregates> {
+  const aggregates = await computeUserAggregates(prisma, userId, now, options)
 
   const row = {
     computedAt: aggregates.computedAt,

--- a/lib/aggregates/types.ts
+++ b/lib/aggregates/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Shapes for the UserTrainingAggregates precomputed training-state layer.
+ *
+ * These types define both the compute layer's output and the JSON column
+ * contents persisted on the UserTrainingAggregates row. Field names follow
+ * docs/SUGGEST_PAYLOAD_SPEC.md (v2, issue #919): snake_case inside the JSON
+ * blobs to match the payload the training-state builder emits downstream, and
+ * effort is always on the RPE-equivalent scale (`avg_effort_rpe_equiv`).
+ */
+
+export type DataMaturity = 'cold_start' | 'partial' | 'established'
+
+/** One entry per FAU with at least one effective set in the trailing 8 weeks. */
+export interface PerFauAggregate {
+  fau: string
+  /** Effective (non-warmup) sets attributed to this FAU's primary muscles, rolling 7d. */
+  rolling_7d_sets: number
+  /** Effective sets, rolling 14d. */
+  rolling_14d_sets: number
+  /** Qualifying sessions in rolling 14d containing >= 1 effective set for this FAU. */
+  sessions_14d: number
+  /**
+   * Trailing 8-week median of this FAU's weekly effective sets, zero weeks
+   * excluded; null until >= 2 non-zero weeks exist.
+   */
+  baseline_weekly_sets: number | null
+  /**
+   * Whole-body low-data flag (identical across all FAUs on a row): true when
+   * the rolling 14d window holds < 3 qualifying sessions or < 20 effective sets.
+   */
+  low_data: boolean
+}
+
+/** A single timestamped top-set observation for a movement pattern. */
+export interface CalibrationObservation {
+  weight_lbs: number
+  days_ago: number
+}
+
+/** One entry per movement pattern with >= 3 observations in the last 30 days. */
+export interface MovementCalibration {
+  movement_pattern: string
+  /** Gap-decayed EWMA of per-session top-set e1RM (Epley), lbs. */
+  ewma_e1rm_lbs: number
+  /** Days since the observation the EWMA was last updated with. */
+  estimate_staleness_days: number
+  /** Mean of `rpe ?? (10 - rir)` across the top-set observations; null when none logged. */
+  avg_effort_rpe_equiv: number | null
+  /** e.g. "5-8" (min-max reps across top sets), or a single value when constant. */
+  typical_rep_range: string
+  /** Number of per-session top-set observations in the 30d window. */
+  observation_count: number
+  /** Last <= 5 top-set observations (actual weight, not e1RM), ordered oldest -> newest. */
+  recent_observations: CalibrationObservation[]
+  /** Days since the most recent observation for this pattern. */
+  last_session_days_ago: number
+}
+
+/**
+ * Full compute output. Timestamps are absolute (the builder converts to
+ * days_ago at request time); the derived `daysSince*` / `detrainingGapDays`
+ * integers are computed relative to `computedAt` for convenience.
+ */
+export interface TrainingAggregates {
+  computedAt: Date
+  sessionsLast7d: number
+  daysSinceAnySession: number | null
+  lastSessionAt: Date | null
+  firstSessionAt: Date | null
+  qualifyingSessionsTotal: number
+  totalWeeklySetsBaseline: number | null
+  acuteChronicRatio: number | null
+  detrainingGapDays: number | null
+  dataMaturity: DataMaturity
+  perFau: PerFauAggregate[]
+  perMovementCalibration: MovementCalibration[]
+}
+
+// ---------------------------------------------------------------------------
+// Compute input
+// ---------------------------------------------------------------------------
+
+export interface AggregateSetInput {
+  /** Raw logged weight; normalized to lbs inside compute via normalizeWeightToLbs. */
+  weight: number
+  weightUnit: string
+  reps: number
+  rpe: number | null
+  rir: number | null
+  isWarmup: boolean
+  /** ExerciseDefinition.movementPattern; null when untagged (excluded from calibration). */
+  movementPattern: string | null
+  /** ExerciseDefinition.isBodyweight; bodyweight weights are excluded from EWMAs. */
+  isBodyweight: boolean
+  /** ExerciseDefinition.primaryFAUs; sets attribute to these for FAU volume. */
+  primaryFAUs: string[]
+}
+
+/** A qualifying session (completed|abandoned, >= 1 non-warmup set) with its sets. */
+export interface AggregateSessionInput {
+  completedAt: Date
+  status: string
+  sets: AggregateSetInput[]
+}
+
+export interface ComputeInput {
+  now: Date
+  /** Detailed qualifying sessions within the trailing detail window (>= ~70d). */
+  detailSessions: AggregateSessionInput[]
+  /** All-time qualifying-session summary (may extend well beyond the detail window). */
+  allTime: {
+    firstSessionAt: Date | null
+    lastSessionAt: Date | null
+    qualifyingSessionsTotal: number
+  }
+}

--- a/lib/aggregates/types.ts
+++ b/lib/aggregates/types.ts
@@ -114,3 +114,38 @@ export interface ComputeInput {
     qualifyingSessionsTotal: number
   }
 }
+
+/**
+ * Tunable thresholds for the aggregates computation. Every field has a
+ * production default (DEFAULT_AGGREGATES_OPTIONS); callers pass a Partial to
+ * override individual values. #937 (TuningConfig + payload preview) supplies
+ * overrides from an admin-editable config; today all values are the defaults.
+ */
+export interface AggregatesOptions {
+  /** low_data: fewer than this many qualifying sessions in 14d flags low data. */
+  lowDataMinSessions: number
+  /** low_data: fewer than this many effective sets in 14d flags low data. */
+  lowDataMinSets: number
+  /** detraining_gap floor: gap must be >= this many days to populate. */
+  detrainingMinDays: number
+  /** detraining_gap: user must have had >= this many qualifying sessions before the gap. */
+  detrainingMinPriorSessions: number
+  /** acute:chronic ratio is null until the trailing-28d window holds >= this many sets. */
+  acrMin28dSets: number
+  /** Number of complete Mon-Sun weeks in the baseline window. */
+  baselineWeeks: number
+  /** Movement-pattern observations are drawn from this trailing window (days). */
+  calibrationWindowDays: number
+  /** A movement pattern needs >= this many observations to emit a calibration entry. */
+  calibrationMinObservations: number
+  /** Base EWMA smoothing factor (see lib/learning/math gapDecayedEwma). */
+  ewmaAlpha: number
+  /** Expected days between observations for the gap-decayed EWMA. */
+  ewmaTypicalGapDays: number
+  /** data_maturity: below this many qualifying sessions is cold_start. */
+  coldStartMinSessions: number
+  /** data_maturity: at/above this many sessions (with span) is established. */
+  establishedMinSessions: number
+  /** data_maturity / ACR: minimum first-session span (days) for established / non-null ACR. */
+  maturityMinSpanDays: number
+}

--- a/lib/queue/aggregates-jobs.ts
+++ b/lib/queue/aggregates-jobs.ts
@@ -74,8 +74,13 @@ export async function publishAggregatesRecomputeJob(
       jobId: `aggregates:${job.userId}`,
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
-      removeOnComplete: 100,
-      removeOnFail: 500,
+      // Remove terminal jobs from Redis immediately. The stable per-user jobId
+      // still coalesces bursts (BullMQ ignores a re-add while a job with that
+      // id is waiting/active), but a *retained* completed/failed job with that
+      // id would block every future enqueue for the user — so aggregates would
+      // stop updating after the first recompute. Must be true, not a count.
+      removeOnComplete: true,
+      removeOnFail: true,
     }),
     timeout,
   ])

--- a/lib/queue/aggregates-jobs.ts
+++ b/lib/queue/aggregates-jobs.ts
@@ -71,7 +71,9 @@ export async function publishAggregatesRecomputeJob(
 
   const bullJob = await Promise.race([
     q.add('recompute', job, {
-      jobId: `aggregates:${job.userId}`,
+      // BullMQ rejects a custom jobId containing ':' (its Redis key separator),
+      // so use '-'. A stable per-user id coalesces bursts.
+      jobId: `aggregates-${job.userId}`,
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
       // Remove terminal jobs from Redis immediately. The stable per-user jobId

--- a/lib/queue/aggregates-jobs.ts
+++ b/lib/queue/aggregates-jobs.ts
@@ -1,0 +1,98 @@
+import { Queue } from 'bullmq'
+import { logger } from '@/lib/logger'
+
+/**
+ * Publisher for the UserTrainingAggregates recompute queue (issue #919).
+ *
+ * Mirrors lib/queue/clone-jobs.ts: a lazy singleton Queue over REDIS_URL. The
+ * job carries only a userId; the worker does a full recompute. Enqueue is
+ * fire-and-forget from workout-completion routes and must never block the
+ * response (callers guard failures).
+ */
+
+export const AGGREGATES_QUEUE_NAME = 'user-training-aggregates'
+
+export interface AggregatesRecomputeJob {
+  userId: string
+}
+
+let queue: Queue | null = null
+
+function parseRedisUrl(url: string) {
+  const parsed = new URL(url)
+  return {
+    host: parsed.hostname,
+    port: parseInt(parsed.port || '6379', 10),
+    password: parsed.password || undefined,
+    db: parseInt(parsed.pathname.slice(1) || '0', 10),
+    maxRetriesPerRequest: null as null,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 30_000,
+  }
+}
+
+function getQueue(): Queue {
+  if (!queue) {
+    const redisUrl = process.env.REDIS_URL
+    if (!redisUrl) {
+      throw new Error('REDIS_URL is not set')
+    }
+    queue = new Queue(AGGREGATES_QUEUE_NAME, {
+      connection: parseRedisUrl(redisUrl),
+    })
+  }
+  return queue
+}
+
+/**
+ * Closes the lazily-created singleton Queue and its Redis connection.
+ * Intended for test teardown — production never needs to call this.
+ */
+export async function closeAggregatesJobsQueue(): Promise<void> {
+  if (queue) {
+    await queue.close()
+    queue = null
+  }
+}
+
+/**
+ * Enqueue a recompute for a user. Coalesces bursts by using a per-user jobId
+ * (BullMQ dedupes an id that is still waiting), so rapid successive completions
+ * don't pile up redundant full recomputes.
+ */
+export async function publishAggregatesRecomputeJob(
+  job: AggregatesRecomputeJob
+): Promise<string | null> {
+  const q = getQueue()
+
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('Redis connection timeout — queue unavailable')), 5000)
+  )
+
+  const bullJob = await Promise.race([
+    q.add('recompute', job, {
+      jobId: `aggregates:${job.userId}`,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: 100,
+      removeOnFail: 500,
+    }),
+    timeout,
+  ])
+
+  logger.info({ userId: job.userId, jobId: bullJob.id }, 'Published aggregates recompute job')
+  return bullJob.id ?? null
+}
+
+/**
+ * Fire-and-forget wrapper for request handlers: enqueues a recompute and
+ * swallows/loggs any failure so a queue outage never breaks the completion
+ * response. Returns nothing; do not await its effect on the response path.
+ */
+export async function enqueueAggregatesRecompute(userId: string): Promise<void> {
+  try {
+    await publishAggregatesRecomputeJob({ userId })
+  } catch (error) {
+    logger.error({ error, userId }, 'Failed to enqueue aggregates recompute (non-fatal)')
+  }
+}

--- a/prisma/migrations/20260702172329_user_training_aggregates/migration.sql
+++ b/prisma/migrations/20260702172329_user_training_aggregates/migration.sql
@@ -1,0 +1,30 @@
+-- Suggest Workout precomputed training-state layer (issue #919).
+-- Adds the UserTrainingAggregates table and the ExerciseDefinition.isBodyweight
+-- flag (backfilled from equipment) per docs/SUGGEST_PAYLOAD_SPEC.md.
+
+-- ExerciseDefinition: bodyweight flag (weights excluded from calibration EWMAs)
+ALTER TABLE "ExerciseDefinition" ADD COLUMN "isBodyweight" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: any exercise whose equipment list includes "bodyweight" is bodyweight-loaded.
+UPDATE "ExerciseDefinition" SET "isBodyweight" = true WHERE 'bodyweight' = ANY("equipment");
+
+-- UserTrainingAggregates: one row per user, refreshed by the recompute job.
+CREATE TABLE "UserTrainingAggregates" (
+    "userId" TEXT NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL,
+    "sessionsLast7d" INTEGER NOT NULL,
+    "daysSinceAnySession" INTEGER,
+    "lastSessionAt" TIMESTAMP(3),
+    "firstSessionAt" TIMESTAMP(3),
+    "qualifyingSessionsTotal" INTEGER NOT NULL DEFAULT 0,
+    "totalWeeklySetsBaseline" DOUBLE PRECISION,
+    "acuteChronicRatio" DOUBLE PRECISION,
+    "detrainingGapDays" INTEGER,
+    "dataMaturity" TEXT NOT NULL,
+    "perFau" JSONB NOT NULL,
+    "perMovementCalibration" JSONB NOT NULL,
+
+    CONSTRAINT "UserTrainingAggregates_pkey" PRIMARY KEY ("userId")
+);
+
+CREATE INDEX "UserTrainingAggregates_computedAt_idx" ON "UserTrainingAggregates"("computedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,11 @@ model ExerciseDefinition {
   movementPattern String?
   // intensityClass: heavy | moderate | light (typical fatigue cost)
   intensityClass  String?
+  // True for bodyweight-loaded exercises (weight logged as 0). Their sets count
+  // toward FAU volume but their weights are excluded from calibration EWMAs
+  // (SUGGEST_PAYLOAD_SPEC global rule 3). Backfilled from equipment containing
+  // "bodyweight"; downstream consumers use this column, never re-infer.
+  isBodyweight    Boolean   @default(false)
   taggedAt        DateTime?
   taggedBy        String?
   exercises      Exercise[]
@@ -634,4 +639,37 @@ model InAppMessage {
   @@index([placement, active])
   @@index([placement, userType, active])
   @@index([ownerType, ownerId])
+}
+
+/// Precomputed training-state layer for the Suggest Workout planner.
+/// One row per user, refreshed off the request path by the aggregates
+/// recompute job (event-triggered on workout completion). Shaped for Suggest
+/// only per docs/SUGGEST_PAYLOAD_SPEC.md (v2). Replaces the dropped
+/// ExercisePerformanceLog: e1RM / effort are computed here. Full recompute per
+/// user (no incremental bookkeeping); timestamps stored absolute, the builder
+/// converts to days_ago at request time.
+model UserTrainingAggregates {
+  userId    String   @id
+  computedAt DateTime
+
+  // ---- whole-body freshness & load (top-level training_state fields) ----
+  sessionsLast7d          Int
+  daysSinceAnySession     Int?
+  lastSessionAt           DateTime?
+  firstSessionAt          DateTime?
+  qualifyingSessionsTotal Int      @default(0)
+  totalWeeklySetsBaseline Float?
+  acuteChronicRatio       Float?
+  detrainingGapDays       Int?
+  // "cold_start" | "partial" | "established" — derived from qualifying-session
+  // counts; the builder may re-derive against exact request time.
+  dataMaturity            String
+
+  // ---- sectioned blobs (shapes defined in lib/aggregates/types.ts) ----
+  // PerFauAggregate[]: per-FAU rolling sets, baseline, sessions_14d, low_data
+  perFau                  Json
+  // MovementCalibration[]: gap-decayed EWMA e1RM, staleness, typical effort
+  perMovementCalibration  Json
+
+  @@index([computedAt])
 }


### PR DESCRIPTION
Closes #919.

Precomputed training-state layer for the Suggest Workout planner, shaped per `docs/SUGGEST_PAYLOAD_SPEC.md` (v2). Replaces the dropped `ExercisePerformanceLog` — e1RM and effort are computed here. Product-owner decisions from the issue thread (worker topology A, add `isBodyweight` column) are implemented.

## What's here

**Schema + migration** (one migration stream)
- `UserTrainingAggregates` — one row/user: freshness/load scalars + `perFau` and `perMovementCalibration` JSON blobs.
- `ExerciseDefinition.isBodyweight` — backfilled from `equipment` containing `"bodyweight"`. Downstream consumers use the column, never re-infer.
- Migration SQL validated against Prisma's canonical diff.

**Compute** (`lib/aggregates/`)
- `compute.ts` — pure, I/O-free: per-FAU 7d/14d effective sets, 8-week baseline medians (zero weeks excluded), `sessions_14d`, whole-body `low_data`, acute:chronic ratio, detraining gap, `data_maturity`, and per-movement gap-decayed EWMA e1RM (`lib/learning/math`) + `estimate_staleness_days` + typical effort. Effort normalized to the RPE-equivalent scale (`effort = rpe ?? 10 - rir`), named `avg_effort_rpe_equiv`.
- Inclusion rules per spec: warmups excluded from calibration; bodyweight weights excluded from EWMAs (still count toward FAU volume); abandoned-session sets count; weights normalized to lbs.
- `computeUserAggregates` (fetch + compute, **no persist** — the #937 dry-run/preview path) and a thin `recomputeUserAggregates` wrapper that upserts. Idempotent.
- All thresholds flow through an `AggregatesOptions` object with today's values as `DEFAULT_AGGREGATES_OPTIONS` (prep for #937's admin-editable config).

**Queue + worker + triggers**
- `lib/queue/aggregates-jobs.ts` publisher on `user-training-aggregates` (per-user job id coalesces bursts).
- Second BullMQ `Worker` registered in the existing `clone-program` container (topology option A — no new image/Helm chart).
- Fire-and-forget enqueue from the two workout-completion routes (regular + ad-hoc). The week-complete route only creates `skipped` rows, so it's not a trigger.

## Testing
- Testcontainers integration test (17 cases): every spec field, `low_data` boundary (session + set floors), deload ACR, 11-day detraining gap (+ negative cases), RIR-user effort aggregation, bodyweight exclusion, zero-history validity, idempotency, dry-run non-persistence, and an options override.
- Type-check + lint clean. Worker verified to compile under the Docker single-client topology.

Schema updated locally. **Production migration auto-applies on deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)