### PR TITLE
feat(aggregates): per-FAU shares/status/last_heavy + goal_progress producer (#941)

### DIFF
--- a/__tests__/api/user-training-aggregates.test.ts
+++ b/__tests__/api/user-training-aggregates.test.ts
@@ -16,6 +16,7 @@ async function createDef(
     primaryFAUs: string[]
     movementPattern?: string | null
     isBodyweight?: boolean
+    intensityClass?: string | null
   }
 ): Promise<string> {
   defCounter += 1
@@ -32,9 +33,25 @@ async function createDef(
       userId: '00000000-0000-0000-0000-000000000000',
       movementPattern: opts.movementPattern ?? null,
       isBodyweight: opts.isBodyweight ?? false,
+      intensityClass: opts.intensityClass ?? null,
     },
   })
   return def.id
+}
+
+/** Seed the user's training profile (ratioTargets drives shares; goalSentences drives goal_progress). */
+async function seedProfile(
+  prisma: PrismaClient,
+  userId: string,
+  opts: { ratioTargets?: Record<string, number>; goalSentences?: string[] }
+): Promise<void> {
+  await prisma.userTrainingProfile.create({
+    data: {
+      userId,
+      ratioTargets: opts.ratioTargets ?? {},
+      goalSentences: opts.goalSentences ?? [],
+    },
+  })
 }
 
 interface SetSpec {
@@ -349,5 +366,273 @@ describe('UserTrainingAggregates recompute', () => {
     // oldest -> newest ordering.
     const daysAgoSeries = cal!.recent_observations.map((o) => o.days_ago)
     expect(daysAgoSeries).toEqual([...daysAgoSeries].sort((a, b) => b - a))
+  })
+
+  // -------------------------------------------------------------------------
+  // per_fau shares + status (#941)
+  // -------------------------------------------------------------------------
+
+  it('emits zero-sum shares that normalize across present FAUs', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    const lats = await createDef(prisma, { primaryFAUs: ['lats'] })
+    // 3 sessions, 20 effective sets in 14d -> not low_data. chest 15, lats 5.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(8) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, lats, { daysAgo: 9, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const shares = agg.perFau
+
+    // Shares are defined over present FAUs and each set sums to 1.
+    const targetSum = shares.reduce((s, f) => s + f.target_share, 0)
+    const actualSum = shares.reduce((s, f) => s + f.actual_14d_share, 0)
+    const deficitSum = shares.reduce((s, f) => s + f.deficit_share, 0)
+    expect(targetSum).toBeCloseTo(1, 3)
+    expect(actualSum).toBeCloseTo(1, 3)
+    expect(deficitSum).toBeCloseTo(0, 3)
+
+    // Default preset (uniform weight 1.0) -> equal target shares.
+    const chestFau = shares.find((f) => f.fau === 'chest')!
+    const latsFau = shares.find((f) => f.fau === 'lats')!
+    expect(chestFau.target_share).toBeCloseTo(0.5, 4)
+    expect(latsFau.target_share).toBeCloseTo(0.5, 4)
+    // 15 / 20 vs 5 / 20 effective sets in 14d.
+    expect(chestFau.actual_14d_share).toBeCloseTo(0.75, 4)
+    expect(latsFau.actual_14d_share).toBeCloseTo(0.25, 4)
+    // deficit = target - actual: chest over-trained, lats neglected.
+    expect(chestFau.deficit_share).toBeCloseTo(-0.25, 4)
+    expect(latsFau.deficit_share).toBeCloseTo(0.25, 4)
+  })
+
+  it('honors ratioTargets weights when deriving target_share', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    const lats = await createDef(prisma, { primaryFAUs: ['lats'] })
+    // Weight lats 3x chest -> target shares 0.25 / 0.75 over the two present FAUs.
+    await seedProfile(prisma, userId, { ratioTargets: { chest: 1, lats: 3 } })
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, lats, { daysAgo: 9, sets: chestSets(6) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const chestFau = agg.perFau.find((f) => f.fau === 'chest')!
+    const latsFau = agg.perFau.find((f) => f.fau === 'lats')!
+    expect(chestFau.target_share).toBeCloseTo(0.25, 4)
+    expect(latsFau.target_share).toBeCloseTo(0.75, 4)
+  })
+
+  it('handles a zero-14d-volume present FAU (share 0, deficit = full target)', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    const lats = await createDef(prisma, { primaryFAUs: ['lats'] })
+    // chest trained recently; lats only trained 30d ago (present in 8wk window,
+    // but zero volume in the rolling 14d window).
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(8) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, chest, { daysAgo: 9, sets: chestSets(6) })
+    await seedSession(prisma, userId, lats, { daysAgo: 30, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const latsFau = agg.perFau.find((f) => f.fau === 'lats')
+    expect(latsFau).toBeDefined()
+    expect(latsFau?.rolling_14d_sets).toBe(0)
+    expect(latsFau?.actual_14d_share).toBe(0)
+    // target_share still defined (present FAU); deficit is the full target.
+    expect(latsFau?.target_share).toBeGreaterThan(0)
+    expect(latsFau?.deficit_share).toBeCloseTo(latsFau!.target_share, 4)
+  })
+
+  it('labels status neglected / over / balanced by the deadband', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    const lats = await createDef(prisma, { primaryFAUs: ['lats'] })
+    // Skewed volume: chest over target, lats under. Deadband 0.03 default.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(8) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(7) })
+    await seedSession(prisma, userId, lats, { daysAgo: 9, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.status).toBe('over')
+    expect(agg.perFau.find((f) => f.fau === 'lats')?.status).toBe('neglected')
+  })
+
+  it('labels status balanced when actual matches target within the deadband', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    const lats = await createDef(prisma, { primaryFAUs: ['lats'] })
+    // Equal volume across two default-weighted FAUs -> deficit ~0 -> balanced.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(5) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(5) })
+    await seedSession(prisma, userId, lats, { daysAgo: 6, sets: chestSets(5) })
+    await seedSession(prisma, userId, lats, { daysAgo: 9, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.status).toBe('balanced')
+    expect(agg.perFau.find((f) => f.fau === 'lats')?.status).toBe('balanced')
+  })
+
+  it('omits status under low_data', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    // Only 2 sessions -> low_data -> status suppressed.
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(8) })
+    await seedSession(prisma, userId, chest, { daysAgo: 5, sets: chestSets(8) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const chestFau = agg.perFau.find((f) => f.fau === 'chest')
+    expect(chestFau?.low_data).toBe(true)
+    expect(chestFau?.status).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // per_fau last_heavy_days_ago (#941)
+  // -------------------------------------------------------------------------
+
+  it('computes last_heavy_days_ago via the EWMA branch', async () => {
+    // Calibrated pattern (>= 3 obs in 30d). Low logged effort (rir 4 -> effort 6)
+    // so the effort branch never fires — heaviness comes from the EWMA compare.
+    const bench = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    for (const daysAgo of [3, 10, 17]) {
+      await seedSession(prisma, userId, bench, {
+        daysAgo,
+        sets: [{ weight: 185, reps: 5, rpe: null, rir: 4 }],
+      })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    // EWMA ~ e1RM(185,5); each session's top set >= 85% of it -> heavy.
+    expect(agg.perMovementCalibration.find((c) => c.movement_pattern === 'horizontal_push')).toBeDefined()
+    expect(agg.perFau.find((f) => f.fau === 'chest')?.last_heavy_days_ago).toBe(3)
+  })
+
+  it('computes last_heavy_days_ago via the intensityClass tag fallback (cold start)', async () => {
+    // < 3 observations -> no EWMA; low effort (rir 4) -> effort branch silent;
+    // intensityClass 'heavy' is the only signal that fires.
+    const heavyLift = await createDef(prisma, {
+      primaryFAUs: ['quads'],
+      movementPattern: 'squat',
+      intensityClass: 'heavy',
+    })
+    await seedSession(prisma, userId, heavyLift, {
+      daysAgo: 4,
+      sets: [{ weight: 225, reps: 5, rpe: null, rir: 4 }],
+    })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    // No calibration entry (too few obs), but tag fallback marks it heavy.
+    expect(agg.perMovementCalibration).toEqual([])
+    expect(agg.perFau.find((f) => f.fau === 'quads')?.last_heavy_days_ago).toBe(4)
+  })
+
+  it('leaves last_heavy_days_ago null when no session was heavy', async () => {
+    // Light intensityClass, low effort, no EWMA -> never heavy.
+    const light = await createDef(prisma, {
+      primaryFAUs: ['biceps'],
+      movementPattern: 'elbow_flexion',
+      intensityClass: 'light',
+    })
+    await seedSession(prisma, userId, light, {
+      daysAgo: 4,
+      sets: [{ weight: 30, reps: 12, rpe: null, rir: 4 }],
+    })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    const biceps = agg.perFau.find((f) => f.fau === 'biceps')
+    expect(biceps?.last_session_days_ago).toBe(4)
+    expect(biceps?.last_heavy_days_ago).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // goal_progress (#941)
+  // -------------------------------------------------------------------------
+
+  it('classifies a progressing goal from a rising e1RM series', async () => {
+    const bench = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    await seedProfile(prisma, userId, { goalSentences: ['Increase my bench press'] })
+    // Rising top-set weights across 4 distinct weeks.
+    await seedSession(prisma, userId, bench, { daysAgo: 22, sets: [{ weight: 135, reps: 5 }] })
+    await seedSession(prisma, userId, bench, { daysAgo: 15, sets: [{ weight: 155, reps: 5 }] })
+    await seedSession(prisma, userId, bench, { daysAgo: 8, sets: [{ weight: 175, reps: 5 }] })
+    await seedSession(prisma, userId, bench, { daysAgo: 1, sets: [{ weight: 185, reps: 5 }] })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.goalProgress).toHaveLength(1)
+    const goal = agg.goalProgress[0]
+    expect(goal.goal).toBe('Increase my bench press')
+    expect(goal.trend).toBe('progressing')
+    expect(goal.weeks_observed).toBe(4)
+    // Oldest -> newest top sets.
+    expect(goal.recent_top_sets_lbs).toEqual([135, 155, 175, 185])
+  })
+
+  it('classifies a regressing goal from a falling e1RM series', async () => {
+    const squat = await createDef(prisma, {
+      primaryFAUs: ['quads'],
+      movementPattern: 'squat',
+    })
+    await seedProfile(prisma, userId, { goalSentences: ['Get a bigger squat'] })
+    await seedSession(prisma, userId, squat, { daysAgo: 22, sets: [{ weight: 275, reps: 5 }] })
+    await seedSession(prisma, userId, squat, { daysAgo: 15, sets: [{ weight: 255, reps: 5 }] })
+    await seedSession(prisma, userId, squat, { daysAgo: 8, sets: [{ weight: 235, reps: 5 }] })
+    await seedSession(prisma, userId, squat, { daysAgo: 1, sets: [{ weight: 225, reps: 5 }] })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.goalProgress[0]?.trend).toBe('regressing')
+  })
+
+  it('classifies a stalled goal from a flat e1RM series', async () => {
+    const bench = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    await seedProfile(prisma, userId, { goalSentences: ['Improve bench press'] })
+    for (const daysAgo of [22, 15, 8, 1]) {
+      await seedSession(prisma, userId, bench, { daysAgo, sets: [{ weight: 185, reps: 5 }] })
+    }
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.goalProgress[0]?.trend).toBe('stalled')
+  })
+
+  it('classifies a cold-start goal as "new" with too few observed weeks', async () => {
+    const squat = await createDef(prisma, {
+      primaryFAUs: ['quads'],
+      movementPattern: 'squat',
+    })
+    await seedProfile(prisma, userId, { goalSentences: ['Squat more weight'] })
+    // Only one session -> a single observed week -> below goalProgressMinWeeks.
+    await seedSession(prisma, userId, squat, { daysAgo: 2, sets: [{ weight: 225, reps: 5 }] })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.goalProgress[0]?.trend).toBe('new')
+    expect(agg.goalProgress[0]?.weeks_observed).toBe(1)
+  })
+
+  it('omits uninterpretable goals and yields none when no goals are set', async () => {
+    const bench = await createDef(prisma, {
+      primaryFAUs: ['chest'],
+      movementPattern: 'horizontal_push',
+    })
+    await seedProfile(prisma, userId, {
+      goalSentences: ['Feel healthier and more energetic'],
+    })
+    await seedSession(prisma, userId, bench, { daysAgo: 2, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    // The goal maps to no movement pattern -> omitted entirely.
+    expect(agg.goalProgress).toEqual([])
+  })
+
+  it('emits an empty goalProgress when the user has no profile', async () => {
+    const chest = await createDef(prisma, { primaryFAUs: ['chest'] })
+    await seedSession(prisma, userId, chest, { daysAgo: 2, sets: chestSets(5) })
+
+    const agg = await recomputeUserAggregates(prisma, userId, NOW)
+    expect(agg.goalProgress).toEqual([])
+
+    // Persisted column round-trips as an empty array.
+    const row = await prisma.userTrainingAggregates.findUnique({ where: { userId } })
+    expect(row?.goalProgress).toEqual([])
   })
 })

--- a/lib/aggregates/compute.ts
+++ b/lib/aggregates/compute.ts
@@ -19,6 +19,11 @@ import {
   epleyE1RM,
   gapDecayedEwma,
 } from '@/lib/learning/math'
+import {
+  type MovementEwma,
+  type MovementEwmaMap,
+  determineMovementHeavy,
+} from '@/lib/learning/weekly-intent'
 import { normalizeWeightToLbs } from '@/lib/stats/exercise-performance'
 import type {
   AggregateSessionInput,
@@ -27,6 +32,9 @@ import type {
   CalibrationObservation,
   ComputeInput,
   DataMaturity,
+  FauStatus,
+  GoalProgress,
+  GoalTrend,
   MovementCalibration,
   PerFauAggregate,
   TrainingAggregates,
@@ -53,6 +61,9 @@ export const DEFAULT_AGGREGATES_OPTIONS: AggregatesOptions = {
   coldStartMinSessions: 3,
   establishedMinSessions: 10,
   maturityMinSpanDays: 28,
+  fauStatusDeadband: 0.03,
+  goalTrendStallBand: 0.02,
+  goalProgressMinWeeks: 2,
 }
 
 /** Merge caller overrides over the production defaults. */
@@ -93,6 +104,34 @@ function round(value: number, decimals = 1): number {
   return Math.round(value * f) / f
 }
 
+const round4 = (value: number): number => round(value, 4)
+
+/**
+ * Keyword -> movement pattern interpretation for goal sentences. Deterministic
+ * substring match against the lowercased goal; first hit (in array order) wins.
+ * Not exhaustive by design — goals with no lift-specific interpretation are
+ * simply omitted from goal_progress.
+ */
+const GOAL_PATTERN_KEYWORDS: ReadonlyArray<[RegExp, string]> = [
+  [/\bdead ?lift/, 'hinge'],
+  [/\brdl\b|romanian|hip ?thrust|good ?morning|\bhinge/, 'hinge'],
+  [/\bsquat/, 'squat'],
+  [/\blunge|split ?squat|bulgarian/, 'lunge'],
+  [/\bbench|chest ?press|\bpush ?up|horizontal ?push/, 'horizontal_push'],
+  [/overhead|\bohp\b|shoulder ?press|military|vertical ?push/, 'vertical_push'],
+  [/pull ?up|chin ?up|lat ?pull|vertical ?pull/, 'vertical_pull'],
+  [/\brow\b|horizontal ?pull/, 'horizontal_pull'],
+]
+
+/** Map a goal sentence to a movement pattern, or null when uninterpretable. */
+function interpretGoalPattern(goal: string): string | null {
+  const g = goal.toLowerCase()
+  for (const [re, pattern] of GOAL_PATTERN_KEYWORDS) {
+    if (re.test(g)) return pattern
+  }
+  return null
+}
+
 /** Start (00:00:00.000 UTC) of the Monday-based week containing `d`. */
 function startOfIsoWeekUtc(d: Date): Date {
   const out = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
@@ -119,15 +158,96 @@ function tallyFauSets(sessions: AggregateSessionInput[]): Map<string, number> {
   return counts
 }
 
+/** Most recent (min days-ago) session with an effective set for each FAU. */
+function lastSessionByFau(now: Date, sessions: AggregateSessionInput[]): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const session of sessions) {
+    const daysAgo = Math.floor(ageDays(now, session.completedAt))
+    const faus = new Set<string>()
+    for (const set of effectiveSets(session)) {
+      for (const fau of set.primaryFAUs) faus.add(fau)
+    }
+    for (const fau of faus) {
+      const prev = out.get(fau)
+      if (prev == null || daysAgo < prev) out.set(fau, daysAgo)
+    }
+  }
+  return out
+}
+
+/**
+ * Most recent (min days-ago) **session-relative-heavy** session for each FAU.
+ * A session is heavy for a FAU when it contains a movement (grouped by pattern)
+ * that `determineMovementHeavy` flags AND that movement's sets attribute to the
+ * FAU. Effort (RPE >= 8) fires regardless of pattern; the EWMA branch needs a
+ * calibrated pattern; the intensityClass tag is the cold-start fallback.
+ */
+function lastHeavyByFau(
+  now: Date,
+  sessions: AggregateSessionInput[],
+  ewmaMap: MovementEwmaMap
+): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const session of sessions) {
+    const daysAgo = Math.floor(ageDays(now, session.completedAt))
+
+    // Group this session's sets by movement pattern (null key allowed —
+    // effort-based heaviness applies even to untagged movements).
+    const byPattern = new Map<string, AggregateSetInput[]>()
+    for (const set of session.sets) {
+      const key = set.movementPattern ?? '__NULL__'
+      const list = byPattern.get(key) ?? []
+      list.push(set)
+      byPattern.set(key, list)
+    }
+
+    for (const [key, sets] of byPattern) {
+      const pattern = key === '__NULL__' ? null : key
+      const intensityClass = sets.find((s) => s.intensityClass === 'heavy')
+        ? 'heavy'
+        : (sets.find((s) => s.intensityClass != null)?.intensityClass ?? null)
+      const verdict = determineMovementHeavy(
+        {
+          movementPattern: pattern,
+          intensityClass,
+          sets: sets.map((s) => ({
+            // Bodyweight-exercise weights are excluded from e1RM (mirror
+            // calibration); effort still counts.
+            weightLbs: s.isBodyweight ? 0 : normalizeWeightToLbs(s.weight, s.weightUnit),
+            reps: s.reps,
+            rpe: s.rpe,
+            rir: s.rir,
+            isWarmup: s.isWarmup,
+          })),
+        },
+        pattern != null ? ewmaMap[pattern] : undefined
+      )
+      if (!verdict.isHeavy) continue
+      const faus = new Set<string>()
+      for (const set of sets) {
+        if (set.isWarmup) continue
+        for (const fau of set.primaryFAUs) faus.add(fau)
+      }
+      for (const fau of faus) {
+        const prev = out.get(fau)
+        if (prev == null || daysAgo < prev) out.set(fau, daysAgo)
+      }
+    }
+  }
+  return out
+}
+
 function computePerFau(
   input: ComputeInput,
   opts: AggregatesOptions,
   lowData: boolean,
   eightWeekStart: Date,
-  currentWeekStart: Date
+  currentWeekStart: Date,
+  ewmaMap: MovementEwmaMap
 ): PerFauAggregate[] {
   const { now, detailSessions } = input
   const baselineWeeks = opts.baselineWeeks
+  const ratioTargets = input.ratioTargets ?? null
 
   const within = (days: number) =>
     detailSessions.filter((s) => ageDays(now, s.completedAt) <= days)
@@ -176,6 +296,19 @@ function computePerFau(
     }
   }
 
+  const lastSession = lastSessionByFau(now, within(baselineWeeks * 7 + 14))
+  const lastHeavy = lastHeavyByFau(now, within(baselineWeeks * 7 + 14), ewmaMap)
+
+  // Zero-sum shares: target_share (from ratioTargets, default weight 1.0) and
+  // actual_14d_share are both normalized over the emitted (present) FAUs so
+  // they each sum to 1 and deficit_share cancels total volume out.
+  const presentList = [...presentFaus]
+  const targetWeightSum = presentList.reduce(
+    (sum, fau) => sum + (ratioTargets?.[fau] ?? 1.0),
+    0
+  )
+  const total14d = presentList.reduce((sum, fau) => sum + (sets14d.get(fau) ?? 0), 0)
+
   const order = new Map(ALL_FAUS.map((f, i) => [f as string, i]))
   const result: PerFauAggregate[] = []
   for (const fau of presentFaus) {
@@ -185,13 +318,26 @@ function computePerFau(
       if (c > 0) weekly.push(c)
     }
     const baseline = weekly.length >= BASELINE_MIN_NONZERO_WEEKS ? median(weekly) : null
+
+    const targetShare = targetWeightSum > 0 ? round4((ratioTargets?.[fau] ?? 1.0) / targetWeightSum) : 0
+    const actualShare = total14d > 0 ? round4((sets14d.get(fau) ?? 0) / total14d) : 0
+    const deficit = round4(targetShare - actualShare)
+    const status: FauStatus = deficit > opts.fauStatusDeadband ? 'neglected' : deficit < -opts.fauStatusDeadband ? 'over' : 'balanced'
+
     result.push({
       fau,
+      last_session_days_ago: lastSession.get(fau) ?? null,
+      last_heavy_days_ago: lastHeavy.get(fau) ?? null,
       rolling_7d_sets: sets7d.get(fau) ?? 0,
       rolling_14d_sets: sets14d.get(fau) ?? 0,
       sessions_14d: sessions14dByFau.get(fau) ?? 0,
       baseline_weekly_sets: baseline,
+      target_share: targetShare,
+      actual_14d_share: actualShare,
+      deficit_share: deficit,
       low_data: lowData,
+      // Suppressed under low data — a cheap model echoes whatever label it gets.
+      ...(lowData ? {} : { status }),
     })
   }
 
@@ -216,13 +362,16 @@ interface TopSetObservation {
   effort: number | null
 }
 
-function computeCalibration(
+/**
+ * Per movement pattern, the top (max-e1RM) qualifying set from each session
+ * within the calibration window. Shared by calibration and goal_progress.
+ * Excludes warmups, bodyweight-exercise weights, and untagged movements.
+ */
+function collectTopSetsByPattern(
   input: ComputeInput,
   opts: AggregatesOptions
-): MovementCalibration[] {
+): Map<string, TopSetObservation[]> {
   const { now, detailSessions } = input
-
-  // Per movement pattern: the top (max-e1RM) qualifying set from each session.
   const byPattern = new Map<string, TopSetObservation[]>()
 
   for (const session of detailSessions) {
@@ -255,7 +404,13 @@ function computeCalibration(
       byPattern.set(pattern, list)
     }
   }
+  return byPattern
+}
 
+function computeCalibration(
+  byPattern: Map<string, TopSetObservation[]>,
+  opts: AggregatesOptions
+): MovementCalibration[] {
   const result: MovementCalibration[] = []
   for (const [pattern, observations] of byPattern) {
     if (observations.length < opts.calibrationMinObservations) continue
@@ -295,6 +450,69 @@ function computeCalibration(
   }
 
   result.sort((a, b) => a.movement_pattern.localeCompare(b.movement_pattern))
+  return result
+}
+
+/**
+ * Field adapter: build the movement-pattern EWMA map the weekly-intent heavy
+ * machinery consumes. Calibration emits `ewma_e1rm_lbs` / `observation_count`;
+ * `determineMovementHeavy` wants `ewmaE1RMLbs` / `observationCount`. Only
+ * patterns with >= calibrationMinObservations appear (they were the only ones
+ * emitted); everything else falls back to effort/tag heaviness by construction.
+ */
+function buildEwmaMap(calibration: MovementCalibration[]): MovementEwmaMap {
+  const map: MovementEwmaMap = {}
+  for (const c of calibration) {
+    const ewma: MovementEwma = {
+      ewmaE1RMLbs: c.ewma_e1rm_lbs,
+      observationCount: c.observation_count,
+    }
+    map[c.movement_pattern] = ewma
+  }
+  return map
+}
+
+// ---------------------------------------------------------------------------
+// goal_progress
+// ---------------------------------------------------------------------------
+
+/** Classify the e1RM series' first->last relative change into a trend. */
+function classifyTrend(e1rmSeries: number[], weeksObserved: number, opts: AggregatesOptions): GoalTrend {
+  if (weeksObserved < opts.goalProgressMinWeeks || e1rmSeries.length < 2) return 'new'
+  const first = e1rmSeries[0]
+  const last = e1rmSeries[e1rmSeries.length - 1]
+  if (!(first > 0)) return 'new'
+  const rel = (last - first) / first
+  if (rel > opts.goalTrendStallBand) return 'progressing'
+  if (rel < -opts.goalTrendStallBand) return 'regressing'
+  return 'stalled'
+}
+
+function computeGoalProgress(
+  goals: string[],
+  byPattern: Map<string, TopSetObservation[]>,
+  opts: AggregatesOptions
+): GoalProgress[] {
+  const result: GoalProgress[] = []
+  for (const goal of goals) {
+    const pattern = interpretGoalPattern(goal)
+    if (!pattern) continue // uninterpretable goals are omitted
+
+    // Oldest -> newest observations for the mapped pattern (may be empty).
+    const observations = [...(byPattern.get(pattern) ?? [])].sort((a, b) => b.daysAgo - a.daysAgo)
+    const e1rmSeries = observations.map((o) => o.e1rm)
+    const recentTopSets = observations.slice(-5).map((o) => round(o.weightLbs))
+    // Distinct 7-day buckets observed within the calibration window.
+    const weeksObserved = new Set(observations.map((o) => Math.floor(o.daysAgo / 7))).size
+
+    result.push({
+      goal,
+      interpretation: `${pattern} EWMA + e1RM trend`,
+      recent_top_sets_lbs: recentTopSets,
+      trend: classifyTrend(e1rmSeries, weeksObserved, opts),
+      weeks_observed: weeksObserved,
+    })
+  }
   return result
 }
 
@@ -386,8 +604,11 @@ export function computeAggregates(
       ? null
       : round(sets7d / (sets28d / 4), 2)
 
-  const perFau = computePerFau(input, opts, lowData, eightWeekStart, currentWeekStart)
-  const perMovementCalibration = computeCalibration(input, opts)
+  const topSetsByPattern = collectTopSetsByPattern(input, opts)
+  const perMovementCalibration = computeCalibration(topSetsByPattern, opts)
+  const ewmaMap = buildEwmaMap(perMovementCalibration)
+  const perFau = computePerFau(input, opts, lowData, eightWeekStart, currentWeekStart, ewmaMap)
+  const goalProgress = computeGoalProgress(input.goals ?? [], topSetsByPattern, opts)
 
   return {
     computedAt: now,
@@ -407,5 +628,6 @@ export function computeAggregates(
     ),
     perFau,
     perMovementCalibration,
+    goalProgress,
   }
 }

--- a/lib/aggregates/recompute.ts
+++ b/lib/aggregates/recompute.ts
@@ -70,7 +70,12 @@ export async function computeUserAggregates(
           exercise: {
             select: {
               exerciseDefinition: {
-                select: { movementPattern: true, isBodyweight: true, primaryFAUs: true },
+                select: {
+                  movementPattern: true,
+                  intensityClass: true,
+                  isBodyweight: true,
+                  primaryFAUs: true,
+                },
               },
             },
           },
@@ -91,6 +96,7 @@ export async function computeUserAggregates(
         rir: s.rir,
         isWarmup: s.isWarmup,
         movementPattern: s.exercise.exerciseDefinition.movementPattern,
+        intensityClass: s.exercise.exerciseDefinition.intensityClass,
         isBodyweight: s.exercise.exerciseDefinition.isBodyweight,
         primaryFAUs: s.exercise.exerciseDefinition.primaryFAUs,
       })),
@@ -119,6 +125,14 @@ export async function computeUserAggregates(
   const firstSessionAt = qualifyingTimes.length ? new Date(Math.min(...qualifyingTimes)) : null
   const lastSessionAt = qualifyingTimes.length ? new Date(Math.max(...qualifyingTimes)) : null
 
+  // Profile inputs for shares (ratioTargets) and goal_progress (goalSentences).
+  // Absent profile => default preset shares and no goal_progress.
+  const profile = await prisma.userTrainingProfile.findUnique({
+    where: { userId },
+    select: { ratioTargets: true, goalSentences: true },
+  })
+  const ratioTargets = normalizeRatioTargets(profile?.ratioTargets)
+
   return computeAggregates(
     {
       now,
@@ -128,9 +142,21 @@ export async function computeUserAggregates(
         lastSessionAt,
         qualifyingSessionsTotal: qualifyingTimes.length,
       },
+      ratioTargets,
+      goals: profile?.goalSentences ?? [],
     },
     opts
   )
+}
+
+/** Coerce a stored ratioTargets JSON blob into a numeric FAU->weight record. */
+function normalizeRatioTargets(value: unknown): Record<string, number> | null {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null
+  const out: Record<string, number> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) out[key] = raw
+  }
+  return Object.keys(out).length > 0 ? out : null
 }
 
 /**
@@ -158,6 +184,7 @@ export async function recomputeUserAggregates(
     dataMaturity: aggregates.dataMaturity,
     perFau: toJson(aggregates.perFau),
     perMovementCalibration: toJson(aggregates.perMovementCalibration),
+    goalProgress: toJson(aggregates.goalProgress),
   }
 
   await prisma.userTrainingAggregates.upsert({

--- a/lib/aggregates/types.ts
+++ b/lib/aggregates/types.ts
@@ -66,7 +66,8 @@ export interface GoalProgress {
   /** Trend classified from the per-session e1RM (Epley) series; `"new"` when
    * fewer than `goalProgressMinWeeks` distinct weeks were observed. */
   trend: GoalTrend
-  /** Distinct calendar-week buckets with an observation in the window. */
+  /** Distinct rolling 7-day buckets (floor(days_ago / 7)) with an observation
+   * in the calibration window. */
   weeks_observed: number
 }
 

--- a/lib/aggregates/types.ts
+++ b/lib/aggregates/types.ts
@@ -10,9 +10,18 @@
 
 export type DataMaturity = 'cold_start' | 'partial' | 'established'
 
+/** Pre-chewed balance label for a FAU; omitted (undefined) when low_data. */
+export type FauStatus = 'neglected' | 'balanced' | 'over'
+
 /** One entry per FAU with at least one effective set in the trailing 8 weeks. */
 export interface PerFauAggregate {
   fau: string
+  /** Days since the most recent qualifying session with an effective set for
+   * this FAU; null when no such session falls in the detail window. */
+  last_session_days_ago: number | null
+  /** Days since the most recent session-relative-heavy session for this FAU;
+   * null when never heavy in the window (see lib/learning/weekly-intent). */
+  last_heavy_days_ago: number | null
   /** Effective (non-warmup) sets attributed to this FAU's primary muscles, rolling 7d. */
   rolling_7d_sets: number
   /** Effective sets, rolling 14d. */
@@ -25,10 +34,40 @@ export interface PerFauAggregate {
    */
   baseline_weekly_sets: number | null
   /**
+   * Target share of total effective volume, derived from the user's
+   * `ratioTargets` (default preset weight 1.0 per FAU when unset), normalized
+   * over the emitted (present) FAUs so shares sum to 1.
+   */
+  target_share: number
+  /** This FAU's share of total rolling-14d effective sets (0 when 14d volume is 0). */
+  actual_14d_share: number
+  /** `target_share - actual_14d_share`; positive = under-trained vs target. */
+  deficit_share: number
+  /**
    * Whole-body low-data flag (identical across all FAUs on a row): true when
    * the rolling 14d window holds < 3 qualifying sessions or < 20 effective sets.
    */
   low_data: boolean
+  /** Pre-chewed balance label; omitted (undefined) whenever `low_data` is true. */
+  status?: FauStatus
+}
+
+/** e1RM trend classification for a goal (spec §goal_progress). */
+export type GoalTrend = 'progressing' | 'stalled' | 'regressing' | 'new'
+
+/** One entry per interpretable goal sentence (mapped to a movement pattern). */
+export interface GoalProgress {
+  /** The goal sentence (pass-through from the profile). */
+  goal: string
+  /** How the goal was mapped to a measurable signal. */
+  interpretation: string
+  /** Last <= 5 top-set weights (lbs) for the mapped pattern, oldest -> newest. */
+  recent_top_sets_lbs: number[]
+  /** Trend classified from the per-session e1RM (Epley) series; `"new"` when
+   * fewer than `goalProgressMinWeeks` distinct weeks were observed. */
+  trend: GoalTrend
+  /** Distinct calendar-week buckets with an observation in the window. */
+  weeks_observed: number
 }
 
 /** A single timestamped top-set observation for a movement pattern. */
@@ -74,6 +113,7 @@ export interface TrainingAggregates {
   dataMaturity: DataMaturity
   perFau: PerFauAggregate[]
   perMovementCalibration: MovementCalibration[]
+  goalProgress: GoalProgress[]
 }
 
 // ---------------------------------------------------------------------------
@@ -90,6 +130,9 @@ export interface AggregateSetInput {
   isWarmup: boolean
   /** ExerciseDefinition.movementPattern; null when untagged (excluded from calibration). */
   movementPattern: string | null
+  /** ExerciseDefinition.intensityClass ('heavy'|'moderate'|'light'); cold-start
+   * fallback signal for session-relative heaviness. */
+  intensityClass: string | null
   /** ExerciseDefinition.isBodyweight; bodyweight weights are excluded from EWMAs. */
   isBodyweight: boolean
   /** ExerciseDefinition.primaryFAUs; sets attribute to these for FAU volume. */
@@ -113,6 +156,12 @@ export interface ComputeInput {
     lastSessionAt: Date | null
     qualifyingSessionsTotal: number
   }
+  /** Per-FAU ratio targets (from the profile); null/absent = default preset
+   * (uniform weight 1.0). Drives `target_share` / `deficit_share` / `status`. */
+  ratioTargets?: Record<string, number> | null
+  /** Goal sentences (from the profile); each interpretable one yields a
+   * `goal_progress[]` entry. Absent/empty = no goal_progress. */
+  goals?: string[]
 }
 
 /**
@@ -148,4 +197,11 @@ export interface AggregatesOptions {
   establishedMinSessions: number
   /** data_maturity / ACR: minimum first-session span (days) for established / non-null ACR. */
   maturityMinSpanDays: number
+  /** per_fau status: |deficit_share| within this band is 'balanced'; above =>
+   * 'neglected' (deficit > band) or 'over' (deficit < -band). */
+  fauStatusDeadband: number
+  /** goal_progress: relative e1RM change within +/- this band is 'stalled'. */
+  goalTrendStallBand: number
+  /** goal_progress: below this many distinct observed weeks => trend 'new'. */
+  goalProgressMinWeeks: number
 }

--- a/lib/learning/weekly-intent.ts
+++ b/lib/learning/weekly-intent.ts
@@ -26,7 +26,7 @@
  * (Risk 4) and issue #908.
  */
 
-import type { WeeklyIntent } from '@/lib/llm/prompts/suggest-workout/schemas'
+import type { WeeklyIntent } from '@/lib/llm/prompts/suggest-workout/types'
 import { epleyE1RM } from './math'
 
 export type { WeeklyIntent }

--- a/lib/llm/prompts/suggest-workout/schemas.ts
+++ b/lib/llm/prompts/suggest-workout/schemas.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod'
 
+import type { WeeklyIntent } from './types'
+
+// Re-exported for existing importers; the canonical definition is the zod-free
+// `./types` so type-only consumers never pull zod into their build graph.
+export type { WeeklyIntent }
+
 /**
  * Zod schemas for the Suggest Workout LLM call.
  *
@@ -47,7 +53,18 @@ export const weeklyIntentSchema = z.discriminatedUnion('type', [
     text: z.string(),
   }),
 ])
-export type WeeklyIntent = z.infer<typeof weeklyIntentSchema>
+
+// Compile-time guard: the hand-written `WeeklyIntent` (in ./types) must stay
+// structurally identical to what this schema infers. Any drift is a type error
+// here rather than a silent divergence between the type and the validator.
+type _WeeklyIntentInSync =
+  [WeeklyIntent] extends [z.infer<typeof weeklyIntentSchema>]
+    ? [z.infer<typeof weeklyIntentSchema>] extends [WeeklyIntent]
+      ? true
+      : false
+    : false
+const _weeklyIntentInSync: _WeeklyIntentInSync = true
+void _weeklyIntentInSync
 
 export const durableProfileSchema = z.object({
   goal_sentences: z.array(z.string()),

--- a/lib/llm/prompts/suggest-workout/types.ts
+++ b/lib/llm/prompts/suggest-workout/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod-free shared types for the Suggest Workout domain.
+ *
+ * `WeeklyIntent` lives here (not in `schemas.ts`) so consumers that only need
+ * the *type* — notably `lib/learning/weekly-intent.ts`, which the aggregates
+ * job pulls into the clone-worker build — do not transitively drag `zod` into
+ * a package that doesn't depend on it (Risk 3 from the Suggest Workout audit).
+ *
+ * `schemas.ts` imports this type and asserts its zod schema stays structurally
+ * identical to it, so the hand-written union can never silently drift from the
+ * validated contract.
+ */
+
+/** Weekly intent discriminated union — mirrors issue #884. */
+export type WeeklyIntent =
+  | {
+      type: 'heavy_session'
+      muscle_group: 'legs' | 'upper' | 'pull' | 'push'
+      min_per_week: number
+    }
+  | {
+      type: 'volume_tilt'
+      toward: string[]
+      away_from: string[]
+      ratio: number
+    }
+  | {
+      type: 'movement_frequency'
+      movement_pattern: string
+      min_per_week: number
+    }
+  | {
+      type: 'free_text'
+      text: string
+    }

--- a/prisma/migrations/20260702202736_add_goal_progress_to_aggregates/migration.sql
+++ b/prisma/migrations/20260702202736_add_goal_progress_to_aggregates/migration.sql
@@ -1,0 +1,2 @@
+-- Add goal_progress JSON column to UserTrainingAggregates (issue #941).
+ALTER TABLE "UserTrainingAggregates" ADD COLUMN "goalProgress" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -694,6 +694,8 @@ model UserTrainingAggregates {
   perFau                  Json
   // MovementCalibration[]: gap-decayed EWMA e1RM, staleness, typical effort
   perMovementCalibration  Json
+  // GoalProgress[]: per-goal e1RM (Epley) trend series + classification
+  goalProgress            Json     @default("[]")
 
   @@index([computedAt])
 }


### PR DESCRIPTION
Closes #941.

Extends the aggregates job (#919) to emit the `training_state` fields the payload builder (#920) would otherwise re-derive — producer boundaries preserved, the builder stays a thin assembler.

## Per-FAU additions (spec §per_fau)
- **`target_share` / `actual_14d_share` / `deficit_share`** — zero-sum shares normalized over the *present* FAUs (each set sums to 1), driven by the profile's `ratioTargets` with a uniform default preset when unset. Zero-14d-volume present FAUs get a 0 actual share and a full-target deficit.
- **`status`** — pre-chewed `neglected`/`balanced`/`over` label by the `fauStatusDeadband`; omitted (undefined) under `low_data` so a cheap downstream model can't echo a bogus label.
- **`last_session_days_ago`** and **`last_heavy_days_ago`** — the latter runs each FAU's session work through `weekly-intent`'s `determineMovementHeavy` (EWMA / effort / intensityClass-tag branches), wired via the documented `estimateLbs → ewmaE1RMLbs` field adapter.

## New `goal_progress[]` producer (spec §goal_progress)
- Per-goal Epley e1RM trend over the calibration window, classified `progressing`/`stalled`/`regressing`/`new` (`"new"` for insufficient distinct weeks). Goals are mapped to a movement pattern by keyword; uninterpretable goals are omitted.
- Persisted on a new `goalProgress` JSON column (migration `20260702202736_add_goal_progress_to_aggregates`, default `[]`).

All new thresholds (`fauStatusDeadband`, `goalTrendStallBand`, `goalProgressMinWeeks`) flow through `AggregatesOptions` / `DEFAULT_AGGREGATES_OPTIONS` per the #937 seam — no new inlined constants.

## Explicitly not here
`recent_sessions[]` and `recent_feedback` remain assigned to the builder / deferred per the 2026-07-02 decisions.

## Tests
13 new tests across the seeder archetypes: shares-sum-to-1 with a zero-volume FAU, `ratioTargets` weighting, `status` boundaries + `low_data` suppression, `last_heavy` via both the EWMA and tag-fallback branches (plus a never-heavy null case), and `goal_progress` trends including the cold-start `"new"` case. Existing 17 aggregates tests stay green; idempotency and zero-history validity preserved.

## Notes
- `normalizeRatioTargets` treats a `≤ 0` weight as unset (falls back to the default preset) rather than a 0 share — a deliberate simplification vs. `muscle-balance.ts`.
- Also fixed 2 stray null bytes left in `compute.ts` by the prior run (had made the file a binary blob) and reverted an unrelated Prisma `6.19.3 → 6.19.0` downgrade + lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)