### PR TITLE
fix: invalid hook call in SignupCompletedTracker (500 on /settings/equipment reload)

### DIFF
--- a/__tests__/components/SignupCompletedTracker.test.tsx
+++ b/__tests__/components/SignupCompletedTracker.test.tsx
@@ -1,0 +1,90 @@
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { trackEvent, flushEvents, getSession } = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  flushEvents: vi.fn(() => Promise.resolve()),
+  getSession: vi.fn(),
+}))
+
+// Mock the analytics layer so we can assert on emitted events without a network.
+vi.mock('@/lib/analytics', () => ({ trackEvent, flushEvents }))
+
+// Mock BetterAuth's client so the tracker never calls a render-phase hook.
+// getSession is the imperative API the tracker relies on (issue #971).
+vi.mock('@/lib/auth-client', () => ({ authClient: { getSession } }))
+
+import { SignupCompletedTracker } from '@/components/features/SignupCompletedTracker'
+import { setPendingOAuthSignup } from '@/lib/signup-attribution'
+
+function sessionResult(createdAt: Date | null) {
+  return {
+    data: createdAt
+      ? { user: { id: 'u1', email: 'a@b.com', createdAt } }
+      : null,
+    error: null,
+  }
+}
+
+describe('SignupCompletedTracker', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    trackEvent.mockClear()
+    flushEvents.mockClear()
+    getSession.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders without throwing an invalid hook call', () => {
+    getSession.mockResolvedValue(sessionResult(null))
+    // The whole point of #971: mounting must not crash.
+    expect(() => render(<SignupCompletedTracker />)).not.toThrow()
+  })
+
+  it('fires signup_completed for a fresh OAuth session with a pending record', async () => {
+    getSession.mockResolvedValue(sessionResult(new Date()))
+    setPendingOAuthSignup('google', { source: 'oauth' })
+
+    render(<SignupCompletedTracker />)
+
+    await waitFor(() => expect(trackEvent).toHaveBeenCalledTimes(1))
+    expect(trackEvent).toHaveBeenCalledWith('signup_completed', {
+      source: 'oauth',
+      method: 'google',
+    })
+    expect(flushEvents).toHaveBeenCalled()
+  })
+
+  it('does not fire when there is no pending OAuth record', async () => {
+    getSession.mockResolvedValue(sessionResult(new Date()))
+
+    render(<SignupCompletedTracker />)
+
+    await waitFor(() => expect(getSession).toHaveBeenCalled())
+    expect(trackEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when there is no session', async () => {
+    getSession.mockResolvedValue(sessionResult(null))
+    setPendingOAuthSignup('google', { source: 'oauth' })
+
+    render(<SignupCompletedTracker />)
+
+    await waitFor(() => expect(getSession).toHaveBeenCalled())
+    expect(trackEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not fire for a stale account outside the fresh-signup window', async () => {
+    const eightMinutesAgo = new Date(Date.now() - 8 * 60 * 1000)
+    getSession.mockResolvedValue(sessionResult(eightMinutesAgo))
+    setPendingOAuthSignup('google', { source: 'oauth' })
+
+    render(<SignupCompletedTracker />)
+
+    await waitFor(() => expect(getSession).toHaveBeenCalled())
+    expect(trackEvent).not.toHaveBeenCalled()
+  })
+})

--- a/components/features/SignupCompletedTracker.tsx
+++ b/components/features/SignupCompletedTracker.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { flushEvents, trackEvent } from '@/lib/analytics'
-import { useSession } from '@/lib/auth-client'
+import { authClient } from '@/lib/auth-client'
 import {
   clearAttribution,
   consumePendingOAuthSignup,
@@ -26,34 +26,55 @@ import {
 const FRESH_SIGNUP_WINDOW_MS = 5 * 60 * 1000
 
 export function SignupCompletedTracker() {
-  const { data: session, isPending } = useSession()
-
+  // Read the session imperatively on mount rather than via the reactive
+  // `useSession` hook. This is a fire-once side effect that renders nothing, so
+  // it never needs to re-render on session changes — and calling BetterAuth's
+  // render-phase hook here pulled its internal `useStore`/`useRef` into the
+  // client boundary in a way that crashed with an invalid hook call on some
+  // server-rendered routes (issue #971).
   useEffect(() => {
-    if (isPending) return
-    if (!session?.user) return
+    let cancelled = false
 
-    const pending = consumePendingOAuthSignup()
-    if (!pending) return
+    void authClient
+      .getSession()
+      .then(({ data }) => {
+        if (cancelled) return
 
-    // Verify the account is genuinely new (avoids re-firing for repeat OAuth
-    // sign-ins that the click handler can't distinguish from real signups).
-    const createdAtMs = session.user.createdAt
-      ? new Date(session.user.createdAt).getTime()
-      : 0
-    if (!createdAtMs || Date.now() - createdAtMs > FRESH_SIGNUP_WINDOW_MS) return
+        const user = data?.user
+        if (!user) return
 
-    const source = resolveSource(pending.method, pending.attribution)
-    const props: Record<string, unknown> = {
-      source,
-      method: pending.method,
+        const pending = consumePendingOAuthSignup()
+        if (!pending) return
+
+        // Verify the account is genuinely new (avoids re-firing for repeat OAuth
+        // sign-ins that the click handler can't distinguish from real signups).
+        const createdAtMs = user.createdAt
+          ? new Date(user.createdAt).getTime()
+          : 0
+        if (!createdAtMs || Date.now() - createdAtMs > FRESH_SIGNUP_WINDOW_MS) {
+          return
+        }
+
+        const source = resolveSource(pending.method, pending.attribution)
+        const props: Record<string, unknown> = {
+          source,
+          method: pending.method,
+        }
+        if (pending.attribution.gymSlug) {
+          props.gymSlug = pending.attribution.gymSlug
+        }
+        trackEvent('signup_completed', props)
+        clearAttribution()
+        void flushEvents(true)
+      })
+      .catch(() => {
+        // Session lookup failed — nothing to attribute, stay silent.
+      })
+
+    return () => {
+      cancelled = true
     }
-    if (pending.attribution.gymSlug) {
-      props.gymSlug = pending.attribution.gymSlug
-    }
-    trackEvent('signup_completed', props)
-    clearAttribution()
-    void flushEvents(true)
-  }, [session, isPending])
+  }, [])
 
   return null
 }


### PR DESCRIPTION
Fixes #971

## Problem

`/settings/equipment` (and other server-rendered routes) returned a **500 on reload** with:

> Invalid hook call / Cannot read properties of null (reading 'useRef')

originating from BetterAuth's `useSession` at `components/features/SignupCompletedTracker.tsx`.

First (client-side) navigation rendered fine; a hard reload — which server-renders the route through the RSC graph — crashed. `/settings` (a `'use client'` page) also calls `useSession` and worked, which pointed at the client/server boundary rather than the tracker's own logic.

## Root cause

`SignupCompletedTracker` is mounted in the shared `(app)` layout. It called BetterAuth's reactive `useSession`, which subscribes to the session store via `useStore` → `useRef` **during render**. BetterAuth's `react-store` module has no `'use client'` directive, so on server-rendered routes it leaked into the RSC/server module graph, where React's dispatcher is null for client hooks — producing the invalid hook call. React is deduped (single instance), so this is a module-boundary issue, not a duplicate-React install.

## Fix

The tracker is a **fire-once side effect that renders `null`** — it never needs to re-render on session changes. It now reads the session **imperatively** via `authClient.getSession()` inside the mount effect instead of subscribing with `useSession`. This removes every BetterAuth React hook from the render path, so the crash can't occur regardless of how the module graph resolves. Observable behavior is unchanged: `signup_completed` still fires exactly once for a fresh OAuth session with a pending attribution record.

Minimal scope: one component + one test file. Other pages mounting the tracker are unaffected (identical behavior).

## Testing

- New `__tests__/components/SignupCompletedTracker.test.tsx` (5 cases): fires once for a fresh OAuth session with a pending record; stays silent with no pending record, no session, or an account outside the fresh-signup window; and mounts without throwing.
- The exact invalid-hook-call is a Turbopack RSC module-graph condition that **cannot be reproduced under jsdom** (single deduped React with a valid dispatcher), so the tests lock in observable behavior as a regression guard rather than reproducing the null dispatcher.
- `npm run type-check` clean; `eslint` clean on changed files (pre-existing lint errors in unrelated `components/workout-logging/*` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)