### PR TITLE
History tab: surface duration, session effort, and per-workout FAU coverage

### DIFF
--- a/__tests__/api/history-list-enrichment.test.ts
+++ b/__tests__/api/history-list-enrichment.test.ts
@@ -1,0 +1,187 @@
+import type { PrismaClient } from '@prisma/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getTestDatabase } from '@/lib/test/database'
+import {
+  createCompleteTestScenario,
+  createTestUser,
+} from '@/lib/test/factories'
+import {
+  computeFauRollup,
+  countWorkingSets,
+  MAX_FAU_CHIPS,
+  resolveDurationSeconds,
+} from '@/lib/workout-history'
+
+/**
+ * The loggedSets shape the history route selects for FAU rollup. Kept in sync
+ * with `app/api/workouts/history/route.ts` so the enrichment test exercises the
+ * same data the endpoint feeds into the shared helpers.
+ */
+const HISTORY_LOGGED_SET_SELECT = {
+  id: true,
+  setNumber: true,
+  reps: true,
+  weight: true,
+  weightUnit: true,
+  isWarmup: true,
+  exercise: {
+    select: {
+      name: true,
+      exerciseGroup: true,
+      order: true,
+      exerciseDefinition: { select: { primaryFAUs: true } },
+    },
+  },
+} as const
+
+function makeSet(primaryFAUs: string[], isWarmup = false) {
+  return { isWarmup, exercise: { exerciseDefinition: { primaryFAUs } } }
+}
+
+describe('computeFauRollup', () => {
+  it('returns no chips for an empty set list', () => {
+    expect(computeFauRollup([])).toEqual({ chips: [], overflow: 0 })
+  })
+
+  it('excludes warmup sets from the rollup', () => {
+    const rollup = computeFauRollup([
+      makeSet(['chest'], true),
+      makeSet(['chest'], false),
+      makeSet(['triceps'], false),
+    ])
+    const chest = rollup.chips.find((c) => c.fau === 'chest')
+    expect(chest?.count).toBe(1)
+    expect(rollup.chips.map((c) => c.fau).sort()).toEqual(['chest', 'triceps'])
+  })
+
+  it('maps known FAU tokens to display labels', () => {
+    const rollup = computeFauRollup([makeSet(['mid-back'])])
+    expect(rollup.chips[0]).toMatchObject({ fau: 'mid-back', label: 'Mid Back' })
+  })
+
+  it('caps chips at the top-N by set count and reports overflow', () => {
+    const sets = [
+      ...Array.from({ length: 5 }, () => makeSet(['chest'])),
+      ...Array.from({ length: 4 }, () => makeSet(['triceps'])),
+      ...Array.from({ length: 3 }, () => makeSet(['front-delts'])),
+      ...Array.from({ length: 2 }, () => makeSet(['quads'])),
+      makeSet(['calves']),
+    ]
+    const rollup = computeFauRollup(sets)
+    expect(rollup.chips).toHaveLength(MAX_FAU_CHIPS)
+    expect(rollup.chips.map((c) => c.fau)).toEqual([
+      'chest',
+      'triceps',
+      'front-delts',
+      'quads',
+    ])
+    expect(rollup.overflow).toBe(1)
+  })
+
+  it('breaks count ties deterministically by FAU token', () => {
+    const rollup = computeFauRollup([makeSet(['triceps']), makeSet(['biceps'])])
+    expect(rollup.chips.map((c) => c.fau)).toEqual(['biceps', 'triceps'])
+  })
+})
+
+describe('resolveDurationSeconds', () => {
+  const completedAt = new Date('2026-07-09T18:30:00Z')
+
+  it('prefers the stored duration', () => {
+    expect(resolveDurationSeconds(2700, null, completedAt)).toBe(2700)
+  })
+
+  it('falls back to completedAt - startedAt when duration is null', () => {
+    const startedAt = new Date('2026-07-09T18:00:00Z')
+    expect(resolveDurationSeconds(null, startedAt, completedAt)).toBe(1800)
+  })
+
+  it('returns null when neither duration nor a usable start exists', () => {
+    expect(resolveDurationSeconds(null, null, completedAt)).toBeNull()
+    expect(resolveDurationSeconds(0, null, completedAt)).toBeNull()
+  })
+})
+
+describe('workout history enrichment (DB-backed)', () => {
+  let prisma: PrismaClient
+  let userId: string
+
+  beforeEach(async () => {
+    const testDb = await getTestDatabase()
+    prisma = testDb.getPrismaClient()
+    await testDb.reset()
+    const user = await createTestUser()
+    userId = user.id
+  })
+
+  it('enriches a populated completion with duration, effort, sets, and FAU chips', async () => {
+    const { completion } = await createCompleteTestScenario(prisma, userId, {
+      status: 'completed',
+      loggedSetCount: 3,
+    })
+    await prisma.workoutCompletion.update({
+      where: { id: completion.id },
+      data: { durationSeconds: 2700, sessionRpe: 8 },
+    })
+
+    const row = await prisma.workoutCompletion.findUniqueOrThrow({
+      where: { id: completion.id },
+      select: {
+        completedAt: true,
+        startedAt: true,
+        durationSeconds: true,
+        sessionRpe: true,
+        loggedSets: { select: HISTORY_LOGGED_SET_SELECT },
+      },
+    })
+
+    const duration = resolveDurationSeconds(
+      row.durationSeconds,
+      row.startedAt,
+      row.completedAt
+    )
+    const workingSets = countWorkingSets(row.loggedSets)
+    const { chips, overflow } = computeFauRollup(row.loggedSets)
+
+    expect(duration).toBe(2700)
+    expect(row.sessionRpe).toBe(8)
+    expect(workingSets).toBe(3)
+    // Default test exercise is tagged chest + triceps, one primary each per set.
+    expect(chips.map((c) => c.fau).sort()).toEqual(['chest', 'triceps'])
+    expect(chips.every((c) => c.count === 3)).toBe(true)
+    expect(overflow).toBe(0)
+  })
+
+  it('degrades gracefully when duration, effort, and sets are absent', async () => {
+    const completion = await prisma.workoutCompletion.create({
+      data: {
+        userId,
+        status: 'completed',
+        isAdHoc: true,
+        name: 'Freestyle',
+        completedAt: new Date(),
+      },
+      select: {
+        completedAt: true,
+        startedAt: true,
+        durationSeconds: true,
+        sessionRpe: true,
+        loggedSets: { select: HISTORY_LOGGED_SET_SELECT },
+      },
+    })
+
+    const duration = resolveDurationSeconds(
+      completion.durationSeconds,
+      completion.startedAt,
+      completion.completedAt
+    )
+    const workingSets = countWorkingSets(completion.loggedSets)
+    const { chips, overflow } = computeFauRollup(completion.loggedSets)
+
+    expect(duration).toBeNull()
+    expect(completion.sessionRpe).toBeNull()
+    expect(workingSets).toBe(0)
+    expect(chips).toEqual([])
+    expect(overflow).toBe(0)
+  })
+})

--- a/app/api/workouts/history/route.ts
+++ b/app/api/workouts/history/route.ts
@@ -2,6 +2,11 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import {
+  computeFauRollup,
+  countWorkingSets,
+  resolveDurationSeconds,
+} from '@/lib/workout-history'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,7 +21,8 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams
     const limit = Math.min(parseInt(searchParams.get('limit') || '5', 10), 20)
 
-    // Fetch recent workout completions with all necessary data
+    // Fetch recent workout completions with all necessary data. Single query
+    // with includes — the FAU rollup is computed in-memory below, no N+1.
     const completions = await prisma.workoutCompletion.findMany({
       where: {
         userId: user.id,
@@ -28,6 +34,9 @@ export async function GET(request: NextRequest) {
         id: true,
         status: true,
         completedAt: true,
+        startedAt: true,
+        durationSeconds: true,
+        sessionRpe: true,
         isAdHoc: true,
         name: true,
         workout: {
@@ -50,11 +59,15 @@ export async function GET(request: NextRequest) {
             reps: true,
             weight: true,
             weightUnit: true,
+            isWarmup: true,
             exercise: {
               select: {
                 name: true,
                 exerciseGroup: true,
-                order: true
+                order: true,
+                exerciseDefinition: {
+                  select: { primaryFAUs: true }
+                }
               }
             }
           }
@@ -65,7 +78,47 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({ completions })
+    // Enrich each completion with derived duration, effort, working-set count,
+    // and FAU rollup. Strip the per-set FAU data from the response — it's only
+    // needed to compute the rollup, so keep the payload lean.
+    const enriched = completions.map(completion => {
+      const { chips, overflow } = computeFauRollup(completion.loggedSets)
+      const workingSets = countWorkingSets(completion.loggedSets)
+
+      return {
+        id: completion.id,
+        status: completion.status,
+        completedAt: completion.completedAt,
+        isAdHoc: completion.isAdHoc,
+        name: completion.name,
+        durationSeconds: resolveDurationSeconds(
+          completion.durationSeconds,
+          completion.startedAt,
+          completion.completedAt
+        ),
+        sessionRpe: completion.sessionRpe,
+        workingSets,
+        fauChips: chips,
+        fauOverflow: overflow,
+        workout: completion.workout,
+        loggedSets: completion.loggedSets.map(set => ({
+          id: set.id,
+          setNumber: set.setNumber,
+          reps: set.reps,
+          weight: set.weight,
+          weightUnit: set.weightUnit,
+          isWarmup: set.isWarmup,
+          exercise: {
+            name: set.exercise.name,
+            exerciseGroup: set.exercise.exerciseGroup,
+            order: set.exercise.order,
+          },
+        })),
+        _count: completion._count,
+      }
+    })
+
+    return NextResponse.json({ completions: enriched })
   } catch (error) {
     logger.error({ error, context: 'workout-history' }, 'Failed to fetch workout history')
     return NextResponse.json(

--- a/components/WorkoutHistoryList.tsx
+++ b/components/WorkoutHistoryList.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight, Clock, Dumbbell, Flame } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
 import { clientLogger } from '@/lib/client-logger'
+import { sessionEffortLabel } from '@/lib/effort-prompt'
 
 type Exercise = {
   name: string
@@ -18,7 +19,14 @@ type LoggedSet = {
   reps: number
   weight: number
   weightUnit: string
+  isWarmup: boolean
   exercise: Exercise
+}
+
+type FauChip = {
+  fau: string
+  label: string
+  count: number
 }
 
 type WorkoutCompletion = {
@@ -27,6 +35,11 @@ type WorkoutCompletion = {
   status: string
   isAdHoc: boolean
   name: string | null
+  durationSeconds: number | null
+  sessionRpe: number | null
+  workingSets: number
+  fauChips: FauChip[]
+  fauOverflow: number
   workout: {
     id: string
     name: string
@@ -40,6 +53,15 @@ type WorkoutCompletion = {
   _count: {
     loggedSets: number
   }
+}
+
+/** Format a duration in seconds as a compact "45 min" / "1h 05m" label. */
+function formatDuration(totalSeconds: number): string {
+  const totalMinutes = Math.max(1, Math.round(totalSeconds / 60))
+  if (totalMinutes < 60) return `${totalMinutes} min`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${hours}h ${minutes.toString().padStart(2, '0')}m`
 }
 
 type Props = {
@@ -153,6 +175,13 @@ export default function WorkoutHistoryList({ count, compact = false }: Props) {
       return orderA - orderB
     })
 
+    const effortLabel = sessionEffortLabel(completion.sessionRpe)
+    const durationLabel =
+      completion.durationSeconds != null
+        ? formatDuration(completion.durationSeconds)
+        : null
+    const workingSets = completion.workingSets
+
     return (
       <div
         key={completion.id}
@@ -197,9 +226,47 @@ export default function WorkoutHistoryList({ count, compact = false }: Props) {
               )}
             </div>
           </div>
-          <div className="mt-3 text-sm text-muted-foreground">
-            {completion._count.loggedSets} {completion._count.loggedSets === 1 ? 'set' : 'sets'} logged
+          {/* Session meta: duration, effort, working sets. Each part is
+              omitted when its data is null so rows degrade gracefully. */}
+          <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+            {durationLabel && (
+              <span className="inline-flex items-center gap-1.5">
+                <Clock aria-hidden="true" className="w-4 h-4 shrink-0" />
+                {durationLabel}
+              </span>
+            )}
+            {effortLabel && (
+              <span className="inline-flex items-center gap-1.5">
+                <Flame aria-hidden="true" className="w-4 h-4 shrink-0" />
+                {effortLabel}
+              </span>
+            )}
+            {workingSets > 0 && (
+              <span className="inline-flex items-center gap-1.5">
+                <Dumbbell aria-hidden="true" className="w-4 h-4 shrink-0" />
+                {workingSets} {workingSets === 1 ? 'set' : 'sets'}
+              </span>
+            )}
           </div>
+
+          {/* Primary FAUs worked this session (warmups excluded). */}
+          {completion.fauChips.length > 0 && (
+            <div className="mt-2.5 flex flex-wrap gap-1.5">
+              {completion.fauChips.map((chip) => (
+                <span
+                  key={chip.fau}
+                  className="bg-muted text-foreground border border-border text-xs font-semibold uppercase tracking-wide px-2 py-0.5"
+                >
+                  {chip.label}
+                </span>
+              ))}
+              {completion.fauOverflow > 0 && (
+                <span className="bg-muted/60 text-muted-foreground border border-border text-xs font-semibold uppercase tracking-wide px-2 py-0.5">
+                  +{completion.fauOverflow}
+                </span>
+              )}
+            </div>
+          )}
         </button>
 
         {/* Expanded Exercise Details */}

--- a/lib/effort-prompt.ts
+++ b/lib/effort-prompt.ts
@@ -18,6 +18,17 @@ export const EFFORT_OPTIONS = [
 export const MIN_SESSION_RPE = 6
 export const MAX_SESSION_RPE = 10
 
+/**
+ * Map a stored session RPE (6–10) to its word label (Easy → Maximal). Returns
+ * null for null/out-of-range values so callers can omit the effort chip rather
+ * than render a placeholder.
+ */
+export function sessionEffortLabel(rpe: number | null | undefined): string | null {
+  if (rpe == null) return null
+  const match = EFFORT_OPTIONS.find(option => option.rpe === rpe)
+  return match?.label ?? null
+}
+
 export function isValidSessionRpe(value: unknown): value is number {
   return (
     typeof value === 'number' &&

--- a/lib/workout-history.ts
+++ b/lib/workout-history.ts
@@ -1,0 +1,66 @@
+import { FAU_DISPLAY_NAMES } from '@/lib/fau-volume'
+
+/** Number of primary-FAU chips shown per workout before collapsing to "+N". */
+export const MAX_FAU_CHIPS = 4
+
+export type FauChip = { fau: string; label: string; count: number }
+
+/** Minimal logged-set shape needed to derive the history enrichment. */
+export type HistoryLoggedSet = {
+  isWarmup: boolean
+  exercise: { exerciseDefinition: { primaryFAUs: string[] } }
+}
+
+/**
+ * Roll up primary FAUs across a completion's working (non-warmup) logged sets.
+ * Counts sets per primary FAU, returns the top chips by set count with a
+ * deterministic tie-break on the FAU token, plus an overflow count for the
+ * remainder. Warmups are excluded so the chips reflect real working volume.
+ */
+export function computeFauRollup(
+  loggedSets: HistoryLoggedSet[]
+): { chips: FauChip[]; overflow: number } {
+  const counts = new Map<string, number>()
+  for (const set of loggedSets) {
+    if (set.isWarmup) continue
+    for (const fau of set.exercise.exerciseDefinition.primaryFAUs) {
+      counts.set(fau, (counts.get(fau) ?? 0) + 1)
+    }
+  }
+
+  const sorted = Array.from(counts.entries())
+    .map(([fau, count]) => ({
+      fau,
+      label: FAU_DISPLAY_NAMES[fau] ?? fau,
+      count,
+    }))
+    .sort((a, b) => b.count - a.count || a.fau.localeCompare(b.fau))
+
+  return {
+    chips: sorted.slice(0, MAX_FAU_CHIPS),
+    overflow: Math.max(0, sorted.length - MAX_FAU_CHIPS),
+  }
+}
+
+/**
+ * Resolve a session duration in seconds. Prefers the stored `durationSeconds`;
+ * falls back to `completedAt − startedAt` when only timestamps exist; returns
+ * null when neither is available so the UI can omit it.
+ */
+export function resolveDurationSeconds(
+  durationSeconds: number | null,
+  startedAt: Date | null,
+  completedAt: Date
+): number | null {
+  if (durationSeconds != null && durationSeconds > 0) return durationSeconds
+  if (startedAt) {
+    const diff = Math.round((completedAt.getTime() - startedAt.getTime()) / 1000)
+    if (diff > 0) return diff
+  }
+  return null
+}
+
+/** Count working (non-warmup) sets in a completion. */
+export function countWorkingSets(loggedSets: Array<{ isWarmup: boolean }>): number {
+  return loggedSets.filter(set => !set.isWarmup).length
+}


### PR DESCRIPTION
Fixes #961

## What

Makes the workout history list genuinely useful by surfacing data that was already persisted but never displayed.

Each history row now shows (each part omitted when its data is null):

- **Duration** from `WorkoutCompletion.durationSeconds`, falling back to `completedAt − startedAt`, omitted when neither is available.
- **Session effort** as its word label (`sessionRpe` 6–10 → Easy / Moderate / Hard / Very hard / Maximal), reusing the existing `EFFORT_OPTIONS` scale.
- **Working set count** (non-warmup logged sets).
- **Per-workout FAU chips**: primary FAUs covered by the workout's working (non-warmup) logged sets, capped to the top ~4 by set count with a `+N` overflow badge.

## How

- `app/api/workouts/history/route.ts` — extends the existing single query with `startedAt`, `durationSeconds`, `sessionRpe`, per-set `isWarmup`, and `exercise.exerciseDefinition.primaryFAUs`, then enriches each completion in-memory (no N+1). Per-set FAU data is stripped from the response to keep the payload lean.
- `lib/workout-history.ts` (new) — shared, pure helpers: `computeFauRollup` (deterministic top-N + overflow, warmups excluded, tie-break on FAU token), `resolveDurationSeconds`, `countWorkingSets`.
- `lib/effort-prompt.ts` — adds `sessionEffortLabel(rpe)` mapping helper (returns null out-of-range so the UI omits the chip).
- `components/WorkoutHistoryList.tsx` — renders the meta row (Clock / Flame / Dumbbell icons) and FAU chip row using DOOM theme tokens, `flex-wrap` so chips never overflow at 375px.

## Testing

- `__tests__/api/history-list-enrichment.test.ts` — unit coverage for the rollup/duration/working-set helpers (empty, warmup-exclusion, label mapping, top-N cap + overflow, tie-break, duration precedence/fallback/null) plus two DB-backed cases asserting the enriched shape for a **populated** completion and a **null/degraded** freestyle completion. All 10 tests pass.
- `npm run type-check` clean; `npm run lint` introduces no new issues (pre-existing errors in unrelated `workout-logging/*` files only).
- Playwright screenshot at 375px width: top row shows duration + effort + sets + CHEST/TRICEPS chips; other rows degrade gracefully (sets + chip only, no placeholders); no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)