### PR TITLE
feat(settings): re-expose equipment checklist entry (#979)

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Dumbbell, Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
+import { Dumbbell, Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun, Wrench } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -290,6 +290,22 @@ export default function SettingsPage() {
                     </span>
                     <span className="block text-sm text-muted-foreground">
                       Set FAU ratios for ad-hoc exercise guidance.
+                    </span>
+                  </span>
+                </span>
+              </Link>
+              <Link
+                href="/settings/equipment"
+                className="flex min-h-14 items-center justify-between gap-3 border-2 border-border bg-card px-4 py-3 text-foreground transition-colors doom-focus-ring hover:border-primary hover:bg-muted/50"
+              >
+                <span className="flex items-center gap-3">
+                  <Wrench size={18} aria-hidden="true" />
+                  <span>
+                    <span className="block text-sm font-bold uppercase tracking-wider">
+                      Equipment
+                    </span>
+                    <span className="block text-sm text-muted-foreground">
+                      Tell us what you train with.
                     </span>
                   </span>
                 </span>


### PR DESCRIPTION
## Summary

Re-adds the settings-tab link to `/settings/equipment` under the existing **Training Targets** section, alongside Muscle Balance. #960 hid this entry while the LLM suggest flow was parked; #971 fixed the page's reload 500. The page and API work, there was just no way to reach them in the UI, so users with a seeded equipment list couldn't edit it.

## Changes

- Restore the Equipment `Link` in `app/(app)/settings/page.tsx`, following the Muscle Balance entry's exact pattern (`border-2`/hover/`doom-focus-ring`, `Wrench` icon + bold uppercase title + one-line description, `min-h-14`).
- Description: "Tell us what you train with."
- Re-import the `Wrench` icon.

No other settings entries added or removed. Page, API, and goals-wizard links are unchanged.

## Verification

- `tsc --noEmit` passes; lint clean for the changed file (pre-existing lint issues in unrelated files remain).
- Playwright (mobile 390x844, seeded user):
  - Settings tab shows Training Targets -> Muscle Balance + Equipment.
  - Equipment link navigates to `/settings/equipment` and the page renders.
  - Page also renders correctly on **reload** (confirms #971 fix holds).

### Settings tab
Equipment entry renders beneath Muscle Balance with matching styling.

## Acceptance criteria

- [x] Settings tab shows Training Targets -> Muscle Balance + Equipment; link navigates and page renders (first load AND reload)
- [x] No other settings entries added or removed
- [x] Playwright screenshot of the settings tab captured before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)