### PR TITLE
feat: target movements (anchors) staleness view (#976)

### DIFF
--- a/__tests__/api/user-training-profile.test.ts
+++ b/__tests__/api/user-training-profile.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeInjuryAreas,
   normalizeOtherActivities,
   normalizePreferredDays,
+  normalizeTargetMovements,
   normalizeUserTrainingProfile,
   updateUserTrainingProfile,
 } from '@/lib/user-training-profile'
@@ -485,5 +486,50 @@ describe('UserTrainingProfile persistence', () => {
     expect(after.updatedAt.getTime()).toBeGreaterThan(
       before.updatedAt.getTime()
     )
+  })
+})
+
+describe('normalizeTargetMovements', () => {
+  it('returns {} for non-object / array / nullish input', () => {
+    expect(normalizeTargetMovements(null)).toEqual({})
+    expect(normalizeTargetMovements(undefined)).toEqual({})
+    expect(normalizeTargetMovements('nope')).toEqual({})
+    expect(normalizeTargetMovements(42)).toEqual({})
+    expect(normalizeTargetMovements([])).toEqual({})
+  })
+
+  it('keeps only known anchor patterns, dropping unknown keys', () => {
+    const result = normalizeTargetMovements({
+      hinge: ['ex_dl'],
+      lunge: ['ex_lunge'], // valid MovementPattern but not an anchor
+      bogus: ['ex_x'],
+    })
+    expect(result).toEqual({ hinge: ['ex_dl'] })
+  })
+
+  it('coerces values: trims, drops non-strings/blanks, dedupes, caps at 5', () => {
+    const result = normalizeTargetMovements({
+      squat: [
+        '  ex_a ',
+        'ex_a', // dupe of trimmed ex_a
+        '',
+        42, // non-string
+        'ex_b',
+        'ex_c',
+        'ex_d',
+        'ex_e',
+        'ex_f', // 6th distinct -> dropped by the cap
+      ],
+    })
+    expect(result.squat).toEqual(['ex_a', 'ex_b', 'ex_c', 'ex_d', 'ex_e'])
+  })
+
+  it('drops patterns that normalize to an empty list', () => {
+    const result = normalizeTargetMovements({
+      hinge: [],
+      squat: ['', 7],
+      vertical_push: ['ex_ohp'],
+    })
+    expect(result).toEqual({ vertical_push: ['ex_ohp'] })
   })
 })

--- a/__tests__/lib/recommendations/anchor-staleness.test.ts
+++ b/__tests__/lib/recommendations/anchor-staleness.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import type { TargetMovements } from '@/lib/exercises/anchor-patterns'
+import {
+  type AnchorStalenessRow,
+  computeAnchorStaleness,
+} from '@/lib/recommendations/anchor-staleness'
+
+// Fixed reference instant so day math is deterministic.
+const NOW = new Date('2026-07-10T12:00:00.000Z')
+
+/** A Date `days` whole days before NOW. */
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000)
+}
+
+function order(rows: AnchorStalenessRow[]): string[] {
+  return rows.map((r) => r.pattern)
+}
+
+describe('computeAnchorStaleness', () => {
+  it('considers only configured patterns with a non-empty id list', () => {
+    const target: TargetMovements = {
+      hinge: ['ex_dl'],
+      squat: [], // empty -> skipped
+    }
+    const rows = computeAnchorStaleness(target, new Map(), NOW)
+    expect(order(rows)).toEqual(['hinge'])
+  })
+
+  it('uses the freshest (min days-since) pick to score a movement', () => {
+    const target: TargetMovements = { hinge: ['ex_dl', 'ex_rdl'] }
+    const logged = new Map<string, Date>([
+      ['ex_dl', daysAgo(20)],
+      ['ex_rdl', daysAgo(3)], // freshest resets the movement
+    ])
+    const [row] = computeAnchorStaleness(target, logged, NOW)
+    expect(row.lastLoggedDaysAgo).toBe(3)
+  })
+
+  it('marks a movement with no logged picks as never logged (null)', () => {
+    const target: TargetMovements = { squat: ['ex_squat'] }
+    const [row] = computeAnchorStaleness(target, new Map(), NOW)
+    expect(row.lastLoggedDaysAgo).toBeNull()
+  })
+
+  it('sorts never-logged first, then by days-since descending', () => {
+    const target: TargetMovements = {
+      hinge: ['ex_dl'], // 2d
+      squat: ['ex_sq'], // 15d
+      horizontal_push: ['ex_bench'], // never
+    }
+    const logged = new Map<string, Date>([
+      ['ex_dl', daysAgo(2)],
+      ['ex_sq', daysAgo(15)],
+    ])
+    const rows = computeAnchorStaleness(target, logged, NOW)
+    expect(order(rows)).toEqual(['horizontal_push', 'squat', 'hinge'])
+  })
+
+  it('breaks ties on the fixed taxonomy order (hinge before squat)', () => {
+    const target: TargetMovements = {
+      squat: ['ex_sq'],
+      hinge: ['ex_dl'],
+    }
+    // Both logged the same number of days ago -> taxonomy order wins.
+    const logged = new Map<string, Date>([
+      ['ex_sq', daysAgo(5)],
+      ['ex_dl', daysAgo(5)],
+    ])
+    expect(order(computeAnchorStaleness(target, logged, NOW))).toEqual(['hinge', 'squat'])
+  })
+
+  it('breaks never-logged ties on taxonomy order too', () => {
+    const target: TargetMovements = {
+      vertical_pull: ['ex_pullup'],
+      horizontal_pull: ['ex_row'],
+    }
+    // Neither logged; horizontal_pull precedes vertical_pull in ANCHOR_PATTERNS.
+    expect(order(computeAnchorStaleness(target, new Map(), NOW))).toEqual([
+      'horizontal_pull',
+      'vertical_pull',
+    ])
+  })
+
+  it('clamps a future last-logged date to 0 (today) rather than going negative', () => {
+    const target: TargetMovements = { hinge: ['ex_dl'] }
+    const logged = new Map<string, Date>([['ex_dl', daysAgo(-3)]]) // 3 days in the future
+    const [row] = computeAnchorStaleness(target, logged, NOW)
+    expect(row.lastLoggedDaysAgo).toBe(0)
+  })
+
+  it('carries the curated ids and display name through onto each row', () => {
+    const target: TargetMovements = { hinge: ['ex_dl', 'ex_rdl'] }
+    const [row] = computeAnchorStaleness(target, new Map(), NOW)
+    expect(row.exerciseIds).toEqual(['ex_dl', 'ex_rdl'])
+    expect(row.displayName).toBe('Hinge')
+  })
+})

--- a/__tests__/lib/suggest/goal-sentences.test.ts
+++ b/__tests__/lib/suggest/goal-sentences.test.ts
@@ -24,6 +24,7 @@ function makeProfile(o: Partial<UserTrainingProfileDTO> = {}): UserTrainingProfi
     otherActivities: [],
     fauImportance: {},
     fauImportancePreset: null,
+    targetMovements: {},
     targetSessionsPerWeek: null,
     targetMinutesPerSession: null,
     patternPreference: null,

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Dumbbell, Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
+import { Anchor, Dumbbell, Heart, KeyRound, MessageSquarePlus, Moon, Palette, Shield, Sun } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import FeedbackModal from '@/components/features/FeedbackModal'
@@ -290,6 +290,22 @@ export default function SettingsPage() {
                     </span>
                     <span className="block text-sm text-muted-foreground">
                       Set FAU ratios for ad-hoc exercise guidance.
+                    </span>
+                  </span>
+                </span>
+              </Link>
+              <Link
+                href="/settings/target-movements"
+                className="flex min-h-14 items-center justify-between gap-3 border-2 border-border bg-card px-4 py-3 text-foreground transition-colors doom-focus-ring hover:border-primary hover:bg-muted/50"
+              >
+                <span className="flex items-center gap-3">
+                  <Anchor size={18} aria-hidden="true" />
+                  <span>
+                    <span className="block text-sm font-bold uppercase tracking-wider">
+                      Target Movements
+                    </span>
+                    <span className="block text-sm text-muted-foreground">
+                      Pin compound lifts to track in the picker's Anchors view.
                     </span>
                   </span>
                 </span>

--- a/app/(app)/settings/target-movements/page.tsx
+++ b/app/(app)/settings/target-movements/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from 'next/navigation'
+import TargetMovementsEditor from '@/components/features/target-movements/TargetMovementsEditor'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import { getOrCreateUserTrainingProfile } from '@/lib/user-training-profile'
+
+export default async function TargetMovementsSettingsPage() {
+  const { user, error } = await getCurrentUser()
+
+  if (error || !user) {
+    redirect('/login')
+  }
+
+  const profile = await getOrCreateUserTrainingProfile(prisma, user.id)
+
+  const ids = Array.from(
+    new Set(Object.values(profile.targetMovements).flat().filter(Boolean))
+  ) as string[]
+  const exercises = ids.length
+    ? await prisma.exerciseDefinition.findMany({
+        where: { id: { in: ids } },
+        select: {
+          id: true,
+          name: true,
+          primaryFAUs: true,
+          secondaryFAUs: true,
+          equipment: true,
+        },
+      })
+    : []
+
+  return (
+    <TargetMovementsEditor
+      initialTargetMovements={profile.targetMovements}
+      initialExercises={exercises}
+    />
+  )
+}

--- a/app/(app)/training/adhoc/[completionId]/page.tsx
+++ b/app/(app)/training/adhoc/[completionId]/page.tsx
@@ -5,7 +5,9 @@ import { RestoringWorkoutSpinner } from '@/components/ui/RestoringWorkoutSpinner
 import { getCurrentUser } from '@/lib/auth/server'
 import { prisma } from '@/lib/db'
 import { getMuscleBalanceSnapshot } from '@/lib/muscle-balance'
+import { getAnchorStaleness } from '@/lib/recommendations/anchor-staleness'
 import { getFauRecoveryRanking } from '@/lib/recommendations/fau-recovery-data'
+import { normalizeTargetMovements } from '@/lib/user-training-profile'
 
 type Props = {
   params: Promise<{ completionId: string }>
@@ -42,7 +44,7 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
     redirect('/login')
   }
 
-  const [completion, muscleBalanceSnapshot] = await Promise.all([
+  const [completion, muscleBalanceSnapshot, trainingProfile] = await Promise.all([
     prisma.workoutCompletion.findUnique({
       where: { id: completionId },
       select: {
@@ -87,6 +89,10 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
       },
     }),
     getMuscleBalanceSnapshot(prisma, user.id),
+    prisma.userTrainingProfile.findUnique({
+      where: { userId: user.id },
+      select: { targetMovements: true },
+    }),
   ])
 
   if (!completion || completion.userId !== user.id || !completion.isAdHoc) {
@@ -105,6 +111,14 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
     user.id,
     muscleBalanceSnapshot
   )
+
+  // Curated "anchor" movements ranked by staleness (#976) for the picker's
+  // Anchors view. Pure days-since-last-logged — independent of the recovery
+  // ranking above. Empty when the user hasn't configured any (picker shows a CTA).
+  const targetMovements = normalizeTargetMovements(
+    trainingProfile?.targetMovements
+  )
+  const anchors = await getAnchorStaleness(user.id, targetMovements)
 
   const exercises: AdHocExercise[] = completion.exercises.map((e) => ({
     id: e.id,
@@ -128,6 +142,7 @@ async function AdHocLoggerLoader({ completionId }: { completionId: string }) {
       initialLoggedSets={completion.loggedSets}
       muscleBalanceSnapshot={muscleBalanceSnapshot}
       recoveryRanking={recoveryRanking ?? undefined}
+      anchors={anchors}
     />
   )
 }

--- a/app/api/exercises/search/route.ts
+++ b/app/api/exercises/search/route.ts
@@ -18,10 +18,18 @@ export async function GET(request: NextRequest) {
     const query = searchParams.get('query') || ''
     const fauFilters = searchParams.get('faus')?.split(',').filter(Boolean) || []
     const equipmentFilters = searchParams.get('equipment')?.split(',').filter(Boolean) || []
+    // Explicit id set (Anchors view, #976): restrict results to these exercise
+    // definitions. Capped so a hand-built query can't request an unbounded IN().
+    const idFilters = (searchParams.get('ids')?.split(',').filter(Boolean) || []).slice(0, 50)
     const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100) // Max 100 results
 
     // Build where conditions
     const whereConditions: Record<string, unknown>[] = []
+
+    // Filter to an explicit id set (curated anchor exercises)
+    if (idFilters.length > 0) {
+      whereConditions.push({ id: { in: idFilters } })
+    }
 
     // Text search on name and aliases
     if (query.trim()) {

--- a/app/api/settings/target-movements/route.ts
+++ b/app/api/settings/target-movements/route.ts
@@ -1,0 +1,171 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/server'
+import { prisma } from '@/lib/db'
+import {
+  isAnchorPattern,
+  MAX_ANCHOR_EXERCISES,
+  type TargetMovements,
+} from '@/lib/exercises/anchor-patterns'
+import { logger } from '@/lib/logger'
+import {
+  checkRateLimitWithHeaders,
+  programManagementLimiter,
+} from '@/lib/rate-limit'
+import {
+  getOrCreateUserTrainingProfile,
+  updateUserTrainingProfile,
+} from '@/lib/user-training-profile'
+
+/** Lightweight exercise shape the editor renders as selected chips. */
+type AnchorExercise = {
+  id: string
+  name: string
+  primaryFAUs: string[]
+  secondaryFAUs: string[]
+  equipment: string[]
+}
+
+type UpdateTargetMovementsRequest = {
+  targetMovements?: Record<string, unknown>
+}
+
+/** Fetch id -> definition for every id referenced by the anchor map. */
+async function resolveAnchorExercises(
+  targetMovements: TargetMovements
+): Promise<AnchorExercise[]> {
+  const ids = Array.from(
+    new Set(Object.values(targetMovements).flat().filter(Boolean))
+  ) as string[]
+  if (ids.length === 0) return []
+  return prisma.exerciseDefinition.findMany({
+    where: { id: { in: ids } },
+    select: {
+      id: true,
+      name: true,
+      primaryFAUs: true,
+      secondaryFAUs: true,
+      equipment: true,
+    },
+  })
+}
+
+export async function GET(_request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const profile = await getOrCreateUserTrainingProfile(prisma, user.id)
+    const exercises = await resolveAnchorExercises(profile.targetMovements)
+
+    return NextResponse.json({
+      success: true,
+      targetMovements: profile.targetMovements,
+      exercises,
+    })
+  } catch (error) {
+    logger.error(
+      { error, context: 'target-movements-get' },
+      'Failed to fetch target movements'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { user, error } = await getCurrentUser()
+    if (error || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const limited = await checkRateLimitWithHeaders(
+      programManagementLimiter,
+      user.id,
+      { endpoint: 'settings/target-movements' }
+    )
+    if (limited.response) return limited.response
+
+    const body = (await request.json()) as UpdateTargetMovementsRequest
+    const validationError = validateUpdateRequest(body)
+    if (validationError) {
+      return NextResponse.json(
+        { error: validationError },
+        { status: 400, headers: limited.headers }
+      )
+    }
+
+    // Drop ids that don't reference a real exercise definition so deleted /
+    // bogus ids never persist. Structural normalization (valid patterns, dedupe,
+    // cap 5) then happens inside updateUserTrainingProfile.
+    const cleaned = await filterToExistingExercises(
+      body.targetMovements as Record<string, string[]>
+    )
+
+    const profile = await updateUserTrainingProfile(prisma, user.id, {
+      targetMovements: cleaned,
+    })
+    const exercises = await resolveAnchorExercises(profile.targetMovements)
+
+    return NextResponse.json(
+      { success: true, targetMovements: profile.targetMovements, exercises },
+      { headers: limited.headers }
+    )
+  } catch (error) {
+    logger.error(
+      { error, context: 'target-movements-update' },
+      'Failed to update target movements'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+function validateUpdateRequest(
+  body: UpdateTargetMovementsRequest
+): string | null {
+  const map = body.targetMovements
+  if (map === undefined) {
+    return 'targetMovements is required'
+  }
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    return 'targetMovements must be an object keyed by movement pattern'
+  }
+  for (const [pattern, value] of Object.entries(map)) {
+    if (!isAnchorPattern(pattern)) {
+      return `Invalid movement pattern: ${pattern}`
+    }
+    if (!Array.isArray(value)) {
+      return `Exercises for ${pattern} must be an array`
+    }
+    if (value.length > MAX_ANCHOR_EXERCISES) {
+      return `Pick at most ${MAX_ANCHOR_EXERCISES} exercises for ${pattern}`
+    }
+    if (value.some((id) => typeof id !== 'string')) {
+      return `Exercise ids for ${pattern} must be strings`
+    }
+  }
+  return null
+}
+
+/** Keep only ids that exist in ExerciseDefinition, preserving per-pattern order. */
+async function filterToExistingExercises(
+  map: Record<string, string[]>
+): Promise<TargetMovements> {
+  const ids = Array.from(new Set(Object.values(map).flat().filter(Boolean)))
+  if (ids.length === 0) return {}
+
+  const existing = await prisma.exerciseDefinition.findMany({
+    where: { id: { in: ids } },
+    select: { id: true },
+  })
+  const valid = new Set(existing.map((e) => e.id))
+
+  const cleaned: TargetMovements = {}
+  for (const [pattern, value] of Object.entries(map)) {
+    if (!isAnchorPattern(pattern)) continue
+    const kept = value.filter((id) => valid.has(id))
+    if (kept.length > 0) cleaned[pattern] = kept
+  }
+  return cleaned
+}

--- a/components/adhoc/AdHocExercisePickerModal.tsx
+++ b/components/adhoc/AdHocExercisePickerModal.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/radix/dialog'
 import { TipAnnotation } from '@/components/ui/TipAnnotation'
 import { ALL_FAUS, type FAUKey } from '@/lib/fau-volume'
+import type { AnchorStalenessRow } from '@/lib/recommendations/anchor-staleness'
 import type { FauNeed } from '@/lib/recommendations/fau-score'
 
 const HYPOTHETICAL_SETS_PER_EXERCISE = 3
@@ -53,6 +54,7 @@ type Props = {
   isBusy: boolean
   muscleBalanceSnapshot: MuscleBalanceSnapshot
   recoveryRanking?: FauNeed[]
+  anchors?: AnchorStalenessRow[]
   plannedExerciseDefinitions?: Array<{
     primaryFAUs: string[]
     secondaryFAUs: string[]
@@ -66,6 +68,7 @@ export function AdHocExercisePickerModal({
   isBusy,
   muscleBalanceSnapshot,
   recoveryRanking,
+  anchors,
   plannedExerciseDefinitions = [],
 }: Props) {
   const isAdd = mode.kind === 'add'
@@ -133,6 +136,7 @@ export function AdHocExercisePickerModal({
             preloadExercises
             muscleBalanceSnapshot={isAdd ? muscleBalanceSnapshot : undefined}
             recoveryRanking={isAdd ? recoveryRanking : undefined}
+            anchors={isAdd ? anchors : undefined}
             plannedFAUVolume={isAdd ? plannedFAUVolume : undefined}
           />
         </DialogBody>

--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/lib/api/adhoc-workout'
 import { FetchError } from '@/lib/api/fetch'
 import { clientLogger } from '@/lib/client-logger'
+import type { AnchorStalenessRow } from '@/lib/recommendations/anchor-staleness'
 import type { FauNeed } from '@/lib/recommendations/fau-score'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
 import type { LoggedSet } from '@/types/workout'
@@ -89,6 +90,8 @@ type Props = {
   muscleBalanceSnapshot: MuscleBalanceSnapshot
   /** Recovery-aware FAU ranking (#963) for the picker's third sort mode. */
   recoveryRanking?: FauNeed[]
+  /** Curated anchor movements + staleness (#976) for the picker's Anchors view. */
+  anchors?: AnchorStalenessRow[]
 }
 
 const EMPTY_SET = {
@@ -106,6 +109,7 @@ export default function AdHocLoggerView({
   initialLoggedSets,
   muscleBalanceSnapshot,
   recoveryRanking,
+  anchors,
 }: Props) {
   const router = useRouter()
   const toast = useToast()
@@ -849,6 +853,7 @@ export default function AdHocLoggerView({
           isBusy={pickerMode.kind === 'add' ? isAdding : isSwapping}
           muscleBalanceSnapshot={muscleBalanceSnapshot}
           recoveryRanking={recoveryRanking}
+          anchors={anchors}
           plannedExerciseDefinitions={exercises.map((exercise) => ({
             primaryFAUs: exercise.exerciseDefinition.primaryFAUs,
             secondaryFAUs: exercise.exerciseDefinition.secondaryFAUs,

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -1,15 +1,21 @@
 'use client'
 
 import { Check, Filter, Search } from 'lucide-react'
+import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clientLogger } from '@/lib/client-logger'
 import { EQUIPMENT_LABELS } from '@/lib/constants/program-metadata'
+import type { AnchorPattern } from '@/lib/exercises/anchor-patterns'
 import { ALL_FAUS, FAU_DISPLAY_NAMES, type FAUKey } from '@/lib/fau-volume'
 import type { MuscleBalanceSnapshot } from '@/lib/muscle-balance'
+import type { AnchorStalenessRow } from '@/lib/recommendations/anchor-staleness'
 import type { FauNeed } from '@/lib/recommendations/fau-score'
+import { daysSinceLabel } from '@/lib/recommendations/staleness'
 import { FilterChoiceSheet } from './FilterChoiceSheet'
 
-type FauSort = 'alphabetical' | 'neglected' | 'recovery'
+// A-Z / Neglected / Recovery reorder the same muscle-group list; 'anchors' is a
+// view swap — the sheet lists the user's curated movements by staleness instead.
+type FauSort = 'alphabetical' | 'neglected' | 'recovery' | 'anchors'
 
 export type ExerciseDefinition = {
   id: string
@@ -36,6 +42,14 @@ interface ExerciseSearchInterfaceProps {
    * reason chip per row. Absent = the mode is not offered (graceful degrade).
    */
   recoveryRanking?: FauNeed[]
+  /**
+   * Curated "anchor" movements with staleness (#976). When provided (even as an
+   * empty array), the view toggle gains an "Anchors" mode that swaps the sheet's
+   * muscle-group rows for movement rows sorted by days-since-last-logged; picking
+   * one filters the exercise list to that movement's curated ids. Absent = the
+   * mode is not offered.
+   */
+  anchors?: AnchorStalenessRow[]
   plannedFAUVolume?: Partial<Record<FAUKey, number>>
   /**
    * When provided, the picker switches to multi-select mode: cards highlight
@@ -78,6 +92,7 @@ export function ExerciseSearchInterface({
   initialFauFilter = null,
   muscleBalanceSnapshot,
   recoveryRanking,
+  anchors,
   plannedFAUVolume = {},
   selectedIds,
 }: ExerciseSearchInterfaceProps) {
@@ -92,6 +107,8 @@ export function ExerciseSearchInterface({
   const [fauSheetOpen, setFauSheetOpen] = useState(false)
   const [equipmentSheetOpen, setEquipmentSheetOpen] = useState(false)
   const [fauSort, setFauSort] = useState<FauSort>('alphabetical')
+  // Anchors view (#976): which curated movement is filtering the list, if any.
+  const [selectedAnchorPattern, setSelectedAnchorPattern] = useState<string | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   const balanceByFau = useMemo(() => {
@@ -104,10 +121,28 @@ export function ExerciseSearchInterface({
     () => new Map((recoveryRanking ?? []).map((entry) => [entry.fau, entry])),
     [recoveryRanking],
   )
-  // The recovery mode can only be active when its data is present; if the prop
-  // disappears, fall back so the sort never silently produces an empty order.
+
+  // Anchors mode is offered whenever the caller passes the prop (even empty — an
+  // empty list renders a "set up" CTA rather than hiding the feature).
+  const anchorsAvailable = anchors !== undefined
+  const anchorByPattern = useMemo(
+    () => new Map((anchors ?? []).map((a) => [a.pattern, a] as const)),
+    [anchors],
+  )
+  const selectedAnchorIds = useMemo(() => {
+    if (selectedAnchorPattern === null) return [] as string[]
+    return anchorByPattern.get(selectedAnchorPattern as AnchorPattern)?.exerciseIds ?? []
+  }, [selectedAnchorPattern, anchorByPattern])
+
+  // A selected sort/view mode can only be active when its data is present; if the
+  // prop disappears, fall back so the sheet never produces an empty order/list.
   const effectiveSort: FauSort =
-    fauSort === 'recovery' && !hasRecovery ? 'neglected' : fauSort
+    fauSort === 'recovery' && !hasRecovery
+      ? 'neglected'
+      : fauSort === 'anchors' && !anchorsAvailable
+        ? 'alphabetical'
+        : fauSort
+  const inAnchorsView = effectiveSort === 'anchors'
 
   const sortModes = useMemo(
     () =>
@@ -115,9 +150,37 @@ export function ExerciseSearchInterface({
         { key: 'alphabetical' as const, label: 'A-Z' },
         { key: 'neglected' as const, label: 'Neglected' },
         ...(hasRecovery ? [{ key: 'recovery' as const, label: 'Recovery' }] : []),
+        ...(anchorsAvailable ? [{ key: 'anchors' as const, label: 'Anchors' }] : []),
       ] satisfies Array<{ key: FauSort; label: string }>,
-    [hasRecovery],
+    [hasRecovery, anchorsAvailable],
   )
+
+  const anchorOptions = useMemo(
+    () => [
+      { value: null, label: 'All configured movements' },
+      ...(anchors ?? []).map((a) => ({
+        value: a.pattern,
+        label: a.displayName,
+        // Days-since as a left-aligned "why" line so long copy ("New — never
+        // logged") wraps cleanly instead of crowding the right-side badge slot.
+        meta: daysSinceLabel(a.lastLoggedDaysAgo),
+      })),
+    ],
+    [anchors],
+  )
+
+  const handleSortModeChange = useCallback((mode: FauSort) => {
+    setFauSort(mode)
+    // Switching dimensions clears the other's filter so stale predicates don't
+    // linger: leaving Anchors drops the id filter; entering it drops the FAU one.
+    if (mode === 'anchors') setSelectedFAU(null)
+    else setSelectedAnchorPattern(null)
+  }, [])
+
+  const handleAnchorSelect = useCallback((pattern: string | null) => {
+    setSelectedAnchorPattern(pattern)
+    if (pattern !== null) setSelectedFAU(null)
+  }, [])
 
   const fauOptions = useMemo(() => {
     const scoreFAU = (fau: FAUKey) => {
@@ -219,6 +282,10 @@ export function ExerciseSearchInterface({
       if (selectedEquipment) {
         params.append('equipment', selectedEquipment)
       }
+      // Anchors view: restrict to the picked movement's curated exercise ids.
+      if (selectedAnchorIds.length > 0) {
+        params.append('ids', selectedAnchorIds.join(','))
+      }
       params.append('limit', '50')
 
       const response = await fetch(`/api/exercises/search?${params}`)
@@ -236,14 +303,27 @@ export function ExerciseSearchInterface({
     } finally {
       setIsLoading(false)
     }
-  }, [searchQuery, selectedFAU, selectedEquipment])
+  }, [searchQuery, selectedFAU, selectedEquipment, selectedAnchorIds])
 
   // Search when query/filters change (respecting preloadExercises)
   useEffect(() => {
-    if (preloadExercises || searchQuery.trim() || selectedFAU || selectedEquipment) {
+    if (
+      preloadExercises ||
+      searchQuery.trim() ||
+      selectedFAU ||
+      selectedEquipment ||
+      selectedAnchorIds.length > 0
+    ) {
       searchExercises()
     }
-  }, [searchQuery, selectedFAU, selectedEquipment, preloadExercises, searchExercises])
+  }, [
+    searchQuery,
+    selectedFAU,
+    selectedEquipment,
+    selectedAnchorIds,
+    preloadExercises,
+    searchExercises,
+  ])
 
   const handleFAUSelect = useCallback((fau: string | null) => {
     setSelectedFAU(fau)
@@ -270,15 +350,24 @@ export function ExerciseSearchInterface({
           />
         </div>
 
-        {/* FAU Filter */}
+        {/* FAU / Anchors Filter */}
         <div>
-          <div className="text-sm font-bold text-foreground mb-2 tracking-wide">Filter by Muscle Group:</div>
+          <div className="text-sm font-bold text-foreground mb-2 tracking-wide">
+            {inAnchorsView ? 'Filter by Movement:' : 'Filter by Muscle Group:'}
+          </div>
           <button
             type="button"
             onClick={() => setFauSheetOpen(true)}
             className="w-full px-4 py-2 border-2 border-input hover:border-primary focus:outline-none focus:border-primary focus:shadow-[0_0_20px_rgba(var(--primary-rgb),0.3)] bg-card text-foreground text-left font-bold"
           >
-            {selectedFAU ? FAU_DISPLAY_NAMES[selectedFAU] : 'All Muscle Groups'}
+            {inAnchorsView
+              ? selectedAnchorPattern
+                ? (anchorByPattern.get(selectedAnchorPattern as AnchorPattern)?.displayName ??
+                  'Movement')
+                : 'All configured movements'
+              : selectedFAU
+                ? FAU_DISPLAY_NAMES[selectedFAU]
+                : 'All Muscle Groups'}
           </button>
         </div>
 
@@ -298,27 +387,31 @@ export function ExerciseSearchInterface({
       <FilterChoiceSheet
         open={fauSheetOpen}
         onOpenChange={setFauSheetOpen}
-        title="Filter by Muscle Group"
-        options={fauOptions}
-        selected={selectedFAU}
-        onSelect={handleFAUSelect}
+        title={inAnchorsView ? 'Filter by Movement' : 'Filter by Muscle Group'}
+        options={inAnchorsView ? anchorOptions : fauOptions}
+        selected={inAnchorsView ? selectedAnchorPattern : selectedFAU}
+        onSelect={inAnchorsView ? handleAnchorSelect : handleFAUSelect}
         headerContent={
-          muscleBalanceSnapshot ? (
+          muscleBalanceSnapshot || anchorsAvailable ? (
             <div>
               <div className="mb-2 text-xs font-bold uppercase tracking-wider text-muted-foreground">
-                Sort muscle groups
+                View
               </div>
               <div
                 className="grid border-2 border-border bg-muted/20"
                 style={{
-                  gridTemplateColumns: `repeat(${sortModes.length}, minmax(0, 1fr))`,
+                  // 4+ modes wrap to two rows so labels ("Neglected") don't clip
+                  // on narrow phones; up to 3 stay in a single row.
+                  gridTemplateColumns: `repeat(${
+                    sortModes.length > 3 ? 2 : sortModes.length
+                  }, minmax(0, 1fr))`,
                 }}
               >
                 {sortModes.map((mode, index) => (
                   <button
                     key={mode.key}
                     type="button"
-                    onClick={() => setFauSort(mode.key)}
+                    onClick={() => handleSortModeChange(mode.key)}
                     className={`min-h-10 px-3 text-sm font-bold uppercase tracking-wider transition-colors doom-focus-ring ${
                       index > 0 ? 'border-l-2 border-border' : ''
                     } ${
@@ -331,6 +424,23 @@ export function ExerciseSearchInterface({
                   </button>
                 ))}
               </div>
+              {inAnchorsView && (anchors?.length ?? 0) === 0 && (
+                <div className="mt-3 border-2 border-dashed border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+                  <p className="mb-2 font-semibold text-foreground">
+                    No target movements yet.
+                  </p>
+                  <p className="mb-2">
+                    Pin the compound lifts you want to keep hitting, then this view
+                    ranks them by how long it's been.
+                  </p>
+                  <Link
+                    href="/settings/target-movements"
+                    className="inline-flex items-center gap-1 font-bold uppercase tracking-wider text-primary hover:underline"
+                  >
+                    Set up Target Movements →
+                  </Link>
+                </div>
+              )}
             </div>
           ) : undefined
         }

--- a/components/exercise-selection/ExerciseSearchInterface.tsx
+++ b/components/exercise-selection/ExerciseSearchInterface.tsx
@@ -400,11 +400,9 @@ export function ExerciseSearchInterface({
               <div
                 className="grid border-2 border-border bg-muted/20"
                 style={{
-                  // 4+ modes wrap to two rows so labels ("Neglected") don't clip
-                  // on narrow phones; up to 3 stay in a single row.
-                  gridTemplateColumns: `repeat(${
-                    sortModes.length > 3 ? 2 : sortModes.length
-                  }, minmax(0, 1fr))`,
+                  // All modes share a single row; type shrinks below so up to
+                  // four labels ("Neglected") still fit without clipping.
+                  gridTemplateColumns: `repeat(${sortModes.length}, minmax(0, 1fr))`,
                 }}
               >
                 {sortModes.map((mode, index) => (
@@ -412,7 +410,7 @@ export function ExerciseSearchInterface({
                     key={mode.key}
                     type="button"
                     onClick={() => handleSortModeChange(mode.key)}
-                    className={`min-h-10 px-3 text-sm font-bold uppercase tracking-wider transition-colors doom-focus-ring ${
+                    className={`min-h-10 whitespace-nowrap px-2 text-center text-xs font-bold uppercase tracking-wide transition-colors doom-focus-ring ${
                       index > 0 ? 'border-l-2 border-border' : ''
                     } ${
                       effectiveSort === mode.key

--- a/components/features/target-movements/TargetMovementsEditor.tsx
+++ b/components/features/target-movements/TargetMovementsEditor.tsx
@@ -1,0 +1,382 @@
+'use client'
+
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  Plus,
+  Save,
+  X,
+  XCircle,
+} from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, useMemo, useState } from 'react'
+import {
+  type ExerciseDefinition,
+  ExerciseSearchInterface,
+} from '@/components/exercise-selection/ExerciseSearchInterface'
+import { Button } from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/radix/dialog'
+import { clientLogger } from '@/lib/client-logger'
+import {
+  ANCHOR_PATTERN_DISPLAY_NAMES,
+  ANCHOR_PATTERNS,
+  type AnchorPattern,
+  MAX_ANCHOR_EXERCISES,
+  type TargetMovements,
+} from '@/lib/exercises/anchor-patterns'
+
+type Props = {
+  initialTargetMovements: TargetMovements
+  initialExercises: ExerciseDefinition[]
+}
+
+export default function TargetMovementsEditor({
+  initialTargetMovements,
+  initialExercises,
+}: Props) {
+  const router = useRouter()
+  const [selections, setSelections] = useState<Record<string, string[]>>(() => {
+    const initial: Record<string, string[]> = {}
+    for (const pattern of ANCHOR_PATTERNS) {
+      initial[pattern] = initialTargetMovements[pattern] ?? []
+    }
+    return initial
+  })
+  const [exerciseById, setExerciseById] = useState<Map<string, ExerciseDefinition>>(
+    () => new Map(initialExercises.map((e) => [e.id, e]))
+  )
+  const [openPattern, setOpenPattern] = useState<AnchorPattern | null>(null)
+  const [expanded, setExpanded] = useState<Set<AnchorPattern>>(new Set())
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const totalSelected = useMemo(
+    () => ANCHOR_PATTERNS.reduce((sum, p) => sum + (selections[p]?.length ?? 0), 0),
+    [selections]
+  )
+
+  const toggleExpanded = useCallback((pattern: AnchorPattern) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(pattern)) next.delete(pattern)
+      else next.add(pattern)
+      return next
+    })
+  }, [])
+
+  const removeExercise = useCallback((pattern: AnchorPattern, id: string) => {
+    setSaved(false)
+    setSelections((prev) => ({
+      ...prev,
+      [pattern]: (prev[pattern] ?? []).filter((x) => x !== id),
+    }))
+  }, [])
+
+  const commitPattern = useCallback(
+    (pattern: AnchorPattern, defs: ExerciseDefinition[]) => {
+      setSaved(false)
+      setExerciseById((prev) => {
+        const next = new Map(prev)
+        for (const def of defs) next.set(def.id, def)
+        return next
+      })
+      setSelections((prev) => ({ ...prev, [pattern]: defs.map((d) => d.id) }))
+      setOpenPattern(null)
+    },
+    []
+  )
+
+  const save = useCallback(async () => {
+    setIsSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      // Only send configured patterns; empty ones are simply omitted.
+      const targetMovements: Record<string, string[]> = {}
+      for (const pattern of ANCHOR_PATTERNS) {
+        const ids = selections[pattern] ?? []
+        if (ids.length > 0) targetMovements[pattern] = ids
+      }
+      const response = await fetch('/api/settings/target-movements', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetMovements }),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save target movements')
+      }
+      setSaved(true)
+      window.setTimeout(() => {
+        router.push('/settings')
+      }, 650)
+    } catch (err) {
+      clientLogger.error('Failed to save target movements:', err)
+      setError(err instanceof Error ? err.message : 'Failed to save settings')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [router, selections])
+
+  const openDefs = openPattern
+    ? (selections[openPattern] ?? [])
+        .map((id) => exerciseById.get(id))
+        .filter((d): d is ExerciseDefinition => Boolean(d))
+    : []
+
+  return (
+    <main className="bg-background px-4 py-6 sm:px-6 sm:py-8">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 flex items-center justify-between gap-3">
+          <div>
+            <Link
+              href="/settings"
+              className="mb-3 inline-flex min-h-11 items-center gap-2 text-sm font-bold uppercase tracking-wider text-muted-foreground doom-focus-ring hover:text-foreground"
+            >
+              <ArrowLeft size={16} aria-hidden="true" />
+              Settings
+            </Link>
+            <h1 className="text-2xl font-bold uppercase tracking-wider text-foreground">
+              Target Movements
+            </h1>
+          </div>
+          <Button type="button" variant="primary" doom loading={isSaving} onClick={save}>
+            <Save size={16} aria-hidden="true" className="mr-1.5" />
+            Save
+          </Button>
+        </div>
+
+        <p className="mb-5 max-w-2xl text-sm text-muted-foreground">
+          Pin the big compound movements you want to keep hitting. Each pattern is
+          optional — add up to {MAX_ANCHOR_EXERCISES} preferred exercises. The
+          workout picker's{' '}
+          <span className="font-bold text-foreground">Anchors</span> view then
+          lists them by how long it's been since you last logged one.
+        </p>
+
+        {(error || saved) && (
+          <div
+            role={error ? 'alert' : 'status'}
+            className={`mb-5 flex items-start gap-3 border-2 p-3 text-sm font-semibold ${
+              error
+                ? 'border-error bg-error/10 text-error'
+                : 'border-success bg-success/10 text-foreground'
+            }`}
+          >
+            {error ? (
+              <XCircle size={18} aria-hidden="true" className="mt-0.5 flex-shrink-0" />
+            ) : (
+              <CheckCircle2
+                size={18}
+                aria-hidden="true"
+                className="mt-0.5 flex-shrink-0 text-success"
+              />
+            )}
+            <span>{error || 'Target movements saved. Returning to settings.'}</span>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {ANCHOR_PATTERNS.map((pattern) => {
+            const ids = selections[pattern] ?? []
+            const isOpen = expanded.has(pattern)
+            return (
+              <section
+                key={pattern}
+                className="border-2 border-border bg-card doom-corners"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleExpanded(pattern)}
+                  aria-expanded={isOpen}
+                  className="flex min-h-14 w-full items-center justify-between gap-3 px-4 py-3 text-left doom-focus-ring"
+                >
+                  <span className="flex items-center gap-3">
+                    <ChevronDown
+                      size={18}
+                      aria-hidden="true"
+                      className={`flex-shrink-0 transition-transform ${
+                        isOpen ? 'rotate-180' : ''
+                      }`}
+                    />
+                    <span className="text-sm font-bold uppercase tracking-wider text-foreground">
+                      {ANCHOR_PATTERN_DISPLAY_NAMES[pattern]}
+                    </span>
+                  </span>
+                  <span
+                    className={`border-2 px-2.5 py-1 text-xs font-bold tabular-nums uppercase tracking-wider ${
+                      ids.length > 0
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border bg-muted text-muted-foreground'
+                    }`}
+                  >
+                    {ids.length > 0 ? `${ids.length} / ${MAX_ANCHOR_EXERCISES}` : 'Off'}
+                  </span>
+                </button>
+
+                {isOpen && (
+                  <div className="border-t border-border px-4 py-3">
+                    {ids.length > 0 ? (
+                      <ul className="mb-3 flex flex-wrap gap-2">
+                        {ids.map((id) => {
+                          const def = exerciseById.get(id)
+                          return (
+                            <li
+                              key={id}
+                              className="inline-flex items-center gap-1.5 border-2 border-border bg-muted/40 py-1 pl-3 pr-1.5 text-sm font-bold text-foreground"
+                            >
+                              <span className="uppercase tracking-wide">
+                                {def?.name ?? 'Unknown exercise'}
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => removeExercise(pattern, id)}
+                                aria-label={`Remove ${def?.name ?? 'exercise'}`}
+                                className="inline-flex h-6 w-6 items-center justify-center border border-border bg-card text-muted-foreground doom-focus-ring hover:border-error hover:text-error"
+                              >
+                                <X size={14} strokeWidth={2.5} />
+                              </button>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    ) : (
+                      <p className="mb-3 text-sm text-muted-foreground">
+                        No exercises pinned yet.
+                      </p>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setOpenPattern(pattern)}
+                      className="inline-flex min-h-11 items-center gap-2 border-2 border-border bg-muted px-3 py-2 text-sm font-bold uppercase tracking-wider text-foreground doom-focus-ring hover:border-primary"
+                    >
+                      <Plus size={16} aria-hidden="true" />
+                      {ids.length > 0 ? 'Edit exercises' : 'Add exercises'}
+                    </button>
+                  </div>
+                )}
+              </section>
+            )
+          })}
+        </div>
+
+        <p className="mt-5 text-sm text-muted-foreground">
+          {totalSelected > 0
+            ? `${totalSelected} exercise${totalSelected === 1 ? '' : 's'} pinned across ${
+                ANCHOR_PATTERNS.filter((p) => (selections[p]?.length ?? 0) > 0).length
+              } movement${
+                ANCHOR_PATTERNS.filter((p) => (selections[p]?.length ?? 0) > 0)
+                  .length === 1
+                  ? ''
+                  : 's'
+              }.`
+            : 'No movements configured yet — the Anchors view stays hidden until you pin at least one.'}
+        </p>
+      </div>
+
+      {openPattern && (
+        <PatternPickerModal
+          pattern={openPattern}
+          initialSelected={openDefs}
+          onClose={() => setOpenPattern(null)}
+          onSave={(defs) => commitPattern(openPattern, defs)}
+        />
+      )}
+    </main>
+  )
+}
+
+function PatternPickerModal({
+  pattern,
+  initialSelected,
+  onClose,
+  onSave,
+}: {
+  pattern: AnchorPattern
+  initialSelected: ExerciseDefinition[]
+  onClose: () => void
+  onSave: (defs: ExerciseDefinition[]) => void
+}) {
+  const [selectedDefs, setSelectedDefs] =
+    useState<ExerciseDefinition[]>(initialSelected)
+  const selectedIds = useMemo(
+    () => new Set(selectedDefs.map((d) => d.id)),
+    [selectedDefs]
+  )
+  const atCap = selectedDefs.length >= MAX_ANCHOR_EXERCISES
+
+  const handleToggle = useCallback((def: ExerciseDefinition) => {
+    setSelectedDefs((prev) => {
+      if (prev.some((d) => d.id === def.id)) {
+        return prev.filter((d) => d.id !== def.id)
+      }
+      // Enforce the cap — silently ignore adds past the limit; the banner
+      // tells the user to remove one first.
+      if (prev.length >= MAX_ANCHOR_EXERCISES) return prev
+      return [...prev, def]
+    })
+  }, [])
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent
+        showClose={false}
+        fullScreenMobile={true}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="w-full h-full sm:w-[90vw] sm:max-w-3xl sm:h-auto sm:max-h-[85vh] rounded-none sm:rounded-none border border-border bg-card"
+      >
+        <DialogHeader className="border-b border-border bg-primary py-2">
+          <DialogTitle className="text-lg font-bold text-primary-foreground tracking-wider uppercase">
+            {ANCHOR_PATTERN_DISPLAY_NAMES[pattern]} exercises
+          </DialogTitle>
+          <DialogDescription className="text-base font-bold text-primary-foreground/70 uppercase tracking-wide">
+            Pick up to {MAX_ANCHOR_EXERCISES} preferred lifts
+          </DialogDescription>
+        </DialogHeader>
+
+        {atCap && (
+          <div className="border-b-2 border-accent bg-accent/10 px-4 py-2 text-sm font-bold uppercase tracking-wide text-accent">
+            Max {MAX_ANCHOR_EXERCISES} reached — remove one to swap.
+          </div>
+        )}
+
+        <DialogBody className="flex-1 min-h-0">
+          <ExerciseSearchInterface
+            onExerciseSelect={handleToggle}
+            selectedIds={selectedIds}
+            preloadExercises
+          />
+        </DialogBody>
+
+        <DialogFooter className="border-t border-border bg-card py-2">
+          <div className="flex items-center justify-end gap-2 w-full">
+            <Button variant="secondary" onClick={onClose} doom>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={() => onSave(selectedDefs)} doom>
+              {selectedDefs.length === 0
+                ? 'Save'
+                : `Save (${selectedDefs.length})`}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/exercises/anchor-patterns.ts
+++ b/lib/exercises/anchor-patterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Anchor movement taxonomy (Target Movements, #976).
+ *
+ * The 6 compound movement patterns a user can curate as "anchors" — big lifts
+ * they want to guarantee periodic exposure to. A deliberate subset of the
+ * auto-tagger's `MOVEMENT_PATTERNS` (`./auto-tag`), omitting the ones that
+ * aren't anchor-worthy (lunge, carry, isolation, accessory).
+ *
+ * This module is intentionally dependency-free (no Prisma, no logger) so both
+ * client components (the picker's Anchors view, the settings editor) and server
+ * code can import the taxonomy without dragging server-only deps into the client
+ * bundle. Keys double as the JSON keys of `UserTrainingProfile.targetMovements`.
+ */
+
+import type { MovementPattern } from './auto-tag';
+
+export const ANCHOR_PATTERNS = [
+  'hinge',
+  'squat',
+  'horizontal_push',
+  'horizontal_pull',
+  'vertical_push',
+  'vertical_pull',
+] as const satisfies readonly MovementPattern[];
+
+export type AnchorPattern = (typeof ANCHOR_PATTERNS)[number];
+
+export const ANCHOR_PATTERN_DISPLAY_NAMES: Record<AnchorPattern, string> = {
+  hinge: 'Hinge',
+  squat: 'Squat',
+  horizontal_push: 'Horizontal Push',
+  horizontal_pull: 'Horizontal Pull',
+  vertical_push: 'Vertical Push',
+  vertical_pull: 'Vertical Pull',
+};
+
+export function isAnchorPattern(value: unknown): value is AnchorPattern {
+  return (
+    typeof value === 'string' &&
+    (ANCHOR_PATTERNS as readonly string[]).includes(value)
+  );
+}
+
+/** Max curated exercises a user can pin to a single anchor pattern. */
+export const MAX_ANCHOR_EXERCISES = 5
+
+/** pattern -> up to {@link MAX_ANCHOR_EXERCISES} ExerciseDefinition ids. */
+export type TargetMovements = Partial<Record<AnchorPattern, string[]>>

--- a/lib/exercises/auto-tag.ts
+++ b/lib/exercises/auto-tag.ts
@@ -28,6 +28,11 @@ export const MOVEMENT_PATTERNS = [
 
 export type MovementPattern = (typeof MOVEMENT_PATTERNS)[number];
 
+// The user-curated "anchor" movement patterns (Target Movements, #976) live in
+// `./anchor-patterns` — a zero-dependency module so client components can import
+// the taxonomy without pulling this module's Prisma/logger deps into the bundle.
+// They are a deliberate subset of MOVEMENT_PATTERNS; see that file.
+
 export const INTENSITY_CLASSES = ['heavy', 'moderate', 'light'] as const;
 export type IntensityClass = (typeof INTENSITY_CLASSES)[number];
 

--- a/lib/recommendations/anchor-staleness.ts
+++ b/lib/recommendations/anchor-staleness.ts
@@ -1,0 +1,119 @@
+/**
+ * Anchor staleness (Target Movements, #976).
+ *
+ * "Staleness" here is pure days-since-last-logged, derived synchronously from
+ * logged-set history — no aggregates job, no deficit/recovery blend (see
+ * docs/features/TARGET_MOVEMENTS.md). A movement's staleness is the days since
+ * the *freshest* of its ≤5 curated picks was last logged; a movement with no
+ * logged picks is "never logged" and sorts to the top.
+ *
+ * The scoring core ({@link computeAnchorStaleness}) is pure and unit-tested; the
+ * async {@link getAnchorStaleness} wrapper is the thin DB seam that feeds it the
+ * last-logged dates via {@link getBatchExercisePerformance}.
+ */
+
+import {
+  ANCHOR_PATTERN_DISPLAY_NAMES,
+  ANCHOR_PATTERNS,
+  type AnchorPattern,
+  type TargetMovements,
+} from '@/lib/exercises/anchor-patterns'
+import { getBatchExercisePerformance } from '@/lib/queries/exercise-history'
+
+export type AnchorStalenessRow = {
+  pattern: AnchorPattern
+  displayName: string
+  /** The movement's curated exercise ids (order preserved from the profile). */
+  exerciseIds: string[]
+  /**
+   * Whole days since the freshest curated pick was last logged, or null when
+   * none of the picks have ever been logged (maximally stale).
+   */
+  lastLoggedDaysAgo: number | null
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/** Whole days between two instants, clamped at 0 (future dates read as today). */
+function daysBetween(now: Date, then: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - then.getTime()) / MS_PER_DAY))
+}
+
+/**
+ * Pure staleness ranking. Considers only patterns present in `targetMovements`
+ * with a non-empty id list. Rows are sorted staleness-descending: never-logged
+ * first, then by days-since descending, with ties broken by the fixed
+ * {@link ANCHOR_PATTERNS} taxonomy order so the output is deterministic.
+ */
+export function computeAnchorStaleness(
+  targetMovements: TargetMovements,
+  lastLoggedByExerciseId: Map<string, Date>,
+  now: Date,
+): AnchorStalenessRow[] {
+  const rows: AnchorStalenessRow[] = []
+
+  for (const pattern of ANCHOR_PATTERNS) {
+    const exerciseIds = targetMovements[pattern]
+    if (!exerciseIds || exerciseIds.length === 0) continue
+
+    let freshest: number | null = null
+    for (const id of exerciseIds) {
+      const logged = lastLoggedByExerciseId.get(id)
+      if (!logged) continue
+      const daysAgo = daysBetween(now, logged)
+      if (freshest === null || daysAgo < freshest) freshest = daysAgo
+    }
+
+    rows.push({
+      pattern,
+      displayName: ANCHOR_PATTERN_DISPLAY_NAMES[pattern],
+      exerciseIds,
+      lastLoggedDaysAgo: freshest,
+    })
+  }
+
+  const taxonomyOrder = new Map(ANCHOR_PATTERNS.map((p, i) => [p, i]))
+  return rows.sort((a, b) => {
+    // null (never logged) is maximally stale -> sorts first.
+    if (a.lastLoggedDaysAgo === null || b.lastLoggedDaysAgo === null) {
+      if (a.lastLoggedDaysAgo === b.lastLoggedDaysAgo) {
+        return (
+          (taxonomyOrder.get(a.pattern) ?? 0) -
+          (taxonomyOrder.get(b.pattern) ?? 0)
+        )
+      }
+      return a.lastLoggedDaysAgo === null ? -1 : 1
+    }
+    if (b.lastLoggedDaysAgo !== a.lastLoggedDaysAgo) {
+      return b.lastLoggedDaysAgo - a.lastLoggedDaysAgo
+    }
+    return (
+      (taxonomyOrder.get(a.pattern) ?? 0) - (taxonomyOrder.get(b.pattern) ?? 0)
+    )
+  })
+}
+
+/**
+ * Assemble the staleness ranking for a user's configured anchors. Returns an
+ * empty array when nothing is configured (the caller renders a "set up" CTA
+ * rather than an empty list). Never throws for missing history — an unlogged /
+ * deleted id simply contributes nothing and reads as "never logged".
+ */
+export async function getAnchorStaleness(
+  userId: string,
+  targetMovements: TargetMovements,
+): Promise<AnchorStalenessRow[]> {
+  const allIds = Array.from(
+    new Set(Object.values(targetMovements).flat().filter(Boolean)),
+  ) as string[]
+
+  if (allIds.length === 0) return []
+
+  const history = await getBatchExercisePerformance(allIds, userId)
+  const lastLoggedByExerciseId = new Map<string, Date>()
+  for (const [id, entry] of history) {
+    lastLoggedByExerciseId.set(id, entry.completedAt)
+  }
+
+  return computeAnchorStaleness(targetMovements, lastLoggedByExerciseId, new Date())
+}

--- a/lib/user-training-profile.ts
+++ b/lib/user-training-profile.ts
@@ -1,5 +1,10 @@
 import type { Prisma, PrismaClient } from '@prisma/client'
 import { normalizeEquipmentAvailability } from '@/lib/equipment-availability'
+import {
+  ANCHOR_PATTERNS,
+  MAX_ANCHOR_EXERCISES,
+  type TargetMovements,
+} from '@/lib/exercises/anchor-patterns'
 import { ALL_FAUS, type FAUKey } from '@/lib/fau-volume'
 import { isRatioPresetId, type RatioPresetId } from '@/lib/learning/ratio-presets'
 import {
@@ -133,6 +138,8 @@ export type OtherActivityEntry = {
 
 export type FauImportance = Partial<Record<FAUKey, number>>
 
+export type { TargetMovements }
+
 export type UserTrainingProfileDTO = {
   goalSentences: string[]
   weeklyIntent: string[]
@@ -160,6 +167,8 @@ export type UserTrainingProfileDTO = {
   fauImportance: FauImportance
   // Id of the last applied importance preset, or null (attribution only).
   fauImportancePreset: RatioPresetId | null
+  // Curated compound movements ("anchors", #976): pattern -> up to 5 exercise ids.
+  targetMovements: TargetMovements
   // Training rhythm
   targetSessionsPerWeek: number | null
   targetMinutesPerSession: number | null
@@ -315,6 +324,41 @@ export function normalizeFauImportance(value: unknown): FauImportance {
   return result
 }
 
+/**
+ * Structural normalization of the target-movements map: keep only known anchor
+ * patterns, coerce values to a deduped list of non-empty string ids, cap each
+ * to {@link MAX_ANCHOR_EXERCISES}, and drop patterns that end up empty. Mirrors
+ * {@link normalizeFauImportance} — pure and DB-free. Exercise-id *existence* is
+ * validated separately at the API write path (where a Prisma client is on hand)
+ * so deleted ids don't linger; unknown ids that slip through simply read as
+ * "never logged" and self-heal.
+ */
+export function normalizeTargetMovements(value: unknown): TargetMovements {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const record = value as Record<string, unknown>
+  const result: TargetMovements = {}
+  for (const pattern of ANCHOR_PATTERNS) {
+    const ids = normalizeExerciseIdList(record[pattern])
+    if (ids.length > 0) result[pattern] = ids
+  }
+  return result
+}
+
+function normalizeExerciseIdList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of value) {
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+    if (result.length >= MAX_ANCHOR_EXERCISES) break
+  }
+  return result
+}
+
 /** Accept a known preset id, else null (unknown ids are dropped, not thrown). */
 export function normalizeFauImportancePreset(
   value: unknown
@@ -348,6 +392,7 @@ type ProfileLike = {
   otherActivities?: Prisma.JsonValue
   fauImportance?: Prisma.JsonValue
   fauImportancePreset?: string | null
+  targetMovements?: Prisma.JsonValue
   targetSessionsPerWeek?: number | null
   targetMinutesPerSession?: number | null
   patternPreference?: string | null
@@ -404,6 +449,7 @@ export function normalizeUserTrainingProfile(
     fauImportancePreset: normalizeFauImportancePreset(
       profile?.fauImportancePreset ?? null
     ),
+    targetMovements: normalizeTargetMovements(profile?.targetMovements),
     targetSessionsPerWeek: clampInt(
       profile?.targetSessionsPerWeek ?? null,
       MIN_SESSIONS_PER_WEEK,
@@ -556,6 +602,9 @@ export async function updateUserTrainingProfile(
     data.fauImportancePreset = normalizeFauImportancePreset(
       update.fauImportancePreset
     )
+  }
+  if ('targetMovements' in update) {
+    data.targetMovements = normalizeTargetMovements(update.targetMovements)
   }
   if ('targetSessionsPerWeek' in update) {
     data.targetSessionsPerWeek = clampInt(

--- a/prisma/migrations/20260711003303_add_target_movements/migration.sql
+++ b/prisma/migrations/20260711003303_add_target_movements/migration.sql
@@ -1,0 +1,3 @@
+-- Curated "anchor" compound movements (#976): { [anchorPattern]: exerciseId[] }.
+-- Additive, nullable — no backfill; a null/absent value reads as "no anchors configured".
+ALTER TABLE "UserTrainingProfile" ADD COLUMN "targetMovements" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,6 +436,11 @@ model UserTrainingProfile {
   // stay editable, so this survives per-FAU tweaks for "based on your X preset" copy.
   fauImportancePreset         String?
 
+  // targetMovements: curated "anchor" compounds (#976) — { [anchorPattern]: exerciseId[] }
+  // Keys from lib/exercises/anchor-patterns ANCHOR_PATTERNS (subset of MovementPattern),
+  // values up to 5 ExerciseDefinition ids. Drives the picker's "Anchors" staleness view.
+  targetMovements             Json?
+
   // Training rhythm
   targetSessionsPerWeek       Int?
   targetMinutesPerSession     Int?


### PR DESCRIPTION
Implements #976 — a user-curated compound-movement layer ("anchors") on top of the exercise picker. Full spec: `docs/features/TARGET_MOVEMENTS.md`.

## What it does
In **Settings → Target Movements**, users optionally fill any of 6 movement patterns (hinge, squat, horizontal/vertical push/pull) with up to 5 preferred exercises. A new **Anchors** view in the workout picker lists those movements sorted by **staleness** — days since any of a movement's picks was last logged. Never-logged movements sort to the top. Tapping a movement filters the exercise list to its curated picks; tapping an exercise adds it as usual (staleness self-resets from the logged set — no separate "fulfilled" event).

## Changes
- **Taxonomy** — `lib/exercises/anchor-patterns.ts`: zero-dependency module (`ANCHOR_PATTERNS`, display names, `isAnchorPattern`, `MAX_ANCHOR_EXERCISES`, `TargetMovements`), a deliberate subset of `MovementPattern`. Kept out of `auto-tag.ts` so client code imports the taxonomy without pulling in Prisma.
- **Data model** — `UserTrainingProfile.targetMovements Json?` + additive migration. Pure `normalizeTargetMovements` (valid patterns, dedupe, cap 5, drop empties), wired into the profile DTO + update path.
- **Staleness engine** — `lib/recommendations/anchor-staleness.ts`: pure `computeAnchorStaleness` (freshest pick resets a movement, never-logged first, taxonomy tiebreak) + async `getAnchorStaleness` over `getBatchExercisePerformance`.
- **Settings** — `/settings/target-movements` page + `TargetMovementsEditor` (6 collapsible rows, reuses `ExerciseSearchInterface` multi-select, capped at 5) + `GET/PUT /api/settings/target-movements` (drops non-existent ids). Linked from the settings hub.
- **Picker** — 4th **Anchors** view in `ExerciseSearchInterface`'s toggle; `ids` param added to the exercise search API; empty-config renders a "Set up Target Movements →" CTA. Client imports only the *type*, so no server code leaks into the bundle.
- **Tests** — `computeAnchorStaleness` (8 cases) and `normalizeTargetMovements` (4 cases).

## Notes
- Independent of #962/#963 for data — shares only the `daysSinceLabel` presentation util.
- **Anchors tab visibility:** the ad-hoc page passes `anchors` unconditionally (empty → CTA), so the tab is discoverable for all users. To gate it to configured users only, change `anchors={anchors}` to `anchors={anchors.length ? anchors : undefined}` in the ad-hoc page.
- Migration is additive (nullable column); production auto-applies on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)