### PR TITLE
docs: note synthetic archetype user seeding in dev startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ doppler run --config dev_personal -- npx prisma generate
 DOPPLER_CONFIG=dev_personal_worktree1 ./scripts/dev.sh start -l postgres,app
 ```
 
-Startup auto-applies schema, creates BetterAuth tables, and seeds a test user: **dmays@test.com / password**.
+Startup auto-applies schema, creates BetterAuth tables, seeds a test user (**dmays@test.com / password**), and seeds synthetic archetype users with workout history (`scripts/seed-synthetic-users.ts`, idempotent, re-run every startup).
 
 See `/WORKTREE_SETUP.md` for full details and troubleshooting.
 

--- a/WORKTREE_SETUP.md
+++ b/WORKTREE_SETUP.md
@@ -36,6 +36,7 @@ The startup automatically:
 - Applies Prisma schema (`prisma db push`)
 - Creates BetterAuth tables
 - Seeds a test user: **dmays@test.com** / **password**
+- Seeds synthetic archetype users with workout history (`scripts/seed-synthetic-users.ts`, idempotent)
 
 ### Primary Repo (no worktree)
 
@@ -49,7 +50,7 @@ No `DOPPLER_CONFIG` needed — defaults to `dev_personal`.
 ## Key Files
 
 - `scripts/worktree-env.sh` — Detects worktree slot, exports `PG_PORT`, `REDIS_PORT`, container names
-- `scripts/start-postgres.sh` — Starts Docker postgres, applies schema, seeds test user
+- `scripts/start-postgres.sh` — Starts Docker postgres, applies schema, seeds test user + synthetic archetype users
 - `scripts/start-redis.sh` — Starts Docker redis with worktree-aware names/ports
 - `Procfile` — Sources `worktree-env.sh`, overrides `DATABASE_URL`/`DIRECT_URL`/`REDIS_URL` after Doppler
 


### PR DESCRIPTION
## Summary

Weekly documentation drift check over the last 14 days of commits. One stale reference found and fixed.

## Triggering code change

Commit `821bb6a` (`chore(dev): auto-seed synthetic archetype users on postgres startup`, #955) added a synthetic-users seed step to `scripts/start-postgres.sh`, run on every local/worktree postgres startup.

## What was stale

Both docs described the startup seed chain as seeding only the test user:

- `CLAUDE.md` — "Startup auto-applies schema, creates BetterAuth tables, and seeds a test user"
- `WORKTREE_SETUP.md` — "Seeds a test user" (startup list + Key Files description of `start-postgres.sh`)

## What was updated

Added a mention that startup also seeds synthetic archetype users with workout history via `scripts/seed-synthetic-users.ts` (idempotent, re-run every startup). No other changes.

## Not changed (already in sync)

Schema additions from this window (`WorkoutCompletion.sessionRpe`/`durationSeconds`, `UserTrainingProfile.equipmentAvailableSet`/`fauImportancePreset`, `TuningConfig`) are already documented in `docs/SUGGEST_PAYLOAD_SPEC.md` and `docs/data-signal-audit.md` and carry descriptive schema comments, so no CLAUDE.md drift there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)