### PR TITLE
fix: gate primary implements in equipment filter (#958)

### DIFF
--- a/__tests__/lib/suggest/__snapshots__/training-state-builder.test.ts.snap
+++ b/__tests__/lib/suggest/__snapshots__/training-state-builder.test.ts.snap
@@ -131,20 +131,6 @@ exports[`buildTrainingStatePayload — golden archetype canaries > assembles a v
     },
     {
       "equipment": "bodyweight",
-      "id": "def-pull-up",
-      "intensity_class": "heavy",
-      "movement_pattern": "vertical_pull",
-      "name": "Pull-Up",
-      "primary_faus": [
-        "lats",
-      ],
-      "secondary_faus": [
-        "biceps",
-        "mid-back",
-      ],
-    },
-    {
-      "equipment": "bodyweight",
       "id": "def-standard-push-up",
       "intensity_class": "moderate",
       "movement_pattern": "horizontal_push",
@@ -588,20 +574,6 @@ exports[`buildTrainingStatePayload — golden archetype canaries > assembles a v
       ],
       "secondary_faus": [
         "triceps",
-      ],
-    },
-    {
-      "equipment": "bodyweight",
-      "id": "def-pull-up",
-      "intensity_class": "heavy",
-      "movement_pattern": "vertical_pull",
-      "name": "Pull-Up",
-      "primary_faus": [
-        "lats",
-      ],
-      "secondary_faus": [
-        "biceps",
-        "mid-back",
       ],
     },
     {
@@ -1455,20 +1427,6 @@ exports[`buildTrainingStatePayload — golden archetype canaries > assembles a v
       ],
     },
     {
-      "equipment": "bodyweight",
-      "id": "def-pull-up",
-      "intensity_class": "heavy",
-      "movement_pattern": "vertical_pull",
-      "name": "Pull-Up",
-      "primary_faus": [
-        "lats",
-      ],
-      "secondary_faus": [
-        "biceps",
-        "mid-back",
-      ],
-    },
-    {
       "equipment": "barbell",
       "id": "def-romanian-deadlift",
       "intensity_class": "heavy",
@@ -2203,20 +2161,6 @@ exports[`buildTrainingStatePayload — golden archetype canaries > assembles a v
       ],
     },
     {
-      "equipment": "bodyweight",
-      "id": "def-pull-up",
-      "intensity_class": "heavy",
-      "movement_pattern": "vertical_pull",
-      "name": "Pull-Up",
-      "primary_faus": [
-        "lats",
-      ],
-      "secondary_faus": [
-        "biceps",
-        "mid-back",
-      ],
-    },
-    {
       "equipment": "barbell",
       "id": "def-romanian-deadlift",
       "intensity_class": "heavy",
@@ -2736,20 +2680,6 @@ exports[`buildTrainingStatePayload — golden archetype canaries > assembles a v
       ],
       "secondary_faus": [
         "triceps",
-      ],
-    },
-    {
-      "equipment": "bodyweight",
-      "id": "def-pull-up",
-      "intensity_class": "heavy",
-      "movement_pattern": "vertical_pull",
-      "name": "Pull-Up",
-      "primary_faus": [
-        "lats",
-      ],
-      "secondary_faus": [
-        "biceps",
-        "mid-back",
       ],
     },
     {

--- a/__tests__/lib/suggest/candidates.test.ts
+++ b/__tests__/lib/suggest/candidates.test.ts
@@ -81,3 +81,100 @@ describe('buildCandidateExercises equipment gating', () => {
     expect(result.map((c) => c.id)).toEqual(['ex-pushup'])
   })
 })
+
+describe('buildCandidateExercises gated primary implements (#958)', () => {
+  const PULL_UP: CatalogExercise = {
+    id: 'ex-pullup',
+    name: 'Pull-Up',
+    equipment: ['pull_up_bar'],
+    primaryFAUs: ['lats'],
+    secondaryFAUs: ['biceps'],
+    movementPattern: 'vertical_pull',
+    intensityClass: 'moderate',
+  }
+  const DIPS: CatalogExercise = {
+    id: 'ex-dips',
+    name: 'Dips',
+    equipment: ['dip_bars'],
+    primaryFAUs: ['chest'],
+    secondaryFAUs: ['triceps'],
+    movementPattern: 'vertical_push',
+    intensityClass: 'moderate',
+  }
+  const EZ_CURL: CatalogExercise = {
+    id: 'ex-ezcurl',
+    name: 'EZ Bar Curl',
+    equipment: ['ez_bar'],
+    primaryFAUs: ['biceps'],
+    secondaryFAUs: [],
+    movementPattern: 'elbow_flexion',
+    intensityClass: 'light',
+  }
+  const AB_WHEEL: CatalogExercise = {
+    id: 'ex-abwheel',
+    name: 'Ab Wheel',
+    equipment: ['ab_wheel'],
+    primaryFAUs: ['abs'],
+    secondaryFAUs: [],
+    movementPattern: 'anti_extension',
+    intensityClass: 'moderate',
+  }
+  const DB_BENCH: CatalogExercise = {
+    id: 'ex-dbbench',
+    name: 'Dumbbell Bench Press',
+    equipment: ['dumbbell', 'bench'],
+    primaryFAUs: ['chest'],
+    secondaryFAUs: ['triceps'],
+    movementPattern: 'horizontal_push',
+    intensityClass: 'moderate',
+  }
+
+  const catalog = [PULL_UP, DIPS, EZ_CURL, AB_WHEEL, DB_BENCH]
+
+  it('excludes gated primary implements a dumbbell/machine user does not own', () => {
+    const { available, unconstrained } = resolveAvailableEquipment(
+      ['dumbbell', 'machine', 'bodyweight'],
+      true,
+    )
+    const result = buildCandidateExercises(catalog, {
+      available,
+      unconstrained,
+      bannedIds: NO_BANS,
+      preferences: NO_PREFS,
+    })
+    const ids = result.map((c) => c.id)
+    expect(ids).not.toContain('ex-pullup')
+    expect(ids).not.toContain('ex-dips')
+    expect(ids).not.toContain('ex-ezcurl')
+    expect(ids).not.toContain('ex-abwheel')
+    // bench is ambient + dumbbell owned → still passes
+    expect(ids).toContain('ex-dbbench')
+  })
+
+  it('includes pull-up exercises when the user explicitly lists pull_up_bar', () => {
+    const { available, unconstrained } = resolveAvailableEquipment(
+      ['pull_up_bar'],
+      true,
+    )
+    const result = buildCandidateExercises(catalog, {
+      available,
+      unconstrained,
+      bannedIds: NO_BANS,
+      preferences: NO_PREFS,
+    })
+    expect(result.map((c) => c.id)).toContain('ex-pullup')
+  })
+
+  it('passes everything for unconstrained users', () => {
+    const { available, unconstrained } = resolveAvailableEquipment([])
+    const result = buildCandidateExercises(catalog, {
+      available,
+      unconstrained,
+      bannedIds: NO_BANS,
+      preferences: NO_PREFS,
+    })
+    expect(result.map((c) => c.id).sort()).toEqual(
+      ['ex-abwheel', 'ex-dbbench', 'ex-dips', 'ex-ezcurl', 'ex-pullup'].sort(),
+    )
+  })
+})

--- a/__tests__/lib/suggest/training-state-builder.test.ts
+++ b/__tests__/lib/suggest/training-state-builder.test.ts
@@ -383,8 +383,9 @@ describe('buildTrainingStatePayload — golden archetype canaries', () => {
 
     const { payload } = await buildTrainingStatePayload(prisma, user.id, REQUEST, NOW)
     const names = payload.candidate_exercises.map((c) => c.name).sort()
-    // Only bodyweight fixtures survive (pull_up_bar is ambient, not gating).
-    expect(names).toEqual(['Pull-Up', 'Standard Push-Up'])
+    // Only pure-bodyweight fixtures survive. Pull-Up requires pull_up_bar, a
+    // gated primary implement (#958), so it's excluded for a bodyweight-only user.
+    expect(names).toEqual(['Standard Push-Up'])
   })
 
   it('leaves candidates unconstrained when no explicit equipment record exists', async () => {

--- a/lib/suggest/candidates.ts
+++ b/lib/suggest/candidates.ts
@@ -65,23 +65,23 @@ const EQUIPMENT_ALIASES: Record<string, string> = {
 }
 
 /**
- * Accessory equipment that never gates availability: benches, bars and small
- * tools are assumed present whenever the user has any primary equipment, so a
- * "dumbbell + bench" exercise isn't excluded just because the profile lists
- * only `dumbbells`.
+ * Accessory equipment that never gates availability on its own: benches and
+ * small support gear are assumed present whenever the user has any primary
+ * equipment, so a "dumbbell + bench" exercise isn't excluded just because the
+ * profile lists only `dumbbells`. These genuinely co-occur with owned weights.
+ *
+ * NOTE: primary implements you either own or you don't — `pull_up_bar`,
+ * `dip_bars`, `parallel_bars`, `ab_wheel`, `roman_chair`, `ez_bar` — are
+ * deliberately NOT ambient (#958). Treating them as ambient let an exercise
+ * whose ONLY requirement was such a token pass for every user (e.g. a beginner
+ * with dumbbells/machines got 13 pull-up-bar exercises).
  */
 const AMBIENT_EQUIPMENT = new Set<string>([
   'bench',
   'incline_bench',
   'decline_bench',
   'preacher_bench',
-  'pull_up_bar',
-  'dip_bars',
-  'parallel_bars',
-  'ez_bar',
-  'ab_wheel',
   'foam_roller',
-  'roman_chair',
   'weight_belt',
 ])
 
@@ -121,9 +121,14 @@ export function isEquipmentAvailable(
   unconstrained: boolean,
 ): boolean {
   if (unconstrained) return true
-  const required = exercise.equipment
-    .map(normalizeEquipmentToken)
-    .filter((token) => !AMBIENT_EQUIPMENT.has(token))
+  const normalized = exercise.equipment.map(normalizeEquipmentToken)
+  const required = normalized.filter((token) => !AMBIENT_EQUIPMENT.has(token))
+  // Backstop (#958): if every required token is ambient, the exercise would
+  // otherwise pass for everyone. Demand that at least one ambient token is
+  // actually owned so a future ambient addition can't reintroduce the leak.
+  if (normalized.length > 0 && required.length === 0) {
+    return normalized.some((token) => available.has(token))
+  }
   return required.every((token) => available.has(token))
 }
 


### PR DESCRIPTION
## Summary

Fixes the ambient-equipment leak from the #957 audit (Finding 1). Previously `AMBIENT_EQUIPMENT` in `lib/suggest/candidates.ts` exempted primary implements like `pull_up_bar` from availability gating, so an exercise whose ONLY requirement was ambient passed for every user — a beginner with `["dumbbell","machine","bodyweight"]` got 13 pull-up-bar exercises plus dips, EZ-bar curls, and ab-wheel work.

## Changes (all in `lib/suggest/candidates.ts`)

1. **Reclassified as gated** (removed from `AMBIENT_EQUIPMENT`): `pull_up_bar`, `dip_bars`, `parallel_bars`, `ab_wheel`, `roman_chair`, `ez_bar` — primary implements you either own or you don't.
2. **Kept ambient**: `bench`, `incline_bench`, `decline_bench`, `preacher_bench`, `foam_roller`, `weight_belt` (genuinely co-occur with owned weights).
3. **Backstop rule** in `isEquipmentAvailable`: if ALL of an exercise's required tokens are ambient, at least one must actually be in the user's available set — prevents future ambient additions from reintroducing the leak.
4. `unconstrained` short-circuit unchanged.

## Tests

- New `candidates.test.ts` cases: dumbbell/machine user excludes Pull-Up/Dips/EZ Bar Curl/Ab Wheel while Dumbbell Bench Press stays; explicit `pull_up_bar` user gets pull-ups; unconstrained users pass everything.
- Updated the bodyweight-only builder expectation (Pull-Up now correctly excluded).
- Regenerated golden snapshots where Pull-Up is now excluded (only Pull-Up carried a gated token, so those are the only diffs — 70 lines, all Pull-Up entries).

## Verification

- `npm run type-check` clean.
- `npm run lint` clean for changed files (pre-existing errors in `FollowAlongTabs.tsx` unrelated).
- `candidates.test.ts` and `training-state-builder.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)