### PR TITLE
fix: stop async history race from zeroing prefilled sets on revisit

### DIFF
--- a/__tests__/hooks/useProgressiveExercises.test.ts
+++ b/__tests__/hooks/useProgressiveExercises.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useProgressiveExercises } from '@/hooks/useProgressiveExercises'
+
+// These tests guard the async-history race that blanked prefilled sets when
+// navigating back to an exercise a second time: history fetches were being
+// dropped mid-navigation and the exercise stranded in a permanent "loading"
+// state. See ExerciseLoggingModal prefill logic.
+
+function jsonResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => data,
+  } as Response
+}
+
+function makeExercise(order: number) {
+  return {
+    id: `ex${order}`,
+    name: `Exercise ${order}`,
+    order,
+    exerciseGroup: null,
+    notes: null,
+    exerciseDefinitionId: `def${order}`,
+    prescribedSets: [
+      { id: `ps${order}`, setNumber: 1, reps: '5', weight: null, rpe: null, rir: null },
+    ],
+  }
+}
+
+function makeHistory(weight: number) {
+  return {
+    completedAt: '2026-07-01T00:00:00.000Z',
+    workoutName: 'Previous Workout',
+    sets: [
+      { setNumber: 1, reps: 5, weight, weightUnit: 'lbs', rpe: null, rir: null, isWarmup: false },
+    ],
+  }
+}
+
+// Weight returned by the mocked history endpoint, keyed by exercise id.
+const HISTORY_WEIGHT: Record<string, number> = { ex1: 100, ex2: 225 }
+
+function installFetchMock() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+
+    const exerciseMatch = url.match(/\/api\/workouts\/w1\/exercises\/(\d+)/)
+    if (exerciseMatch) {
+      const order = Number(exerciseMatch[1])
+      return jsonResponse({ exercise: makeExercise(order), totalExercises: 2 })
+    }
+
+    const historyMatch = url.match(/\/api\/exercises\/(ex\d+)\/history/)
+    if (historyMatch) {
+      const weight = HISTORY_WEIGHT[historyMatch[1]]
+      const history = makeHistory(weight)
+      return jsonResponse({ history, sessions: [history] })
+    }
+
+    return jsonResponse({}, false)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('useProgressiveExercises history persistence', () => {
+  beforeEach(() => {
+    installFetchMock()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps previous-workout history available when navigating back to an exercise', async () => {
+    const { result } = renderHook(() => useProgressiveExercises('w1', 2))
+
+    // Exercise 1 loads with its previous-workout history.
+    await waitFor(() => expect(result.current.currentExercise?.id).toBe('ex1'))
+    await waitFor(() =>
+      expect(result.current.currentExerciseHistory?.sets[0].weight).toBe(100)
+    )
+    expect(result.current.currentHistoryState).toBe('loaded')
+
+    // Swipe to exercise 2 — it too preloads its own history.
+    act(() => {
+      result.current.goToNext()
+    })
+    await waitFor(() => expect(result.current.currentExercise?.id).toBe('ex2'))
+    await waitFor(() =>
+      expect(result.current.currentExerciseHistory?.sets[0].weight).toBe(225)
+    )
+
+    // Swipe back to exercise 1. Regression: history used to be gone (stranded in
+    // "loading"), which zeroed the prefilled set. It must still be present.
+    act(() => {
+      result.current.goToPrevious()
+    })
+    await waitFor(() => expect(result.current.currentExercise?.id).toBe('ex1'))
+    expect(result.current.currentHistoryState).toBe('loaded')
+    expect(result.current.currentExerciseHistory?.sets[0].weight).toBe(100)
+  })
+
+  it('does not refetch history that is already loaded on revisit', async () => {
+    const fetchMock = installFetchMock()
+    const { result } = renderHook(() => useProgressiveExercises('w1', 2))
+
+    await waitFor(() =>
+      expect(result.current.currentExerciseHistory?.sets[0].weight).toBe(100)
+    )
+
+    act(() => {
+      result.current.goToNext()
+    })
+    await waitFor(() => expect(result.current.currentExercise?.id).toBe('ex2'))
+
+    const ex1HistoryCallsBefore = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/api/exercises/ex1/history')
+    ).length
+
+    act(() => {
+      result.current.goToPrevious()
+    })
+    await waitFor(() => expect(result.current.currentExercise?.id).toBe('ex1'))
+
+    const ex1HistoryCallsAfter = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/api/exercises/ex1/history')
+    ).length
+
+    expect(ex1HistoryCallsAfter).toBe(ex1HistoryCallsBefore)
+  })
+})

--- a/__tests__/lib/workout-prefill.test.ts
+++ b/__tests__/lib/workout-prefill.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { type PrefillCandidateSet, pickPrefillSourceSet } from '@/lib/workout/prefill'
+import {
+  type PrefillCandidateSet,
+  pickPrefillSourceSet,
+  resolvePrefill,
+} from '@/lib/workout/prefill'
 
 function set(partial: Partial<PrefillCandidateSet> & { setNumber: number }): PrefillCandidateSet {
   return {
@@ -89,5 +93,92 @@ describe('pickPrefillSourceSet', () => {
 
     expect(result?.rpe).toBe(8)
     expect(result?.rir).toBe(2)
+  })
+})
+
+describe('resolvePrefill', () => {
+  const blank = { reps: '', weight: '', rpe: '', rir: '' }
+  const prescribed = { reps: '5', rpe: null, rir: null }
+
+  it('prefills a freshly-entered exercise from history', () => {
+    const history = [set({ setNumber: 1, reps: 5, weight: 200 })]
+
+    const values = resolvePrefill({
+      isNewTarget: true,
+      current: blank,
+      snapshot: null,
+      sessionSets: [],
+      historySets: history,
+      prescribed,
+    })
+
+    expect(values).not.toBeNull()
+    expect(values?.weight).toBe('200')
+    expect(values?.reps).toBe('5')
+  })
+
+  it('upgrades a prescribed fallback to history once it arrives (form untouched)', () => {
+    // First pass: history not loaded yet — falls back to prescribed reps + 0.
+    const fallback = resolvePrefill({
+      isNewTarget: true,
+      current: blank,
+      snapshot: null,
+      sessionSets: [],
+      historySets: null,
+      prescribed,
+    })
+    expect(fallback?.reps).toBe('5')
+    expect(fallback?.weight).toBe('0')
+
+    const snapshot = {
+      reps: fallback!.reps,
+      weight: fallback!.weight,
+      rpe: fallback!.rpe,
+      rir: fallback!.rir,
+    }
+
+    // History arrives; the form still shows the fallback (untouched).
+    const upgraded = resolvePrefill({
+      isNewTarget: false,
+      current: snapshot,
+      snapshot,
+      sessionSets: [],
+      historySets: [set({ setNumber: 1, reps: 8, weight: 315 })],
+      prescribed,
+    })
+
+    expect(upgraded?.weight).toBe('315')
+    expect(upgraded?.reps).toBe('8')
+  })
+
+  it('does not clobber the form after the user edits it', () => {
+    const snapshot = { reps: '5', weight: '0', rpe: '', rir: '' }
+    const edited = { reps: '5', weight: '185', rpe: '', rir: '' } // user typed weight
+
+    const values = resolvePrefill({
+      isNewTarget: false,
+      current: edited,
+      snapshot,
+      sessionSets: [],
+      historySets: [set({ setNumber: 1, reps: 8, weight: 315 })],
+      prescribed,
+    })
+
+    expect(values).toBeNull()
+  })
+
+  it('skips a redundant re-apply when nothing changed', () => {
+    const snapshot = { reps: '5', weight: '200', rpe: '', rir: '' }
+
+    const values = resolvePrefill({
+      isNewTarget: false,
+      current: snapshot,
+      snapshot,
+      sessionSets: [],
+      historySets: [set({ setNumber: 1, reps: 5, weight: 200 })],
+      prescribed,
+    })
+
+    expect(values).toBeNull()
   })
 })

--- a/components/ExerciseLoggingModal.tsx
+++ b/components/ExerciseLoggingModal.tsx
@@ -17,7 +17,7 @@ import { completeDraft, discardDraft } from '@/lib/api/workout-sets'
 import { clientLogger } from '@/lib/client-logger'
 import { parseRepsFromPrescribed } from '@/lib/constants/intensity-presets'
 import { formatPrescribedSummary } from '@/lib/format/prescribed-summary'
-import { computePrefillValues } from '@/lib/workout/prefill'
+import { type PrefillFormState, resolvePrefill } from '@/lib/workout/prefill'
 import type { LoggedSet } from '@/types/workout'
 import ExerciseDefinitionEditorModal from './features/exercise-definition/ExerciseDefinitionEditorModal'
 import ExerciseActionsFooter from './workout-logging/ExerciseActionsFooter'
@@ -248,35 +248,33 @@ export default function ExerciseLoggingModal({
   const hasRpe = hasIntensityAccess && currentPrescribedSets.some((s) => s.rpe !== null)
   const hasRir = hasIntensityAccess && currentPrescribedSets.some((s) => s.rir !== null)
 
-  // Pre-fill form when exercise loads or set number changes.
-  //
-  // Priority: carry forward the last set completed *this session* for the
-  // exercise (so swiping away and back during supersets keeps your numbers),
-  // then fall back to the previous workout's last set (history), and only then
-  // to the prescribed plan / zeros. Previous performance wins over the plan.
+  // Pre-fill the form when the exercise or set changes. Priority and the
+  // untouched/upgrade rules live in resolvePrefill; `lastPrefillKey` tracks the
+  // exercise/set we prefilled and `prefilledSnapshot` records what we wrote so
+  // an untouched form can be told from an edited one.
   const lastPrefillKey = useRef<string>('')
+  const prefilledSnapshot = useRef<PrefillFormState | null>(null)
   useEffect(() => {
     if (!currentExercise) return
 
-    // History loads asynchronously after we land on an exercise. If there are
-    // no session sets to carry forward yet, wait for history to settle before
-    // prefilling so a late-arriving previous workout isn't dropped in favor of
-    // the prescribed fallback.
-    const sessionHasSets = currentExerciseLoggedSets.length > 0
-    const historySettled =
-      currentHistoryState === 'loaded' || currentHistoryState === 'error'
-    if (!sessionHasSets && !historySettled) return
-
     const prefillKey = `${currentExercise.id}-${nextSetNumber}`
-    if (lastPrefillKey.current === prefillKey) return
+    const values = resolvePrefill({
+      isNewTarget: lastPrefillKey.current !== prefillKey,
+      current: currentSet,
+      snapshot: prefilledSnapshot.current,
+      sessionSets: currentExerciseLoggedSets,
+      historySets: currentExerciseHistory?.sets,
+      prescribed: currentPrescribedSets.find(s => s.setNumber === nextSetNumber),
+    })
+    if (!values) return
+
     lastPrefillKey.current = prefillKey
-
-    const values = computePrefillValues(
-      currentExerciseLoggedSets,
-      currentExerciseHistory?.sets,
-      currentPrescribedSets.find(s => s.setNumber === nextSetNumber)
-    )
-
+    prefilledSnapshot.current = {
+      reps: values.reps,
+      weight: values.weight,
+      rpe: values.rpe,
+      rir: values.rir,
+    }
     setCurrentSet(prev => ({
       ...prev,
       reps: values.reps,
@@ -291,7 +289,7 @@ export default function ExerciseLoggingModal({
     currentPrescribedSets,
     currentExerciseLoggedSets,
     currentExerciseHistory,
-    currentHistoryState,
+    currentSet,
   ])
 
   const handleLogSet = useCallback(() => {

--- a/hooks/useProgressiveExercises.ts
+++ b/hooks/useProgressiveExercises.ts
@@ -207,7 +207,10 @@ export function useProgressiveExercises(
     if (loadedExercises.has(index) && exerciseLoadStates.get(index) === 'loaded') {
       // Exercise already loaded, check if we need history
       const exercise = loadedExercises.get(index)
-      if (exercise && !historyByExerciseId.has(exercise.id) && historyLoadStates.get(exercise.id) !== 'loading') {
+      // Retry whenever history isn't loaded yet — gate concurrency on
+      // prefetchingRef, not the load state, so a previously dropped fetch (e.g.
+      // interrupted by fast navigation) isn't stranded in "loading" forever.
+      if (exercise && !historyByExerciseId.has(exercise.id)) {
         const historyKey = `history-${exercise.id}`
         if (!prefetchingRef.current.has(historyKey)) {
           prefetchingRef.current.add(historyKey)
@@ -257,7 +260,7 @@ export function useProgressiveExercises(
     }
 
     prefetchingRef.current.delete(prefetchKey)
-  }, [loadedExercises, exerciseLoadStates, historyByExerciseId, historyLoadStates, fetchExercise, fetchHistory])
+  }, [loadedExercises, exerciseLoadStates, historyByExerciseId, fetchExercise, fetchHistory])
 
   const prefetchSequentially = useCallback(async (startIndex: number) => {
     const indicesToLoad = [startIndex, startIndex + 1, startIndex + 2, startIndex + 3]
@@ -270,15 +273,23 @@ export function useProgressiveExercises(
     }
   }, [totalExercises, loadExerciseWithHistory])
 
-  // Prefetch exercises on navigation — see #196
-  /* eslint-disable react-hooks/set-state-in-effect */
+  // Track true mount/unmount so async fetches don't set state after the hook
+  // unmounts. This MUST be separate from the prefetch effect below: that effect
+  // re-runs on every navigation (and whenever prefetchSequentially's identity
+  // changes), so folding this in flipped mountedRef to false mid-navigation and
+  // caused in-flight history fetches to be dropped — stranding exercises in a
+  // permanent "loading" state and blanking their prefilled sets.
   useEffect(() => {
     mountedRef.current = true
-    prefetchSequentially(currentIndex)
-
     return () => {
       mountedRef.current = false
     }
+  }, [])
+
+  // Prefetch exercises on navigation — see #196
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    prefetchSequentially(currentIndex)
   }, [currentIndex, prefetchSequentially])
   /* eslint-enable react-hooks/set-state-in-effect */
 

--- a/lib/workout/prefill.ts
+++ b/lib/workout/prefill.ts
@@ -102,3 +102,54 @@ export function computePrefillValues(
     rir: prescribed?.rir != null ? String(prescribed.rir) : '',
   }
 }
+
+/** The reps/weight/intensity currently shown in (or last written to) the form. */
+export type PrefillFormState = {
+  reps: string
+  weight: string
+  rpe: string
+  rir: string
+}
+
+function sameForm(a: PrefillFormState, b: PrefillFormState): boolean {
+  return a.reps === b.reps && a.weight === b.weight && a.rpe === b.rpe && a.rir === b.rir
+}
+
+/**
+ * Decide whether to (re)prefill the logging form and with what values.
+ *
+ * Previous-workout history arrives asynchronously, so the form is prefilled
+ * immediately with the best data available and *upgraded* once history loads.
+ * To avoid clobbering the user's own input (or the in-exercise set progression),
+ * a re-apply only happens while the form is untouched — i.e. still equal to the
+ * `snapshot` of what we last wrote.
+ *
+ * @returns the values to apply, or null to leave the form as-is.
+ */
+export function resolvePrefill(params: {
+  /** True when this is a freshly-entered exercise/set we haven't prefilled. */
+  isNewTarget: boolean
+  /** Current form values. */
+  current: PrefillFormState
+  /** What we last prefilled for this target (null if none yet). */
+  snapshot: PrefillFormState | null
+  sessionSets: PrefillCandidateSet[]
+  historySets?: PrefillCandidateSet[] | null
+  prescribed: PrefillPrescribedTarget | undefined
+}): PrefillValues | null {
+  const { isNewTarget, current, snapshot, sessionSets, historySets, prescribed } = params
+
+  // Already prefilled this target: only re-apply if the user hasn't touched it.
+  if (!isNewTarget && (snapshot == null || !sameForm(snapshot, current))) {
+    return null
+  }
+
+  const values = computePrefillValues(sessionSets, historySets, prescribed)
+
+  // Nothing new to show — skip a redundant re-render.
+  if (!isNewTarget && snapshot != null && sameForm(snapshot, values)) {
+    return null
+  }
+
+  return values
+}


### PR DESCRIPTION
## Problem

Follow-up to #984. That fix wired previous-workout history into prefill, but sets still **zeroed out when navigating back to an exercise a second time**, with a visible hiccup while history loaded on some exercises.

## Root cause

An async race in `useProgressiveExercises`:

- `mountedRef` was toggled **inside the prefetch effect**, which re-runs on every navigation. That let in-flight `fetchHistory` results be dropped mid-navigation.
- The history re-fetch guard was keyed on the `loading` **state**, so a dropped fetch left the exercise stranded in a permanent `loading` state that was never retried.
- The prefill effect waited for history to *settle* before running — so for a stranded exercise it never ran, leaving the form blank/zeroed.

## Fix

**Hook (`useProgressiveExercises`)**
- Track true mount/unmount in a dedicated `useEffect(…, [])` so navigation no longer flips `mountedRef` and drops fetches.
- Gate history re-fetch on `prefetchingRef` (actual in-flight guard) instead of the `loading` state, so a dropped fetch is retried rather than stranded.

**Component (`ExerciseLoggingModal` prefill)**
- No longer gates on the history load-state enum. It prefills immediately with the best data available and **upgrades to previous-workout history when it arrives** — but only while the form is untouched (tracked via a snapshot), so user edits and the in-exercise set progression are never clobbered.
- Priority/upgrade/no-clobber logic extracted to `resolvePrefill` in `lib/workout/prefill.ts` (pure + unit-tested). This also kept `ExerciseLoggingModal.tsx` under the 1000-line limit.

## Tests
- `__tests__/lib/workout-prefill.test.ts` — `resolvePrefill`: fresh prefill from history, upgrade of a prescribed fallback once history arrives, no-clobber after the user edits, and skipping redundant re-applies. (Plus the existing `pickPrefillSourceSet`/`computePrefillValues` priority tests.)
- `__tests__/hooks/useProgressiveExercises.test.ts` — history stays available when navigating away and back, and isn't refetched when already loaded.
- 13 tests pass; typecheck + lint clean (pre-existing `cloud-functions/clone-program` Prisma errors are unrelated).

Note: the exact timing race isn't deterministically reproducible in jsdom, so the hook test guards the navigation/history contract rather than reproducing the interruption itself; the `resolvePrefill` tests deterministically cover the prefill/upgrade behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)