### PR TITLE
feat(suggest): TuningConfig admin knobs + payload preview (#937)

### DIFF
--- a/__tests__/lib/learning/weekly-intent-tuning.test.ts
+++ b/__tests__/lib/learning/weekly-intent-tuning.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type EvaluatedSession,
+  evaluateWeeklyIntent,
+  type MovementEwmaMap,
+  type WeeklyIntent,
+} from '@/lib/learning/weekly-intent'
+
+/**
+ * #937: the tunable heaviness thresholds must actually change a weekly-intent
+ * verdict. A "heavy legs" intent over one squat session whose top set sits at
+ * ~93% of the movement EWMA flips satisfied → unsatisfied as heavyE1rmFraction
+ * crosses that ratio, with RPE unlogged so the effort branch can't mask it.
+ */
+describe('heavy thresholds flip a weekly-intent verdict', () => {
+  const intent: WeeklyIntent = { type: 'heavy_session', muscle_group: 'legs', min_per_week: 1 }
+
+  // Squat top set: e1RM = 200 * (1 + 5/30) = 233.3; EWMA 250 → ratio ≈ 0.933.
+  const sessions: EvaluatedSession[] = [
+    {
+      daysAgo: 1,
+      movements: [
+        {
+          movementPattern: 'squat',
+          faus: ['quads'],
+          sets: [{ weightLbs: 200, reps: 5, rpe: null, rir: null }],
+        },
+      ],
+    },
+  ]
+  const ewmaMap: MovementEwmaMap = { squat: { ewmaE1RMLbs: 250, observationCount: 5 } }
+
+  it('is satisfied when the fraction is below the top-set ratio', () => {
+    const verdict = evaluateWeeklyIntent(intent, sessions, ewmaMap, {
+      heavyE1rmFraction: 0.85,
+      heavyEffortCutoff: 8,
+    })
+    expect(verdict.satisfiedLast7d).toBe(true)
+  })
+
+  it('is NOT satisfied when the fraction is above the top-set ratio', () => {
+    const verdict = evaluateWeeklyIntent(intent, sessions, ewmaMap, {
+      heavyE1rmFraction: 0.95,
+      heavyEffortCutoff: 8,
+    })
+    expect(verdict.satisfiedLast7d).toBe(false)
+  })
+
+  it('effort cutoff overrides the load branch when RPE is logged', () => {
+    const rpeSessions: EvaluatedSession[] = [
+      {
+        daysAgo: 1,
+        movements: [
+          {
+            movementPattern: 'squat',
+            faus: ['quads'],
+            sets: [{ weightLbs: 200, reps: 5, rpe: 8, rir: null }],
+          },
+        ],
+      },
+    ]
+    // High e1RM fraction would say "not heavy", but RPE 8 ≥ cutoff 8 fires first.
+    const heavy = evaluateWeeklyIntent(intent, rpeSessions, ewmaMap, {
+      heavyE1rmFraction: 0.99,
+      heavyEffortCutoff: 8,
+    })
+    expect(heavy.satisfiedLast7d).toBe(true)
+    // Raise the effort cutoff above the logged RPE and the load branch decides
+    // again — 0.933 < 0.99 → not heavy.
+    const notHeavy = evaluateWeeklyIntent(intent, rpeSessions, ewmaMap, {
+      heavyE1rmFraction: 0.99,
+      heavyEffortCutoff: 9,
+    })
+    expect(notHeavy.satisfiedLast7d).toBe(false)
+  })
+})

--- a/__tests__/lib/suggest/training-state-builder.test.ts
+++ b/__tests__/lib/suggest/training-state-builder.test.ts
@@ -180,7 +180,7 @@ const EXPECTED_BEGINNER_GOAL_SENTENCES = [
   SIGNUP_INTENT_SENTENCES.new_to_apps,
 ]
 
-type Payload = Awaited<ReturnType<typeof buildTrainingStatePayload>>
+type Payload = Awaited<ReturnType<typeof buildTrainingStatePayload>>['payload']
 
 const ARCHETYPE_ASSERTIONS: Record<ArchetypeKey, (p: Payload) => void> = {
   beginner: (p) => {
@@ -233,7 +233,7 @@ describe('buildTrainingStatePayload — golden archetype canaries', () => {
     await seedProfile(prisma, user.id, archetype)
     await seedArchetypeHistory(prisma, user.id, archetype, lookup)
 
-    const payload = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
+    const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
 
     // The builder validates internally; re-assert the contract explicitly.
     expect(suggestWorkoutPayloadSchema.safeParse(payload).success).toBe(true)
@@ -301,7 +301,7 @@ describe('buildTrainingStatePayload — golden archetype canaries', () => {
       })
     }
 
-    const payload = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
+    const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
     const recent = payload.training_state.recent_sessions
     expect(recent).toHaveLength(1)
     expect(recent[0].notes).toHaveLength(5) // capped at 5 per session

--- a/__tests__/lib/suggest/tuning-config-preview.test.ts
+++ b/__tests__/lib/suggest/tuning-config-preview.test.ts
@@ -1,0 +1,196 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  buildTrainingStatePayload,
+  type SuggestRequestInput,
+} from '@/lib/suggest/training-state-builder'
+import { getTestDatabase } from '@/lib/test/database'
+import { createTestUser } from '@/lib/test/factories'
+import { DEFAULT_TUNING_CONFIG, type TuningConfig } from '@/lib/tuning/config'
+import { TUNING_CONFIG_SINGLETON_ID } from '@/lib/tuning/store'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = new Date('2026-07-01T18:00:00.000Z')
+
+const REQUEST: SuggestRequestInput = {
+  time_budget_minutes: 45,
+  intensity_vibe: 'solid',
+  deprioritize_freetext: null,
+  prioritize_freetext: null,
+  equipment_override: null,
+}
+
+const SQUAT_FAU = 'quads'
+
+/**
+ * Seed a controlled squat-only history designed so the heaviness knobs are the
+ * deciding signal: RPE is never logged (effort branch can't fire), the pattern
+ * has ≥3 calibration observations (EWMA branch active), and the most recent
+ * top set sits at ~93% of the movement EWMA. Sessions span >30d so some fall
+ * outside the calibration window but inside the heavy-scan window.
+ */
+async function seedSquatHistory(prisma: PrismaClient, userId: string): Promise<void> {
+  await prisma.exerciseDefinition.create({
+    data: {
+      id: `def-squat-${userId}`,
+      name: 'Test Barbell Squat',
+      normalizedName: `test barbell squat ${userId}`,
+      aliases: [],
+      userId: 'system-fixture',
+      isSystem: true,
+      equipment: ['barbell'],
+      primaryFAUs: [SQUAT_FAU],
+      secondaryFAUs: ['glutes'],
+      movementPattern: 'squat',
+      intensityClass: 'moderate',
+      isBodyweight: false,
+    },
+  })
+
+  await prisma.userTrainingProfile.create({
+    data: {
+      userId,
+      goalSentences: ['Get stronger on squat'],
+      weeklyIntent: [],
+      equipmentAvailable: ['barbell'],
+      bannedExerciseIds: [],
+      ratioTargets: {},
+      defaultIntensityPreference: null,
+    },
+  })
+
+  // Older sessions at 225 lb, most recent at 200 lb; all 5 reps, no RPE.
+  const plan: { daysAgo: number; weight: number }[] = [
+    { daysAgo: 40, weight: 225 },
+    { daysAgo: 33, weight: 225 },
+    { daysAgo: 26, weight: 225 },
+    { daysAgo: 19, weight: 225 },
+    { daysAgo: 12, weight: 225 },
+    { daysAgo: 2, weight: 200 },
+  ]
+
+  for (const s of plan) {
+    const completedAt = new Date(NOW.getTime() - s.daysAgo * DAY_MS)
+    const completion = await prisma.workoutCompletion.create({
+      data: {
+        userId,
+        status: 'completed',
+        isAdHoc: true,
+        name: 'Squat Day',
+        startedAt: new Date(completedAt.getTime() - 55 * 60 * 1000),
+        completedAt,
+      },
+    })
+    await prisma.exercise.create({
+      data: {
+        name: 'Test Barbell Squat',
+        exerciseDefinitionId: `def-squat-${userId}`,
+        order: 1,
+        userId,
+        workoutCompletionId: completion.id,
+        loggedSets: {
+          create: [1, 2, 3].map((setNumber) => ({
+            setNumber,
+            reps: 5,
+            weight: s.weight,
+            weightUnit: 'lbs',
+            rpe: null,
+            isWarmup: false,
+            completionId: completion.id,
+            userId,
+            createdAt: completedAt,
+          })),
+        },
+      },
+    })
+  }
+}
+
+describe('TuningConfig payload preview / plumbing', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+    const user = await createTestUser()
+    userId = user.id
+    await seedSquatHistory(prisma, userId)
+  })
+
+  const build = (tuning?: TuningConfig) =>
+    buildTrainingStatePayload(prisma, userId, REQUEST, NOW, tuning)
+
+  it('with NO config row is byte-identical to explicit code defaults', async () => {
+    const noRow = await build(undefined)
+    const explicitDefaults = await build(DEFAULT_TUNING_CONFIG)
+
+    expect(JSON.stringify(noRow.payload)).toBe(JSON.stringify(explicitDefaults.payload))
+    expect(noRow.configStamp).toEqual(DEFAULT_TUNING_CONFIG)
+  })
+
+  it('a malformed config row never breaks the pipeline — falls back to defaults', async () => {
+    const defaults = await build(DEFAULT_TUNING_CONFIG)
+
+    await prisma.tuningConfig.create({
+      data: {
+        id: TUNING_CONFIG_SINGLETON_ID,
+        // Garbage: wrong types, out of range, unknown keys, missing fields.
+        values: { heavyE1rmFraction: 'heavy', ewmaAlpha: 999, bogus: true },
+      },
+    })
+
+    const malformed = await build(undefined)
+    expect(JSON.stringify(malformed.payload)).toBe(JSON.stringify(defaults.payload))
+    expect(malformed.configStamp).toEqual(DEFAULT_TUNING_CONFIG)
+  })
+
+  it('a saved config row is loaded and stamped when no override is passed', async () => {
+    const saved: TuningConfig = { ...DEFAULT_TUNING_CONFIG, lowDataMinSessions: 1, lowDataMinSets: 5 }
+    await prisma.tuningConfig.create({
+      data: { id: TUNING_CONFIG_SINGLETON_ID, values: { ...saved } },
+    })
+
+    const result = await build(undefined)
+    expect(result.configStamp).toEqual(saved)
+  })
+
+  it('heavyE1rmFraction override provably changes the payload', async () => {
+    const low = await build({ ...DEFAULT_TUNING_CONFIG, heavyE1rmFraction: 0.85 })
+    const high = await build({ ...DEFAULT_TUNING_CONFIG, heavyE1rmFraction: 0.99 })
+
+    // The whole payload must differ...
+    expect(JSON.stringify(low.payload)).not.toBe(JSON.stringify(high.payload))
+
+    // ...specifically per_fau.last_heavy_days_ago for the squat FAU: at 0.85 the
+    // recent 200 lb session counts heavy (days_ago 2); at 0.99 only the earlier
+    // 225 lb sessions do (a larger days_ago).
+    const lowFau = low.payload.training_state.per_fau.find((f) => f.fau === SQUAT_FAU)
+    const highFau = high.payload.training_state.per_fau.find((f) => f.fau === SQUAT_FAU)
+    expect(lowFau?.last_heavy_days_ago).not.toBe(highFau?.last_heavy_days_ago)
+    expect(lowFau?.last_heavy_days_ago).toBe(2)
+    expect(highFau?.last_heavy_days_ago).toBeGreaterThan(2)
+  })
+
+  it('low-data thresholds override flips per_fau.low_data and the payload', async () => {
+    // Default: only 2 sessions / 6 effective sets in 14d → low_data true.
+    const strict = await build(DEFAULT_TUNING_CONFIG)
+    // Relaxed thresholds clear the flag.
+    const relaxed = await build({
+      ...DEFAULT_TUNING_CONFIG,
+      lowDataMinSessions: 1,
+      lowDataMinSets: 5,
+    })
+
+    const strictFau = strict.payload.training_state.per_fau.find((f) => f.fau === SQUAT_FAU)
+    const relaxedFau = relaxed.payload.training_state.per_fau.find((f) => f.fau === SQUAT_FAU)
+
+    expect(strictFau?.low_data).toBe(true)
+    expect(relaxedFau?.low_data).toBe(false)
+    // low_data suppresses the status label; clearing it surfaces one.
+    expect(strictFau?.status).toBeUndefined()
+    expect(relaxedFau?.status).toBeDefined()
+    expect(JSON.stringify(strict.payload)).not.toBe(JSON.stringify(relaxed.payload))
+  })
+})

--- a/__tests__/lib/tuning/config.test.ts
+++ b/__tests__/lib/tuning/config.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_AGGREGATES_OPTIONS } from '@/lib/aggregates/compute'
+import { DEFAULT_EWMA_ALPHA, DEFAULT_TYPICAL_GAP_DAYS, WEEKLY_DECAY_FACTOR } from '@/lib/learning/math'
+import { HEAVY_E1RM_FRACTION, HEAVY_EFFORT_RPE } from '@/lib/learning/weekly-intent'
+import {
+  DEFAULT_TUNING_CONFIG,
+  parseTuningConfig,
+  TUNING_KNOBS,
+  toAggregatesOptions,
+  toHeavyOptions,
+} from '@/lib/tuning/config'
+import { validateTuningConfigWrite } from '@/lib/tuning/schema'
+
+describe('TuningConfig defaults', () => {
+  it('sources every default from the constant it shadows', () => {
+    expect(DEFAULT_TUNING_CONFIG).toEqual({
+      heavyE1rmFraction: HEAVY_E1RM_FRACTION,
+      heavyEffortCutoff: HEAVY_EFFORT_RPE,
+      betaWeeklyDecay: WEEKLY_DECAY_FACTOR,
+      ewmaAlpha: DEFAULT_EWMA_ALPHA,
+      ewmaTypicalGapDays: DEFAULT_TYPICAL_GAP_DAYS,
+      lowDataMinSessions: DEFAULT_AGGREGATES_OPTIONS.lowDataMinSessions,
+      lowDataMinSets: DEFAULT_AGGREGATES_OPTIONS.lowDataMinSets,
+      detrainingGapDays: DEFAULT_AGGREGATES_OPTIONS.detrainingMinDays,
+    })
+  })
+
+  it('has a knob-metadata entry for every config field, all in-range', () => {
+    const keys = Object.keys(DEFAULT_TUNING_CONFIG).sort()
+    const metaKeys = TUNING_KNOBS.map((k) => k.key).sort()
+    expect(metaKeys).toEqual(keys)
+    for (const knob of TUNING_KNOBS) {
+      const def = DEFAULT_TUNING_CONFIG[knob.key]
+      expect(def).toBeGreaterThanOrEqual(knob.min)
+      expect(def).toBeLessThanOrEqual(knob.max)
+      if (knob.integer) expect(Number.isInteger(def)).toBe(true)
+    }
+  })
+})
+
+describe('parseTuningConfig — read-path fallback', () => {
+  it('returns code defaults for null / non-object / array', () => {
+    expect(parseTuningConfig(null)).toEqual(DEFAULT_TUNING_CONFIG)
+    expect(parseTuningConfig(undefined)).toEqual(DEFAULT_TUNING_CONFIG)
+    expect(parseTuningConfig(42)).toEqual(DEFAULT_TUNING_CONFIG)
+    expect(parseTuningConfig('nope')).toEqual(DEFAULT_TUNING_CONFIG)
+    expect(parseTuningConfig([])).toEqual(DEFAULT_TUNING_CONFIG)
+    expect(parseTuningConfig({})).toEqual(DEFAULT_TUNING_CONFIG)
+  })
+
+  it('keeps valid overrides and falls back per-field for the rest', () => {
+    const result = parseTuningConfig({
+      heavyE1rmFraction: 0.7, // valid
+      ewmaAlpha: 0.5, // valid
+      lowDataMinSessions: 5, // valid
+    })
+    expect(result.heavyE1rmFraction).toBe(0.7)
+    expect(result.ewmaAlpha).toBe(0.5)
+    expect(result.lowDataMinSessions).toBe(5)
+    // Untouched fields keep defaults.
+    expect(result.betaWeeklyDecay).toBe(DEFAULT_TUNING_CONFIG.betaWeeklyDecay)
+    expect(result.detrainingGapDays).toBe(DEFAULT_TUNING_CONFIG.detrainingGapDays)
+  })
+
+  it('falls back for out-of-range, wrong-type, non-finite, and non-integer values', () => {
+    const result = parseTuningConfig({
+      heavyE1rmFraction: 2.0, // > max 1.0
+      heavyEffortCutoff: 'eight', // wrong type
+      ewmaAlpha: Number.NaN, // non-finite
+      ewmaTypicalGapDays: 7.5, // non-integer for an integer knob
+      lowDataMinSessions: -1, // < min
+    })
+    expect(result).toEqual(DEFAULT_TUNING_CONFIG)
+  })
+})
+
+describe('mappers', () => {
+  it('toAggregatesOptions maps the aggregates-relevant subset', () => {
+    const cfg = { ...DEFAULT_TUNING_CONFIG, detrainingGapDays: 14, lowDataMinSets: 25 }
+    expect(toAggregatesOptions(cfg)).toEqual({
+      lowDataMinSessions: cfg.lowDataMinSessions,
+      lowDataMinSets: 25,
+      detrainingMinDays: 14, // renamed
+      ewmaAlpha: cfg.ewmaAlpha,
+      ewmaTypicalGapDays: cfg.ewmaTypicalGapDays,
+      heavyE1rmFraction: cfg.heavyE1rmFraction,
+      heavyEffortCutoff: cfg.heavyEffortCutoff,
+    })
+  })
+
+  it('toHeavyOptions maps just the heaviness knobs', () => {
+    const cfg = { ...DEFAULT_TUNING_CONFIG, heavyE1rmFraction: 0.6, heavyEffortCutoff: 9 }
+    expect(toHeavyOptions(cfg)).toEqual({ heavyE1rmFraction: 0.6, heavyEffortCutoff: 9 })
+  })
+})
+
+describe('validateTuningConfigWrite — write-path range enforcement', () => {
+  it('accepts a full in-range config', () => {
+    const result = validateTuningConfigWrite(DEFAULT_TUNING_CONFIG)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.config).toEqual(DEFAULT_TUNING_CONFIG)
+  })
+
+  it('rejects an out-of-range value', () => {
+    const result = validateTuningConfigWrite({ ...DEFAULT_TUNING_CONFIG, heavyE1rmFraction: 5 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errors.join(' ')).toMatch(/heavyE1rmFraction/i)
+  })
+
+  it('rejects a non-integer value for an integer knob', () => {
+    const result = validateTuningConfigWrite({ ...DEFAULT_TUNING_CONFIG, detrainingGapDays: 10.5 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a missing knob', () => {
+    const { heavyEffortCutoff, ...partial } = DEFAULT_TUNING_CONFIG
+    void heavyEffortCutoff
+    expect(validateTuningConfigWrite(partial).ok).toBe(false)
+  })
+
+  it('rejects unknown keys (strict)', () => {
+    const result = validateTuningConfigWrite({ ...DEFAULT_TUNING_CONFIG, sneakyKnob: 1 })
+    expect(result.ok).toBe(false)
+  })
+})

--- a/app/(app)/admin/layout.tsx
+++ b/app/(app)/admin/layout.tsx
@@ -25,6 +25,7 @@ export default async function AdminLayout({
     { href: '/admin/exercises', label: 'Exercises' },
     { href: '/admin/community-programs', label: 'Programs' },
     { href: '/admin/messages', label: 'Messages' },
+    { href: '/admin/tuning', label: 'Tuning' },
     { href: '/admin/feedback', label: 'Feedback' },
     { href: '/admin/analytics', label: 'Analytics' },
     { href: '/admin/signups', label: 'Signups' },

--- a/app/(app)/admin/tuning/page.tsx
+++ b/app/(app)/admin/tuning/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { TuningConfigForm } from '@/components/admin/TuningConfigForm'
+import { isAdminRole } from '@/lib/admin/auth'
+import { getCurrentUser } from '@/lib/auth/server'
+
+/**
+ * Admin page for the learning-pipeline TuningConfig (issue #937).
+ *
+ * Admin-only (the shared admin layout allows editors, so re-guard here). The
+ * form itself is a client component that reads/writes /api/admin/tuning-config.
+ */
+export default async function TuningConfigPage() {
+  const { user, error } = await getCurrentUser()
+  if (error || !user) redirect('/login')
+  if (!isAdminRole(user.role)) redirect('/settings')
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">Learning Tuning</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Admin-editable thresholds for the Suggest learning pipeline. Changes take effect on
+            the next recompute and suggestion — no redeploy needed.
+          </p>
+        </div>
+        <Link
+          href="/admin/tuning/preview"
+          className="text-sm font-semibold text-primary hover:underline shrink-0 uppercase tracking-wider"
+        >
+          Payload preview →
+        </Link>
+      </div>
+      <TuningConfigForm />
+    </div>
+  )
+}

--- a/app/(app)/admin/tuning/preview/page.tsx
+++ b/app/(app)/admin/tuning/preview/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { TuningPreview } from '@/components/admin/TuningPreview'
+import { isAdminRole } from '@/lib/admin/auth'
+import { getCurrentUser } from '@/lib/auth/server'
+
+/**
+ * Payload-preview page for the TuningConfig admin (issue #937). Admin-only.
+ * Renders the exact Suggest payload for a chosen subject (self or a synthetic
+ * archetype) under ephemeral, unsaved knob overrides. No LLM call.
+ */
+export default async function TuningPreviewPage() {
+  const { user, error } = await getCurrentUser()
+  if (error || !user) redirect('/login')
+  if (!isAdminRole(user.role)) redirect('/settings')
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">Payload Preview</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Render the exact Suggest payload for a subject under unsaved knob overrides. Previews
+            the input to the model — no suggestion is generated.
+          </p>
+        </div>
+        <Link
+          href="/admin/tuning"
+          className="text-sm font-semibold text-primary hover:underline shrink-0 uppercase tracking-wider"
+        >
+          ← Config
+        </Link>
+      </div>
+      <TuningPreview />
+    </div>
+  )
+}

--- a/app/api/admin/tuning-config/preview/route.ts
+++ b/app/api/admin/tuning-config/preview/route.ts
@@ -1,0 +1,134 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { buildArchetypePlans } from '@/lib/eval/synthetic-history'
+import type { ArchetypeKey } from '@/lib/eval/types'
+import { logger } from '@/lib/logger'
+import {
+  buildTrainingStatePayload,
+  type SuggestRequestInput,
+} from '@/lib/suggest/training-state-builder'
+import { validateTuningConfigWrite } from '@/lib/tuning/schema'
+import { loadTuningConfig } from '@/lib/tuning/store'
+
+/**
+ * Payload-preview generator for the TuningConfig admin (issue #937).
+ *
+ * Admin-only. Picks a subject (the admin themselves, or a synthetic archetype
+ * from the dev seeder) and renders the EXACT payload the training-state builder
+ * would produce, with ephemeral (unsaved) knob overrides applied. No LLM call —
+ * this previews the input, not the suggestion. The builder recomputes aggregates
+ * in dry-run (in-memory, no persistence), so knob changes that affect
+ * aggregates-time computation are reflected.
+ */
+
+/** Fixed request-modal context for the preview (the request fields aren't tunable). */
+const PREVIEW_REQUEST: SuggestRequestInput = {
+  time_budget_minutes: 45,
+  intensity_vibe: 'solid',
+  deprioritize_freetext: null,
+  prioritize_freetext: null,
+  equipment_override: null,
+}
+
+/** Synthetic archetype subjects (seeder ids `synthetic-<key>`) + a self option. */
+function archetypeSubjects(): { userId: string; key: ArchetypeKey; label: string }[] {
+  const plans = buildArchetypePlans()
+  return (Object.keys(plans) as ArchetypeKey[]).map((key) => ({
+    userId: `synthetic-${key}`,
+    key,
+    label: plans[key].displayName,
+  }))
+}
+
+/** Whitelist of previewable subject ids: self + the synthetic archetypes. */
+function allowedSubjectIds(selfId: string): Set<string> {
+  return new Set([selfId, ...archetypeSubjects().map((s) => s.userId)])
+}
+
+/** GET /api/admin/tuning-config/preview — list selectable subjects. */
+export async function GET() {
+  try {
+    const auth = await requireAdmin()
+    if (auth.response) return auth.response
+
+    return NextResponse.json({
+      data: {
+        self: { userId: auth.user.id, label: `You (${auth.user.email ?? 'self'})` },
+        archetypes: archetypeSubjects(),
+      },
+    })
+  } catch (error) {
+    logger.error({ error }, 'Error listing preview subjects')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/admin/tuning-config/preview — render the payload for a subject under
+ * ephemeral knob overrides. Body: { userId, config }. The config is validated
+ * with the same range schema as a real write (invalid ranges → 422), then
+ * applied as an in-memory override without persisting.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireAdmin({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    let body: { userId?: unknown; config?: unknown }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const userId = typeof body.userId === 'string' ? body.userId : auth.user.id
+    if (!allowedSubjectIds(auth.user.id).has(userId)) {
+      return NextResponse.json({ error: 'Unknown preview subject' }, { status: 422 })
+    }
+
+    const validation = validateTuningConfigWrite(body.config)
+    if (!validation.ok) {
+      return NextResponse.json(
+        { error: 'Invalid tuning config', details: validation.errors },
+        { status: 422 },
+      )
+    }
+
+    // Guard against previewing a synthetic subject that hasn't been seeded — the
+    // payload would silently render as an empty cold-start user. (No Prisma User
+    // model exists — BetterAuth owns the user table — so probe a seeder-created
+    // row instead.)
+    if (userId !== auth.user.id) {
+      const exists = await prisma.userSettings.findUnique({
+        where: { userId },
+        select: { userId: true },
+      })
+      if (!exists) {
+        return NextResponse.json(
+          {
+            error:
+              'Synthetic subject not seeded. Run scripts/seed-synthetic-users.ts against this database.',
+          },
+          { status: 404 },
+        )
+      }
+    }
+
+    const savedConfig = await loadTuningConfig(prisma)
+    const { payload, configStamp } = await buildTrainingStatePayload(
+      prisma,
+      userId,
+      PREVIEW_REQUEST,
+      new Date(),
+      validation.config,
+    )
+
+    return NextResponse.json({
+      data: { payload, configStamp, savedConfig },
+    })
+  } catch (error) {
+    logger.error({ error }, 'Error generating tuning preview')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/tuning-config/route.ts
+++ b/app/api/admin/tuning-config/route.ts
@@ -1,0 +1,90 @@
+import type { Prisma } from '@prisma/client'
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { DEFAULT_TUNING_CONFIG, TUNING_KNOBS } from '@/lib/tuning/config'
+import { validateTuningConfigWrite } from '@/lib/tuning/schema'
+import { loadTuningConfig, TUNING_CONFIG_SINGLETON_ID } from '@/lib/tuning/store'
+
+/**
+ * Admin API for the learning-pipeline TuningConfig singleton (issue #937).
+ *
+ * Admin-only (not editor). GET returns the effective config + per-knob metadata
+ * (code default, range, effect copy) for the form. PUT zod-validates the full
+ * config against each knob's range at WRITE time and upserts the single row.
+ *
+ * The READ path used by the pipeline (lib/tuning/store.ts) is zod-free and
+ * reachable from the clone-worker; validation lives only here.
+ */
+
+/** GET /api/admin/tuning-config — current config + defaults + knob metadata. */
+export async function GET() {
+  try {
+    const auth = await requireAdmin()
+    if (auth.response) return auth.response
+
+    const config = await loadTuningConfig(prisma)
+
+    return NextResponse.json({
+      data: {
+        config,
+        defaults: DEFAULT_TUNING_CONFIG,
+        knobs: TUNING_KNOBS,
+      },
+    })
+  } catch (error) {
+    logger.error({ error }, 'Error loading tuning config')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * PUT /api/admin/tuning-config — replace the config. Body is the full knob set.
+ * Out-of-range or unknown-key writes are rejected 422 at the API layer.
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const auth = await requireAdmin({ rateLimit: true })
+    if (auth.response) return auth.response
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const validation = validateTuningConfigWrite(body)
+    if (!validation.ok) {
+      return NextResponse.json(
+        { error: 'Invalid tuning config', details: validation.errors },
+        { status: 422 },
+      )
+    }
+
+    const values = validation.config as unknown as Prisma.InputJsonObject
+    await prisma.tuningConfig.upsert({
+      where: { id: TUNING_CONFIG_SINGLETON_ID },
+      create: {
+        id: TUNING_CONFIG_SINGLETON_ID,
+        values,
+        updatedBy: auth.user.id,
+      },
+      update: {
+        values,
+        updatedBy: auth.user.id,
+      },
+    })
+
+    logger.info(
+      { userId: auth.user.id, config: validation.config },
+      'Tuning config updated',
+    )
+
+    return NextResponse.json({ data: { config: validation.config } })
+  } catch (error) {
+    logger.error({ error }, 'Error updating tuning config')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/cloud-functions/clone-program/src/index.ts
+++ b/cloud-functions/clone-program/src/index.ts
@@ -5,6 +5,10 @@ import { recomputeUserAggregates } from '@/lib/aggregates/recompute'
 // Shared code from the repo root lib/ — resolved via the @/* path alias
 // (see tsconfig.json). Proves worker containers can consume lib/ modules.
 import { logger } from '@/lib/logger'
+// TuningConfig read path (#937). MUST stay zod-free — it is reachable here in
+// the worker image; write-time validation lives in the admin API route.
+import { toAggregatesOptions } from '@/lib/tuning/config'
+import { loadTuningConfig } from '@/lib/tuning/store'
 import { cloneStrengthProgramData, type ProgramCloneJob } from './cloning'
 
 const QUEUE_NAME = 'program-clone-jobs'
@@ -212,7 +216,10 @@ async function processAggregatesJob(job: Job<AggregatesRecomputeJob>): Promise<v
     throw new Error('Invalid aggregates job payload: missing userId')
   }
   console.log(`[aggregates ${job.id}] recomputing for user=${userId}`)
-  await recomputeUserAggregates(prisma, userId)
+  // Apply admin-editable tuning knobs (#937); a missing/malformed config row
+  // falls back to code defaults inside loadTuningConfig.
+  const tuning = await loadTuningConfig(prisma)
+  await recomputeUserAggregates(prisma, userId, undefined, toAggregatesOptions(tuning))
   console.log(`[aggregates ${job.id}] done user=${userId}`)
 }
 

--- a/components/admin/TuningConfigForm.tsx
+++ b/components/admin/TuningConfigForm.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { RotateCcw, Save } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { clientLogger } from '@/lib/client-logger'
+import type { KnobMeta, TuningConfig } from '@/lib/tuning/config'
+
+interface ConfigResponse {
+  config: TuningConfig
+  defaults: TuningConfig
+  knobs: KnobMeta[]
+}
+
+/** Format a number without trailing float noise (e.g. 0.985, 8, 0.3). */
+function fmt(n: number): string {
+  return Number.isFinite(n) ? String(n) : ''
+}
+
+/**
+ * Admin form for the TuningConfig knob set (issue #937). Each knob shows its
+ * current value, code default, valid range, and downstream-effect copy. Ranges
+ * are enforced server-side on save; the inputs mirror them for fast feedback.
+ * Reset-to-defaults loads the code defaults into the form (unsaved until Save).
+ */
+export function TuningConfigForm() {
+  const [knobs, setKnobs] = useState<KnobMeta[]>([])
+  const [defaults, setDefaults] = useState<TuningConfig | null>(null)
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const hydrate = useCallback((data: ConfigResponse) => {
+    setKnobs(data.knobs)
+    setDefaults(data.defaults)
+    const next: Record<string, string> = {}
+    for (const knob of data.knobs) {
+      next[knob.key] = fmt(data.config[knob.key])
+    }
+    setValues(next)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/admin/tuning-config')
+        if (!res.ok) throw new Error(`Failed to load config (${res.status})`)
+        const body = await res.json()
+        if (!cancelled) hydrate(body.data as ConfigResponse)
+      } catch (err) {
+        clientLogger.error('[TuningConfigForm] load failed', err)
+        if (!cancelled) setError('Failed to load tuning config.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [hydrate])
+
+  const setValue = (key: string, raw: string) => {
+    setValues((prev) => ({ ...prev, [key]: raw }))
+    setSaved(false)
+  }
+
+  const resetToDefaults = () => {
+    if (!defaults) return
+    const next: Record<string, string> = {}
+    for (const knob of knobs) next[knob.key] = fmt(defaults[knob.key])
+    setValues(next)
+    setSaved(false)
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      const payload: Record<string, number> = {}
+      for (const knob of knobs) {
+        const num = Number(values[knob.key])
+        if (!Number.isFinite(num)) {
+          throw new Error(`${knob.label} must be a number`)
+        }
+        payload[knob.key] = num
+      }
+      const res = await fetch('/api/admin/tuning-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        const detail = Array.isArray(body?.details) ? body.details.join('; ') : body?.error
+        throw new Error(detail || `Save failed (${res.status})`)
+      }
+      setSaved(true)
+    } catch (err) {
+      clientLogger.error('[TuningConfigForm] save failed', err)
+      setError(err instanceof Error ? err.message : 'Save failed.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading tuning config…</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="border-2 border-error bg-error/10 text-error text-sm px-3 py-2">
+          {error}
+        </div>
+      )}
+      {saved && (
+        <div className="border-2 border-success bg-success/10 text-success text-sm px-3 py-2">
+          Tuning config saved. Effective on the next recompute + suggestion.
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {knobs.map((knob) => {
+          const current = values[knob.key] ?? ''
+          const def = defaults ? fmt(defaults[knob.key]) : ''
+          const isDefault = current === def
+          return (
+            <div
+              key={knob.key}
+              className="border-2 border-border bg-card p-4 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-start"
+            >
+              <div className="min-w-0">
+                <label
+                  htmlFor={`knob-${knob.key}`}
+                  className="text-sm font-bold text-foreground"
+                >
+                  {knob.label}
+                </label>
+                <p className="text-xs text-muted-foreground mt-1">{knob.effect}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Code default: <span className="font-mono text-foreground">{def}</span>{' '}
+                  · Range:{' '}
+                  <span className="font-mono text-foreground">
+                    {knob.min}–{knob.max}
+                  </span>
+                  {knob.integer ? ' (integer)' : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 sm:flex-col sm:items-end">
+                <input
+                  id={`knob-${knob.key}`}
+                  type="number"
+                  inputMode="decimal"
+                  step={knob.step}
+                  min={knob.min}
+                  max={knob.max}
+                  value={current}
+                  onChange={(e) => setValue(knob.key, e.target.value)}
+                  className="w-32 px-3 py-2 bg-input border-2 border-border text-foreground font-mono text-right focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                {!isDefault && (
+                  <span className="text-[10px] uppercase tracking-wider text-warning font-bold">
+                    overridden
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button variant="primary" onClick={save} disabled={saving}>
+          <Save size={16} /> {saving ? 'Saving…' : 'Save config'}
+        </Button>
+        <Button variant="secondary" onClick={resetToDefaults} disabled={saving}>
+          <RotateCcw size={16} /> Reset to defaults
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/TuningPreview.tsx
+++ b/components/admin/TuningPreview.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { Play, RotateCcw } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { clientLogger } from '@/lib/client-logger'
+import type { KnobMeta, TuningConfig } from '@/lib/tuning/config'
+
+interface Subject {
+  userId: string
+  label: string
+}
+
+interface PreviewResult {
+  payload: unknown
+  configStamp: TuningConfig
+  savedConfig: TuningConfig
+}
+
+function fmt(n: number): string {
+  return Number.isFinite(n) ? String(n) : ''
+}
+
+/**
+ * TuningConfig payload-preview UI (issue #937). Pick a subject (self or a
+ * synthetic archetype), adjust knobs ephemerally, and render the exact payload
+ * the builder would produce. Shows the effective config stamp (what #921 embeds
+ * into requestPayload) and a saved-vs-override knob diff.
+ */
+export function TuningPreview() {
+  const [knobs, setKnobs] = useState<KnobMeta[]>([])
+  const [subjects, setSubjects] = useState<Subject[]>([])
+  const [subjectId, setSubjectId] = useState<string>('')
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [savedConfig, setSavedConfig] = useState<TuningConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<PreviewResult | null>(null)
+
+  const seedValues = useCallback((config: TuningConfig, knobList: KnobMeta[]) => {
+    const next: Record<string, string> = {}
+    for (const knob of knobList) next[knob.key] = fmt(config[knob.key])
+    setValues(next)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const [cfgRes, subjRes] = await Promise.all([
+          fetch('/api/admin/tuning-config'),
+          fetch('/api/admin/tuning-config/preview'),
+        ])
+        if (!cfgRes.ok || !subjRes.ok) throw new Error('Failed to load preview inputs')
+        const cfgBody = await cfgRes.json()
+        const subjBody = await subjRes.json()
+        if (cancelled) return
+        const knobList: KnobMeta[] = cfgBody.data.knobs
+        const config: TuningConfig = cfgBody.data.config
+        setKnobs(knobList)
+        setSavedConfig(config)
+        seedValues(config, knobList)
+        const list: Subject[] = [
+          subjBody.data.self,
+          ...subjBody.data.archetypes.map((a: { userId: string; label: string }) => ({
+            userId: a.userId,
+            label: a.label,
+          })),
+        ]
+        setSubjects(list)
+        setSubjectId(list[0]?.userId ?? '')
+      } catch (err) {
+        clientLogger.error('[TuningPreview] load failed', err)
+        if (!cancelled) setError('Failed to load preview inputs.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [seedValues])
+
+  const resetOverrides = () => {
+    if (savedConfig) seedValues(savedConfig, knobs)
+  }
+
+  const run = async () => {
+    setRunning(true)
+    setError(null)
+    try {
+      const config: Record<string, number> = {}
+      for (const knob of knobs) config[knob.key] = Number(values[knob.key])
+      const res = await fetch('/api/admin/tuning-config/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: subjectId, config }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        const detail = Array.isArray(body?.details) ? body.details.join('; ') : body?.error
+        throw new Error(detail || `Preview failed (${res.status})`)
+      }
+      setResult(body.data as PreviewResult)
+    } catch (err) {
+      clientLogger.error('[TuningPreview] run failed', err)
+      setError(err instanceof Error ? err.message : 'Preview failed.')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading preview…</p>
+  }
+
+  const changedKnobs = result
+    ? knobs.filter((k) => result.configStamp[k.key] !== result.savedConfig[k.key])
+    : []
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="border-2 border-error bg-error/10 text-error text-sm px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="border-2 border-border bg-card p-4 space-y-4">
+        <div className="grid gap-2 sm:grid-cols-[auto_1fr] sm:items-center">
+          <label htmlFor="subject" className="text-sm font-bold text-foreground">
+            Subject
+          </label>
+          <select
+            id="subject"
+            value={subjectId}
+            onChange={(e) => setSubjectId(e.target.value)}
+            className="w-full sm:max-w-md px-3 py-2 bg-input border-2 border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            {subjects.map((s) => (
+              <option key={s.userId} value={s.userId}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          {knobs.map((knob) => (
+            <div key={knob.key} className="min-w-0">
+              <label
+                htmlFor={`preview-${knob.key}`}
+                className="text-xs font-semibold text-muted-foreground block truncate"
+                title={knob.label}
+              >
+                {knob.label}
+              </label>
+              <input
+                id={`preview-${knob.key}`}
+                type="number"
+                inputMode="decimal"
+                step={knob.step}
+                min={knob.min}
+                max={knob.max}
+                value={values[knob.key] ?? ''}
+                onChange={(e) => {
+                  setValues((prev) => ({ ...prev, [knob.key]: e.target.value }))
+                }}
+                className="mt-1 w-full px-2 py-1.5 bg-input border-2 border-border text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button variant="primary" onClick={run} disabled={running || !subjectId}>
+            <Play size={16} /> {running ? 'Rendering…' : 'Generate preview'}
+          </Button>
+          <Button variant="secondary" onClick={resetOverrides} disabled={running}>
+            <RotateCcw size={16} /> Reset to saved
+          </Button>
+        </div>
+      </div>
+
+      {result && (
+        <div className="space-y-4">
+          <div className="border-2 border-border bg-card p-4">
+            <h2 className="text-sm font-bold text-foreground uppercase tracking-wider">
+              Config stamp
+            </h2>
+            <p className="text-xs text-muted-foreground mt-1">
+              Effective knobs this payload was built with (#921 embeds this into
+              <span className="font-mono"> requestPayload</span>).
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {knobs.map((k) => {
+                const changed = changedKnobs.some((c) => c.key === k.key)
+                return (
+                  <span
+                    key={k.key}
+                    className={`text-xs font-mono px-2 py-1 border-2 ${
+                      changed
+                        ? 'border-warning text-warning'
+                        : 'border-border text-muted-foreground'
+                    }`}
+                    title={changed ? `saved: ${result.savedConfig[k.key]}` : undefined}
+                  >
+                    {k.key}={result.configStamp[k.key]}
+                    {changed ? ` (was ${result.savedConfig[k.key]})` : ''}
+                  </span>
+                )
+              })}
+            </div>
+            {changedKnobs.length === 0 && (
+              <p className="text-xs text-muted-foreground mt-2">
+                No overrides — this matches the saved config.
+              </p>
+            )}
+          </div>
+
+          <div className="border-2 border-border bg-card p-4">
+            <h2 className="text-sm font-bold text-foreground uppercase tracking-wider">
+              Payload
+            </h2>
+            <pre className="mt-2 text-xs font-mono text-foreground overflow-auto max-h-[60vh] whitespace-pre-wrap break-words">
+              {JSON.stringify(result.payload, null, 2)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/aggregates/compute.ts
+++ b/lib/aggregates/compute.ts
@@ -20,6 +20,9 @@ import {
   gapDecayedEwma,
 } from '@/lib/learning/math'
 import {
+  type HeavyThresholds,
+  HEAVY_E1RM_FRACTION,
+  HEAVY_EFFORT_RPE,
   type MovementEwma,
   type MovementEwmaMap,
   determineMovementHeavy,
@@ -64,6 +67,8 @@ export const DEFAULT_AGGREGATES_OPTIONS: AggregatesOptions = {
   fauStatusDeadband: 0.03,
   goalTrendStallBand: 0.02,
   goalProgressMinWeeks: 2,
+  heavyE1rmFraction: HEAVY_E1RM_FRACTION,
+  heavyEffortCutoff: HEAVY_EFFORT_RPE,
 }
 
 /** Merge caller overrides over the production defaults. */
@@ -185,7 +190,8 @@ function lastSessionByFau(now: Date, sessions: AggregateSessionInput[]): Map<str
 function lastHeavyByFau(
   now: Date,
   sessions: AggregateSessionInput[],
-  ewmaMap: MovementEwmaMap
+  ewmaMap: MovementEwmaMap,
+  thresholds: HeavyThresholds
 ): Map<string, number> {
   const out = new Map<string, number>()
   for (const session of sessions) {
@@ -220,7 +226,8 @@ function lastHeavyByFau(
             isWarmup: s.isWarmup,
           })),
         },
-        pattern != null ? ewmaMap[pattern] : undefined
+        pattern != null ? ewmaMap[pattern] : undefined,
+        thresholds
       )
       if (!verdict.isHeavy) continue
       const faus = new Set<string>()
@@ -297,7 +304,10 @@ function computePerFau(
   }
 
   const lastSession = lastSessionByFau(now, within(baselineWeeks * 7 + 14))
-  const lastHeavy = lastHeavyByFau(now, within(baselineWeeks * 7 + 14), ewmaMap)
+  const lastHeavy = lastHeavyByFau(now, within(baselineWeeks * 7 + 14), ewmaMap, {
+    heavyE1rmFraction: opts.heavyE1rmFraction,
+    heavyEffortCutoff: opts.heavyEffortCutoff,
+  })
 
   // Zero-sum shares: target_share (from ratioTargets, default weight 1.0) and
   // actual_14d_share are both normalized over the emitted (present) FAUs so

--- a/lib/aggregates/compute.ts
+++ b/lib/aggregates/compute.ts
@@ -20,12 +20,12 @@ import {
   gapDecayedEwma,
 } from '@/lib/learning/math'
 import {
-  type HeavyThresholds,
+  determineMovementHeavy,
   HEAVY_E1RM_FRACTION,
   HEAVY_EFFORT_RPE,
+  type HeavyThresholds,
   type MovementEwma,
   type MovementEwmaMap,
-  determineMovementHeavy,
 } from '@/lib/learning/weekly-intent'
 import { normalizeWeightToLbs } from '@/lib/stats/exercise-performance'
 import type {

--- a/lib/aggregates/types.ts
+++ b/lib/aggregates/types.ts
@@ -205,4 +205,10 @@ export interface AggregatesOptions {
   goalTrendStallBand: number
   /** goal_progress: below this many distinct observed weeks => trend 'new'. */
   goalProgressMinWeeks: number
+  /** last_heavy: top-set e1RM >= this fraction of the movement EWMA is heavy
+   * (mirrors lib/learning/weekly-intent HEAVY_E1RM_FRACTION; #937-tunable). */
+  heavyE1rmFraction: number
+  /** last_heavy: logged effort (RPE-equiv) >= this counts as heavy regardless of
+   * load (mirrors HEAVY_EFFORT_RPE; #937-tunable). */
+  heavyEffortCutoff: number
 }

--- a/lib/learning/weekly-intent.ts
+++ b/lib/learning/weekly-intent.ts
@@ -53,6 +53,22 @@ export const HEAVY_EFFORT_RPE = 8
  * fall back to the static `intensityClass` tag (cold start only). */
 export const MIN_EWMA_OBSERVATIONS = 3
 
+/**
+ * Tunable heaviness thresholds (issue #937). `HEAVY_E1RM_FRACTION` and
+ * `HEAVY_EFFORT_RPE` are the code defaults; the admin TuningConfig can override
+ * them per request. Callers pass the resolved values through; omitting the
+ * argument reproduces today's constants exactly.
+ */
+export interface HeavyThresholds {
+  heavyE1rmFraction: number
+  heavyEffortCutoff: number
+}
+
+export const DEFAULT_HEAVY_THRESHOLDS: HeavyThresholds = {
+  heavyE1rmFraction: HEAVY_E1RM_FRACTION,
+  heavyEffortCutoff: HEAVY_EFFORT_RPE,
+}
+
 /** muscle_group → movement patterns that count toward a "heavy X day". Movement
  * patterns follow ExerciseDefinition.movementPattern (see schema.prisma). */
 export const MUSCLE_GROUP_PATTERNS: Record<string, string[]> = {
@@ -201,14 +217,15 @@ function topSetE1RMOf(sets: IntentLoggedSet[]): number | null {
  */
 export function determineMovementHeavy(
   movement: SessionMovement,
-  ewma: MovementEwma | undefined
+  ewma: MovementEwma | undefined,
+  thresholds: HeavyThresholds = DEFAULT_HEAVY_THRESHOLDS
 ): HeavyDetermination {
   const sets = workingSets(movement)
   const peakEffort = peakEffortOf(sets)
   const topSetE1RM = topSetE1RMOf(sets)
 
   // Effort is a direct, calibration-free signal; check it first.
-  if (peakEffort != null && peakEffort >= HEAVY_EFFORT_RPE) {
+  if (peakEffort != null && peakEffort >= thresholds.heavyEffortCutoff) {
     return { isHeavy: true, reason: 'effort', topSetE1RM, peakEffort }
   }
 
@@ -222,7 +239,7 @@ export function determineMovementHeavy(
     // EWMA branch: compare measured load against the user's own estimate.
     if (
       topSetE1RM != null &&
-      topSetE1RM >= HEAVY_E1RM_FRACTION * (ewma!.ewmaE1RMLbs as number)
+      topSetE1RM >= thresholds.heavyE1rmFraction * (ewma!.ewmaE1RMLbs as number)
     ) {
       return { isHeavy: true, reason: 'ewma', topSetE1RM, peakEffort }
     }
@@ -244,14 +261,17 @@ export function determineMovementHeavy(
 export function isSessionHeavyForPatterns(
   session: EvaluatedSession,
   patterns: string[],
-  ewmaMap: MovementEwmaMap
+  ewmaMap: MovementEwmaMap,
+  thresholds: HeavyThresholds = DEFAULT_HEAVY_THRESHOLDS
 ): boolean {
   const wanted = new Set(patterns)
   for (const movement of session.movements) {
     if (movement.movementPattern == null || !wanted.has(movement.movementPattern)) {
       continue
     }
-    if (determineMovementHeavy(movement, ewmaMap[movement.movementPattern]).isHeavy) {
+    if (
+      determineMovementHeavy(movement, ewmaMap[movement.movementPattern], thresholds).isHeavy
+    ) {
       return true
     }
   }
@@ -306,16 +326,17 @@ function findLastSatisfiedDaysAgo(
 function evaluateHeavySession(
   intent: Extract<WeeklyIntent, { type: 'heavy_session' }>,
   sessions: EvaluatedSession[],
-  ewmaMap: MovementEwmaMap
+  ewmaMap: MovementEwmaMap,
+  thresholds: HeavyThresholds
 ): WeeklyIntentVerdict {
   const patterns = MUSCLE_GROUP_PATTERNS[intent.muscle_group] ?? []
   const predicate = (windowSessions: EvaluatedSession[]) =>
-    windowSessions.filter((s) => isSessionHeavyForPatterns(s, patterns, ewmaMap))
+    windowSessions.filter((s) => isSessionHeavyForPatterns(s, patterns, ewmaMap, thresholds))
       .length >= intent.min_per_week
 
   const current = sessionsInWindow(sessions, 0)
   const heavyNow = current.filter((s) =>
-    isSessionHeavyForPatterns(s, patterns, ewmaMap)
+    isSessionHeavyForPatterns(s, patterns, ewmaMap, thresholds)
   ).length
   const satisfiedLast7d = heavyNow >= intent.min_per_week
 
@@ -406,11 +427,12 @@ function evaluateVolumeTilt(
 export function evaluateWeeklyIntent(
   intent: WeeklyIntent,
   sessions: EvaluatedSession[],
-  ewmaMap: MovementEwmaMap = {}
+  ewmaMap: MovementEwmaMap = {},
+  thresholds: HeavyThresholds = DEFAULT_HEAVY_THRESHOLDS
 ): WeeklyIntentVerdict {
   switch (intent.type) {
     case 'heavy_session':
-      return evaluateHeavySession(intent, sessions, ewmaMap)
+      return evaluateHeavySession(intent, sessions, ewmaMap, thresholds)
     case 'movement_frequency':
       return evaluateMovementFrequency(intent, sessions)
     case 'volume_tilt':
@@ -430,7 +452,8 @@ export function evaluateWeeklyIntent(
 export function evaluateWeeklyIntents(
   intents: WeeklyIntent[],
   sessions: EvaluatedSession[],
-  ewmaMap: MovementEwmaMap = {}
+  ewmaMap: MovementEwmaMap = {},
+  thresholds: HeavyThresholds = DEFAULT_HEAVY_THRESHOLDS
 ): WeeklyIntentVerdict[] {
-  return intents.map((intent) => evaluateWeeklyIntent(intent, sessions, ewmaMap))
+  return intents.map((intent) => evaluateWeeklyIntent(intent, sessions, ewmaMap, thresholds))
 }

--- a/lib/suggest/training-state-builder.ts
+++ b/lib/suggest/training-state-builder.ts
@@ -55,17 +55,22 @@
 import type { PrismaClient } from '@prisma/client'
 
 import { computeUserAggregates } from '@/lib/aggregates/recompute'
-import type { AggregatesOptions, MovementCalibration } from '@/lib/aggregates/types'
+import type { MovementCalibration } from '@/lib/aggregates/types'
 import {
   computeInjuryBanList,
   type InjuryBanExercise,
 } from '@/lib/learning/injury-ban-list'
-import { WEEKLY_DECAY_FACTOR } from '@/lib/learning/math'
 import {
   type EvaluatedSession,
   evaluateWeeklyIntents,
   type MovementEwmaMap,
 } from '@/lib/learning/weekly-intent'
+import {
+  type TuningConfig,
+  toAggregatesOptions,
+  toHeavyOptions,
+} from '@/lib/tuning/config'
+import { loadTuningConfig } from '@/lib/tuning/store'
 import {
   type SuggestWorkoutPayload,
   suggestWorkoutPayloadSchema,
@@ -241,13 +246,26 @@ function toCalibrationPayload(c: MovementCalibration) {
 }
 
 /**
+ * The builder's return: the validated payload plus the effective knob values it
+ * was built with. #921 embeds `configStamp` into `Suggestion.requestPayload` so
+ * every persisted suggestion is self-describing regardless of later config edits.
+ */
+export interface TrainingStateBuildResult {
+  payload: SuggestWorkoutPayload
+  configStamp: TuningConfig
+}
+
+/**
  * Build and validate the complete Suggest payload for a user at request time.
  *
  * @param prisma   Prisma client (or transaction handle).
  * @param userId   The requesting user.
  * @param request  Ephemeral request-modal fields.
  * @param now      Request time. Injectable for deterministic tests/snapshots.
- * @param options  Aggregates tuning overrides (#937); production uses defaults.
+ * @param tuning   Effective tuning knobs (#937). Omit to load the saved config
+ *                 (code defaults when no row exists); pass an ephemeral config
+ *                 for the admin preview's unsaved overrides.
+ * @returns The validated payload and the effective config stamp.
  * @throws ZodError if the assembled payload violates the payload contract.
  */
 export async function buildTrainingStatePayload(
@@ -255,8 +273,9 @@ export async function buildTrainingStatePayload(
   userId: string,
   request: SuggestRequestInput,
   now: Date = new Date(),
-  options?: Partial<AggregatesOptions>,
-): Promise<SuggestWorkoutPayload> {
+  tuning?: TuningConfig,
+): Promise<TrainingStateBuildResult> {
+  const config = tuning ?? (await loadTuningConfig(prisma))
   const [profileRow, settings, aggregates, sessionRows, catalogRows, prefRows] =
     await Promise.all([
       prisma.userTrainingProfile.findUnique({ where: { userId } }),
@@ -264,7 +283,7 @@ export async function buildTrainingStatePayload(
         where: { userId },
         select: { signupIntent: true },
       }),
-      computeUserAggregates(prisma, userId, now, options),
+      computeUserAggregates(prisma, userId, now, toAggregatesOptions(config)),
       prisma.workoutCompletion.findMany({
         where: {
           userId,
@@ -339,6 +358,7 @@ export async function buildTrainingStatePayload(
     weeklyIntents,
     evaluatedSessions,
     toEwmaMap(aggregates.perMovementCalibration),
+    toHeavyOptions(config),
   )
   const weeklyIntentStatus = toWeeklyIntentStatuses(verdicts)
 
@@ -356,7 +376,7 @@ export async function buildTrainingStatePayload(
   const { available, unconstrained } = resolveAvailableEquipment(
     request.equipment_override ?? profile.equipmentAvailable,
   )
-  const preferences = decayPreferences(prefRows, now, WEEKLY_DECAY_FACTOR)
+  const preferences = decayPreferences(prefRows, now, config.betaWeeklyDecay)
   const candidateExercises = buildCandidateExercises(catalog, {
     available,
     unconstrained,
@@ -414,5 +434,8 @@ export async function buildTrainingStatePayload(
 
   // Validate against the payload contract BEFORE it reaches the prompt layer.
   // A failure here is a builder bug, not a user error — surface it loudly.
-  return suggestWorkoutPayloadSchema.parse(payload)
+  return {
+    payload: suggestWorkoutPayloadSchema.parse(payload),
+    configStamp: config,
+  }
 }

--- a/lib/suggest/training-state-builder.ts
+++ b/lib/suggest/training-state-builder.ts
@@ -66,17 +66,17 @@ import {
   type MovementEwmaMap,
 } from '@/lib/learning/weekly-intent'
 import {
-  type TuningConfig,
-  toAggregatesOptions,
-  toHeavyOptions,
-} from '@/lib/tuning/config'
-import { loadTuningConfig } from '@/lib/tuning/store'
-import {
   type SuggestWorkoutPayload,
   suggestWorkoutPayloadSchema,
 } from '@/lib/llm/prompts/suggest-workout/schemas'
 import type { WeeklyIntent } from '@/lib/llm/prompts/suggest-workout/types'
 import { normalizeWeightToLbs } from '@/lib/stats/exercise-performance'
+import {
+  type TuningConfig,
+  toAggregatesOptions,
+  toHeavyOptions,
+} from '@/lib/tuning/config'
+import { loadTuningConfig } from '@/lib/tuning/store'
 import {
   normalizeUserTrainingProfile,
   type UserTrainingProfileDTO,

--- a/lib/test/database.ts
+++ b/lib/test/database.ts
@@ -143,7 +143,9 @@ export class TestDatabase {
       'CommunityProgram',
       'UserSettings',
       'InAppMessage',
-      'WaiverAcceptance'
+      'WaiverAcceptance',
+      // Singleton row — must be cleared or it leaks across tests (id collision).
+      'TuningConfig'
     ]
 
     for (const table of tablesToClear) {

--- a/lib/tuning/config.ts
+++ b/lib/tuning/config.ts
@@ -1,0 +1,225 @@
+/**
+ * TuningConfig — the deliberately-minimal, admin-editable set of learning-pipeline
+ * knobs (issue #937).
+ *
+ * This module is the single source of truth for the knob set, their code
+ * defaults (imported from where each value already lives — change the default
+ * there, not here), their valid ranges, and their downstream-effect copy. It is
+ * also the READ path: `parseTuningConfig` turns a stored JSON blob into a fully
+ * populated config with per-field fallback to the code default, so a malformed,
+ * partial, or missing row can never break the pipeline.
+ *
+ * DEPENDENCY BOUNDARY (see #942 CI break): the aggregates compute path runs
+ * inside the clone-worker image, and this module is reachable from it. It MUST
+ * NOT import zod (not even `import type`). Write-time validation with ranges
+ * lives in `lib/tuning/schema.ts`, imported only by the admin write route.
+ *
+ * Explicitly NOT tunable: write-time normalizations (the RIR→RPE mapping
+ * `10 − rir`, preference-evidence normalization). Those are contracts, not
+ * parameters — changing them would silently reinterpret stored history. Resist
+ * adding knobs beyond this curated v1 set.
+ */
+
+import { DEFAULT_AGGREGATES_OPTIONS } from '@/lib/aggregates/compute'
+import type { AggregatesOptions } from '@/lib/aggregates/types'
+import {
+  DEFAULT_EWMA_ALPHA,
+  DEFAULT_TYPICAL_GAP_DAYS,
+  WEEKLY_DECAY_FACTOR,
+} from '@/lib/learning/math'
+import { HEAVY_E1RM_FRACTION, HEAVY_EFFORT_RPE } from '@/lib/learning/weekly-intent'
+
+/** The curated v1 knob set. All values are plain numbers. */
+export interface TuningConfig {
+  /** Session-relative "heavy": top-set e1RM ≥ this fraction of the movement EWMA. */
+  heavyE1rmFraction: number
+  /** Session-relative "heavy": logged effort (RPE-equivalent) ≥ this counts as heavy. */
+  heavyEffortCutoff: number
+  /** Weekly multiplicative decay on exercise-preference (Beta) evidence. */
+  betaWeeklyDecay: number
+  /** Base EWMA smoothing factor for strength calibration. */
+  ewmaAlpha: number
+  /** Expected days between observations for the gap-decayed EWMA. */
+  ewmaTypicalGapDays: number
+  /** Fewer than this many qualifying sessions in 14d flags low_data. */
+  lowDataMinSessions: number
+  /** Fewer than this many effective sets in 14d flags low_data. */
+  lowDataMinSets: number
+  /** A gap of at least this many days since the last session populates detraining_gap. */
+  detrainingGapDays: number
+}
+
+/**
+ * Code defaults, sourced from the constants each knob shadows so "code default"
+ * shown in the admin UI is genuinely today's production behavior.
+ */
+export const DEFAULT_TUNING_CONFIG: TuningConfig = {
+  heavyE1rmFraction: HEAVY_E1RM_FRACTION,
+  heavyEffortCutoff: HEAVY_EFFORT_RPE,
+  betaWeeklyDecay: WEEKLY_DECAY_FACTOR,
+  ewmaAlpha: DEFAULT_EWMA_ALPHA,
+  ewmaTypicalGapDays: DEFAULT_TYPICAL_GAP_DAYS,
+  lowDataMinSessions: DEFAULT_AGGREGATES_OPTIONS.lowDataMinSessions,
+  lowDataMinSets: DEFAULT_AGGREGATES_OPTIONS.lowDataMinSets,
+  detrainingGapDays: DEFAULT_AGGREGATES_OPTIONS.detrainingMinDays,
+}
+
+/** Per-knob metadata for validation (ranges) and the admin form (label/effect). */
+export interface KnobMeta {
+  key: keyof TuningConfig
+  label: string
+  /** Inclusive minimum enforced at write time and in the read-path fallback. */
+  min: number
+  /** Inclusive maximum enforced at write time and in the read-path fallback. */
+  max: number
+  /** UI slider/step granularity. */
+  step: number
+  /** Whether the value must be an integer. */
+  integer: boolean
+  /** One-line description of the downstream effect (shown in the form). */
+  effect: string
+}
+
+/**
+ * The knob table. Ranges are conservative guardrails, not the mathematically
+ * valid domain — e.g. ewmaAlpha's true domain is (0,1) but we clamp tighter so
+ * an admin can't drive smoothing to a useless extreme.
+ */
+export const TUNING_KNOBS: readonly KnobMeta[] = [
+  {
+    key: 'heavyE1rmFraction',
+    label: 'Heavy e1RM fraction',
+    min: 0.5,
+    max: 1.0,
+    step: 0.01,
+    integer: false,
+    effect:
+      'Top-set e1RM at or above this fraction of the movement-pattern EWMA counts a session as heavy — drives weekly-intent "heavy day" verdicts and per_fau.last_heavy_days_ago.',
+  },
+  {
+    key: 'heavyEffortCutoff',
+    label: 'Heavy effort cutoff (RPE-equiv)',
+    min: 5,
+    max: 10,
+    step: 0.5,
+    integer: false,
+    effect:
+      'Logged effort (RPE, or 10−RIR) at or above this counts a set as heavy regardless of load.',
+  },
+  {
+    key: 'betaWeeklyDecay',
+    label: 'Preference weekly decay',
+    min: 0.9,
+    max: 0.999,
+    step: 0.001,
+    integer: false,
+    effect:
+      'Weekly multiplicative decay on exercise-preference evidence; lower fades old likes/dislikes faster so recent signal dominates.',
+  },
+  {
+    key: 'ewmaAlpha',
+    label: 'EWMA alpha',
+    min: 0.05,
+    max: 0.95,
+    step: 0.05,
+    integer: false,
+    effect:
+      'Base smoothing for the strength-calibration EWMA; higher lets the newest session move the estimate more.',
+  },
+  {
+    key: 'ewmaTypicalGapDays',
+    label: 'EWMA typical gap (days)',
+    min: 1,
+    max: 28,
+    step: 1,
+    integer: true,
+    effect:
+      'Expected days between sessions for the gap-decayed EWMA; a gap this long reproduces the base alpha, longer gaps weight the new observation more.',
+  },
+  {
+    key: 'lowDataMinSessions',
+    label: 'Low-data min sessions (14d)',
+    min: 1,
+    max: 10,
+    step: 1,
+    integer: true,
+    effect:
+      'Fewer than this many qualifying sessions in the last 14 days flags the user low_data, suppressing per_fau status labels.',
+  },
+  {
+    key: 'lowDataMinSets',
+    label: 'Low-data min sets (14d)',
+    min: 5,
+    max: 60,
+    step: 1,
+    integer: true,
+    effect: 'Fewer than this many effective sets in the last 14 days flags low_data.',
+  },
+  {
+    key: 'detrainingGapDays',
+    label: 'Detraining gap floor (days)',
+    min: 3,
+    max: 60,
+    step: 1,
+    integer: true,
+    effect:
+      'A gap of at least this many days since the last session (with prior training) populates detraining_gap.',
+  },
+] as const
+
+/** True when `value` is within the knob's range and integer constraint. */
+function isValidKnobValue(meta: KnobMeta, value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= meta.min &&
+    value <= meta.max &&
+    (!meta.integer || Number.isInteger(value))
+  )
+}
+
+/**
+ * READ PATH. Coerce a stored JSON blob into a complete TuningConfig. Every field
+ * that is missing, the wrong type, non-finite, out of range, or (for integer
+ * knobs) non-integer falls back to its code default. Never throws — a bad row
+ * degrades to defaults so the pipeline behaves exactly as it does with no row.
+ */
+export function parseTuningConfig(raw: unknown): TuningConfig {
+  const out: TuningConfig = { ...DEFAULT_TUNING_CONFIG }
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return out
+  const obj = raw as Record<string, unknown>
+  for (const meta of TUNING_KNOBS) {
+    const value = obj[meta.key]
+    if (isValidKnobValue(meta, value)) {
+      out[meta.key] = value
+    }
+  }
+  return out
+}
+
+/** Heavy-determination knobs consumed by lib/learning/weekly-intent. */
+export interface HeavyOptions {
+  heavyE1rmFraction: number
+  heavyEffortCutoff: number
+}
+
+/** Extract the aggregates-relevant subset of the config for computeAggregates. */
+export function toAggregatesOptions(cfg: TuningConfig): Partial<AggregatesOptions> {
+  return {
+    lowDataMinSessions: cfg.lowDataMinSessions,
+    lowDataMinSets: cfg.lowDataMinSets,
+    detrainingMinDays: cfg.detrainingGapDays,
+    ewmaAlpha: cfg.ewmaAlpha,
+    ewmaTypicalGapDays: cfg.ewmaTypicalGapDays,
+    heavyE1rmFraction: cfg.heavyE1rmFraction,
+    heavyEffortCutoff: cfg.heavyEffortCutoff,
+  }
+}
+
+/** Extract the heavy-determination knobs for the weekly-intent evaluator. */
+export function toHeavyOptions(cfg: TuningConfig): HeavyOptions {
+  return {
+    heavyE1rmFraction: cfg.heavyE1rmFraction,
+    heavyEffortCutoff: cfg.heavyEffortCutoff,
+  }
+}

--- a/lib/tuning/schema.ts
+++ b/lib/tuning/schema.ts
@@ -1,0 +1,49 @@
+/**
+ * WRITE-PATH validation for TuningConfig (issue #937).
+ *
+ * This is the ONLY place zod touches the tuning feature. It is imported solely
+ * by the admin write route (`app/api/admin/tuning-config`), never by the read
+ * path — the clone-worker's aggregates compute must stay zod-free (#942). Ranges
+ * are derived from the same TUNING_KNOBS table the read-path fallback uses, so
+ * write validation and read coercion can never drift.
+ */
+
+import { z } from 'zod'
+import { TUNING_KNOBS, type TuningConfig } from './config'
+
+/** Build a zod object schema enforcing each knob's range + integer constraint. */
+function buildTuningConfigSchema() {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const meta of TUNING_KNOBS) {
+    let field = z
+      .number({ error: `${meta.label} must be a number` })
+      .min(meta.min, `${meta.label} must be ≥ ${meta.min}`)
+      .max(meta.max, `${meta.label} must be ≤ ${meta.max}`)
+    if (meta.integer) {
+      field = field.int(`${meta.label} must be a whole number`)
+    }
+    shape[meta.key] = field
+  }
+  // strictObject rejects unknown keys — resist silently persisting stray knobs.
+  return z.strictObject(shape)
+}
+
+/** Full-config schema: every knob required and in range. Rejects unknown keys. */
+export const tuningConfigWriteSchema = buildTuningConfigSchema()
+
+/**
+ * Validate a candidate config for persistence. Returns the typed config on
+ * success or a flat list of human-readable errors on failure.
+ */
+export function validateTuningConfigWrite(
+  input: unknown,
+): { ok: true; config: TuningConfig } | { ok: false; errors: string[] } {
+  const result = tuningConfigWriteSchema.safeParse(input)
+  if (result.success) {
+    return { ok: true, config: result.data as unknown as TuningConfig }
+  }
+  const errors = result.error.issues.map((issue) =>
+    issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message,
+  )
+  return { ok: false, errors }
+}

--- a/lib/tuning/store.ts
+++ b/lib/tuning/store.ts
@@ -1,0 +1,42 @@
+/**
+ * TuningConfig persistence — the singleton-row read path (issue #937).
+ *
+ * DEPENDENCY BOUNDARY (see #942): this module is reachable from the clone-worker
+ * image via the aggregates recompute path. It MUST stay zod-free. It reads the
+ * one-row TuningConfig table and delegates coercion to `parseTuningConfig`,
+ * which applies per-field code-default fallback. Any read failure (missing
+ * table, missing row, malformed JSON) degrades to DEFAULT_TUNING_CONFIG so the
+ * pipeline is never broken by config state.
+ *
+ * The WRITE path (with zod range validation) lives in the admin API route.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { logger } from '@/lib/logger'
+import {
+  DEFAULT_TUNING_CONFIG,
+  parseTuningConfig,
+  type TuningConfig,
+} from './config'
+
+/** Fixed primary key for the single TuningConfig row. */
+export const TUNING_CONFIG_SINGLETON_ID = 'singleton'
+
+/**
+ * Load the effective tuning config. Returns code defaults when no row exists or
+ * on any read error. Callers pass the result down through the pipeline's options
+ * objects; they never read raw knob values directly.
+ */
+export async function loadTuningConfig(prisma: PrismaClient): Promise<TuningConfig> {
+  try {
+    const row = await prisma.tuningConfig.findUnique({
+      where: { id: TUNING_CONFIG_SINGLETON_ID },
+      select: { values: true },
+    })
+    return parseTuningConfig(row?.values ?? null)
+  } catch (error) {
+    // A malformed/missing config must never break the pipeline — fall back.
+    logger.warn({ error }, 'Failed to load TuningConfig; using code defaults')
+    return DEFAULT_TUNING_CONFIG
+  }
+}

--- a/prisma/migrations/20260704232622_add_tuning_config/migration.sql
+++ b/prisma/migrations/20260704232622_add_tuning_config/migration.sql
@@ -1,0 +1,10 @@
+-- TuningConfig: singleton row of admin-editable learning-pipeline knobs (#937).
+-- One row (id = 'singleton'); `values` holds the TuningConfig knob-set JSON.
+CREATE TABLE "TuningConfig" (
+    "id" TEXT NOT NULL,
+    "values" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "TuningConfig_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -699,3 +699,17 @@ model UserTrainingAggregates {
 
   @@index([computedAt])
 }
+
+/// Singleton row holding the admin-editable learning-pipeline knobs (issue
+/// #937). One row (id = "singleton"). `values` is a JSON blob of the TuningConfig
+/// knob set (lib/tuning/config.ts). Writes are zod-validated at the admin API
+/// layer; the read path (lib/tuning/store.ts, reachable from the clone-worker)
+/// parses the blob with per-field code-default fallback and NO zod import, so a
+/// malformed/missing row never breaks the pipeline.
+model TuningConfig {
+  id        String   @id
+  values    Json
+  updatedAt DateTime @updatedAt
+  /// User id of the admin who last saved the config (audit trail only).
+  updatedBy String?
+}


### PR DESCRIPTION
Closes #937.

Exposes a deliberately-minimal set of learning-pipeline thresholds as an admin-editable singleton, plus a payload preview so the effect on the LLM input is visible before committing.

## What's in it

**Data layer (`lib/tuning/`)**
- `config.ts` — canonical 8-knob set (`heavyE1rmFraction`, `heavyEffortCutoff`, `betaWeeklyDecay`, EWMA `alpha`/`typicalGapDays`, `lowDataMinSessions`/`lowDataMinSets`, `detrainingGapDays`), code defaults sourced from the constants each knob shadows, per-knob metadata (range + one-line effect), the **zod-free** `parseTuningConfig` read path with per-field fallback, and mappers to the pipeline's options objects.
- `store.ts` — `loadTuningConfig` reads the singleton; any missing/malformed/errored read degrades to code defaults.
- `schema.ts` — the **only** place zod touches tuning; imported solely by the admin write route.

**Dependency boundary (#942)** — the read path and everything reachable from the clone-worker stays zod-free (verified by tracing the import set). Write-time range validation is zod, isolated to the admin route.

**Plumbing** — knobs flow through `AggregatesOptions` (new `heavyE1rmFraction`/`heavyEffortCutoff`), `computeUserAggregates`, `evaluateWeeklyIntents` (threaded `HeavyThresholds`), and preference decay. The clone-worker aggregates processor loads the config before recompute.

**Config stamp** — `buildTrainingStatePayload` now returns `{ payload, configStamp }` so #921 can stamp the effective knobs into `Suggestion.requestPayload`.

**Admin UI** — `/admin/tuning` (+ `/preview`), admin-only. Form shows current value, code default, valid range, downstream-effect copy, and reset-to-defaults. Preview picks self or a synthetic archetype, applies ephemeral (unsaved) overrides, and renders the exact payload with the config stamp + a saved-vs-override diff.

## Acceptance criteria
- ✅ No `TuningConfig` row → byte-identical to today's constants (regression-tested; malformed row too).
- ✅ Out-of-range / unknown-key writes rejected at the API layer; admin-only enforced on all routes.
- ✅ Knob override provably changes the payload for a synthetic subject (heavyE1rmFraction flips a weekly-intent verdict + shifts `per_fau.last_heavy_days_ago`).
- ✅ Builder emits the config stamp for #921 to persist.

## Migration
`20260704232622_add_tuning_config` (adds the `TuningConfig` singleton table). Schema updated locally; production migration auto-applies on deploy.

## Tests
- `__tests__/lib/tuning/config.test.ts` — parse/fallback/mappers/validation
- `__tests__/lib/learning/weekly-intent-tuning.test.ts` — heaviness knobs flip a verdict
- `__tests__/lib/suggest/tuning-config-preview.test.ts` — no-row + malformed-row byte-identical to defaults; override changes the payload; config-stamp correctness

## Verification
Type-check + biome clean. Drove the admin form and preview page in a real browser against a seeded DB (screenshots captured) — config loads all 8 knobs, preview renders a real payload for the cyclist archetype with the override diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)