### PR TITLE
Persist workout duration to WorkoutCompletion

### DIFF
--- a/__tests__/api/adhoc.test.ts
+++ b/__tests__/api/adhoc.test.ts
@@ -153,8 +153,9 @@ async function simulateLogSet(
 async function simulateComplete(
   prisma: PrismaClient,
   completionId: string,
-  userId: string
-): Promise<SimResult<{ status: string }>> {
+  userId: string,
+  now: Date = new Date()
+): Promise<SimResult<{ status: string; durationSeconds: number | null }>> {
   const completion = await prisma.workoutCompletion.findUnique({
     where: { id: completionId },
   })
@@ -168,11 +169,19 @@ async function simulateComplete(
   if (setCount === 0)
     return { ok: false, status: 400, error: 'Log at least one set before completing.' }
 
+  const durationSeconds = completion.startedAt
+    ? Math.max(0, Math.round((now.getTime() - completion.startedAt.getTime()) / 1000))
+    : null
+
   const updated = await prisma.workoutCompletion.update({
     where: { id: completionId },
-    data: { status: 'completed', completedAt: new Date() },
+    data: { status: 'completed', completedAt: now, durationSeconds },
   })
-  return { ok: true, status: 200, data: { status: updated.status } }
+  return {
+    ok: true,
+    status: 200,
+    data: { status: updated.status, durationSeconds: updated.durationSeconds },
+  }
 }
 
 describe('Ad-hoc Workout API', () => {
@@ -260,6 +269,71 @@ describe('Ad-hoc Workout API', () => {
 
       expect(added1.data.order).toBe(1)
       expect(added2.data.order).toBe(2)
+    })
+  })
+
+  describe('Duration persistence (#933)', () => {
+    it('persists durationSeconds from startedAt on completion', async () => {
+      const exerciseDef = await createTestExerciseDefinition(prisma, { name: 'Press' })
+      const startedAt = new Date('2026-07-03T10:00:00Z')
+      const created = await simulateCreateAdHoc(prisma, userId, startedAt)
+      expect(created.ok).toBe(true)
+      if (!created.ok) return
+      const completionId = created.data.completion.id
+
+      const added = await simulateAddExercise(prisma, completionId, userId, exerciseDef.id)
+      expect(added.ok).toBe(true)
+      if (!added.ok) return
+      await simulateLogSet(prisma, completionId, userId, {
+        exerciseId: added.data.exerciseId,
+        setNumber: 1,
+        reps: 5,
+        weight: 100,
+        weightUnit: 'lbs',
+      })
+
+      // Complete 25 minutes later
+      const completedAt = new Date('2026-07-03T10:25:00Z')
+      const completed = await simulateComplete(prisma, completionId, userId, completedAt)
+      expect(completed.ok).toBe(true)
+      if (!completed.ok) return
+      expect(completed.data.durationSeconds).toBe(25 * 60)
+
+      const row = await prisma.workoutCompletion.findUnique({ where: { id: completionId } })
+      expect(row?.durationSeconds).toBe(25 * 60)
+    })
+
+    it('persists null durationSeconds when startedAt is null', async () => {
+      const exerciseDef = await createTestExerciseDefinition(prisma, { name: 'Fly' })
+      // Create an ad-hoc completion without startedAt
+      const completion = await prisma.workoutCompletion.create({
+        data: {
+          workoutId: null,
+          userId,
+          status: 'draft',
+          isAdHoc: true,
+          name: 'Open Workout — no start',
+          startedAt: null,
+        },
+      })
+      const added = await simulateAddExercise(prisma, completion.id, userId, exerciseDef.id)
+      expect(added.ok).toBe(true)
+      if (!added.ok) return
+      await simulateLogSet(prisma, completion.id, userId, {
+        exerciseId: added.data.exerciseId,
+        setNumber: 1,
+        reps: 8,
+        weight: 50,
+        weightUnit: 'lbs',
+      })
+
+      const completed = await simulateComplete(prisma, completion.id, userId)
+      expect(completed.ok).toBe(true)
+      if (!completed.ok) return
+      expect(completed.data.durationSeconds).toBeNull()
+
+      const row = await prisma.workoutCompletion.findUnique({ where: { id: completion.id } })
+      expect(row?.durationSeconds).toBeNull()
     })
   })
 

--- a/__tests__/api/guided-completion.test.ts
+++ b/__tests__/api/guided-completion.test.ts
@@ -22,9 +22,10 @@ async function simulateCompleteAPI(
       rir: number | null
     }>
     guidedCompletion?: boolean
+    now?: Date
   } = {}
 ) {
-  const { fallbackSets, guidedCompletion } = options
+  const { fallbackSets, guidedCompletion, now = new Date() } = options
 
   const workout = await prisma.workout.findUnique({
     where: { id: workoutId },
@@ -51,10 +52,18 @@ async function simulateCompleteAPI(
 
       const draftSetCount = draft?.loggedSets?.length ?? 0
 
+      const completedAt = now
+      const durationSeconds = draft?.startedAt
+        ? Math.max(
+            0,
+            Math.round((completedAt.getTime() - draft.startedAt.getTime()) / 1000)
+          )
+        : null
+
       if (draft && draftSetCount > 0) {
         return tx.workoutCompletion.update({
           where: { id: draft.id },
-          data: { status: 'completed', completedAt: new Date() },
+          data: { status: 'completed', completedAt, durationSeconds },
         })
       }
 
@@ -63,10 +72,10 @@ async function simulateCompleteAPI(
         const completionRecord = draft
           ? await tx.workoutCompletion.update({
               where: { id: draft.id },
-              data: { status: 'completed', completedAt: new Date() },
+              data: { status: 'completed', completedAt, durationSeconds },
             })
           : await tx.workoutCompletion.create({
-              data: { workoutId, userId, status: 'completed', completedAt: new Date() },
+              data: { workoutId, userId, status: 'completed', completedAt, durationSeconds },
             })
         return completionRecord
       }
@@ -78,10 +87,10 @@ async function simulateCompleteAPI(
       const completionRecord = draft
         ? await tx.workoutCompletion.update({
             where: { id: draft.id },
-            data: { status: 'completed', completedAt: new Date() },
+            data: { status: 'completed', completedAt, durationSeconds },
           })
         : await tx.workoutCompletion.create({
-            data: { workoutId, userId, status: 'completed', completedAt: new Date() },
+            data: { workoutId, userId, status: 'completed', completedAt, durationSeconds },
           })
 
       await tx.loggedSet.createMany({
@@ -201,6 +210,56 @@ describe('Guided Completion (Follow Along Mode)', () => {
     expect(result.success).toBe(true)
     expect(result.completion!.id).toBe(draft!.id) // Same record, flipped status
     expect(result.completion!.status).toBe('completed')
+  })
+
+  it('persists durationSeconds from draft startedAt on completion (#933)', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 2,
+      status: 'draft',
+    })
+
+    const startedAt = new Date('2026-07-03T09:00:00Z')
+    await prisma.workoutCompletion.updateMany({
+      where: { workoutId: scenario.workout.id, userId, status: 'draft' },
+      data: { startedAt },
+    })
+
+    // Complete 40 minutes later
+    const completedAt = new Date('2026-07-03T09:40:00Z')
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId, {
+      now: completedAt,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.completion!.durationSeconds).toBe(40 * 60)
+
+    const row = await prisma.workoutCompletion.findUnique({
+      where: { id: result.completion!.id },
+    })
+    expect(row?.durationSeconds).toBe(40 * 60)
+  })
+
+  it('persists null durationSeconds when draft startedAt is null (#933)', async () => {
+    const scenario = await createCompleteTestScenario(prisma, userId, {
+      loggedSetCount: 2,
+      status: 'draft',
+    })
+
+    // Factory leaves startedAt null; ensure it stays null
+    await prisma.workoutCompletion.updateMany({
+      where: { workoutId: scenario.workout.id, userId, status: 'draft' },
+      data: { startedAt: null },
+    })
+
+    const result = await simulateCompleteAPI(prisma, scenario.workout.id, userId)
+
+    expect(result.success).toBe(true)
+    expect(result.completion!.durationSeconds).toBeNull()
+
+    const row = await prisma.workoutCompletion.findUnique({
+      where: { id: result.completion!.id },
+    })
+    expect(row?.durationSeconds).toBeNull()
   })
 
   it('should not allow guided completion on already-completed workout', async () => {

--- a/app/api/workouts/[workoutId]/complete/route.ts
+++ b/app/api/workouts/[workoutId]/complete/route.ts
@@ -72,6 +72,16 @@ export async function POST(
 
       const draftSetCount = draft?.loggedSets?.length ?? 0
 
+      // Persist elapsed session time when the draft recorded a start (#933).
+      // Create branches have no draft, so duration is null there.
+      const completedAt = new Date()
+      const durationSeconds = draft?.startedAt
+        ? Math.max(
+            0,
+            Math.round((completedAt.getTime() - draft.startedAt.getTime()) / 1000)
+          )
+        : null
+
       // If we have a draft with sets, just flip the status
       if (draft && draftSetCount > 0) {
         // Safety fallback: if client reports more sets than DB has, use fallback
@@ -99,7 +109,7 @@ export async function POST(
 
         return tx.workoutCompletion.update({
           where: { id: draft.id },
-          data: { status: 'completed', completedAt: new Date() },
+          data: { status: 'completed', completedAt, durationSeconds },
         })
       }
 
@@ -109,10 +119,10 @@ export async function POST(
         const completionRecord = draft
           ? await tx.workoutCompletion.update({
               where: { id: draft.id },
-              data: { status: 'completed', completedAt: new Date() },
+              data: { status: 'completed', completedAt, durationSeconds },
             })
           : await tx.workoutCompletion.create({
-              data: { workoutId, userId: user.id, status: 'completed', completedAt: new Date() },
+              data: { workoutId, userId: user.id, status: 'completed', completedAt, durationSeconds },
             })
         return completionRecord
       }
@@ -126,10 +136,10 @@ export async function POST(
       const completionRecord = draft
         ? await tx.workoutCompletion.update({
             where: { id: draft.id },
-            data: { status: 'completed', completedAt: new Date() },
+            data: { status: 'completed', completedAt, durationSeconds },
           })
         : await tx.workoutCompletion.create({
-            data: { workoutId, userId: user.id, status: 'completed', completedAt: new Date() },
+            data: { workoutId, userId: user.id, status: 'completed', completedAt, durationSeconds },
           })
 
       await tx.loggedSet.createMany({

--- a/app/api/workouts/adhoc/[completionId]/complete/route.ts
+++ b/app/api/workouts/adhoc/[completionId]/complete/route.ts
@@ -44,9 +44,19 @@ export async function POST(
       )
     }
 
+    const completedAt = new Date()
+    const durationSeconds = lookup.completion.startedAt
+      ? Math.max(
+          0,
+          Math.round(
+            (completedAt.getTime() - lookup.completion.startedAt.getTime()) / 1000
+          )
+        )
+      : null
+
     const completion = await prisma.workoutCompletion.update({
       where: { id: completionId },
-      data: { status: 'completed', completedAt: new Date() },
+      data: { status: 'completed', completedAt, durationSeconds },
       select: { id: true, completedAt: true, status: true },
     })
 

--- a/lib/stats/workout-rollup.ts
+++ b/lib/stats/workout-rollup.ts
@@ -99,6 +99,7 @@ export async function computeWorkoutRollup(
       id: true,
       completedAt: true,
       startedAt: true,
+      durationSeconds: true,
       workoutId: true,
       name: true,
       isAdHoc: true,
@@ -155,14 +156,15 @@ export async function computeWorkoutRollup(
   ])
 
   const durationSeconds =
-    completion.startedAt && completion.completedAt
+    completion.durationSeconds ??
+    (completion.startedAt && completion.completedAt
       ? Math.max(
           0,
           Math.round(
             (completion.completedAt.getTime() - completion.startedAt.getTime()) / 1000
           )
         )
-      : null
+      : null)
 
   if (workingSets.length === 0) {
     return {

--- a/prisma/migrations/20260703151552_add_workout_completion_duration/migration.sql
+++ b/prisma/migrations/20260703151552_add_workout_completion_duration/migration.sql
@@ -1,0 +1,2 @@
+-- Add persisted session duration to WorkoutCompletion (#933)
+ALTER TABLE "WorkoutCompletion" ADD COLUMN "durationSeconds" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,6 +189,7 @@ model WorkoutCompletion {
   cycleNumber     Int         @default(1)
   isAdHoc         Boolean     @default(false)
   name            String?
+  durationSeconds Int?
   exercises       Exercise[]
   loggedSets      LoggedSet[]
   workout         Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

Persists session duration to `WorkoutCompletion` so downstream consumers (aggregates job, `recent_sessions` payload) can read it without recomputation. Split from #929 (part A).

Duration was already derived on the rollup screen from `completedAt − startedAt` and then discarded. This threads a persisted value through the completion routes.

## Changes

- **Schema**: `WorkoutCompletion.durationSeconds Int?` (nullable) + hand-written migration.
- **Ad-hoc complete route**: computes `durationSeconds` from `startedAt` (null when `startedAt` is null) and writes it on completion.
- **Programmed complete route**: computes duration once from the draft's `startedAt` and threads it into all completion branches (draft-with-sets, guided, fallback update/create). Create branches have no draft → null.
- **Rollup** (`lib/stats/workout-rollup.ts`): prefers the persisted `durationSeconds`, falls back to the existing computed value.
- **No backfill**: nullable column; consumers treat null as missing.

## Tests

- `__tests__/api/adhoc.test.ts`: asserts `durationSeconds` persisted from `startedAt`, and null when `startedAt` is null.
- `__tests__/api/guided-completion.test.ts`: asserts persistence on the programmed route and null when the draft's `startedAt` is null.
- All existing completion + rollup tests remain green (adhoc: 11, guided: 7, rollup: 10).

## Migration note

Schema updated locally. **Production migration auto-applies on deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)