### PR TITLE
chore(dev): auto-seed synthetic archetype users on postgres startup

### DIFF
--- a/scripts/start-postgres.sh
+++ b/scripts/start-postgres.sh
@@ -106,6 +106,17 @@ for f in "$SEEDS_DIR"/0[0-8]_*.sql; do
 done
 echo "Exercise definitions seeded"
 
+# Seed synthetic archetype users with workout history (requires exercise
+# definitions above). Idempotent per archetype (deterministic synthetic-<key>
+# ids, delete-and-recreate) and seeded-RNG deterministic relative to "now", so
+# re-running on every startup is intended — no run-once guard. A failure here
+# must not abort postgres startup, so warn and continue.
+echo "Seeding synthetic archetype users..."
+DATABASE_URL="$LOCAL_DB_URL" DIRECT_URL="$LOCAL_DB_URL" \
+  npx tsx "$SCRIPT_DIR/seed-synthetic-users.ts" 2>&1 \
+  || echo "Warning: synthetic user seeding failed (continuing)"
+echo "Synthetic archetype users seeded"
+
 # Seed curated community programs (idempotent — skips if already present)
 echo "Seeding community programs..."
 DATABASE_URL="$LOCAL_DB_URL" DIRECT_URL="$LOCAL_DB_URL" \


### PR DESCRIPTION
## Summary

Adds a synthetic-users step to the local `scripts/start-postgres.sh` seed chain so the 5 archetype users (beginner, inconsistent, cyclist, bodybuilder, powerlifter) from `scripts/seed-synthetic-users.ts` (#910) are seeded automatically on every local/worktree postgres startup — required for the tuning-preview panel (#937) and the #946 dogfood checkpoint.

## Changes

- New step in `start-postgres.sh` **after exercise definitions** (the seeder requires them), before community programs.
- Uses the same `DATABASE_URL`/`DIRECT_URL` override pattern as the other TS seed steps — nothing hardcodes a port, so worktree port overrides from `worktree-env.sh` are respected.
- No run-once guard: the seeder is idempotent per archetype (deterministic `synthetic-<key>` ids, delete-and-recreate) and seeded-RNG deterministic relative to "now", so re-running keeps detraining-gap/ACR realistic. This is intended.
- Failure is tolerated (`|| echo "Warning..."`) so a seeding error cannot abort postgres startup.
- No changes to the seeder itself.

## Verification

Ran the full flow against a fresh empty DB on this worktree's port (schema push → exercise defs → new step):

- 5 `synthetic-*` users created, 5 `UserSettings`, 69 `WorkoutCompletion` rows.
- Re-running the seeder produced identical counts (5 users / 69 completions) — idempotency preserved.
- Invocation uses `npx tsx`, matching the seeder's documented/tested usage.

## Out of scope

- Staging/prod seeding (manual one-off, handled separately).

Fixes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)