### PR TITLE
feat: neglected calculator v2 — time-window lookback + recency blend (#962)

### DIFF
--- a/__tests__/api/muscle-balance.test.ts
+++ b/__tests__/api/muscle-balance.test.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  type CompletionForBalance,
   calculateMuscleBalanceSnapshot,
   getDefaultMuscleBalanceTargets,
   getMuscleBalanceSnapshot,
@@ -50,6 +51,114 @@ describe('Muscle balance calculations', () => {
   })
 })
 
+describe('Muscle balance v2 (time window + recency blend)', () => {
+  const settings = normalizeMuscleBalanceSettings({
+    targets: getDefaultMuscleBalanceTargets(),
+    lookbackWorkouts: 8,
+    lookbackDays: 14,
+    includeSecondary: true,
+    secondaryWeight: 0.5,
+    excludeWarmups: true,
+  })
+  const now = new Date('2026-07-10T00:00:00Z')
+
+  function makeCompletion(
+    primaryFAUs: string[],
+    setCount: number,
+    completedAt: Date
+  ): CompletionForBalance {
+    return {
+      completedAt,
+      loggedSets: Array.from({ length: setCount }, () => ({
+        isWarmup: false,
+        exercise: {
+          exerciseDefinition: { primaryFAUs, secondaryFAUs: [] as string[] },
+        },
+      })),
+    }
+  }
+
+  function daysAgo(days: number): Date {
+    return new Date(now.getTime() - days * 24 * 60 * 60 * 1000)
+  }
+
+  it('(a) time window beats workout count on a gap-heavy history', () => {
+    // Chest was the most recent trained FAU by *workout count*, but it falls
+    // outside the 14-day window; side-delts is the only in-window training.
+    const snapshot = calculateMuscleBalanceSnapshot(
+      settings,
+      [
+        makeCompletion(['side-delts'], 5, daysAgo(2)),
+        makeCompletion(['chest'], 5, daysAgo(20)),
+      ],
+      now
+    )
+
+    const chest = snapshot.items.find((item) => item.fau === 'chest')
+    const sideDelts = snapshot.items.find((item) => item.fau === 'side-delts')
+
+    // Chest is excluded by the time window even though it is recent by count.
+    expect(chest?.actualSets).toBe(0)
+    expect(chest?.lastTrainedDaysAgo).toBeNull()
+    expect(chest?.recencyScore).toBe(1)
+    expect(chest?.status).toBe('neglected')
+
+    // Side-delts is the only in-window volume, so it is not neglected.
+    expect(sideDelts?.actualSets).toBe(5)
+    expect(sideDelts?.status).not.toBe('neglected')
+
+    // Chest outranks side-delts in the neglected ordering.
+    const chestIndex = snapshot.items.findIndex((item) => item.fau === 'chest')
+    const sideDeltIndex = snapshot.items.findIndex((item) => item.fau === 'side-delts')
+    expect(chestIndex).toBeLessThan(sideDeltIndex)
+  })
+
+  it('(b) recency reorders FAUs with equal deficits', () => {
+    // Biceps and triceps get identical in-window volume => identical deficit.
+    // Biceps was trained longer ago, so it should rank ahead of triceps.
+    const snapshot = calculateMuscleBalanceSnapshot(
+      settings,
+      [
+        makeCompletion(['biceps'], 3, daysAgo(10)),
+        makeCompletion(['triceps'], 3, daysAgo(2)),
+      ],
+      now
+    )
+
+    const biceps = snapshot.items.find((item) => item.fau === 'biceps')
+    const triceps = snapshot.items.find((item) => item.fau === 'triceps')
+
+    expect(biceps?.actualSets).toBe(3)
+    expect(triceps?.actualSets).toBe(3)
+    expect(biceps?.deficitShare).toBeCloseTo(triceps?.deficitShare ?? Number.NaN, 10)
+    expect(biceps?.recencyScore).toBeGreaterThan(triceps?.recencyScore ?? 0)
+
+    const bicepsIndex = snapshot.items.findIndex((item) => item.fau === 'biceps')
+    const tricepsIndex = snapshot.items.findIndex((item) => item.fau === 'triceps')
+    expect(bicepsIndex).toBeLessThan(tricepsIndex)
+  })
+
+  it('(c) zero-history user gets stable, neutral output', () => {
+    const first = calculateMuscleBalanceSnapshot(settings, [], now)
+    const second = calculateMuscleBalanceSnapshot(settings, [], now)
+
+    expect(first.items).toHaveLength(18)
+    expect(first.lookback.totalEffectiveSets).toBe(0)
+
+    for (const item of first.items) {
+      expect(item.lastTrainedDaysAgo).toBeNull()
+      expect(item.recencyScore).toBe(1)
+      expect(Number.isNaN(item.deficitShare)).toBe(false)
+      expect(Number.isNaN(item.recencyScore)).toBe(false)
+    }
+
+    // All deficits are equal, so ordering is deterministic across runs.
+    expect(first.items.map((item) => item.fau)).toEqual(
+      second.items.map((item) => item.fau)
+    )
+  })
+})
+
 describe('Muscle balance persistence', () => {
   let prisma: PrismaClient
   let userId: string
@@ -72,7 +181,7 @@ describe('Muscle balance persistence', () => {
     expect(snapshot.items.some((item) => String(item.fau) === 'neck')).toBe(false)
   })
 
-  it('uses the last N completed strength workouts', async () => {
+  it('counts only completed strength workouts inside the days window', async () => {
     const chestDefinition = await createTestExerciseDefinition(prisma, {
       name: `Chest Press ${Date.now()}`,
       primaryFAUs: ['chest'],
@@ -88,21 +197,28 @@ describe('Muscle balance persistence', () => {
       data: {
         userId,
         targets: getDefaultMuscleBalanceTargets(),
-        lookbackWorkouts: 1,
+        lookbackWorkouts: 8,
+        lookbackDays: 14,
         includeSecondary: true,
         secondaryWeight: 0.5,
         excludeWarmups: true,
       },
     })
 
-    await createCompletedWorkout(prisma, userId, sideDeltDefinition.id, 4, {
-      completedAt: new Date('2026-01-01T00:00:00Z'),
-    })
+    const now = Date.now()
+    const daysAgo = (days: number) => new Date(now - days * 24 * 60 * 60 * 1000)
+
+    // Chest trained 20 days ago -> outside the 14-day window.
     await createCompletedWorkout(prisma, userId, chestDefinition.id, 4, {
-      completedAt: new Date('2026-01-02T00:00:00Z'),
+      completedAt: daysAgo(20),
     })
+    // Side-delts trained 3 days ago -> inside the window.
+    await createCompletedWorkout(prisma, userId, sideDeltDefinition.id, 4, {
+      completedAt: daysAgo(3),
+    })
+    // Draft workout is ignored regardless of recency.
     await createCompletedWorkout(prisma, userId, sideDeltDefinition.id, 10, {
-      completedAt: new Date('2026-01-03T00:00:00Z'),
+      completedAt: daysAgo(1),
       status: 'draft',
     })
 
@@ -110,10 +226,12 @@ describe('Muscle balance persistence', () => {
     const chest = snapshot.items.find((item) => item.fau === 'chest')
     const sideDelts = snapshot.items.find((item) => item.fau === 'side-delts')
 
+    expect(snapshot.lookback.windowDays).toBe(14)
     expect(snapshot.lookback.completedWorkouts).toBe(1)
-    expect(chest?.actualSets).toBe(4)
-    expect(sideDelts?.actualSets).toBe(0)
-    expect(sideDelts?.status).toBe('neglected')
+    expect(chest?.actualSets).toBe(0)
+    expect(chest?.status).toBe('neglected')
+    expect(sideDelts?.actualSets).toBe(4)
+    expect(sideDelts?.lastTrainedDaysAgo).toBe(3)
   })
 
 })

--- a/app/api/settings/muscle-balance/route.ts
+++ b/app/api/settings/muscle-balance/route.ts
@@ -16,6 +16,7 @@ import {
 type UpdateMuscleBalanceRequest = {
   targets?: Record<string, unknown>
   lookbackWorkouts?: unknown
+  lookbackDays?: unknown
   includeSecondary?: unknown
   secondaryWeight?: unknown
   excludeWarmups?: unknown
@@ -65,6 +66,7 @@ export async function PUT(request: NextRequest) {
     await updateMuscleBalanceSettings(prisma, user.id, {
       targets: body.targets as MuscleBalanceTargets | undefined,
       lookbackWorkouts: body.lookbackWorkouts as number | undefined,
+      lookbackDays: body.lookbackDays as number | undefined,
       includeSecondary: body.includeSecondary as boolean | undefined,
       secondaryWeight: body.secondaryWeight as number | undefined,
       excludeWarmups: body.excludeWarmups as boolean | undefined,
@@ -107,6 +109,15 @@ function validateUpdateRequest(body: UpdateMuscleBalanceRequest): string | null 
       (body.lookbackWorkouts as number) > 52)
   ) {
     return 'Lookback workouts must be an integer between 1 and 52'
+  }
+
+  if (
+    body.lookbackDays !== undefined &&
+    (!Number.isInteger(body.lookbackDays) ||
+      (body.lookbackDays as number) < 1 ||
+      (body.lookbackDays as number) > 365)
+  ) {
+    return 'Lookback days must be an integer between 1 and 365'
   }
 
   if (

--- a/components/features/muscle-balance/MuscleBalanceSettingsEditor.tsx
+++ b/components/features/muscle-balance/MuscleBalanceSettingsEditor.tsx
@@ -56,6 +56,7 @@ export default function MuscleBalanceSettingsEditor({ initialSnapshot }: Props) 
     () => ({
       targets,
       lookbackWorkouts: lookbackWorkouts ?? snapshot.settings.lookbackWorkouts,
+      lookbackDays: snapshot.settings.lookbackDays,
       includeSecondary,
       secondaryWeight,
       excludeWarmups,
@@ -64,6 +65,7 @@ export default function MuscleBalanceSettingsEditor({ initialSnapshot }: Props) 
       targets,
       lookbackWorkouts,
       snapshot.settings.lookbackWorkouts,
+      snapshot.settings.lookbackDays,
       includeSecondary,
       secondaryWeight,
       excludeWarmups,
@@ -100,6 +102,7 @@ export default function MuscleBalanceSettingsEditor({ initialSnapshot }: Props) 
       const payload: MuscleBalanceSettingsDTO = {
         targets,
         lookbackWorkouts,
+        lookbackDays: snapshot.settings.lookbackDays,
         includeSecondary,
         secondaryWeight,
         excludeWarmups,

--- a/lib/muscle-balance.ts
+++ b/lib/muscle-balance.ts
@@ -2,16 +2,27 @@ import type { Prisma, PrismaClient } from '@prisma/client'
 import { ALL_FAUS, FAU_DISPLAY_NAMES, type FAUKey } from '@/lib/fau-volume'
 
 export const DEFAULT_LOOKBACK_WORKOUTS = 8
+export const DEFAULT_LOOKBACK_DAYS = 14
+export const MIN_LOOKBACK_DAYS = 1
+export const MAX_LOOKBACK_DAYS = 365
 export const DEFAULT_SECONDARY_WEIGHT = 0.5
 export const MIN_TARGET_WEIGHT = 0
 export const MAX_TARGET_WEIGHT = 2
 export const TARGET_STEP = 0.05
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Weight of the recency signal when blending it into the neglected ordering.
+// Kept small so it only reorders FAUs with near-equal deficits ("similar
+// deficits, staler ranks first") rather than overriding real deficit gaps.
+const RECENCY_BLEND_WEIGHT = 0.01
 
 export type MuscleBalanceTargets = Record<FAUKey, number>
 
 export type MuscleBalanceSettingsDTO = {
   targets: MuscleBalanceTargets
   lookbackWorkouts: number
+  lookbackDays: number
   includeSecondary: boolean
   secondaryWeight: number
   excludeWarmups: boolean
@@ -27,6 +38,11 @@ export type MuscleBalanceItem = {
   deficitShare: number
   fulfillment: number
   status: 'neglected' | 'balanced' | 'over'
+  // v2 additive fields (backward compatible). Null when the FAU has no
+  // effective sets inside the lookback window (never trained / long staleness).
+  lastTrainedDaysAgo: number | null
+  // 0 = trained today, 1 = at/beyond the window edge (maximally stale).
+  recencyScore: number
 }
 
 export type MuscleBalanceSnapshot = {
@@ -35,12 +51,17 @@ export type MuscleBalanceSnapshot = {
     requestedWorkouts: number
     completedWorkouts: number
     totalEffectiveSets: number
+    // v2 additive field: the days-based window actually applied.
+    windowDays: number
   }
   items: MuscleBalanceItem[]
   neglected: MuscleBalanceItem[]
 }
 
-type CompletionForBalance = {
+export type CompletionForBalance = {
+  // Optional for read-compat with callers that don't provide it; when omitted
+  // the completion is treated as in-window but contributes no recency signal.
+  completedAt?: Date | null
   loggedSets: Array<{
     isWarmup: boolean
     exercise: {
@@ -50,6 +71,11 @@ type CompletionForBalance = {
       }
     }
   }>
+}
+
+type FauRecency = {
+  lastTrainedDaysAgo: number | null
+  recencyScore: number
 }
 
 export function getDefaultMuscleBalanceTargets(): MuscleBalanceTargets {
@@ -81,6 +107,7 @@ export function normalizeMuscleBalanceSettings(
     | {
         targets: Prisma.JsonValue
         lookbackWorkouts: number
+        lookbackDays?: number | null
         includeSecondary: boolean
         secondaryWeight: number
         excludeWarmups: boolean
@@ -95,6 +122,12 @@ export function normalizeMuscleBalanceSettings(
       DEFAULT_LOOKBACK_WORKOUTS,
       1,
       52
+    ),
+    lookbackDays: normalizeInteger(
+      settings?.lookbackDays,
+      DEFAULT_LOOKBACK_DAYS,
+      MIN_LOOKBACK_DAYS,
+      MAX_LOOKBACK_DAYS
     ),
     includeSecondary: settings?.includeSecondary ?? true,
     secondaryWeight: normalizeNumber(
@@ -119,6 +152,7 @@ export async function getOrCreateMuscleBalanceSettings(
       userId,
       targets: defaults,
       lookbackWorkouts: DEFAULT_LOOKBACK_WORKOUTS,
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
       includeSecondary: true,
       secondaryWeight: DEFAULT_SECONDARY_WEIGHT,
       excludeWarmups: true,
@@ -143,6 +177,15 @@ export async function updateMuscleBalanceSettings(
       input.lookbackWorkouts !== undefined
         ? normalizeInteger(input.lookbackWorkouts, current.lookbackWorkouts, 1, 52)
         : current.lookbackWorkouts,
+    lookbackDays:
+      input.lookbackDays !== undefined
+        ? normalizeInteger(
+            input.lookbackDays,
+            current.lookbackDays,
+            MIN_LOOKBACK_DAYS,
+            MAX_LOOKBACK_DAYS
+          )
+        : current.lookbackDays,
     includeSecondary: input.includeSecondary ?? current.includeSecondary,
     secondaryWeight:
       input.secondaryWeight !== undefined
@@ -156,6 +199,7 @@ export async function updateMuscleBalanceSettings(
     update: {
       targets: next.targets,
       lookbackWorkouts: next.lookbackWorkouts,
+      lookbackDays: next.lookbackDays,
       includeSecondary: next.includeSecondary,
       secondaryWeight: next.secondaryWeight,
       excludeWarmups: next.excludeWarmups,
@@ -164,6 +208,7 @@ export async function updateMuscleBalanceSettings(
       userId,
       targets: next.targets,
       lookbackWorkouts: next.lookbackWorkouts,
+      lookbackDays: next.lookbackDays,
       includeSecondary: next.includeSecondary,
       secondaryWeight: next.secondaryWeight,
       excludeWarmups: next.excludeWarmups,
@@ -178,15 +223,18 @@ export async function getMuscleBalanceSnapshot(
   userId: string
 ): Promise<MuscleBalanceSnapshot> {
   const settings = await getOrCreateMuscleBalanceSettings(prisma, userId)
+  const now = new Date()
+  const windowStart = new Date(now.getTime() - settings.lookbackDays * DAY_MS)
   const completions = await prisma.workoutCompletion.findMany({
     where: {
       userId,
       status: 'completed',
       isArchived: false,
+      completedAt: { gte: windowStart },
     },
     orderBy: { completedAt: 'desc' },
-    take: settings.lookbackWorkouts,
     select: {
+      completedAt: true,
       loggedSets: {
         select: {
           isWarmup: true,
@@ -205,99 +253,113 @@ export async function getMuscleBalanceSnapshot(
     },
   })
 
-  return calculateMuscleBalanceSnapshot(settings, completions)
+  return calculateMuscleBalanceSnapshot(settings, completions, now)
 }
 
 export function calculateMuscleBalanceSnapshot(
   settings: MuscleBalanceSettingsDTO,
-  completions: CompletionForBalance[]
+  completions: CompletionForBalance[],
+  now: Date = new Date()
 ): MuscleBalanceSnapshot {
+  const cutoffMs = now.getTime() - settings.lookbackDays * DAY_MS
+  // Keep completions inside the days-based window. Completions without a
+  // completedAt (legacy/synthetic callers) are treated as in-window.
+  const inWindow = completions.filter(
+    (completion) => !completion.completedAt || completion.completedAt.getTime() >= cutoffMs
+  )
+
   const volume = ALL_FAUS.reduce((acc, fau) => {
     acc[fau] = 0
     return acc
   }, {} as MuscleBalanceTargets)
+  const lastTrainedByFau: Partial<Record<FAUKey, number>> = {}
 
-  for (const completion of completions) {
+  for (const completion of inWindow) {
+    const touched = new Set<FAUKey>()
     for (const set of completion.loggedSets) {
       if (settings.excludeWarmups && set.isWarmup) continue
       const definition = set.exercise.exerciseDefinition
       for (const fau of definition.primaryFAUs) {
-        if (isFAUKey(fau)) volume[fau] += 1
+        if (isFAUKey(fau)) {
+          volume[fau] += 1
+          touched.add(fau)
+        }
       }
       if (settings.includeSecondary) {
         for (const fau of definition.secondaryFAUs) {
-          if (isFAUKey(fau)) volume[fau] += settings.secondaryWeight
+          if (isFAUKey(fau)) {
+            volume[fau] += settings.secondaryWeight
+            touched.add(fau)
+          }
+        }
+      }
+    }
+
+    const completedAtMs = completion.completedAt?.getTime()
+    if (completedAtMs !== undefined) {
+      for (const fau of touched) {
+        const prev = lastTrainedByFau[fau]
+        if (prev === undefined || completedAtMs > prev) {
+          lastTrainedByFau[fau] = completedAtMs
         }
       }
     }
   }
 
-  const targetTotal = ALL_FAUS.reduce(
-    (sum, fau) => sum + Math.max(0, settings.targets[fau]),
-    0
-  )
-  const safeTargetTotal = targetTotal > 0 ? targetTotal : ALL_FAUS.length
+  const recencyByFau = ALL_FAUS.reduce((acc, fau) => {
+    acc[fau] = computeRecency(lastTrainedByFau[fau], now, settings.lookbackDays)
+    return acc
+  }, {} as Record<FAUKey, FauRecency>)
+
   const totalEffectiveSets = ALL_FAUS.reduce((sum, fau) => sum + volume[fau], 0)
-
-  const items = ALL_FAUS.map((fau) => {
-    const targetWeight =
-      targetTotal > 0 ? settings.targets[fau] : getDefaultMuscleBalanceTargets()[fau]
-    const targetShare = Math.max(0, targetWeight) / safeTargetTotal
-    const actualSets = volume[fau]
-    const actualShare = totalEffectiveSets > 0 ? actualSets / totalEffectiveSets : 0
-    const deficitShare = targetShare - actualShare
-    const fulfillment =
-      targetShare > 0 ? Math.min(actualShare / targetShare, 9.99) : actualSets > 0 ? 9.99 : 1
-    const status =
-      targetShare === 0 || Math.abs(deficitShare) <= 0.02
-        ? 'balanced'
-        : deficitShare > 0
-          ? 'neglected'
-          : 'over'
-
-    return {
-      fau,
-      label: FAU_DISPLAY_NAMES[fau],
-      targetWeight,
-      targetShare,
-      actualSets,
-      actualShare,
-      deficitShare,
-      fulfillment,
-      status,
-    } satisfies MuscleBalanceItem
-  }).sort((a, b) => b.deficitShare - a.deficitShare)
+  const items = buildBalanceItems(settings, volume, recencyByFau, totalEffectiveSets)
 
   return {
     settings,
     lookback: {
       requestedWorkouts: settings.lookbackWorkouts,
-      completedWorkouts: completions.length,
+      completedWorkouts: inWindow.length,
       totalEffectiveSets,
+      windowDays: settings.lookbackDays,
     },
     items,
     neglected: items.filter((item) => item.status === 'neglected').slice(0, 5),
   }
 }
 
-export function updateMuscleBalanceSnapshotSettings(
-  snapshot: MuscleBalanceSnapshot,
-  settings: MuscleBalanceSettingsDTO
-): MuscleBalanceSnapshot {
-  const totalEffectiveSets = snapshot.lookback.totalEffectiveSets
+function computeRecency(
+  lastTrainedMs: number | undefined,
+  now: Date,
+  lookbackDays: number
+): FauRecency {
+  if (lastTrainedMs === undefined) {
+    // Never trained inside the window: maximally stale.
+    return { lastTrainedDaysAgo: null, recencyScore: 1 }
+  }
+  const daysAgo = Math.max(0, Math.floor((now.getTime() - lastTrainedMs) / DAY_MS))
+  const recencyScore = lookbackDays > 0 ? clamp(daysAgo / lookbackDays, 0, 1) : 0
+  return { lastTrainedDaysAgo: daysAgo, recencyScore }
+}
+
+// Builds the per-FAU items and applies the deficit-first, recency-blended
+// ordering. A small recency weight only reorders FAUs with near-equal deficits
+// (staler ranks first); a FAU with zero in-window sets carries both the largest
+// deficit and maximal staleness, so it sorts to the top.
+function buildBalanceItems(
+  settings: MuscleBalanceSettingsDTO,
+  volumeByFau: MuscleBalanceTargets,
+  recencyByFau: Record<FAUKey, FauRecency>,
+  totalEffectiveSets: number
+): MuscleBalanceItem[] {
   const targetTotal = ALL_FAUS.reduce(
     (sum, fau) => sum + Math.max(0, settings.targets[fau]),
     0
   )
   const safeTargetTotal = targetTotal > 0 ? targetTotal : ALL_FAUS.length
-  const volumeByFau = snapshot.items.reduce((acc, item) => {
-    acc[item.fau] = item.actualSets
-    return acc
-  }, {} as MuscleBalanceTargets)
+  const defaults = getDefaultMuscleBalanceTargets()
 
-  const items = ALL_FAUS.map((fau) => {
-    const targetWeight =
-      targetTotal > 0 ? settings.targets[fau] : getDefaultMuscleBalanceTargets()[fau]
+  return ALL_FAUS.map((fau) => {
+    const targetWeight = targetTotal > 0 ? settings.targets[fau] : defaults[fau]
     const targetShare = Math.max(0, targetWeight) / safeTargetTotal
     const actualSets = volumeByFau[fau] ?? 0
     const actualShare = totalEffectiveSets > 0 ? actualSets / totalEffectiveSets : 0
@@ -310,6 +372,7 @@ export function updateMuscleBalanceSnapshotSettings(
         : deficitShare > 0
           ? 'neglected'
           : 'over'
+    const recency = recencyByFau[fau] ?? { lastTrainedDaysAgo: null, recencyScore: 1 }
 
     return {
       fau,
@@ -321,18 +384,51 @@ export function updateMuscleBalanceSnapshotSettings(
       deficitShare,
       fulfillment,
       status,
+      lastTrainedDaysAgo: recency.lastTrainedDaysAgo,
+      recencyScore: recency.recencyScore,
     } satisfies MuscleBalanceItem
-  }).sort((a, b) => b.deficitShare - a.deficitShare)
+  }).sort((a, b) => {
+    const scoreDiff = neglectSortScore(b) - neglectSortScore(a)
+    if (scoreDiff !== 0) return scoreDiff
+    // Deterministic final tiebreak.
+    return a.fau.localeCompare(b.fau)
+  })
+}
+
+// Blended sort key: deficit dominates, recency breaks near-ties.
+function neglectSortScore(item: MuscleBalanceItem): number {
+  return item.deficitShare + RECENCY_BLEND_WEIGHT * item.recencyScore
+}
+
+export function updateMuscleBalanceSnapshotSettings(
+  snapshot: MuscleBalanceSnapshot,
+  settings: MuscleBalanceSettingsDTO
+): MuscleBalanceSnapshot {
+  const totalEffectiveSets = snapshot.lookback.totalEffectiveSets
+  const volumeByFau = snapshot.items.reduce((acc, item) => {
+    acc[item.fau] = item.actualSets
+    return acc
+  }, {} as MuscleBalanceTargets)
+  // Recency is derived from logged-set dates, which this client-side recompute
+  // can't re-window; carry the previously computed values forward.
+  const recencyByFau = ALL_FAUS.reduce((acc, fau) => {
+    const item = snapshot.items.find((entry) => entry.fau === fau)
+    acc[fau] = {
+      lastTrainedDaysAgo: item?.lastTrainedDaysAgo ?? null,
+      recencyScore: item?.recencyScore ?? 1,
+    }
+    return acc
+  }, {} as Record<FAUKey, FauRecency>)
+
+  const items = buildBalanceItems(settings, volumeByFau, recencyByFau, totalEffectiveSets)
 
   return {
     settings,
     lookback: {
       ...snapshot.lookback,
       requestedWorkouts: settings.lookbackWorkouts,
-      completedWorkouts: Math.min(
-        snapshot.lookback.completedWorkouts,
-        settings.lookbackWorkouts
-      ),
+      completedWorkouts: snapshot.lookback.completedWorkouts,
+      windowDays: settings.lookbackDays,
     },
     items,
     neglected: items.filter((item) => item.status === 'neglected').slice(0, 5),

--- a/prisma/migrations/20260710141740_add_muscle_balance_lookback_days/migration.sql
+++ b/prisma/migrations/20260710141740_add_muscle_balance_lookback_days/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "UserMuscleBalanceSettings" ADD COLUMN "lookbackDays" INTEGER NOT NULL DEFAULT 14;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -383,6 +383,10 @@ model UserMuscleBalanceSettings {
   userId           String   @unique
   targets          Json
   lookbackWorkouts Int      @default(8)
+  // Days-based lookback window for the neglected calculator (v2). Replaces
+  // lookbackWorkouts as the driver of which logged sets count; lookbackWorkouts
+  // is retained for read-compat with existing rows/consumers.
+  lookbackDays     Int      @default(14)
   includeSecondary Boolean  @default(true)
   secondaryWeight  Float    @default(0.5)
   excludeWarmups   Boolean  @default(true)


### PR DESCRIPTION
## Summary

Reworks the muscle-balance neglected sorter (`lib/muscle-balance.ts`, consumed by `ExerciseSearchInterface`'s FAU sort and the ad-hoc picker) from a **workout-count** lookback to a **days-based time window** plus a **per-FAU recency blend**. Fixes #962.

### What changed
- **Time-window lookback**: `getMuscleBalanceSnapshot` filters completed workouts by `completedAt >= now - lookbackDays` (new `UserMuscleBalanceSettings.lookbackDays`, default **14**) instead of `take: lookbackWorkouts`. A 3-workouts-in-9-days user and a 3-workouts-in-5-weeks user now read differently; a FAU trained 20 days ago no longer looks "covered".
- **Recency blend**: per FAU, `lastTrainedDaysAgo` / `recencyScore` are computed from the same in-window logged-set data (no aggregates-job dependency — stays live/synchronous). Ordering uses a deficit-first, recency-blended score so that among near-equal deficits the staler FAU ranks first; a FAU with zero in-window sets carries both the largest deficit and maximal staleness, so it sorts to the top.
- **Backward compatible output**: additive fields only — `MuscleBalanceItem.lastTrainedDaysAgo`, `MuscleBalanceItem.recencyScore`, `lookback.windowDays`. Existing consumers (`actualSets`, `status`, `deficitShare`) are untouched.
- **Settings read-compat**: `lookbackWorkouts` is retained on the model/DTO (no saved rows broken); the API validates the new `lookbackDays` (1–365). Migration adds the column with a safe default.

### Non-goals
The recovery-aware composite (effort penalties, heavy staleness, detraining mode) is the follow-up issue and is intentionally not built here.

## Tests
`npm test muscle-balance` — 6 passing, including three deterministic fixtures:
- (a) time window beats workout count on a gap-heavy history
- (b) recency reorders FAUs with equal deficits
- (c) zero-history user gets stable, neutral output

Also: type-check clean, biome lint clean on changed files.

## Migration
`prisma/migrations/20260710141740_add_muscle_balance_lookback_days` — `ALTER TABLE "UserMuscleBalanceSettings" ADD COLUMN "lookbackDays" INTEGER NOT NULL DEFAULT 14;`. Production migration auto-applies on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)