### PR TITLE
feat(rollup): session effort rating chips (RPE-equivalent storage)

### DIFF
--- a/__tests__/api/session-effort.test.ts
+++ b/__tests__/api/session-effort.test.ts
@@ -1,0 +1,124 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  EFFORT_OPTIONS,
+  EFFORT_PROMPT_COOLDOWN_MS,
+  isValidSessionRpe,
+  shouldShowEffortPrompt,
+} from '@/lib/effort-prompt'
+import { getTestDatabase } from '@/lib/test/database'
+import { createCompleteTestScenario, createTestUser } from '@/lib/test/factories'
+
+/**
+ * Mirrors the scoped update the PATCH endpoint performs. Keeping the query
+ * shape identical to the route lets us verify authorization + persistence
+ * without an HTTP layer (auth is enforced separately in the route handler).
+ */
+async function simulateSetEffort(
+  prisma: PrismaClient,
+  completionId: string,
+  userId: string,
+  sessionRpe: number
+): Promise<number> {
+  const result = await prisma.workoutCompletion.updateMany({
+    where: { id: completionId, userId },
+    data: { sessionRpe },
+  })
+  return result.count
+}
+
+describe('isValidSessionRpe', () => {
+  it('accepts integers 6 through 10', () => {
+    for (const rpe of [6, 7, 8, 9, 10]) {
+      expect(isValidSessionRpe(rpe)).toBe(true)
+    }
+  })
+
+  it('rejects out-of-range, non-integer, and non-number values', () => {
+    for (const value of [5, 11, 0, 7.5, '8', null, undefined, NaN]) {
+      expect(isValidSessionRpe(value)).toBe(false)
+    }
+  })
+
+  it('maps word labels to the expected RPE scale', () => {
+    expect(EFFORT_OPTIONS.map((o) => o.rpe)).toEqual([6, 7, 8, 9, 10])
+    expect(EFFORT_OPTIONS.find((o) => o.label === 'Hard')?.rpe).toBe(8)
+  })
+})
+
+describe('shouldShowEffortPrompt (throttle)', () => {
+  const now = Date.now()
+
+  it('hides until settings load', () => {
+    expect(shouldShowEffortPrompt(null, now)).toBe(false)
+  })
+
+  it('shows when never prompted', () => {
+    expect(shouldShowEffortPrompt({ lastPostSessionPromptAt: null }, now)).toBe(true)
+  })
+
+  it('hides within the cooldown window (cadence exhausted)', () => {
+    const recent = new Date(now - EFFORT_PROMPT_COOLDOWN_MS + 60_000).toISOString()
+    expect(shouldShowEffortPrompt({ lastPostSessionPromptAt: recent }, now)).toBe(false)
+  })
+
+  it('shows again once the cooldown has elapsed', () => {
+    const old = new Date(now - EFFORT_PROMPT_COOLDOWN_MS - 60_000).toISOString()
+    expect(shouldShowEffortPrompt({ lastPostSessionPromptAt: old }, now)).toBe(true)
+  })
+})
+
+describe('session effort persistence', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('stores the RPE-equivalent value on the owner completion', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      status: 'completed',
+    })
+
+    const count = await simulateSetEffort(prisma, completion.id, userId, 8)
+    expect(count).toBe(1)
+
+    const updated = await prisma.workoutCompletion.findUnique({
+      where: { id: completion.id },
+      select: { sessionRpe: true },
+    })
+    expect(updated?.sessionRpe).toBe(8)
+  })
+
+  it('leaves sessionRpe null when never rated', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      status: 'completed',
+    })
+    const fresh = await prisma.workoutCompletion.findUnique({
+      where: { id: completion.id },
+      select: { sessionRpe: true },
+    })
+    expect(fresh?.sessionRpe).toBeNull()
+  })
+
+  it('does not update a completion owned by another user', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      status: 'completed',
+    })
+    const other = await createTestUser()
+
+    const count = await simulateSetEffort(prisma, completion.id, other.id, 9)
+    expect(count).toBe(0)
+
+    const unchanged = await prisma.workoutCompletion.findUnique({
+      where: { id: completion.id },
+      select: { sessionRpe: true },
+    })
+    expect(unchanged?.sessionRpe).toBeNull()
+  })
+})

--- a/app/api/workouts/completions/[completionId]/effort/route.ts
+++ b/app/api/workouts/completions/[completionId]/effort/route.ts
@@ -1,0 +1,78 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { isValidSessionRpe } from '@/lib/effort-prompt'
+import { logger } from '@/lib/logger'
+import { checkRateLimitWithHeaders, workoutActionLimiter } from '@/lib/rate-limit'
+
+/**
+ * PATCH /api/workouts/completions/[completionId]/effort
+ *
+ * Persists a session-level effort rating (RPE-equivalent 6–10) captured via
+ * the word-label chips on the rollup. Fire-and-forget from the client; never
+ * blocks dismissal. Update is scoped to `{ id, userId }` so a user can only
+ * rate their own completions.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ completionId: string }> }
+) {
+  try {
+    const { completionId } = await params
+
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimitWithHeaders(
+      workoutActionLimiter,
+      user.id,
+      { endpoint: 'completions/effort' }
+    )
+    if (limited.response) return limited.response
+
+    let body: { sessionRpe?: unknown }
+    try {
+      body = (await request.json()) as { sessionRpe?: unknown }
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON body' },
+        { status: 400, headers: limited.headers }
+      )
+    }
+
+    if (!isValidSessionRpe(body.sessionRpe)) {
+      return NextResponse.json(
+        { error: 'sessionRpe must be an integer between 6 and 10' },
+        { status: 400, headers: limited.headers }
+      )
+    }
+
+    const result = await prisma.workoutCompletion.updateMany({
+      where: { id: completionId, userId: user.id },
+      data: { sessionRpe: body.sessionRpe },
+    })
+
+    if (result.count === 0) {
+      return NextResponse.json(
+        { error: 'Not found' },
+        { status: 404, headers: limited.headers }
+      )
+    }
+
+    return NextResponse.json(
+      { success: true, sessionRpe: body.sessionRpe },
+      { headers: limited.headers }
+    )
+  } catch (err) {
+    logger.error(
+      { error: err, context: 'completions-effort' },
+      'Failed to persist session effort rating'
+    )
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/features/training/EffortChips.tsx
+++ b/components/features/training/EffortChips.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useUserSettings } from '@/hooks/useUserSettings'
+import { clientLogger } from '@/lib/client-logger'
+import { EFFORT_OPTIONS, shouldShowEffortPrompt } from '@/lib/effort-prompt'
+
+interface EffortChipsProps {
+  completionId: string
+}
+
+/**
+ * One-tap session effort rating on the rollup's stats view. Shows a single
+ * word-label scale for everyone (Easy → Maximal), stored as RPE-equivalent
+ * 6–10 on `WorkoutCompletion.sessionRpe`.
+ *
+ * - Fire-and-forget PATCH; never blocks modal dismissal.
+ * - Shown on ALL completions (including minimal "marked complete" sessions),
+ *   always skippable.
+ * - Throttled via the existing post-session prompt fields so it doesn't nag on
+ *   back-to-back completions. Returns null when the cadence is exhausted.
+ */
+export function EffortChips({ completionId }: EffortChipsProps) {
+  const { settings, updateSettings } = useUserSettings()
+  const [visible, setVisible] = useState(false)
+  const [selectedRpe, setSelectedRpe] = useState<number | null>(null)
+  const decidedRef = useRef(false)
+
+  // Decide visibility once when settings load. When shown, start the throttle
+  // cooldown (fire-and-forget) so it won't re-surface on the next completion
+  // within the cooldown window.
+  useEffect(() => {
+    if (decidedRef.current) return
+    if (!settings) return
+    decidedRef.current = true
+    if (!shouldShowEffortPrompt(settings)) return
+    // Visibility is decided once when async settings load; the ref guard above
+    // ensures this runs at most once.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVisible(true)
+    updateSettings({
+      postSessionPromptCount: settings.postSessionPromptCount + 1,
+      lastPostSessionPromptAt: new Date().toISOString(),
+    }).catch(() => {
+      // Non-critical — worst case the row re-shows next session.
+    })
+  }, [settings, updateSettings])
+
+  if (!visible) return null
+
+  const handleSelect = (rpe: number) => {
+    setSelectedRpe(rpe)
+    // Fire-and-forget: persistence never blocks dismissal.
+    fetch(`/api/workouts/completions/${completionId}/effort`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionRpe: rpe }),
+    }).catch((err) => {
+      clientLogger.error('Failed to save session effort rating:', err)
+    })
+  }
+
+  return (
+    <div className="border-t-2 border-border/50 pt-4">
+      <p className="text-sm font-semibold text-foreground uppercase tracking-wider mb-2">
+        {selectedRpe === null ? 'How was that?' : 'Effort logged'}
+      </p>
+      <div className="grid grid-cols-5 gap-1.5">
+        {EFFORT_OPTIONS.map(({ label, rpe }) => (
+          <button
+            key={rpe}
+            type="button"
+            onClick={() => handleSelect(rpe)}
+            aria-label={`${label} effort`}
+            aria-pressed={selectedRpe === rpe}
+            className={`relative min-h-[44px] flex items-center justify-center text-center px-1 py-2 border-2 text-[11px] font-semibold uppercase tracking-wide leading-tight transition-colors doom-focus-ring before:content-[''] before:absolute before:-inset-1 ${
+              selectedRpe === rpe
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted text-foreground border-border hover:bg-secondary/10'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/features/training/WorkoutRollupModal.tsx
+++ b/components/features/training/WorkoutRollupModal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import type { RollupExercise, WorkoutRollup } from '@/lib/stats/workout-rollup'
 import { POST_SESSION_REFINEMENTS } from '@/types/feedback'
+import { EffortChips } from './EffortChips'
 
 const SAVED_NAME_DATE_FMT = new Intl.DateTimeFormat('en-US', {
   month: 'long',
@@ -454,6 +455,9 @@ export function WorkoutRollupModal({ open, rollup, onClose }: WorkoutRollupModal
                   Marked complete. Nice work.
                 </p>
               )}
+
+              {/* Session effort rating — one-tap, skippable, throttled. */}
+              <EffortChips completionId={rollup.completionId} />
             </div>
           )}
 

--- a/lib/effort-prompt.ts
+++ b/lib/effort-prompt.ts
@@ -1,0 +1,53 @@
+import type { UserSettings } from '@/hooks/useUserSettings'
+
+/**
+ * Session effort rating (word-label chips) — RPE-equivalent storage.
+ *
+ * One word-label scale for everyone regardless of `defaultIntensityRating`
+ * (RIR does not extend to a whole session). Stored as RPE 6–10 in
+ * `WorkoutCompletion.sessionRpe`.
+ */
+export const EFFORT_OPTIONS = [
+  { label: 'Easy', rpe: 6 },
+  { label: 'Moderate', rpe: 7 },
+  { label: 'Hard', rpe: 8 },
+  { label: 'Very hard', rpe: 9 },
+  { label: 'Maximal', rpe: 10 },
+] as const
+
+export const MIN_SESSION_RPE = 6
+export const MAX_SESSION_RPE = 10
+
+export function isValidSessionRpe(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= MIN_SESSION_RPE &&
+    value <= MAX_SESSION_RPE
+  )
+}
+
+/**
+ * Throttle cooldown for the effort-rating row. The row surfaces on the rollup
+ * at most once per window so back-to-back completions (or reopening the modal)
+ * don't nag. Roughly one training day.
+ */
+export const EFFORT_PROMPT_COOLDOWN_MS = 20 * 60 * 60 * 1000 // 20 hours
+
+/**
+ * Decide whether to show the effort-rating chips, throttled via the existing
+ * post-session prompt fields (`lastPostSessionPromptAt`). Returns false until
+ * settings load so we don't double-count or flash the row before we know the
+ * throttle state.
+ */
+export function shouldShowEffortPrompt(
+  settings: Pick<UserSettings, 'lastPostSessionPromptAt'> | null,
+  now: number = Date.now()
+): boolean {
+  if (!settings) return false
+  const last = settings.lastPostSessionPromptAt
+  if (!last) return true
+  const lastMs = new Date(last).getTime()
+  if (Number.isNaN(lastMs)) return true
+  return now - lastMs >= EFFORT_PROMPT_COOLDOWN_MS
+}

--- a/prisma/migrations/20260704232101_add_workout_completion_session_rpe/migration.sql
+++ b/prisma/migrations/20260704232101_add_workout_completion_session_rpe/migration.sql
@@ -1,0 +1,2 @@
+-- Add session-level effort rating (RPE-equivalent 6-10) to WorkoutCompletion
+ALTER TABLE "WorkoutCompletion" ADD COLUMN "sessionRpe" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,6 +190,7 @@ model WorkoutCompletion {
   isAdHoc         Boolean     @default(false)
   name            String?
   durationSeconds Int?
+  sessionRpe      Int?
   exercises       Exercise[]
   loggedSets      LoggedSet[]
   workout         Workout?    @relation(fields: [workoutId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

Adds a one-tap **session effort rating** to the workout rollup's stats view (closes #934, split from #929 part B).

One word-label scale for everyone regardless of `defaultIntensityRating` — RIR does not extend to a whole session:

```
How was that?
[ Easy ] [ Moderate ] [ Hard ] [ Very hard ] [ Maximal ]
```

Stored as RPE-equivalent `6/7/8/9/10` on `WorkoutCompletion.sessionRpe`.

## Changes

- **Schema + migration**: `WorkoutCompletion.sessionRpe Int?` (additive, non-destructive `ALTER TABLE ... ADD COLUMN`).
- **PATCH `/api/workouts/completions/[completionId]/effort`**: `getCurrentUser` auth, rate-limited (`workoutActionLimiter`), validates integer 6–10, update scoped to `{ id, userId }` (404 when not owned).
- **`EffortChips`** (own component file — rollup modal is near the 1000-line cap): word-label row on the stats view. Fire-and-forget PATCH, never blocks dismissal. Shown on **all** completions including minimal "marked complete" sessions; always skippable. Throttled via existing `postSessionPromptCount` / `lastPostSessionPromptAt` (20h cooldown → row hidden when cadence exhausted).
- **`lib/effort-prompt.ts`**: pure helpers (`isValidSessionRpe`, `shouldShowEffortPrompt`, label→RPE map) shared by the route, component, and tests.
- 44px touch targets via the `::before` overlay pattern; DOOM theme tokens (matches the existing feedback rating row styling).

## Verification

- **Type-check + lint**: clean for all new/changed files (pre-existing errors in unrelated files unchanged).
- **Tests** (`__tests__/api/session-effort.test.ts`, 10 passing): RPE validation (6–10), throttle cooldown, scoped persistence, cross-user isolation.
- **Live end-to-end** against a running dev server:
  - Tap "Hard" → `PATCH … {sessionRpe:8}` → `200`, DB `sessionRpe = 8`.
  - Invalid `5` → `400`; unknown completion → `404`; unrated stays `null`.
- **Playwright screenshot** of the rollup with the chips row (viewport 390×844) captured and inspected locally: the `HOW WAS THAT?` row renders below the exercise list with the five DOOM-themed chips (`EASY / MODERATE / HARD / VERY HARD / MAXIMAL`) above the footer.

> Note: the full `npm test` suite is slow/flaky under Testcontainers in this sandbox when run alongside a dev server; the affected test file was run in isolation and passes. `computeWorkoutRollup` and feedback logic are untouched, so existing rollup/feedback tests are unaffected.

**Schema updated locally. Production migration auto-applies on deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
