### PR TITLE
fix: wire tap-to-prefill into the ad-hoc (freestyle) logger

### DIFF
--- a/components/adhoc/AdHocLoggerView.tsx
+++ b/components/adhoc/AdHocLoggerView.tsx
@@ -37,6 +37,7 @@ import { clientLogger } from '@/lib/client-logger'
 import type { AnchorStalenessRow } from '@/lib/recommendations/anchor-staleness'
 import type { FauNeed } from '@/lib/recommendations/fau-score'
 import type { WorkoutRollup } from '@/lib/stats/workout-rollup'
+import { type ApplicableSet, appliedSetToForm } from '@/lib/workout/prefill'
 import type { LoggedSet } from '@/types/workout'
 import {
   AdHocEmptyState,
@@ -232,6 +233,20 @@ export default function AdHocLoggerView({
     currentSet.reps,
     currentSet.weight,
   ])
+
+  // Tap-to-prefill: copy a set's numbers into the form. Used by the "Last time"
+  // reference (previous workout) and by tapping an already-logged set this
+  // session. Mark the exercise as prefilled so the history effect above won't
+  // fire over the tapped-in values.
+  const applySetToForm = useCallback(
+    (source: ApplicableSet) => {
+      if (!currentExercise) return
+      prefilledFromHistoryIds.current.add(currentExercise.id)
+      const v = appliedSetToForm(source, hasIntensityAccess)
+      setCurrentSet(prev => ({ ...prev, ...v, weightUnit: v.weightUnit ?? prev.weightUnit }))
+    },
+    [currentExercise, hasIntensityAccess]
+  )
 
   // Shared onRetry callback so users see a "reconnecting…" toast on slow links
   // before the request either succeeds or terminally fails.
@@ -759,6 +774,7 @@ export default function AdHocLoggerView({
                     : 'pending'
               }
               onDeleteSet={handleDeleteSet}
+              onApplySet={applySetToForm}
               loggingForm={
                 <SetLoggingForm
                   prescribedSet={undefined}


### PR DESCRIPTION
## Root cause (finally!)

All the prefill/tap work landed in the **program logger** (`ExerciseLoggingModal`). The **freestyle logger** (`AdHocLoggerView`) is a separate component. It renders the *same* `ExerciseDisplayTabs`, but never passed the `onApplySet` prop — so `LastSessionReference` and `SetList` rendered their rows as plain `<div>`s with no tap targets. That's exactly why tap-to-prefill worked in the program logger but not the ad-hoc logger.

Confirmed on live staging via browser: the program logger's logged-set tap works (reps 10→12), and the deployed code/build/rollout were all fine — the gap was simply that the ad-hoc view was never wired up.

## Fix

- Add an `applySetToForm` handler in `AdHocLoggerView` (reuses the shared `appliedSetToForm` helper).
- Pass `onApplySet={applySetToForm}` to its `ExerciseDisplayTabs`.
- The handler marks the exercise in `prefilledFromHistoryIds` so the one-shot history prefill effect doesn't overwrite the tapped-in values (the effect already bails when the form is non-empty).

Now both loggers behave identically: tap the "Last time" row or any logged set to prefill.

## Verification
- Type-check + lint clean.
- Mirrors the program-logger wiring that I verified working on live staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)