### PR TITLE
chore(msv): repoint to Mechanical recommendations v1

### DIFF
--- a/.msv.yaml
+++ b/.msv.yaml
@@ -1,4 +1,4 @@
 owner: aptx-health
 repo: ripit-fitness
-milestone: "Suggest Workout: build phase"
-graph_file: milestones/suggest-workout-build.md
+milestone: "Mechanical recommendations v1"
+graph_file: milestones/mechanical-recommendations.md


### PR DESCRIPTION
M16 closed 2026-07-09 (descope, see #957). Points msv at the new milestone and its graph file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)