### PR TITLE
Builder follow-ups: persisted duration, equipmentAvailableSet, notes-cap doc

### DIFF
--- a/__tests__/lib/suggest/candidates.test.ts
+++ b/__tests__/lib/suggest/candidates.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCandidateExercises,
+  type CatalogExercise,
+  type DecayedPreference,
+  resolveAvailableEquipment,
+} from '@/lib/suggest/candidates'
+
+const NO_PREFS = new Map<string, DecayedPreference>()
+const NO_BANS = new Set<string>()
+
+const BARBELL_SQUAT: CatalogExercise = {
+  id: 'ex-squat',
+  name: 'Barbell Squat',
+  equipment: ['barbell'],
+  primaryFAUs: ['quads'],
+  secondaryFAUs: ['glutes'],
+  movementPattern: 'squat',
+  intensityClass: 'heavy',
+}
+
+const PUSHUP: CatalogExercise = {
+  id: 'ex-pushup',
+  name: 'Push-up',
+  equipment: ['bodyweight'],
+  primaryFAUs: ['chest'],
+  secondaryFAUs: ['triceps'],
+  movementPattern: 'horizontal_push',
+  intensityClass: 'moderate',
+}
+
+describe('resolveAvailableEquipment', () => {
+  it('treats an empty list as unconstrained when no explicit record exists', () => {
+    const { available, unconstrained } = resolveAvailableEquipment([])
+    expect(unconstrained).toBe(true)
+    expect(available.has('bodyweight')).toBe(true)
+  })
+
+  it('defaults to unconstrained when equipmentSet is omitted (back-compat)', () => {
+    expect(resolveAvailableEquipment(['dumbbell']).unconstrained).toBe(false)
+    expect(resolveAvailableEquipment([]).unconstrained).toBe(true)
+  })
+
+  it('treats an empty list as bodyweight-only when the record is explicit', () => {
+    const { available, unconstrained } = resolveAvailableEquipment([], true)
+    expect(unconstrained).toBe(false)
+    expect(available.has('bodyweight')).toBe(true)
+    expect(available.size).toBe(1) // only bodyweight
+  })
+
+  it('keeps a populated explicit list constrained to its tokens', () => {
+    const { available, unconstrained } = resolveAvailableEquipment(['dumbbells'], true)
+    expect(unconstrained).toBe(false)
+    expect(available.has('dumbbell')).toBe(true) // normalized alias
+    expect(available.has('bodyweight')).toBe(true)
+  })
+})
+
+describe('buildCandidateExercises equipment gating', () => {
+  const catalog = [BARBELL_SQUAT, PUSHUP]
+
+  it('includes non-bodyweight exercises when equipment is unconstrained', () => {
+    const { available, unconstrained } = resolveAvailableEquipment([])
+    const result = buildCandidateExercises(catalog, {
+      available,
+      unconstrained,
+      bannedIds: NO_BANS,
+      preferences: NO_PREFS,
+    })
+    expect(result.map((c) => c.id).sort()).toEqual(['ex-pushup', 'ex-squat'])
+  })
+
+  it('restricts to bodyweight when the explicit list is empty', () => {
+    const { available, unconstrained } = resolveAvailableEquipment([], true)
+    const result = buildCandidateExercises(catalog, {
+      available,
+      unconstrained,
+      bannedIds: NO_BANS,
+      preferences: NO_PREFS,
+    })
+    expect(result.map((c) => c.id)).toEqual(['ex-pushup'])
+  })
+})

--- a/__tests__/lib/suggest/training-state-builder.test.ts
+++ b/__tests__/lib/suggest/training-state-builder.test.ts
@@ -309,4 +309,102 @@ describe('buildTrainingStatePayload — golden archetype canaries', () => {
     expect(recent[0].total_sets).toBe(6)
     expect(recent[0].duration_min).toBe(60)
   })
+
+  it('prefers persisted durationSeconds over the completedAt − startedAt derivation', async () => {
+    const user = await createTestUser()
+    await prisma.userTrainingProfile.create({
+      data: {
+        userId: user.id,
+        goalSentences: ['Stay healthy'],
+        weeklyIntent: [],
+        equipmentAvailable: ['dumbbells', 'machines'],
+        bannedExerciseIds: [],
+        ratioTargets: {},
+        defaultIntensityPreference: null,
+      },
+    })
+
+    const completedAt = new Date(NOW.getTime() - 2 * DAY_MS)
+    const completion = await prisma.workoutCompletion.create({
+      data: {
+        userId: user.id,
+        status: 'completed',
+        isAdHoc: true,
+        name: 'Duration Test',
+        // startedAt derivation would give 60 min; the persisted value wins.
+        startedAt: new Date(completedAt.getTime() - 60 * 60 * 1000),
+        durationSeconds: 45 * 60,
+        completedAt,
+      },
+    })
+    const defId = lookup.get(normalizeName('Goblet Squat')) as string
+    await prisma.exercise.create({
+      data: {
+        name: 'Goblet Squat',
+        exerciseDefinitionId: defId,
+        order: 1,
+        userId: user.id,
+        workoutCompletionId: completion.id,
+        loggedSets: {
+          create: [
+            {
+              setNumber: 1,
+              reps: 10,
+              weight: 100,
+              weightUnit: 'lbs',
+              isWarmup: false,
+              completionId: completion.id,
+              userId: user.id,
+              createdAt: completedAt,
+            },
+          ],
+        },
+      },
+    })
+
+    const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
+    expect(payload.training_state.recent_sessions[0].duration_min).toBe(45)
+  })
+
+  it('restricts candidates to bodyweight when equipment record is explicit and empty', async () => {
+    const user = await createTestUser()
+    await prisma.userTrainingProfile.create({
+      data: {
+        userId: user.id,
+        goalSentences: ['Stay healthy'],
+        weeklyIntent: [],
+        equipmentAvailable: [],
+        equipmentAvailableSet: true, // authoritative empty list = bodyweight only
+        bannedExerciseIds: [],
+        ratioTargets: {},
+        defaultIntensityPreference: null,
+      },
+    })
+
+    const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
+    const names = payload.candidate_exercises.map((c) => c.name).sort()
+    // Only bodyweight fixtures survive (pull_up_bar is ambient, not gating).
+    expect(names).toEqual(['Pull-Up', 'Standard Push-Up'])
+  })
+
+  it('leaves candidates unconstrained when no explicit equipment record exists', async () => {
+    const user = await createTestUser()
+    await prisma.userTrainingProfile.create({
+      data: {
+        userId: user.id,
+        goalSentences: ['Stay healthy'],
+        weeklyIntent: [],
+        equipmentAvailable: [],
+        equipmentAvailableSet: false, // no record → assume full access
+        bannedExerciseIds: [],
+        ratioTargets: {},
+        defaultIntensityPreference: null,
+      },
+    })
+
+    const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
+    const names = payload.candidate_exercises.map((c) => c.name)
+    // A barbell-only exercise survives when equipment is unconstrained.
+    expect(names).toContain('Barbell Back Squat')
+  })
 })

--- a/docs/SUGGEST_PAYLOAD_SPEC.md
+++ b/docs/SUGGEST_PAYLOAD_SPEC.md
@@ -416,7 +416,7 @@ notes, session RPE) in one block.
 [
   {
     "days_ago": 2,
-    "duration_min": 52,                     // null when start time is missing
+    "duration_min": 52,                     // persisted durationSeconds preferred; null when neither it nor a start time exists
     "total_sets": 18,                       // effective (non-warmup) sets, incl. abandoned sessions
     "abandoned": false,
     "session_rpe": 4,                       // OMITTED when not logged (opt-in 1-tap, may not exist)
@@ -430,11 +430,11 @@ notes, session RPE) in one block.
 | Field | Type | Nullable | Producer | Rules |
 |---|---|---|---|---|
 | `days_ago` | `number` (int) | no | aggregates + builder | |
-| `duration_min` | `number` (int) | yes | aggregates | `completedAt − startedAt`, rounded to minutes; `null` when `startedAt` is missing |
+| `duration_min` | `number` (int) | yes | builder | prefers persisted `WorkoutCompletion.durationSeconds` (÷60, rounded); falls back to `completedAt − startedAt` rounded to minutes; `null` when neither is available |
 | `total_sets` | `number` (int) | no | aggregates | effective sets in the session |
 | `abandoned` | `boolean` | no | aggregates | `true` for `status: 'abandoned'` completions |
 | `session_rpe` | `number` (int, 1–5) | omitted when absent | aggregates | from `WorkoutCompletion.sessionRpe` if/when the 1-tap rollup chip ships; **omitted**, not nulled, when not logged |
-| `notes` | `{ exercise: string, text: string }[]` | no (may be `[]`) | aggregates | non-empty `Exercise.notes`, each truncated to ~120 chars, ≤ 5 notes per session |
+| `notes` | `{ exercise: string, text: string }[]` | no (may be `[]`) | builder | non-empty `Exercise.notes`, each truncated to ~120 chars, ≤ 5 notes per session (tightened from the 10 originally floated in #920 — 5 keeps the block token-cheap while still surfacing the exercises a user actually annotated) |
 
 Cold-start: contains whatever sessions exist (0–2 entries). This block is the
 one place a nearly-new user's actual behavior is visible to the model.
@@ -490,6 +490,8 @@ Cold-start: empty arrays + the low-confidence note.
 Producer: **builder** (deterministic pre-filter: equipment match, FAU
 relevance, not in `banned_exercise_ids`). ~80–150 entries typical. Sent
 unordered — the LLM ranks (spec rule 10). Unchanged from v1.
+
+Equipment gating honors the explicit-record flag (`UserTrainingProfile.equipmentAvailableSet`, #927): when the user has an explicit equipment record, the list is authoritative and an **empty** list yields bodyweight-only candidates. Without an explicit record (or a request `equipment_override`, which is always authoritative), an empty list means "unconstrained — assume full access" so a user who never filled in equipment isn't stranded.
 
 ```jsonc
 {

--- a/lib/suggest/candidates.ts
+++ b/lib/suggest/candidates.ts
@@ -92,19 +92,26 @@ function normalizeEquipmentToken(token: string): string {
 
 /**
  * Build the set of available equipment tokens. `equipment_override` (from the
- * request) wins over the durable profile list. An EMPTY list is treated as "no
- * constraint" (assume full access) rather than "nothing available" — the latter
- * would strand a user who never filled in equipment with a bodyweight-only
- * (possibly empty) candidate list.
+ * request) wins over the durable profile list.
+ *
+ * `equipmentSet` records whether the list is authoritative (#927):
+ * - `false` (no explicit record): an EMPTY list means "no constraint" (assume
+ *   full access) rather than "nothing available" — the latter would strand a
+ *   user who never filled in equipment with a bodyweight-only candidate list.
+ * - `true` (explicit record): the list is the user's real selection. An empty
+ *   list means bodyweight-only, NOT unconstrained.
  */
-export function resolveAvailableEquipment(equipment: readonly string[]): {
+export function resolveAvailableEquipment(
+  equipment: readonly string[],
+  equipmentSet = false,
+): {
   available: Set<string>
   unconstrained: boolean
 } {
   const normalized = equipment.map(normalizeEquipmentToken).filter(Boolean)
   const available = new Set(normalized)
   available.add('bodyweight')
-  return { available, unconstrained: normalized.length === 0 }
+  return { available, unconstrained: !equipmentSet && normalized.length === 0 }
 }
 
 /** Does the user have the equipment this exercise requires? */

--- a/lib/suggest/training-state-builder.ts
+++ b/lib/suggest/training-state-builder.ts
@@ -137,6 +137,7 @@ function daysAgoOf(now: Date, when: Date): number {
 interface SessionRow {
   completedAt: Date
   startedAt: Date | null
+  durationSeconds: number | null
   status: string
   exercises: {
     name: string
@@ -185,6 +186,24 @@ function toEvaluatedSession(now: Date, session: SessionRow): EvaluatedSession {
   }
 }
 
+/**
+ * Session length in whole minutes. Prefers the persisted
+ * `WorkoutCompletion.durationSeconds` (#933/#945) — the authoritative logged
+ * duration — and falls back to the live `completedAt − startedAt` derivation.
+ * Returns null when neither is available.
+ */
+function sessionDurationMinutes(session: SessionRow): number | null {
+  if (session.durationSeconds != null) {
+    return Math.round(session.durationSeconds / 60)
+  }
+  if (session.startedAt) {
+    return Math.round(
+      (session.completedAt.getTime() - session.startedAt.getTime()) / 60000,
+    )
+  }
+  return null
+}
+
 /** Build the newest-first recent_sessions block from qualifying completions. */
 function toRecentSessions(now: Date, qualifying: SessionRow[]) {
   return qualifying.slice(0, MAX_RECENT_SESSIONS).map((session) => {
@@ -202,10 +221,7 @@ function toRecentSessions(now: Date, qualifying: SessionRow[]) {
 
     return {
       days_ago: daysAgoOf(now, session.completedAt),
-      // duration_min is null when the workout has no recorded start time.
-      duration_min: session.startedAt
-        ? Math.round((session.completedAt.getTime() - session.startedAt.getTime()) / 60000)
-        : null,
+      duration_min: sessionDurationMinutes(session),
       total_sets: totalSets,
       abandoned: session.status === 'abandoned',
       // session_rpe is OMITTED (no sessionRpe column exists yet).
@@ -296,6 +312,7 @@ export async function buildTrainingStatePayload(
         select: {
           completedAt: true,
           startedAt: true,
+          durationSeconds: true,
           status: true,
           exercises: {
             select: {
@@ -373,8 +390,12 @@ export async function buildTrainingStatePayload(
   const bannedIds = new Set<string>([...profile.bannedExerciseIds, ...banResult.bannedExerciseIds])
 
   const catalog: CatalogExercise[] = catalogRows
+  // An explicit request override is authoritative (even when empty = bodyweight
+  // only); otherwise fall back to the durable list and its explicit-record flag.
+  const equipmentOverride = request.equipment_override ?? null
   const { available, unconstrained } = resolveAvailableEquipment(
-    request.equipment_override ?? profile.equipmentAvailable,
+    equipmentOverride ?? profile.equipmentAvailable,
+    equipmentOverride != null ? true : profile.equipmentAvailableSet,
   )
   const preferences = decayPreferences(prefRows, now, config.betaWeeklyDecay)
   const candidateExercises = buildCandidateExercises(catalog, {


### PR DESCRIPTION
## Summary

Builder follow-ups from the #949 / #947 reviews (issue #950). Scoped per the autopilot dispatch note — item 1 (cautioned-exercise payload block) is intentionally left for the #946 dogfood checkpoint.

**Item 2 — prefer persisted duration.** `recent_sessions[].duration_min` now prefers the persisted `WorkoutCompletion.durationSeconds` (#933/#945) and falls back to the live `completedAt − startedAt` derivation; `null` only when neither exists. Added `durationSeconds` to the builder's completion select and a `sessionDurationMinutes` helper.

**Item 3 — session-notes cap.** Kept the builder's `MAX_SESSION_NOTES = 5` and documented the intentional tightening from the 10 originally floated in #920 in `docs/SUGGEST_PAYLOAD_SPEC.md`.

**Item 4 — honor `equipmentAvailableSet`.** `resolveAvailableEquipment` now takes the explicit-record flag (#927). When the record is authoritative, an **empty** list yields bodyweight-only candidates; without an explicit record it keeps meaning "unconstrained — assume full access". A request `equipment_override` is always treated as authoritative. Documented in the spec's `candidate_exercises` section.

## Tests

- `__tests__/lib/suggest/candidates.test.ts` (new) — `resolveAvailableEquipment` both branches + `buildCandidateExercises` equipment gating.
- `__tests__/lib/suggest/training-state-builder.test.ts` — persisted-duration preference; explicit-empty equipment → bodyweight only; unset record → unconstrained.
- All 9 builder tests (incl. golden snapshots, unchanged) + 6 candidate tests pass. Type-check clean; lint clean on changed files.

## Out of scope

Item 1 (cautioned-exercise payload block) — deferred to the #946 dogfood checkpoint per the issue body. The existing "computed but not emitted" design-decision comment in the builder is left untouched.

Fixes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)